### PR TITLE
Avoid using Jitify everywhere inside CuPy

### DIFF
--- a/cupyx/jit/cub.py
+++ b/cupyx/jit/cub.py
@@ -29,7 +29,7 @@ def _include_cub(env):
         # WAR: warp_reduce.cuh is implicitly included.
         env.generated.add_code('#include <cub/block/block_reduce.cuh>')
         env.generated.backend = 'nvrtc'
-        env.generated.jitify = True
+        env.generated.jitify = False
 
 
 def _get_cub_namespace():

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -168,7 +168,7 @@ if runtime.is_hip:
 '''
 else:
     includes = r'''
-#include <type_traits>  // let Jitify handle this
+#include <cupy/cuda_workaround.h>  // provide C++ std:: coverage
 #include <cupy/math_constants.h>
 
 template<> struct std::is_floating_point<float16> : std::true_type {};
@@ -307,7 +307,7 @@ def _generate_nd_kernel(name, pre, found, post, mode, w_shape, int_type,
     if has_mask:
         name += '_with_mask'
     preamble = includes + _CAST_FUNCTION + preamble
-    options += ('--std=c++11', '-DCUPY_USE_JITIFY')
+    options += ('--std=c++11', )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   reduce_dims=False, preamble=preamble,
                                   options=options)

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -199,9 +199,9 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
 
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
     if runtime.is_hip:
-       include_type_traits = ''
+        include_type_traits = ''
     else:
-       include_type_traits = '''
+        include_type_traits = '''
 #include <cupy/cuda_workaround.h>  // provide C++ std:: coverage
 '''
     code = '''#include "cupy/carray.cuh"

--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -198,9 +198,15 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
                     loop.format(end, in_length, b))
 
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
+    if runtime.is_hip:
+       include_type_traits = ''
+    else:
+       include_type_traits = '''
+#include <cupy/cuda_workaround.h>  // provide C++ std:: coverage
+'''
     code = '''#include "cupy/carray.cuh"
 #include "cupy/complex.cuh"
-{include_type_traits}  // let Jitify handle this
+{include_type_traits}
 
 namespace raw_kernel {{\n{rk_code}\n}}
 
@@ -261,8 +267,6 @@ void {name}(const byte* input, byte* output, const idx_t* x) {{
              # wouldn't compile if code only contains device functions, so this
              # is necessary.
              rk_code=rk.code.replace('__global__', '__device__'),
-             include_type_traits=(
-                 '' if runtime.is_hip else '#include <type_traits>\n'),
+             include_type_traits=include_type_traits,
              CAST=_filters_core._CAST_FUNCTION)
-    return cupy.RawKernel(code, name, ('--std=c++11',) + rk.options,
-                          jitify=True)
+    return cupy.RawKernel(code, name, ('--std=c++11',) + rk.options)

--- a/cupyx/signal/_filtering/_filtering.py
+++ b/cupyx/signal/_filtering/_filtering.py
@@ -414,7 +414,7 @@ def _get_channelizer_8x8_module():
             '_cupy_channelizer_8x8<complex<float>,complex<float>>',
             '_cupy_channelizer_8x8<double,complex<double>>',
             '_cupy_channelizer_8x8<complex<double>,complex<double>>'],
-        jitify=True)
+        )
 
 
 _CHANNELIZER_16X16_KERNEL = _CHANNELIZER_KERNEL_PREAMBLE + r"""
@@ -529,7 +529,7 @@ def _get_channelizer_16x16_module():
             '_cupy_channelizer_16x16<complex<float>,complex<float>>',
             '_cupy_channelizer_16x16<double,complex<double>>',
             '_cupy_channelizer_16x16<complex<double>,complex<double>>'],
-        jitify=True)
+        )
 
 
 _CHANNELIZER_32X32_KERNEL = _CHANNELIZER_KERNEL_PREAMBLE + r"""
@@ -643,7 +643,7 @@ def _get_channelizer_32x32_module():
             '_cupy_channelizer_32x32<complex<float>,complex<float>>',
             '_cupy_channelizer_32x32<double,complex<double>>',
             '_cupy_channelizer_32x32<complex<double>,complex<double>>'],
-        jitify=True)
+        )
 
 
 def _check_supported_type(np_type, k_type):

--- a/cupyx/signal/_filtering/_filtering.py
+++ b/cupyx/signal/_filtering/_filtering.py
@@ -414,7 +414,7 @@ def _get_channelizer_8x8_module():
             '_cupy_channelizer_8x8<complex<float>,complex<float>>',
             '_cupy_channelizer_8x8<double,complex<double>>',
             '_cupy_channelizer_8x8<complex<double>,complex<double>>'],
-        )
+    )
 
 
 _CHANNELIZER_16X16_KERNEL = _CHANNELIZER_KERNEL_PREAMBLE + r"""
@@ -529,7 +529,7 @@ def _get_channelizer_16x16_module():
             '_cupy_channelizer_16x16<complex<float>,complex<float>>',
             '_cupy_channelizer_16x16<double,complex<double>>',
             '_cupy_channelizer_16x16<complex<double>,complex<double>>'],
-        )
+    )
 
 
 _CHANNELIZER_32X32_KERNEL = _CHANNELIZER_KERNEL_PREAMBLE + r"""
@@ -643,7 +643,7 @@ def _get_channelizer_32x32_module():
             '_cupy_channelizer_32x32<complex<float>,complex<float>>',
             '_cupy_channelizer_32x32<double,complex<double>>',
             '_cupy_channelizer_32x32<complex<double>,complex<double>>'],
-        )
+    )
 
 
 def _check_supported_type(np_type, k_type):


### PR DESCRIPTION
Follow-up of #8412. This PR addresses the first item from https://github.com/cupy/cupy/issues/8209#issuecomment-2272753019:
> 1. There are a few places where the similar treatment can be done to avoid using Jitify

This is not critical to be merged/backported if time is short, just a nice to have.