### PR TITLE
Extend runtime header search logic to conda

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import json
 import os
 import os.path
+import platform
 import re
 import shutil
 import sys
@@ -459,7 +460,7 @@ You can install the library by:
 ''')
 
 
-def _get_include_dir_from_wheel(major: int, minor: int) -> List[str]:
+def _get_include_dir_from_conda_or_wheel(major: int, minor: int) -> List[str]:
     # FP16 headers from CUDA 12.2+ depends on headers from CUDA Runtime.
     # See https://github.com/cupy/cupy/issues/8466.
     if major < 12 or (major == 12 and minor < 2):
@@ -467,9 +468,24 @@ def _get_include_dir_from_wheel(major: int, minor: int) -> List[str]:
 
     config = get_preload_config()
     if config is not None and config['packaging'] == 'conda':
-        # Not applicable for conda installation.
-        return []
+        if sys.platform.startswith('linux'):
+            arch = platform.processor()
+            if arch == "aarch64":
+                arch = "sbsa"
+            target_dir = f"{arch}-linux"
+            return [
+                os.path.join(sys.prefix, "targets", target_dir, "include"),
+                os.path.join(sys.prefix, "include"),
+            ]
+        elif sys.platform.startswith('win'):
+            return [
+                os.path.join(sys.prefix, "Library", "include"),
+            ]
+        else:
+            # No idea what this platform is. Do nothing?
+            return []
 
+    # Look for headers in wheels
     pkg_name = f'nvidia-cuda-runtime-cu{major}'
     ver_str = f'{major}.{minor}'
     _log(f'Looking for {pkg_name}=={ver_str}.*')

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -149,7 +149,10 @@ def _get_extra_include_dir_opts():
     major, minor = _get_nvrtc_version()
     return tuple(
         f'-I{d}'
-        for d in _environment._get_include_dir_from_wheel(major, minor))
+        for d in _environment._get_include_dir_from_conda_or_wheel(
+            major, minor
+        )
+    )
 
 
 @_util.memoize(for_each_device=True)

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -181,7 +181,7 @@ class _RuntimeInfo:
                 self.cuda_extra_include_dirs = '(NVRTC unavailable)'
             else:
                 self.cuda_extra_include_dirs = str(
-                    cupy._environment._get_include_dir_from_wheel(
+                    cupy._environment._get_include_dir_from_conda_or_wheel(
                         *nvrtc_version))
 
         # cuDNN


### PR DESCRIPTION
As CuPy also needs a bit of help searching for headers in the conda case, extend the logic used to search for wheel headers in PR ( https://github.com/cupy/cupy/pull/8489 ) to also search for conda headers. In particular this searches the targets directory for the platform where CuPy is being run on so that it can find headers there.

Fixes https://github.com/cupy/cupy/issues/8466