### PR TITLE
upfirdn: mode=None -> mode="constant"

### DIFF
--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -492,6 +492,8 @@ def upfirdn(
     .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
        Prentice Hall, 1993.
     """
+    if mode is None:
+        mode = "constant"  # For backwards compatibility
     if mode != "constant" or cval != 0:
         raise NotImplementedError(f"{mode = } and {cval =} not implemented.")
 

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -441,7 +441,7 @@ def upfirdn(
     up=1,
     down=1,
     axis=-1,
-    mode=None,
+    mode="constant",
     cval=0
 ):
     """
@@ -462,9 +462,9 @@ def upfirdn(
         linear filter. The filter is applied to each subarray along
         this axis. Default is -1.
     mode : str, optional
-        This parameter is not implemented.
+        This parameter is not implemented for values other than ``"constant"``.
     cval : float, optional
-        This parameter is not implemented.
+        This parameter is not implemented for values other than 0.
 
     Returns
     -------
@@ -492,7 +492,7 @@ def upfirdn(
     .. [1] P. P. Vaidyanathan, Multirate Systems and Filter Banks,
        Prentice Hall, 1993.
     """
-    if mode is not None or cval != 0:
+    if mode != "constant" or cval != 0:
         raise NotImplementedError(f"{mode = } and {cval =} not implemented.")
 
     ufd = _UpFIRDn(h, x.dtype, int(up), int(down))

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
@@ -103,6 +103,9 @@ _upfirdn_modes = [
     'constant', 'wrap', 'edge', 'smooth', 'symmetric', 'reflect',
     'antisymmetric', 'antireflect', 'line',
 ]
+_upfirdn_unsupported_mode = pytest.mark.xfail(
+    reason="upfirdn `mode=...` not implemented"
+)
 
 
 @testing.with_requires('scipy')
@@ -166,17 +169,22 @@ class TestUpfirdn:
         y = scp.signal.upfirdn(h, x, up=1, down=down)
         return y
 
-    @pytest.mark.xfail(reason="upfirdn `mode=...` not implemented")
+    @pytest.mark.parametrize('size', [8])
+    # include cases with h_len > 2*size
+    @pytest.mark.parametrize('h_len', [4, 5, 26])
     @pytest.mark.parametrize(
-        'size, h_len, mode, dtype',
-        product(
-            [8],
-            [4, 5, 26],  # include cases with h_len > 2*size
-            _upfirdn_modes,
-            [np.float32, np.float64, np.complex64, np.complex128],
-        )
+        'mode',
+        [
+            pytest.param(mode, marks=_upfirdn_unsupported_mode)
+            if mode != 'constant'
+            else mode
+            for mode in _upfirdn_modes
+        ]
     )
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @pytest.mark.parametrize(
+        'dtype', [np.float32, np.float64, np.complex64, np.complex128]
+    )
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5)
     def test_modes(self, xp, scp, size, h_len, mode, dtype):
         random_state = np.random.RandomState(5)
         x = random_state.randn(size).astype(dtype)


### PR DESCRIPTION
scipy.signal.upfirdn supports a number of modes, of which the default is "constant". cupyx supports only this mode, but used `None` to select it. Code that didn't pass the argument would work interchangeably between scipy and cupyx, but code that explicitly passed `mode="constant"` would raise an exception under cupyx.

With this change, cupyx behaves the same as scipy for this mode: not passing the argument, or explicitly passing `mode="constant"` works, and explicit passing `mode=None` raises an exception. Note that the latter is a **backwards-incompatible** change.

Closes #8449.