### PR TITLE
Bump NumPy/SciPy versions in cuda-example CI

### DIFF
--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -1629,7 +1629,7 @@ CuPy CI Test Coverage
      - 
    * - numpy
      - 1.22
-     - 7
+     - 6
      - ✅
      - ✅
      - 
@@ -1658,14 +1658,14 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - ✅
+     - 
      - 
      - ✅
      - 
      - 
    * - 
      - 1.23
-     - 10
+     - 11
      - 
      - 
      - ✅
@@ -1694,7 +1694,7 @@ CuPy CI Test Coverage
      - ✅
      - 
      - ✅
-     - 
+     - ✅
      - 
      - 
      - 
@@ -1881,7 +1881,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 1.7
-     - 5
+     - 4
      - ✅
      - ✅
      - 
@@ -1910,14 +1910,14 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - ✅
+     - 
      - 
      - ✅
      - 
      - 
    * - 
      - 1.8
-     - 4
+     - 5
      - 
      - 
      - ✅
@@ -1946,7 +1946,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - 
+     - ✅
      - 
      - 
      - 

--- a/.pfnci/linux/tests/cuda-example.Dockerfile
+++ b/.pfnci/linux/tests/cuda-example.Dockerfile
@@ -28,6 +28,6 @@ RUN pyenv install 3.9.6 && \
     pyenv global 3.9.6 && \
     pip install -U setuptools pip wheel
 
-RUN pip install -U 'numpy==1.22.*' 'scipy==1.7.*' 'optuna==3.*' 'cython==0.29.*'
+RUN pip install -U 'numpy==1.23.*' 'scipy==1.8.*' 'optuna==3.*' 'cython==0.29.*'
 RUN pip uninstall -y mpi4py cuda-python && \
     pip check

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -492,8 +492,8 @@
   cusparselt: null  # TODO use cuSPARSELt 0.6+ after bumping CUDA to 12.x
   cudnn: "8.8"
   python: "3.9"
-  numpy: "1.22"
-  scipy: "1.7"
+  numpy: "1.23"
+  scipy: "1.8"
   optuna: "3"
   mpi4py: null
   cython: "0.29"


### PR DESCRIPTION
This is required because `matplotlib` 3.9.0 (installed [here](https://github.com/cupy/cupy/blob/64c3b26df94907716f8f24f72dcec9676c75533a/.pfnci/linux/tests/actions/example.sh#L10)) now requires NumPy 1.23+.
