### PR TITLE
Fix ROCm 4.3 binary package build broken

### DIFF
--- a/cupy/_core/include/cupy/complex/namespace.h
+++ b/cupy/_core/include/cupy/complex/namespace.h
@@ -1,6 +1,6 @@
-#ifndef __CUDACC_RTC__
-#include <thrust/detail/config.h>
-#else
+#if defined(__CUDACC_RTC__) || defined(__HIPCC_RTC__) || ( defined(__HIPCC__) && HIP_VERSION < 50000000 )
 #define THRUST_NAMESPACE_BEGIN namespace thrust {
 #define THRUST_NAMESPACE_END }
+#else
+#include <thrust/detail/config.h>
 #endif


### PR DESCRIPTION
`THRUST_NAMESPACE_BEGIN` looks new in ROCm 5.