### PR TITLE
Use `.toarray()` instead of `.A` attribute

### DIFF
--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -388,7 +388,7 @@ def _convert_output_to_ndarray(c_out, n_out, sp_name, check_sparse_format):
         assert scipy.sparse.issparse(n_out)
         if check_sparse_format:
             assert c_out.format == n_out.format
-        return c_out.A, n_out.A
+        return c_out.toarray(), n_out.toarray()
     if (isinstance(c_out, cupy.ndarray)
             and isinstance(n_out, (numpy.ndarray, numpy.generic))):
         # ndarray output case.

--- a/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/sparse_tests/test_solve.py
@@ -61,7 +61,7 @@ class TestLschol(unittest.TestCase):
 
     @_condition.retry(10)
     def test_ndarray(self):
-        A = cp.array(self.A.A, dtype=self.dtype)
+        A = cp.array(self.A.toarray(), dtype=self.dtype)
         b = cp.array(self.b, dtype=self.dtype)
         x = cupyx.linalg.sparse.lschol(A, b)
         testing.assert_array_almost_equal(x, self.x, decimal=self.decimal)


### PR DESCRIPTION
`.A` attribute of sparse array is removed in SciPy 1.14.
https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations