### PR TITLE
Fix spline temp container size in make_interp_spline

### DIFF
--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -287,6 +287,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if nleft > 0:
         x0 = cupy.array([x[0]], dtype=x.dtype)
         rows = cupy.zeros((nleft, nt), dtype=float)
+
         for j, m in enumerate(deriv_l_ords):
             # place the derivatives of the order m at x[0] into `temp`
             d_boor_kernel((1,), (1,),

--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -269,7 +269,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         # Prepare the I/O arrays for the kernels. We only need the non-zero
         # b-splines at x[0] and x[-1], but the kernel wants more arrays which
         # we allocate and ignore (mode != 1)
-        temp = cupy.zeros((nt, ), dtype=float)
+        temp = cupy.zeros((2 * k + 1, ), dtype=float)
         num_c = 1
         dummy_c = cupy.empty((nt, num_c), dtype=float)
         out = cupy.empty((1, 1), dtype=dummy_c.dtype)
@@ -287,7 +287,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     if nleft > 0:
         x0 = cupy.array([x[0]], dtype=x.dtype)
         rows = cupy.zeros((nleft, nt), dtype=float)
-
         for j, m in enumerate(deriv_l_ords):
             # place the derivatives of the order m at x[0] into `temp`
             d_boor_kernel((1,), (1,),


### PR DESCRIPTION
See https://github.com/cupy/cupy/pull/8290#issuecomment-2175220453

This prevents the `d_boor` kernel from performing an out-of-bounds array access, this was caused due to the size of `temp` in `make_interp_spline`, which was shorter than the expected value. After this PR, the confirmed segfault caused when running the following test no longer appears:

```
compute-sanitizer --tool memcheck --padding 32 python -m pytest -v  tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py  -k test_minimum_points_and_deriv
```

![imagen](https://github.com/cupy/cupy/assets/1878982/fad5fe48-82c3-4fb0-8c11-6ccab977cf9c)
