### PR TITLE
Improving performance of `cupy.random.choice`

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -1136,12 +1136,11 @@ class RandomState(object):
             raise NotImplementedError
 
         if p is not None:
-            p = cupy.broadcast_to(p, (size, a_size))
-            index = cupy.argmax(cupy.log(p) +
-                                self.gumbel(size=(size, a_size)),
-                                axis=1)
-            if not isinstance(shape, int):
-                index = cupy.reshape(index, shape)
+            # https://github.com/numpy/numpy/blob/v2.0.1/numpy/random/mtrand.pyx#L1013  # NOQA
+            cdf = p.cumsum()
+            cdf /= cdf[-1]
+            uniform_samples = self.random_sample(shape)
+            index = cdf.searchsorted(uniform_samples, side='right')
         else:
             if a_size == 0:  # TODO: (#4511) Fix `randint` instead
                 a_size = 1


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/issues/8477.

current master:

```
CPU:   528.909 us   +/-  8.817 (min:   513.830 / max:   556.690) us     GPU-0: 22175.946 us   +/- 21.370 (min: 22132.736 / max: 22215.679) us
```

This PR:

```
CPU:   542.260 us   +/- 226.564 (min:   510.556 / max:  2789.806) us     GPU-0:   548.843 us   +/- 227.403 (min:   517.088 / max:  2804.736) u
```

Reproducer:

```py
import cupy as cp
from cupyx.profiler import benchmark

def f():
    cp.random.choice(10000, size=10000, p=cp.ones(10000)/10000)

print(benchmark(f, (), n_repeat=20))
```