### PR TITLE
Fix order 'K' with shape given for *_like array creation

### DIFF
--- a/cupy/_creation/basic.py
+++ b/cupy/_creation/basic.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Optional
 
 import numpy
@@ -56,7 +57,8 @@ def _new_like_order_and_strides(
     if order == 'K':
         strides = _get_strides_for_order_K(a, numpy.dtype(dtype), shape)
         order = 'C'
-        memptr = cupy.empty(a.size, dtype=dtype).data if get_memptr else None
+        size = math.prod(shape) if shape is not None else a.size
+        memptr = cupy.empty(size, dtype=dtype).data if get_memptr else None
         return order, strides, memptr
     else:
         return order, None, None


### PR DESCRIPTION
Fix allocation size on *_like array creation, which caused potentially illegal memory access. We had wrong allocation size when the order is K and the shape is different from that of the prototype array.

