### PR TITLE
Fix the size of temporary CUB output space to consider its alignment

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -172,7 +172,8 @@ def device_reduce(_ndarray_base x, op, tuple reduce_axis, tuple out_axis,
         y = _core.ndarray((), x.dtype)
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
-        kv_bytes = (4 + x.dtype.itemsize)
+        # Note that the key may be padded to make the value aligned.
+        kv_bytes = (x.dtype.alignment + x.dtype.itemsize)
         y = _core.ndarray((kv_bytes,), numpy.int8)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -172,8 +172,14 @@ def device_reduce(_ndarray_base x, op, tuple reduce_axis, tuple out_axis,
         y = _core.ndarray((), x.dtype)
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
-        # Note that the key may be padded to make the value aligned.
-        kv_bytes = (max(4, x.dtype.alignment) + x.dtype.itemsize)
+        # Note that:
+        # - The key may be padded to make the value aligned.
+        # - Unlike a regular structure, thrust::complex<T> is aligned to the
+        #   twice of the size of T.
+        if x.dtype.char in 'FD':
+            kv_bytes = x.dtype.alignment * 2 + x.dtype.itemsize
+        else:
+            kv_bytes = max(4, x.dtype.alignment) + x.dtype.itemsize
         y = _core.ndarray((kv_bytes,), numpy.int8)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -173,7 +173,7 @@ def device_reduce(_ndarray_base x, op, tuple reduce_axis, tuple out_axis,
     else:  # argmin and argmax
         # cub::KeyValuePair has 1 int + 1 arbitrary type
         # Note that the key may be padded to make the value aligned.
-        kv_bytes = (x.dtype.alignment + x.dtype.itemsize)
+        kv_bytes = (max(4, x.dtype.alignment) + x.dtype.itemsize)
         y = _core.ndarray((kv_bytes,), numpy.int8)
     x_ptr = <void *>x.data.ptr
     y_ptr = <void *>y.data.ptr


### PR DESCRIPTION
This should be one of potential causes of illegal memory access we're facing at #8290.

ref:
- https://github.com/NVIDIA/cccl/blob/7a3dae72b36d2ce939de1d1b68e0b251d287074f/cub/cub/util_type.cuh#L667
- https://github.com/NVIDIA/cccl/blob/694e963e72c60384d85abdcf7affed504aa9ed04/thrust/thrust/complex.h#L76