### PR TITLE
MAINT: Avoid using np.compat.integer_types

### DIFF
--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -1098,7 +1098,7 @@ def fftshift(x, axes=None):
     x = cupy.asarray(x)
     if axes is None:
         axes = list(range(x.ndim))
-    elif isinstance(axes, np.compat.integer_types):
+    elif isinstance(axes, int):
         axes = (axes,)
     return cupy.roll(x, [x.shape[axis] // 2 for axis in axes], axes)
 
@@ -1119,6 +1119,6 @@ def ifftshift(x, axes=None):
     x = cupy.asarray(x)
     if axes is None:
         axes = list(range(x.ndim))
-    elif isinstance(axes, np.compat.integer_types):
+    elif isinstance(axes, int):
         axes = (axes,)
     return cupy.roll(x, [-(x.shape[axis] // 2) for axis in axes], axes)


### PR DESCRIPTION
This was removed in 2.0, since it is just `int` anyway since Python 2 is not a thing anymore.

A better pattern is probably:
```
        try:
            axes = (operator.index(axes),)
        except TypeError:
            pass
```
(broadening this to non Python integers).  But it doens't matter much and this is the more trivial change.