### PR TITLE
Fix `sparse.linalg` function signatures following SciPy 1.14

### DIFF
--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -9,8 +9,8 @@ from cupyx.scipy.sparse import _csr
 from cupyx.scipy.sparse.linalg import _interface
 
 
-def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
-       atol=None):
+def cg(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
+       callback=None):
     """Uses Conjugate Gradient iteration to solve ``Ax = b``.
 
     Args:
@@ -22,7 +22,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
         b (cupy.ndarray): Right hand side of the linear system with shape
             ``(n,)`` or ``(n, 1)``.
         x0 (cupy.ndarray): Starting guess for the solution.
-        tol (float): Tolerance for convergence.
+        rtol, atol (float): Tolerance for convergence.
         maxiter (int): Maximum number of iterations.
         M (ndarray, spmatrix or LinearOperator): Preconditioner for ``A``.
             The preconditioner should approximate the inverse of ``A``.
@@ -32,7 +32,6 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
         callback (function): User-specified function to call after each
             iteration. It is called as ``callback(xk)``, where ``xk`` is the
             current solution vector.
-        atol (float): Tolerance for convergence.
 
     Returns:
         tuple:
@@ -54,10 +53,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
     b_norm = cupy.linalg.norm(b)
     if b_norm == 0:
         return b, 0
-    if atol is None:
-        atol = tol * float(b_norm)
-    else:
-        atol = max(float(atol), tol * float(b_norm))
+    atol = max(float(atol), rtol * float(b_norm))
 
     r = b - matvec(x)
     iters = 0
@@ -89,8 +85,8 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
     return x, info
 
 
-def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
-          callback=None, atol=None, callback_type=None):
+def gmres(A, b, x0=None, *, rtol=1e-5, atol=0.0, restart=None, maxiter=None,
+          M=None, callback=None, callback_type=None):
     """Uses Generalized Minimal RESidual iteration to solve ``Ax = b``.
 
     Args:
@@ -101,7 +97,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
         b (cupy.ndarray): Right hand side of the linear system with shape
             ``(n,)`` or ``(n, 1)``.
         x0 (cupy.ndarray): Starting guess for the solution.
-        tol (float): Tolerance for convergence.
+        rtol, atol (float): Tolerance for convergence.
         restart (int): Number of iterations between restarts. Larger values
             increase iteration cost, but may be necessary for convergence.
         maxiter (int): Maximum number of iterations.
@@ -116,7 +112,6 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
         callback_type (str): 'x' or 'pr_norm'. If 'x', the current solution
             vector is used as an argument of callback function. if 'pr_norm',
             relative (preconditioned) residual norm is used as an argument.
-        atol (float): Tolerance for convergence.
 
     Returns:
         tuple:
@@ -140,10 +135,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
     b_norm = cupy.linalg.norm(b)
     if b_norm == 0:
         return b, 0
-    if atol is None:
-        atol = tol * float(b_norm)
-    else:
-        atol = max(float(atol), tol * float(b_norm))
+    atol = max(float(atol), rtol * float(b_norm))
     if maxiter is None:
         maxiter = n * 10
     if restart is None:
@@ -200,8 +192,8 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None, M=None,
     return mx, info
 
 
-def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
-        atol=None):
+def cgs(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
+        callback=None):
     """Use Conjugate Gradient Squared iteration to solve ``Ax = b``.
 
     Args:
@@ -210,7 +202,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
         b (cupy.ndarray): Right hand side of the linear system with shape
             ``(n,)`` or ``(n, 1)``.
         x0 (cupy.ndarray): Starting guess for the solution.
-        tol (float): Tolerance for convergence.
+        rtol, atol (float): Tolerance for convergence.
         maxiter (int): Maximum number of iterations.
         M (ndarray, spmatrix or LinearOperator): Preconditioner for ``A``.
             The preconditioner should approximate the inverse of ``A``.
@@ -220,7 +212,6 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
         callback (function): User-specified function to call after each
             iteration. It is called as ``callback(xk)``, where ``xk`` is the
             current solution vector.
-        atol (float): Tolerance for convergence.
 
     Returns:
         tuple:
@@ -241,10 +232,7 @@ def cgs(A, b, x0=None, tol=1e-5, maxiter=None, M=None, callback=None,
     b_norm = cupy.linalg.norm(b)
     if b_norm == 0:
         return b, 0
-    if atol is None:
-        atol = tol * float(b_norm)
-    else:
-        atol = max(float(atol), tol * float(b_norm))
+    atol = max(float(atol), rtol * float(b_norm))
     if maxiter is None:
         maxiter = n * 5
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -367,16 +367,10 @@ class TestCg:
         x0 = None
         if self.x0 == 'ones':
             x0 = xp.ones((self.n,), dtype=dtype)
-        atol = None
+        atol = 0.0
         if self.atol == 'select-by-dtype':
             atol = self._atol[dtype.char.lower()]
-        if atol is None and xp == numpy:
-            # Note: If atol is None or not specified, Scipy (at least 1.5.3)
-            # raises DeprecationWarning
-            with pytest.deprecated_call():
-                return sp.linalg.cg(a, b, x0=x0, M=M, atol=atol)
-        else:
-            return sp.linalg.cg(a, b, x0=x0, M=M, atol=atol)
+        return sp.linalg.cg(a, b, x0=x0, M=M, atol=atol)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
@@ -521,18 +515,11 @@ class TestGmres:
         x0 = None
         if self.x0 == 'ones':
             x0 = xp.ones((self.n,), dtype=dtype)
-        atol = None
+        atol = 0.0
         if self.atol == 'select-by-dtype':
             atol = self._atol[dtype.char.lower()]
-        if atol is None and xp == numpy:
-            # Note: If atol is None or not specified, Scipy (at least 1.5.3)
-            # raises DeprecationWarning
-            with pytest.deprecated_call():
-                return sp.linalg.gmres(
-                    a, b, x0=x0, restart=self.restart, M=M, atol=atol)
-        else:
-            return sp.linalg.gmres(
-                a, b, x0=x0, restart=self.restart, M=M, atol=atol)
+        return sp.linalg.gmres(
+            a, b, x0=x0, restart=self.restart, M=M, atol=atol)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
@@ -1502,16 +1489,10 @@ class TestCgs:
         x0 = None
         if self.x0 == 'ones':
             x0 = xp.ones((self.n,), dtype=dtype)
-        atol = None
+        atol = 0.0
         if self.atol == 'select-by-dtype':
             atol = self._atol[dtype.char.lower()]
-        if atol is None and xp == numpy:
-            # Note: If atol is None or not specified, Scipy (at least 1.5.3)
-            # raises DeprecationWarning
-            with pytest.deprecated_call():
-                return sp.linalg.cgs(a, b, x0=x0, M=M, atol=atol)
-        else:
-            return sp.linalg.cgs(a, b, x0=x0, M=M, atol=atol)
+        return sp.linalg.cgs(a, b, x0=x0, M=M, atol=atol)
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8272

https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations