### PR TITLE
Fix cudart header detection for conda

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2240,8 +2240,7 @@ cpdef tuple assemble_cupy_compiler_options(tuple options):
             wheel_dir_count = len(
                 _environment._get_include_dir_from_conda_or_wheel(
                     major, minor))
-            assert 0 <= wheel_dir_count <= 1
-            _headers_from_wheel_available = (wheel_dir_count == 1)
+            _headers_from_wheel_available = (0 < wheel_dir_count)
 
         if (_bundled_include is None and
                 _cuda_path is None and


### PR DESCRIPTION
The assumption of `0 <= len(wheel_dir_count) <=1` is no longer valid as we now support loading from conda packages: https://github.com/cupy/cupy/blob/d717917e1d72c4318fcdcb73b4c9b29fbda176ff/cupy/_environment.py#L476-L479
xref #8519