### PR TITLE
Add Incomplete Elliptic Integrals to special

### DIFF
--- a/cupy/_core/include/cupy/special/cephes/ellie.h
+++ b/cupy/_core/include/cupy/special/cephes/ellie.h
@@ -1,0 +1,293 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     ellie.c
+ *
+ *     Incomplete elliptic integral of the second kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double phi, m, y, ellie();
+ *
+ * y = ellie( phi, m );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *                 phi
+ *                  -
+ *                 | |
+ *                 |                   2
+ * E(phi_\m)  =    |    sqrt( 1 - m sin t ) dt
+ *                 |
+ *               | |
+ *                -
+ *                 0
+ *
+ * of amplitude phi and modulus m, using the arithmetic -
+ * geometric mean algorithm.
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ * Tested at random arguments with phi in [-10, 10] and m in
+ * [0, 1].
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE     -10,10      150000       3.3e-15     1.4e-16
+ */
+
+/*
+ * Cephes Math Library Release 2.0:  April, 1987
+ * Copyright 1984, 1987, 1993 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+/* Copyright 2014, Eric W. Moore */
+
+/*     Incomplete elliptic integral of second kind     */
+#pragma once
+
+#include "../config.h"
+#include "const.h"
+#include "ellpe.h"
+#include "ellpk.h"
+#include "unity.h"
+
+namespace special {
+namespace cephes {
+    namespace detail {
+
+        /* To calculate legendre's incomplete elliptical integral of the second kind for
+         * negative m, we use a power series in phi for small m*phi*phi, an asymptotic
+         * series in m for large m*phi*phi* and the relation to Carlson's symmetric
+         * integrals, R_F(x,y,z) and R_D(x,y,z).
+         *
+         * E(phi, m) = sin(phi) * R_F(cos(phi)^2, 1 - m * sin(phi)^2, 1.0)
+         *             - m * sin(phi)^3 * R_D(cos(phi)^2, 1 - m * sin(phi)^2, 1.0) / 3
+         *
+         *           = R_F(c-1, c-m, c) - m * R_D(c-1, c-m, c) / 3
+         *
+         * where c = csc(phi)^2. We use the second form of this for (approximately)
+         * phi > 1/(sqrt(DBL_MAX) ~ 1e-154, where csc(phi)^2 overflows. Elsewhere we
+         * use the first form, accounting for the smallness of phi.
+         *
+         * The algorithm used is described in Carlson, B. C. Numerical computation of
+         * real or complex elliptic integrals. (1994) https://arxiv.org/abs/math/9409227
+         * Most variable names reflect Carlson's usage.
+         *
+         * In this routine, we assume m < 0 and  0 > phi > pi/2.
+         */
+        SPECFUN_HOST_DEVICE inline double ellie_neg_m(double phi, double m) {
+            double x, y, z, x1, y1, z1, ret, Q;
+            double A0f, Af, Xf, Yf, Zf, E2f, E3f, scalef;
+            double A0d, Ad, seriesn, seriesd, Xd, Yd, Zd, E2d, E3d, E4d, E5d, scaled;
+            int n = 0;
+            double mpp = (m * phi) * phi;
+
+            if (-mpp < 1e-6 && phi < -m) {
+                return phi + (mpp * phi * phi / 30.0 - mpp * mpp / 40.0 - mpp / 6.0) * phi;
+            }
+
+            if (-mpp > 1e6) {
+                double sm = std::sqrt(-m);
+                double sp = std::sin(phi);
+                double cp = std::cos(phi);
+
+                double a = -cosm1(phi);
+                double b1 = std::log(4 * sp * sm / (1 + cp));
+                double b = -(0.5 + b1) / 2.0 / m;
+                double c = (0.75 + cp / sp / sp - b1) / 16.0 / m / m;
+                return (a + b + c) * sm;
+            }
+
+            if (phi > 1e-153 && m > -1e200) {
+                double s = std::sin(phi);
+                double csc2 = 1.0 / s / s;
+                scalef = 1.0;
+                scaled = m / 3.0;
+                x = 1.0 / std::tan(phi) / std::tan(phi);
+                y = csc2 - m;
+                z = csc2;
+            } else {
+                scalef = phi;
+                scaled = mpp * phi / 3.0;
+                x = 1.0;
+                y = 1 - mpp;
+                z = 1.0;
+            }
+
+            if (x == y && x == z) {
+                return (scalef + scaled / x) / std::sqrt(x);
+            }
+
+            A0f = (x + y + z) / 3.0;
+            Af = A0f;
+            A0d = (x + y + 3.0 * z) / 5.0;
+            Ad = A0d;
+            x1 = x;
+            y1 = y;
+            z1 = z;
+            seriesd = 0.0;
+            seriesn = 1.0;
+            /* Carlson gives 1/pow(3*r, 1.0/6.0) for this constant. if r == eps,
+             * it is ~338.38. */
+
+            /* N.B. This will evaluate its arguments multiple times. */
+            Q = 400.0 * std::fmax(std::abs(A0f - x), std::fmax(std::abs(A0f - y), std::abs(A0f - z)));
+
+            while (Q > std::abs(Af) && Q > std::abs(Ad) && n <= 100) {
+                double sx = std::sqrt(x1);
+                double sy = std::sqrt(y1);
+                double sz = std::sqrt(z1);
+                double lam = sx * sy + sx * sz + sy * sz;
+                seriesd += seriesn / (sz * (z1 + lam));
+                x1 = (x1 + lam) / 4.0;
+                y1 = (y1 + lam) / 4.0;
+                z1 = (z1 + lam) / 4.0;
+                Af = (x1 + y1 + z1) / 3.0;
+                Ad = (Ad + lam) / 4.0;
+                n += 1;
+                Q /= 4.0;
+                seriesn /= 4.0;
+            }
+
+            Xf = (A0f - x) / Af / (1 << 2 * n);
+            Yf = (A0f - y) / Af / (1 << 2 * n);
+            Zf = -(Xf + Yf);
+
+            E2f = Xf * Yf - Zf * Zf;
+            E3f = Xf * Yf * Zf;
+
+            ret = scalef * (1.0 - E2f / 10.0 + E3f / 14.0 + E2f * E2f / 24.0 - 3.0 * E2f * E3f / 44.0) / sqrt(Af);
+
+            Xd = (A0d - x) / Ad / (1 << 2 * n);
+            Yd = (A0d - y) / Ad / (1 << 2 * n);
+            Zd = -(Xd + Yd) / 3.0;
+
+            E2d = Xd * Yd - 6.0 * Zd * Zd;
+            E3d = (3 * Xd * Yd - 8.0 * Zd * Zd) * Zd;
+            E4d = 3.0 * (Xd * Yd - Zd * Zd) * Zd * Zd;
+            E5d = Xd * Yd * Zd * Zd * Zd;
+
+            ret -= scaled *
+                   (1.0 - 3.0 * E2d / 14.0 + E3d / 6.0 + 9.0 * E2d * E2d / 88.0 - 3.0 * E4d / 22.0 -
+                    9.0 * E2d * E3d / 52.0 + 3.0 * E5d / 26.0) /
+                   (1 << 2 * n) / Ad / sqrt(Ad);
+            ret -= 3.0 * scaled * seriesd;
+            return ret;
+        }
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double ellie(double phi, double m) {
+        double a, b, c, e, temp;
+        double lphi, t, E, denom, npio2;
+        int d, mod, sign;
+
+        if (std::isnan(phi) || std::isnan(m))
+            return std::numeric_limits<double>::quiet_NaN();
+        if (m > 1.0)
+            return std::numeric_limits<double>::quiet_NaN();
+        ;
+        if (std::isinf(phi))
+            return phi;
+        if (std::isinf(m))
+            return -m;
+        if (m == 0.0)
+            return (phi);
+        lphi = phi;
+        npio2 = std::floor(lphi / M_PI_2);
+        if (std::fmod(std::abs(npio2), 2.0) == 1.0)
+            npio2 += 1;
+        lphi = lphi - npio2 * M_PI_2;
+        if (lphi < 0.0) {
+            lphi = -lphi;
+            sign = -1;
+        } else {
+            sign = 1;
+        }
+        a = 1.0 - m;
+        E = ellpe(m);
+        if (a == 0.0) {
+            temp = std::sin(lphi);
+            goto done;
+        }
+        if (a > 1.0) {
+            temp = detail::ellie_neg_m(lphi, m);
+            goto done;
+        }
+
+        if (lphi < 0.135) {
+            double m11 = (((((-7.0 / 2816.0) * m + (5.0 / 1056.0)) * m - (7.0 / 2640.0)) * m + (17.0 / 41580.0)) * m -
+                          (1.0 / 155925.0)) *
+                         m;
+            double m9 = ((((-5.0 / 1152.0) * m + (1.0 / 144.0)) * m - (1.0 / 360.0)) * m + (1.0 / 5670.0)) * m;
+            double m7 = ((-m / 112.0 + (1.0 / 84.0)) * m - (1.0 / 315.0)) * m;
+            double m5 = (-m / 40.0 + (1.0 / 30)) * m;
+            double m3 = -m / 6.0;
+            double p2 = lphi * lphi;
+
+            temp = ((((m11 * p2 + m9) * p2 + m7) * p2 + m5) * p2 + m3) * p2 * lphi + lphi;
+            goto done;
+        }
+        t = std::tan(lphi);
+        b = std::sqrt(a);
+        /* Thanks to Brian Fitzgerald <fitzgb@mml0.meche.rpi.edu>
+         * for pointing out an instability near odd multiples of pi/2.  */
+        if (std::abs(t) > 10.0) {
+            /* Transform the amplitude */
+            e = 1.0 / (b * t);
+            /* ... but avoid multiple recursions.  */
+            if (std::abs(e) < 10.0) {
+                e = std::atan(e);
+                temp = E + m * std::sin(lphi) * std::sin(e) - ellie(e, m);
+                goto done;
+            }
+        }
+        c = std::sqrt(m);
+        a = 1.0;
+        d = 1;
+        e = 0.0;
+        mod = 0;
+
+        while (std::abs(c / a) > detail::MACHEP) {
+            temp = b / a;
+            lphi = lphi + atan(t * temp) + mod * M_PI;
+            denom = 1 - temp * t * t;
+            if (std::abs(denom) > 10 * detail::MACHEP) {
+                t = t * (1.0 + temp) / denom;
+                mod = (lphi + M_PI_2) / M_PI;
+            } else {
+                t = std::tan(lphi);
+                mod = static_cast<int>(std::floor((lphi - std::atan(t)) / M_PI));
+            }
+            c = (a - b) / 2.0;
+            temp = std::sqrt(a * b);
+            a = (a + b) / 2.0;
+            b = temp;
+            d += d;
+            e += c * std::sin(lphi);
+        }
+
+        temp = E / ellpk(1.0 - m);
+        temp *= (std::atan(t) + mod * M_PI) / (d * a);
+        temp += e;
+
+    done:
+
+        if (sign < 0)
+            temp = -temp;
+        temp += npio2 * E;
+        return (temp);
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/ellik.h
+++ b/cupy/_core/include/cupy/special/cephes/ellik.h
@@ -1,0 +1,251 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     ellik.c
+ *
+ *     Incomplete elliptic integral of the first kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double phi, m, y, ellik();
+ *
+ * y = ellik( phi, m );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *
+ *                phi
+ *                 -
+ *                | |
+ *                |           dt
+ * F(phi | m) =   |    ------------------
+ *                |                   2
+ *              | |    sqrt( 1 - m sin t )
+ *               -
+ *                0
+ *
+ * of amplitude phi and modulus m, using the arithmetic -
+ * geometric mean algorithm.
+ *
+ *
+ *
+ *
+ * ACCURACY:
+ *
+ * Tested at random points with m in [0, 1] and phi as indicated.
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE     -10,10       200000      7.4e-16     1.0e-16
+ *
+ *
+ */
+
+/*
+ * Cephes Math Library Release 2.0:  April, 1987
+ * Copyright 1984, 1987 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+/* Copyright 2014, Eric W. Moore */
+
+/*     Incomplete elliptic integral of first kind      */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "const.h"
+#include "ellpk.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+
+        /* To calculate legendre's incomplete elliptical integral of the first kind for
+         * negative m, we use a power series in phi for small m*phi*phi, an asymptotic
+         * series in m for large m*phi*phi* and the relation to Carlson's symmetric
+         * integral of the first kind.
+         *
+         * F(phi, m) = sin(phi) * R_F(cos(phi)^2, 1 - m * sin(phi)^2, 1.0)
+         *           = R_F(c-1, c-m, c)
+         *
+         * where c = csc(phi)^2. We use the second form of this for (approximately)
+         * phi > 1/(sqrt(DBL_MAX) ~ 1e-154, where csc(phi)^2 overflows. Elsewhere we
+         * use the first form, accounting for the smallness of phi.
+         *
+         * The algorithm used is described in Carlson, B. C. Numerical computation of
+         * real or complex elliptic integrals. (1994) https://arxiv.org/abs/math/9409227
+         * Most variable names reflect Carlson's usage.
+         *
+         * In this routine, we assume m < 0 and  0 > phi > pi/2.
+         */
+        SPECFUN_HOST_DEVICE inline double ellik_neg_m(double phi, double m) {
+            double x, y, z, x1, y1, z1, A0, A, Q, X, Y, Z, E2, E3, scale;
+            int n = 0;
+            double mpp = (m * phi) * phi;
+
+            if (-mpp < 1e-6 && phi < -m) {
+                return phi + (-mpp * phi * phi / 30.0 + 3.0 * mpp * mpp / 40.0 + mpp / 6.0) * phi;
+            }
+
+            if (-mpp > 4e7) {
+                double sm = std::sqrt(-m);
+                double sp = std::sin(phi);
+                double cp = std::cos(phi);
+
+                double a = log(4 * sp * sm / (1 + cp));
+                double b = -(1 + cp / sp / sp - a) / 4 / m;
+                return (a + b) / sm;
+            }
+
+            if (phi > 1e-153 && m > -1e305) {
+                double s = std::sin(phi);
+                double csc2 = 1.0 / (s * s);
+                scale = 1.0;
+                x = 1.0 / (std::tan(phi) * std::tan(phi));
+                y = csc2 - m;
+                z = csc2;
+            } else {
+                scale = phi;
+                x = 1.0;
+                y = 1 - m * scale * scale;
+                z = 1.0;
+            }
+
+            if (x == y && x == z) {
+                return scale / std::sqrt(x);
+            }
+
+            A0 = (x + y + z) / 3.0;
+            A = A0;
+            x1 = x;
+            y1 = y;
+            z1 = z;
+            /* Carlson gives 1/pow(3*r, 1.0/6.0) for this constant. if r == eps,
+             * it is ~338.38. */
+            Q = 400.0 * std::fmax(std::abs(A0 - x), std::fmax(std::abs(A0 - y), std::abs(A0 - z)));
+
+            while (Q > std::abs(A) && n <= 100) {
+                double sx = std::sqrt(x1);
+                double sy = std::sqrt(y1);
+                double sz = std::sqrt(z1);
+                double lam = sx * sy + sx * sz + sy * sz;
+                x1 = (x1 + lam) / 4.0;
+                y1 = (y1 + lam) / 4.0;
+                z1 = (z1 + lam) / 4.0;
+                A = (x1 + y1 + z1) / 3.0;
+                n += 1;
+                Q /= 4;
+            }
+            X = (A0 - x) / A / (1 << 2 * n);
+            Y = (A0 - y) / A / (1 << 2 * n);
+            Z = -(X + Y);
+
+            E2 = X * Y - Z * Z;
+            E3 = X * Y * Z;
+
+            return scale * (1.0 - E2 / 10.0 + E3 / 14.0 + E2 * E2 / 24.0 - 3.0 * E2 * E3 / 44.0) / sqrt(A);
+        }
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double ellik(double phi, double m) {
+        double a, b, c, e, temp, t, K, denom, npio2;
+        int d, mod, sign;
+
+        if (std::isnan(phi) || std::isnan(m))
+            return std::numeric_limits<double>::quiet_NaN();
+        if (m > 1.0)
+            return std::numeric_limits<double>::quiet_NaN();
+        if (std::isinf(phi) || std::isinf(m)) {
+            if (std::isinf(m) && std::isfinite(phi))
+                return 0.0;
+            else if (std::isinf(phi) && std::isfinite(m))
+                return phi;
+            else
+                return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (m == 0.0)
+            return (phi);
+        a = 1.0 - m;
+        if (a == 0.0) {
+            if (std::abs(phi) >= (double) M_PI_2) {
+                set_error("ellik", SF_ERROR_SINGULAR, NULL);
+                return (std::numeric_limits<double>::infinity());
+            }
+            /* DLMF 19.6.8, and 4.23.42 */
+            return std::asinh(std::tan(phi));
+        }
+        npio2 = floor(phi / M_PI_2);
+        if (std::fmod(std::abs(npio2), 2.0) == 1.0)
+            npio2 += 1;
+        if (npio2 != 0.0) {
+            K = ellpk(a);
+            phi = phi - npio2 * M_PI_2;
+        } else
+            K = 0.0;
+        if (phi < 0.0) {
+            phi = -phi;
+            sign = -1;
+        } else
+            sign = 0;
+        if (a > 1.0) {
+            temp = detail::ellik_neg_m(phi, m);
+            goto done;
+        }
+        b = std::sqrt(a);
+        t = std::tan(phi);
+        if (std::abs(t) > 10.0) {
+            /* Transform the amplitude */
+            e = 1.0 / (b * t);
+            /* ... but avoid multiple recursions.  */
+            if (std::abs(e) < 10.0) {
+                e = std::atan(e);
+                if (npio2 == 0)
+                    K = ellpk(a);
+                temp = K - ellik(e, m);
+                goto done;
+            }
+        }
+        a = 1.0;
+        c = std::sqrt(m);
+        d = 1;
+        mod = 0;
+
+        while (std::abs(c / a) > detail::MACHEP) {
+            temp = b / a;
+            phi = phi + atan(t * temp) + mod * M_PI;
+            denom = 1.0 - temp * t * t;
+            if (std::abs(denom) > 10 * detail::MACHEP) {
+                t = t * (1.0 + temp) / denom;
+                mod = (phi + M_PI_2) / M_PI;
+            } else {
+                t = std::tan(phi);
+                mod = static_cast<int>(std::floor((phi - std::atan(t)) / M_PI));
+            }
+            c = (a - b) / 2.0;
+            temp = std::sqrt(a * b);
+            a = (a + b) / 2.0;
+            b = temp;
+            d += d;
+        }
+
+        temp = (std::atan(t) + mod * M_PI) / (d * a);
+
+    done:
+        if (sign < 0)
+            temp = -temp;
+        temp += npio2 * K;
+        return (temp);
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/ellpe.h
+++ b/cupy/_core/include/cupy/special/cephes/ellpe.h
@@ -1,0 +1,107 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     ellpe.c
+ *
+ *     Complete elliptic integral of the second kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double m, y, ellpe();
+ *
+ * y = ellpe( m );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *            pi/2
+ *             -
+ *            | |                 2
+ * E(m)  =    |    sqrt( 1 - m sin t ) dt
+ *          | |
+ *           -
+ *            0
+ *
+ * Where m = 1 - m1, using the approximation
+ *
+ *      P(x)  -  x log x Q(x).
+ *
+ * Though there are no singularities, the argument m1 is used
+ * internally rather than m for compatibility with ellpk().
+ *
+ * E(1) = 1; E(0) = pi/2.
+ *
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE       0, 1       10000       2.1e-16     7.3e-17
+ *
+ *
+ * ERROR MESSAGES:
+ *
+ *   message         condition      value returned
+ * ellpe domain      x<0, x>1            0.0
+ *
+ */
+
+/*                                                     ellpe.c         */
+
+/* Elliptic integral of second kind */
+
+/*
+ * Cephes Math Library, Release 2.1:  February, 1989
+ * Copyright 1984, 1987, 1989 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ *
+ * Feb, 2002:  altered by Travis Oliphant
+ * so that it is called with argument m
+ * (which gets immediately converted to m1 = 1-m)
+ */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "polevl.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+
+        constexpr double ellpe_P[] = {1.53552577301013293365E-4, 2.50888492163602060990E-3, 8.68786816565889628429E-3,
+                                      1.07350949056076193403E-2, 7.77395492516787092951E-3, 7.58395289413514708519E-3,
+                                      1.15688436810574127319E-2, 2.18317996015557253103E-2, 5.68051945617860553470E-2,
+                                      4.43147180560990850618E-1, 1.00000000000000000299E0};
+
+        constexpr double ellpe_Q[] = {3.27954898576485872656E-5, 1.00962792679356715133E-3, 6.50609489976927491433E-3,
+                                      1.68862163993311317300E-2, 2.61769742454493659583E-2, 3.34833904888224918614E-2,
+                                      4.27180926518931511717E-2, 5.85936634471101055642E-2, 9.37499997197644278445E-2,
+                                      2.49999999999888314361E-1};
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double ellpe(double x) {
+        x = 1.0 - x;
+        if (x <= 0.0) {
+            if (x == 0.0)
+                return (1.0);
+            set_error("ellpe", SF_ERROR_DOMAIN, NULL);
+            return (std::numeric_limits<double>::quiet_NaN());
+        }
+        if (x > 1.0) {
+            return ellpe(1.0 - 1 / x) * std::sqrt(x);
+        }
+        return (polevl(x, detail::ellpe_P, 10) - std::log(x) * (x * polevl(x, detail::ellpe_Q, 9)));
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/ellpk.h
+++ b/cupy/_core/include/cupy/special/cephes/ellpk.h
@@ -1,0 +1,117 @@
+/* Translated into C++ by SciPy developers in 2024.
+ * Original header with Copyright information appears below.
+ */
+
+/*                                                     ellpk.c
+ *
+ *     Complete elliptic integral of the first kind
+ *
+ *
+ *
+ * SYNOPSIS:
+ *
+ * double m1, y, ellpk();
+ *
+ * y = ellpk( m1 );
+ *
+ *
+ *
+ * DESCRIPTION:
+ *
+ * Approximates the integral
+ *
+ *
+ *
+ *            pi/2
+ *             -
+ *            | |
+ *            |           dt
+ * K(m)  =    |    ------------------
+ *            |                   2
+ *          | |    sqrt( 1 - m sin t )
+ *           -
+ *            0
+ *
+ * where m = 1 - m1, using the approximation
+ *
+ *     P(x)  -  log x Q(x).
+ *
+ * The argument m1 is used internally rather than m so that the logarithmic
+ * singularity at m = 1 will be shifted to the origin; this
+ * preserves maximum accuracy.
+ *
+ * K(0) = pi/2.
+ *
+ * ACCURACY:
+ *
+ *                      Relative error:
+ * arithmetic   domain     # trials      peak         rms
+ *    IEEE       0,1        30000       2.5e-16     6.8e-17
+ *
+ * ERROR MESSAGES:
+ *
+ *   message         condition      value returned
+ * ellpk domain       x<0, x>1           0.0
+ *
+ */
+
+/*                                                     ellpk.c */
+
+/*
+ * Cephes Math Library, Release 2.0:  April, 1987
+ * Copyright 1984, 1987 by Stephen L. Moshier
+ * Direct inquiries to 30 Frost Street, Cambridge, MA 02140
+ */
+#pragma once
+
+#include "../config.h"
+#include "../error.h"
+#include "const.h"
+#include "polevl.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+
+        constexpr double ellpk_P[] = {1.37982864606273237150E-4, 2.28025724005875567385E-3, 7.97404013220415179367E-3,
+                                      9.85821379021226008714E-3, 6.87489687449949877925E-3, 6.18901033637687613229E-3,
+                                      8.79078273952743772254E-3, 1.49380448916805252718E-2, 3.08851465246711995998E-2,
+                                      9.65735902811690126535E-2, 1.38629436111989062502E0};
+
+        constexpr double ellpk_Q[] = {2.94078955048598507511E-5, 9.14184723865917226571E-4, 5.94058303753167793257E-3,
+                                      1.54850516649762399335E-2, 2.39089602715924892727E-2, 3.01204715227604046988E-2,
+                                      3.73774314173823228969E-2, 4.88280347570998239232E-2, 7.03124996963957469739E-2,
+                                      1.24999999999870820058E-1, 4.99999999999999999821E-1};
+
+        constexpr double ellpk_C1 = 1.3862943611198906188E0; /* log(4) */
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double ellpk(double x) {
+
+        if (x < 0.0) {
+            set_error("ellpk", SF_ERROR_DOMAIN, NULL);
+            return (std::numeric_limits<double>::quiet_NaN());
+        }
+
+        if (x > 1.0) {
+            if (std::isinf(x)) {
+                return 0.0;
+            }
+            return ellpk(1 / x) / std::sqrt(x);
+        }
+
+        if (x > detail::MACHEP) {
+            return (polevl(x, detail::ellpk_P, 10) - std::log(x) * polevl(x, detail::ellpk_Q, 10));
+        } else {
+            if (x == 0.0) {
+                set_error("ellpk", SF_ERROR_SINGULAR, NULL);
+                return (std::numeric_limits<double>::infinity());
+            } else {
+                return (detail::ellpk_C1 - 0.5 * std::log(x));
+            }
+        }
+    }
+} // namespace cephes
+} // namespace special

--- a/cupy/_core/include/cupy/special/cephes/unity.h
+++ b/cupy/_core/include/cupy/special/cephes/unity.h
@@ -1,0 +1,186 @@
+/* Translated into C++ by SciPy developers in 2024. */
+
+/*                                                     unity.c
+ *
+ * Relative error approximations for function arguments near
+ * unity.
+ *
+ *    log1p(x) = log(1+x)
+ *    expm1(x) = exp(x) - 1
+ *    cosm1(x) = cos(x) - 1
+ *    lgam1p(x) = lgam(1+x)
+ *
+ */
+
+/* Scipy changes:
+ * - 06-10-2016: added lgam1p
+ */
+#pragma once
+
+#include "../config.h"
+
+#include "const.h"
+#include "gamma.h"
+#include "polevl.h"
+#include "zeta.h"
+
+namespace special {
+namespace cephes {
+
+    namespace detail {
+
+        /* log1p(x) = log(1 + x)  */
+
+        /* Coefficients for log(1+x) = x - x**2/2 + x**3 P(x)/Q(x)
+         * 1/sqrt(2) <= x < sqrt(2)
+         * Theoretical peak relative error = 2.32e-20
+         */
+
+        constexpr double unity_LP[] = {
+            4.5270000862445199635215E-5, 4.9854102823193375972212E-1, 6.5787325942061044846969E0,
+            2.9911919328553073277375E1,  6.0949667980987787057556E1,  5.7112963590585538103336E1,
+            2.0039553499201281259648E1,
+        };
+
+        constexpr double unity_LQ[] = {
+            /* 1.0000000000000000000000E0, */
+            1.5062909083469192043167E1, 8.3047565967967209469434E1, 2.2176239823732856465394E2,
+            3.0909872225312059774938E2, 2.1642788614495947685003E2, 6.0118660497603843919306E1,
+        };
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double log1p(double x) {
+        double z;
+
+        z = 1.0 + x;
+        if ((z < M_SQRT1_2) || (z > M_SQRT2))
+            return (std::log(z));
+        z = x * x;
+        z = -0.5 * z + x * (z * polevl(x, detail::unity_LP, 6) / p1evl(x, detail::unity_LQ, 6));
+        return (x + z);
+    }
+
+    /* log(1 + x) - x */
+    SPECFUN_HOST_DEVICE inline double log1pmx(double x) {
+        if (std::abs(x) < 0.5) {
+            uint64_t n;
+            double xfac = x;
+            double term;
+            double res = 0;
+
+            for (n = 2; n < detail::MAXITER; n++) {
+                xfac *= -x;
+                term = xfac / n;
+                res += term;
+                if (std::abs(term) < detail::MACHEP * std::abs(res)) {
+                    break;
+                }
+            }
+            return res;
+        } else {
+            return log1p(x) - x;
+        }
+    }
+
+    /* expm1(x) = exp(x) - 1  */
+
+    /*  e^x =  1 + 2x P(x^2)/( Q(x^2) - P(x^2) )
+     * -0.5 <= x <= 0.5
+     */
+
+    namespace detail {
+
+        constexpr double unity_EP[3] = {
+            1.2617719307481059087798E-4,
+            3.0299440770744196129956E-2,
+            9.9999999999999999991025E-1,
+        };
+
+        constexpr double unity_EQ[4] = {
+            3.0019850513866445504159E-6,
+            2.5244834034968410419224E-3,
+            2.2726554820815502876593E-1,
+            2.0000000000000000000897E0,
+        };
+
+    } // namespace detail
+
+    SPECFUN_HOST_DEVICE inline double expm1(double x) {
+        double r, xx;
+
+        if (!std::isfinite(x)) {
+            if (std::isnan(x)) {
+                return x;
+            } else if (x > 0) {
+                return x;
+            } else {
+                return -1.0;
+            }
+        }
+        if ((x < -0.5) || (x > 0.5))
+            return (std::exp(x) - 1.0);
+        xx = x * x;
+        r = x * polevl(xx, detail::unity_EP, 2);
+        r = r / (polevl(xx, detail::unity_EQ, 3) - r);
+        return (r + r);
+    }
+
+    /* cosm1(x) = cos(x) - 1  */
+
+    namespace detail {
+        constexpr double unity_coscof[7] = {
+            4.7377507964246204691685E-14, -1.1470284843425359765671E-11, 2.0876754287081521758361E-9,
+            -2.7557319214999787979814E-7, 2.4801587301570552304991E-5,   -1.3888888888888872993737E-3,
+            4.1666666666666666609054E-2,
+        };
+
+    }
+
+    SPECFUN_HOST_DEVICE inline double cosm1(double x) {
+        double xx;
+
+        if ((x < -M_PI_4) || (x > M_PI_4))
+            return (std::cos(x) - 1.0);
+        xx = x * x;
+        xx = -0.5 * xx + xx * xx * polevl(xx, detail::unity_coscof, 6);
+        return xx;
+    }
+
+    namespace detail {
+        /* Compute lgam(x + 1) around x = 0 using its Taylor series. */
+        SPECFUN_HOST_DEVICE inline double lgam1p_taylor(double x) {
+            int n;
+            double xfac, coeff, res;
+
+            if (x == 0) {
+                return 0;
+            }
+            res = -SCIPY_EULER * x;
+            xfac = -x;
+            for (n = 2; n < 42; n++) {
+                xfac *= -x;
+                coeff = special::cephes::zeta(n, 1) * xfac / n;
+                res += coeff;
+                if (std::abs(coeff) < detail::MACHEP * std::abs(res)) {
+                    break;
+                }
+            }
+
+            return res;
+        }
+    } // namespace detail
+
+    /* Compute lgam(x + 1). */
+    SPECFUN_HOST_DEVICE inline double lgam1p(double x) {
+        if (std::abs(x) <= 0.5) {
+            return detail::lgam1p_taylor(x);
+        } else if (std::abs(x - 1) < 0.5) {
+            return std::log(x) + detail::lgam1p_taylor(x - 1);
+        } else {
+            return lgam(x + 1);
+        }
+    }
+
+} // namespace cephes
+} // namespace special

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -118,3 +118,5 @@ from cupy._math.special import sinc  # NOQA
 from cupyx.scipy.special._ellip import ellipk  # NOQA
 from cupyx.scipy.special._ellip import ellipkm1  # NOQA
 from cupyx.scipy.special._ellip import ellipj  # NOQA
+from cupyx.scipy.special._ellip import ellipkinc  # NOQA
+from cupyx.scipy.special._ellip import ellipeinc  # NOQA

--- a/cupyx/scipy/special/_ellip.py
+++ b/cupyx/scipy/special/_ellip.py
@@ -232,3 +232,32 @@ ellipj = _core.create_ufunc(
      .. seealso:: :data:`scipy.special.ellipj`
     """
 )
+
+ellipkinc_preamble = "#include <cupy/special/cephes/ellik.h>"
+ellipeinc_preamble = "#include <cupy/special/cephes/ellie.h>"
+
+ellipkinc = _core.create_ufunc(
+    'cupyx_scipy_special_ellipkinc', ('ff->f', 'dd->d'),
+    'out0 = special::cephes::ellik(in0, in1)',
+    preamble=ellipkinc_preamble,
+    doc="""ellipkinc
+
+    Incomplete elliptic integral of the first kind
+
+    .. seealso:: :meth:`scipy.special.ellipkinc`
+
+    """
+)
+
+ellipeinc = _core.create_ufunc(
+    'cupyx_scipy_special_ellipeinc', ('ff->f', 'dd->d'),
+    'out0 = special::cephes::ellie(in0, in1)',
+    preamble=ellipeinc_preamble,
+    doc="""ellipeinc
+
+    Incomplete elliptic integral of the second kind
+
+    .. seealso:: :meth:`scipy.special.ellipeinc`
+
+    """
+)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ellipk.py
@@ -25,3 +25,29 @@ class TestEllipj:
     def test_basic(self, xp, scp):
         el = scp.special.ellipj(0.2, 0)
         return el
+
+
+@testing.with_requires('scipy')
+class TestEllipkinc:
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15)
+    def test_values(self, xp, scp, dtype):
+        phi = xp.linspace(-xp.pi, xp.pi, 5)
+        m = xp.linspace(-1.0, 1.0, 5)
+        phi, m = xp.meshgrid(phi, m)
+        phi, m = phi.ravel(), m.ravel()
+
+        return scp.special.ellipkinc(phi, m)
+
+
+@testing.with_requires('scipy')
+class TestEllipeinc:
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15)
+    def test_values(self, xp, scp, dtype):
+        phi = xp.linspace(-xp.pi, xp.pi, 5)
+        m = xp.linspace(-1.0, 1.0, 5)
+        phi, m = xp.meshgrid(phi, m)
+        phi, m = phi.ravel(), m.ravel()
+
+        return scp.special.ellipeinc(phi, m)


### PR DESCRIPTION
This PR adds the functions `ellipkinc` and `ellipeinc` to special for Incomplete Elliptic Integrals of the first and second kind respectively.
