### PR TITLE
Properly allocate in RNG when specified dtype is neither float32/float64

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -152,6 +152,10 @@ class Generator:
         if out is not None:
             self._check_output_array(dtype, size, out)
 
+        dtype_ = numpy.dtype(dtype)
+        if dtype_.char not in 'fd':
+            raise TypeError(f'Unsupported dtype {dtype_} for random')
+
         y = _core.ndarray(size if size is not None else (), dtype)
         if y.dtype.char == 'd':
             _launch_dist(self.bit_generator, random_uniform, y, ())

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -374,4 +374,4 @@ class TestDrichlet(
 class TestLarge:
     def test_large(self):
         gen = random.Generator(random.XORWOW(1234))
-        gen.random(2**31 + 1, dtype=cupy.int8)
+        gen.random(2**31 + 1, dtype=cupy.float32)

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -374,4 +374,4 @@ class TestDrichlet(
 class TestLarge:
     def test_large(self):
         gen = random.Generator(random.XORWOW(1234))
-        gen.random(2**31 + 1, dtype=cupy.float32)
+        gen.random(2**31 + 1, dtype=cupy.int8)


### PR DESCRIPTION
Fix to properly allocate output arrays for some RNG methods when dtype is specified. This potentially had illegal memory access.
