### PR TITLE
Fix `cupyx.scipy.sparse` tests for SciPy 1.14

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
@@ -11,7 +11,7 @@ from cupy import testing
 from cupyx.scipy import sparse
 
 
-@testing.with_requires('scipy>=1.11')
+@testing.with_requires('scipy>=1.14')
 class TestSpmatrix(unittest.TestCase):
 
     def dummy_class(self, sp):
@@ -34,7 +34,8 @@ class TestSpmatrix(unittest.TestCase):
             class DummySparseCPU(scipy.sparse._base._spbase):
 
                 def __init__(self, maxprint=50, shape=None, nnz=0):
-                    super(DummySparseCPU, self).__init__(maxprint)
+                    super(DummySparseCPU, self).__init__(
+                        None, maxprint=maxprint)
                     self._shape = shape
                     self._nnz = nnz
 
@@ -47,7 +48,7 @@ class TestSpmatrix(unittest.TestCase):
         for sp in (scipy.sparse, sparse):
             with pytest.raises(ValueError):
                 if sp is scipy.sparse:
-                    sp._base._spbase()
+                    sp._base._spbase(None)
                 else:
                     # TODO(asi1024): Replace with sp._base._spbase
                     sp.spmatrix()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -205,20 +205,30 @@ class TestCooMatrix:
         ], dtype=self.dtype)
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy')
+    @testing.with_requires('scipy>=1.14')
     def test_str(self):
+        dtype_name = numpy.dtype(self.dtype).name
         if numpy.dtype(self.dtype).kind == 'b':
-            expect = '''  (0, 0)\tFalse
+            expect = f'''<COOrdinate sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\tFalse
   (0, 1)\tTrue
   (1, 3)\tTrue
   (2, 2)\tTrue'''
         elif numpy.dtype(self.dtype).kind == 'f':
-            expect = '''  (0, 0)\t0.0
+            expect = f'''<COOrdinate sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0.0
   (0, 1)\t1.0
   (1, 3)\t2.0
   (2, 2)\t3.0'''
         elif numpy.dtype(self.dtype).kind == 'c':
-            expect = '''  (0, 0)\t0j
+            expect = f'''<COOrdinate sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0j
   (0, 1)\t(1+0j)
   (1, 3)\t(2+0j)
   (2, 2)\t(3+0j)'''
@@ -511,10 +521,11 @@ class TestCooMatrixScipyComparison:
         m = self.make(xp, sp, self.dtype)
         return m.toarray()
 
+    @testing.with_requires('scipy<1.14')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_A(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
-        return m.A
+        return m.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -246,18 +246,25 @@ class TestCscMatrix:
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy')
+    @testing.with_requires('scipy>=1.14')
     def test_str(self):
+        dtype_name = numpy.dtype(self.dtype).name
         if numpy.dtype(self.dtype).kind == 'f':
-            expect = '''  (0, 0)\t0.0
+            expect = f'''<Compressed Sparse Column sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0.0
   (0, 1)\t1.0
   (2, 2)\t3.0
-  (1, 3)\t2.0'''
+  (1, 3)\t2.0'''  # NOQA
         elif numpy.dtype(self.dtype).kind == 'c':
-            expect = '''  (0, 0)\t0j
+            expect = f'''<Compressed Sparse Column sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0j
   (0, 1)\t(1+0j)
   (2, 2)\t(3+0j)
-  (1, 3)\t(2+0j)'''
+  (1, 3)\t(2+0j)'''  # NOQA
 
         assert str(self.m) == expect
 
@@ -506,6 +513,7 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.toarray(order='#')
 
+    @testing.with_requires('scipy<1.14')
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_A(self, xp, sp):
         m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -294,18 +294,25 @@ class TestCsrMatrix:
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy')
+    @testing.with_requires('scipy>=1.14')
     def test_str(self):
+        dtype_name = numpy.dtype(self.dtype).name
         if numpy.dtype(self.dtype).kind == 'f':
-            expect = '''  (0, 0)\t0.0
+            expect = f'''<Compressed Sparse Row sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0.0
   (0, 1)\t1.0
   (1, 3)\t2.0
-  (2, 2)\t3.0'''
+  (2, 2)\t3.0'''  # NOQA
         elif numpy.dtype(self.dtype).kind == 'c':
-            expect = '''  (0, 0)\t0j
+            expect = f'''<Compressed Sparse Row sparse matrix of dtype '{dtype_name}'
+\twith 4 stored elements and shape (3, 4)>
+  Coords\tValues
+  (0, 0)\t0j
   (0, 1)\t(1+0j)
   (1, 3)\t(2+0j)
-  (2, 2)\t(3+0j)'''
+  (2, 2)\t(3+0j)'''  # NOQA
 
         assert str(self.m) == expect
 
@@ -564,6 +571,7 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.toarray(order='#')
 
+    @testing.with_requires('scipy<1.14')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_A(self, xp, sp):
         m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -84,18 +84,25 @@ class TestDiaMatrix(unittest.TestCase):
         n = _make_complex(cupy, sparse, self.dtype)
         cupy.testing.assert_array_equal(n.conjugate().data, n.data.conj())
 
-    @unittest.skipUnless(scipy_available, 'requires scipy')
+    @testing.with_requires('scipy>=1.14')
     def test_str(self):
+        dtype_name = numpy.dtype(self.dtype).name
         if numpy.dtype(self.dtype).kind == 'f':
-            expect = '''  (1, 1)\t1.0
+            expect = f'''<DIAgonal sparse matrix of dtype '{dtype_name}'
+\twith 5 stored elements (2 diagonals) and shape (3, 4)>
+  Coords\tValues
+  (1, 1)\t1.0
   (2, 2)\t2.0
   (1, 0)\t3.0
-  (2, 1)\t4.0'''
+  (2, 1)\t4.0'''  # NOQA
         else:
-            expect = '''  (1, 1)\t(1+0j)
+            expect = f'''<DIAgonal sparse matrix of dtype '{dtype_name}'
+\twith 5 stored elements (2 diagonals) and shape (3, 4)>
+  Coords\tValues
+  (1, 1)\t(1+0j)
   (2, 2)\t(2+0j)
   (1, 0)\t(3+0j)
-  (2, 1)\t(4+0j)'''
+  (2, 1)\t(4+0j)'''  # NOQA
         assert str(self.m) == expect
 
     def test_toarray(self):
@@ -239,6 +246,7 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.toarray()
 
+    @testing.with_requires('scipy<1.14')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_A(self, xp, sp):
         m = self.make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -61,7 +61,7 @@ class TestLsqr(unittest.TestCase):
     @_condition.retry(10)
     @testing.numpy_cupy_allclose(atol=1e-1, sp_name='sp')
     def test_ndarray(self, xp, sp):
-        A = xp.array(self.A.A, dtype=self.dtype)
+        A = xp.array(self.A.toarray(), dtype=self.dtype)
         b = xp.array(self.b, dtype=self.dtype)
         x = sp.linalg.lsqr(A, b)
         return x[0]


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8272

- Use `.toarray()` instead of `.A`
- `sparse._base._spbase()` => `sparse._base._spbase(dummy)`
- `str(spmatrix)` is changed

https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#scipy-sparse-improvements