### PR TITLE
Skip some tests in aarch64 CI

### DIFF
--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -321,7 +321,12 @@ class ndarray(object):
                     if self._numpy_array is None:
                         self._numpy_array = base._numpy_array.view(type=_type)
                         self._numpy_array.shape = self._cupy_array.shape
-                        self._numpy_array.strides = self._cupy_array.strides
+                        # In some scenarios, the numpy array strides may be
+                        # different. Copying the strides directly will cause
+                        # cause errors. This has been observed in ARM systems
+                        cupy_strides = self._cupy_array.strides
+                        if self._numpy_array.strides != cupy_strides:
+                            self._numpy_array.strides = cupy_strides
         else:
             # not cupy-compatible
             if base is not None:

--- a/cupyx/fallback_mode/fallback.py
+++ b/cupyx/fallback_mode/fallback.py
@@ -321,12 +321,7 @@ class ndarray(object):
                     if self._numpy_array is None:
                         self._numpy_array = base._numpy_array.view(type=_type)
                         self._numpy_array.shape = self._cupy_array.shape
-                        # In some scenarios, the numpy array strides may be
-                        # different. Copying the strides directly will cause
-                        # cause errors. This has been observed in ARM systems
-                        cupy_strides = self._cupy_array.strides
-                        if self._numpy_array.strides != cupy_strides:
-                            self._numpy_array.strides = cupy_strides
+                        self._numpy_array.strides = self._cupy_array.strides
         else:
             # not cupy-compatible
             if base is not None:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy
 import pytest
 
@@ -222,6 +224,9 @@ class TestFilter(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
+        if self.dtype == numpy.uint8 and platform.processor() == "aarch64":
+            pytest.skip(
+                "aarch64 scipy does not match cupy/x86 see Scipy #20158")
         self._hip_skip_invalid_condition()
         if self.dtype == getattr(self, 'output', None):
             pytest.skip("redundant")

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -1,3 +1,5 @@
+import platform
+
 import cupy
 
 import cupyx.scipy.signal as signal
@@ -315,6 +317,9 @@ class TestFirls:
         # negative weight
         # assert_raises(ValueError, firls, 11, [0.1, 0.2], [0, 0], [-1])
 
+    @pytest.mark.xfail(
+        platform.processor() == "aarch64",
+        reason="aarch64 scipy does not match cupy/x86 see Scipy #20160")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-13)
     def test_firls(self, xp, scp):
         N = 11  # number of taps in the filter

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 
 import cupy
@@ -572,8 +573,9 @@ class TestPlacePoles:
         self._check(A, B, P, method='YT')
 
     @pytest.mark.xfail(
-        sys.platform.startswith('win32'),
-        reason='passes locally, fails on windows CI')
+        sys.platform.startswith('win32')
+        or platform.processor() == "aarch64",
+        reason='passes locally, fails on windows CI, aarch64')
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_real_2(self, xp, scp):
         # Try to reach the specific case in _YT_real where two singular

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -46,7 +46,7 @@ class TestPolygamma(unittest.TestCase):
 
     @pytest.mark.xfail(
         platform.processor() == "aarch64",
-        reason="aarch64 scipy does not match cupy/x86 see Scipy")
+        reason="aarch64 scipy does not match cupy/x86 see Scipy #20159")
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -1,8 +1,10 @@
+import platform
 import unittest
 
 from cupy import testing
 import cupyx.scipy.special  # NOQA
 import numpy
+import pytest
 
 import warnings
 
@@ -42,6 +44,9 @@ class TestPolygamma(unittest.TestCase):
         return scp.special.polygamma(
             dtype(2.), dtype(1.5)).astype(numpy.float32)
 
+    @pytest.mark.xfail(
+        platform.processor() == "aarch64",
+        reason="aarch64 scipy does not match cupy/x86 see Scipy")
     @testing.with_requires('scipy>=1.1.0')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')


### PR DESCRIPTION
Some of the routines here rely in scipy functions that don't return the same results in x86/arm. Seems that the CUDA routines are written to mach the results in x86 causing several tests to fail.

https://github.com/scipy/scipy/issues/20158
https://github.com/scipy/scipy/issues/20160