### PR TITLE
CI: skip CUDA 12.1/12.2/12.3/12.4 CI on "mini" trigger

### DIFF
--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -95,52 +95,44 @@
     "cupy.linux.cuda121": [
         "@push",
         "full",
-        "mini",
         "cuda121"
     ],
     "cupy.linux.cuda121.multi": [
         "@push",
         "full",
-        "mini",
         "multi",
         "cuda121"
     ],
     "cupy.linux.cuda122": [
         "@push",
         "full",
-        "mini",
         "cuda122"
     ],
     "cupy.linux.cuda122.multi": [
         "@push",
         "full",
-        "mini",
         "multi",
         "cuda122"
     ],
     "cupy.linux.cuda123": [
         "@push",
         "full",
-        "mini",
         "cuda123"
     ],
     "cupy.linux.cuda123.multi": [
         "@push",
         "full",
-        "mini",
         "multi",
         "cuda123"
     ],
     "cupy.linux.cuda124": [
         "@push",
         "full",
-        "mini",
         "cuda124"
     ],
     "cupy.linux.cuda124.multi": [
         "@push",
         "full",
-        "mini",
         "multi",
         "cuda124"
     ],
@@ -219,28 +211,24 @@
     "cupy.win.cuda121": [
         "@push",
         "full",
-        "mini",
         "windows",
         "cuda121"
     ],
     "cupy.win.cuda122": [
         "@push",
         "full",
-        "mini",
         "windows",
         "cuda122"
     ],
     "cupy.win.cuda123": [
         "@push",
         "full",
-        "mini",
         "windows",
         "cuda123"
     ],
     "cupy.win.cuda124": [
         "@push",
         "full",
-        "mini",
         "windows",
         "cuda124"
     ],

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -246,7 +246,7 @@
 # CUDA 12.1 | Linux
 - project: "cupy.linux.cuda121"
   target: "cuda121"
-  tags: ["@push", "full", "mini", "cuda121"]
+  tags: ["@push", "full", "cuda121"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "12.1"
@@ -268,7 +268,7 @@
 # CUDA 12.1 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda121.multi"
   _inherits: "cupy.linux.cuda121"
-  tags: ["@push", "full", "mini", "multi", "cuda121"]
+  tags: ["@push", "full", "multi", "cuda121"]
   target: "cuda121.multi"
   mpi4py: "3"
   test: "unit-multi"
@@ -276,7 +276,7 @@
 # CUDA 12.2 | Linux
 - project: "cupy.linux.cuda122"
   target: "cuda122"
-  tags: ["@push", "full", "mini", "cuda122"]
+  tags: ["@push", "full", "cuda122"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "12.2"
@@ -298,7 +298,7 @@
 # CUDA 12.2 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda122.multi"
   _inherits: "cupy.linux.cuda122"
-  tags: ["@push", "full", "mini", "multi", "cuda122"]
+  tags: ["@push", "full", "multi", "cuda122"]
   target: "cuda122.multi"
   mpi4py: "3"
   test: "unit-multi"
@@ -306,7 +306,7 @@
 # CUDA 12.3 | Linux
 - project: "cupy.linux.cuda123"
   target: "cuda123"
-  tags: ["@push", "full", "mini", "cuda123"]
+  tags: ["@push", "full", "cuda123"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "12.3"
@@ -328,7 +328,7 @@
 # CUDA 12.3 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda123.multi"
   _inherits: "cupy.linux.cuda123"
-  tags: ["@push", "full", "mini", "multi", "cuda123"]
+  tags: ["@push", "full", "multi", "cuda123"]
   target: "cuda123.multi"
   mpi4py: "3"
   test: "unit-multi"
@@ -336,7 +336,7 @@
 # CUDA 12.4 | Linux
 - project: "cupy.linux.cuda124"
   target: "cuda124"
-  tags: ["@push", "full", "mini", "cuda124"]
+  tags: ["@push", "full", "cuda124"]
   system: "linux"
   os: "ubuntu:20.04"
   cuda: "12.4"
@@ -358,7 +358,7 @@
 # CUDA 12.4 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda124.multi"
   _inherits: "cupy.linux.cuda124"
-  tags: ["@push", "full", "mini", "multi", "cuda124"]
+  tags: ["@push", "full", "multi", "cuda124"]
   target: "cuda124.multi"
   mpi4py: "3"
   test: "unit-multi"
@@ -640,25 +640,25 @@
 - project: "cupy.win.cuda121"
   _extern: true
   target: "cuda121"
-  tags: ["@push", "full", "mini", "windows", "cuda121"]
+  tags: ["@push", "full", "windows", "cuda121"]
   system: "windows"
 
 - project: "cupy.win.cuda122"
   _extern: true
   target: "cuda122"
-  tags: ["@push", "full", "mini", "windows", "cuda122"]
+  tags: ["@push", "full", "windows", "cuda122"]
   system: "windows"
 
 - project: "cupy.win.cuda123"
   _extern: true
   target: "cuda123"
-  tags: ["@push", "full", "mini", "windows", "cuda123"]
+  tags: ["@push", "full", "windows", "cuda123"]
   system: "windows"
 
 - project: "cupy.win.cuda124"
   _extern: true
   target: "cuda124"
-  tags: ["@push", "full", "mini", "windows", "cuda124"]
+  tags: ["@push", "full", "windows", "cuda124"]
   system: "windows"
 
 - project: "cupy.win.cuda125"


### PR DESCRIPTION
As far as I recall we haven't experienced any issues specific to these CUDA versions, so I think it's ok to skip these tests on `/test mini` trigger (to reduce 💰). Note that these tests will run continue to run when PR got merged OR `/test full` is triggered.

Coverage: https://github.com/cupy/cupy/blob/main/.pfnci/coverage.rst