### PR TITLE
Fix copyto for NumPy 2 compatibility

### DIFF
--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -35,6 +35,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         # NumPy 1.x and 2.0 make implementing copyto cast safety hard, so
         # test whether NumPy copy allows the copy operation:
         numpy.copyto(dst_arr, src, casting=casting)
+        can_cast = True
         src_is_scalar = True
     elif src_type in (fusion._FusionVarScalar, _fusion_interface._ScalarProxy):
         src_dtype = src.dtype

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -27,15 +27,19 @@ def copyto(dst, src, casting='same_kind', where=None):
     .. seealso:: :func:`numpy.copyto`
 
     """
-    src_is_numpy_scalar = False
-
+    src_is_scalar = False
     src_type = type(src)
-    src_is_python_scalar = src_type in (
-        int, bool, float, complex,
-        fusion._FusionVarScalar, _fusion_interface._ScalarProxy)
-    if src_is_python_scalar:
-        src_dtype = numpy.dtype(type(src))
-        can_cast = numpy.can_cast(src, dst.dtype, casting)
+
+    if src_type in (bool, int, float, complex):
+        dst_arr = numpy.empty((), dtype=dst.dtype)
+        # NumPy 1.x and 2.0 make implementing copyto cast safety hard, so
+        # test whether NumPy copy allows the copy operation:
+        numpy.copyto(dst_arr, src, casting=casting)
+        src_is_scalar = True
+    elif src_type in (fusion._FusionVarScalar, _fusion_interface._ScalarProxy):
+        src_dtype = src.dtype
+        can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
+        src_is_scalar = True
     elif isinstance(src, numpy.ndarray) or numpy.isscalar(src):
         if src.size != 1:
             raise ValueError(
@@ -43,7 +47,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src, dst.dtype, casting)
         src = src.item()
-        src_is_numpy_scalar = True
+        src_is_scalar = True
     else:
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
@@ -63,7 +67,7 @@ def copyto(dst, src, casting='same_kind', where=None):
             fusion._call_ufunc(search._where_ufunc, where, src, dst, dst)
         return
 
-    if not src_is_python_scalar and not src_is_numpy_scalar:
+    if not src_is_scalar:
         # Check broadcast condition
         # - for fast-paths and
         # - for a better error message (than ufunc's).
@@ -88,7 +92,7 @@ def copyto(dst, src, casting='same_kind', where=None):
     if dst.size == 0:
         return
 
-    if src_is_python_scalar or src_is_numpy_scalar:
+    if src_is_scalar:
         _core.elementwise_copy(src, dst)
         return
 


### PR DESCRIPTION
NumPy two has some bad definitions with `copyto` and NEP 50 in that `copyto` currently ignores it. That is a trickier NumPy problem.

However, it is very hard to write code that does the right thing on both versions and even harder to do the same thing as NumPy 2 (because it is not quite consistent).

Short of a version switch, the only good way seems to be to just call `copyto` directly for Python scalar input.

Closes gh-8408, gh-8391

(I'll test this with cuml to be sure.)

---

As you can see, I gave up on trying to find a solution that doesn't just try with NumPy directly.  Yes, unfortunately `can_cast` is almost twice as fast as `copyto` (~200ns for me).
Hopefully that is just small compared to all the other overheads here?

The alternative would be to special case integers and check for integer dtype.