### PR TITLE
Fix `RandomState.seed()` for NumPy 2 compatibility

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -810,7 +810,7 @@ class RandomState(object):
                 seed = int(hashlib.md5(seed).hexdigest()[:16], 16)
             else:
                 seed_arr = numpy.asarray(seed)
-                if seed_arr.dtype.kind not in 'iu':
+                if seed_arr.dtype.kind not in 'biu':
                     raise TypeError('Seed must be an integer.')
                 seed = int(seed_arr)
                 # Check that no integer overflow occurred during the cast

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -809,8 +809,14 @@ class RandomState(object):
             if isinstance(seed, numpy.ndarray):
                 seed = int(hashlib.md5(seed).hexdigest()[:16], 16)
             else:
-                seed = int(
-                    numpy.asarray(seed).astype(numpy.uint64, casting='safe'))
+                seed_arr = numpy.asarray(seed)
+                if seed_arr.dtype.kind not in 'iu':
+                    raise TypeError('Seed must be an integer.')
+                seed = int(seed_arr)
+                # Check that no integer overflow occurred during the cast
+                if seed < 0 or seed >= 2**64:
+                    raise ValueError(
+                        'Seed must be an integer between 0 and 2**64 - 1')
 
         curand.setPseudoRandomGeneratorSeed(self._generator, seed)
         if (self.method not in (curand.CURAND_RNG_PSEUDO_MT19937,


### PR DESCRIPTION
Without value based casting allowing "safe" casts from signed to unsigned integer scalars, NumPy 2 rejects practically all inputs here.

Unfortunately, even same-kind does not allow for signed -> unsigned so we need to do a larger dance.

The given diff was used together with cudf and cuml to successfully run tests with NumPy 2 and cupy 13.2.

Closes gh-8407, gh-8392