### PR TITLE
Decrease number of threads to avoid "system error: excessive memory usage is detected"

### DIFF
--- a/.pfnci/linux/tests/actions/build.sh
+++ b/.pfnci/linux/tests/actions/build.sh
@@ -2,4 +2,4 @@
 
 set -uex
 
-time CUPY_NUM_NVCC_THREADS=8 CUPY_NUM_BUILD_JOBS=8 python3 -m pip install --user -v ".[test]"
+time CUPY_NUM_NVCC_THREADS=5 CUPY_NUM_BUILD_JOBS=8 python3 -m pip install --user -v ".[test]"


### PR DESCRIPTION
It seems the memory usage has increased during the build phase.

e.g. Example CI in main branch failing with `[ABORTED] excessive memory usage is detected`:
https://ci.preferred.jp/cupy.linux.cuda-example/166617/
