### PR TITLE
Support `half` option in `scipy.signal.minimum_phase`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -406,6 +406,7 @@ class TestMinimumPhase:
         assert_raises(ValueError, signal.minimum_phase,
                       cupy.ones(10), method='foo')
 
+    @testing.with_requires("scipy>=1.14")
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_homomorphic(self, xp, scp):
         # check that it can recover frequency responses of arbitrary
@@ -414,6 +415,14 @@ class TestMinimumPhase:
         # for some cases we can get the actual filter back
         h = xp.asarray([1, -1])
         h_new = scp.signal.minimum_phase(xp.convolve(h, h[::-1]))
+        return h_new
+
+    @testing.with_requires("scipy>=1.14")
+    @pytest.mark.parametrize("half", [True, False])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_homomorphic_half(self, xp, scp, half):
+        h = xp.asarray([1, -1])
+        h_new = scp.signal.minimum_phase(xp.convolve(h, h[::-1]), half=half)
         return h_new
 
     @pytest.mark.parametrize("n", [2, 3, 10, 11, 15, 16, 17, 20, 21, 100, 101])


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8272
Follow https://github.com/scipy/scipy/pull/19706