### PR TITLE
add nccl.broadcast 64-bit support

### DIFF
--- a/cupy_backends/cuda/libs/nccl.pyx
+++ b/cupy_backends/cuda/libs/nccl.pyx
@@ -420,7 +420,7 @@ cdef class NcclCommunicator:
                                  <runtime.Stream>stream)
         check_status(status)
 
-    def broadcast(self, intptr_t sendbuff, intptr_t recvbuff, int count,
+    def broadcast(self, intptr_t sendbuff, intptr_t recvbuff, size_t count,
                   int datatype, int root, intptr_t stream):
         if NCCL_VERSION_CODE < 2200:
             # ncclBroadcast is not available in NCCL 2.1 or older.
@@ -436,7 +436,7 @@ cdef class NcclCommunicator:
                                     self._comm, <runtime.Stream>stream)
         check_status(status)
 
-    def bcast(self, intptr_t buff, int count, int datatype,
+    def bcast(self, intptr_t buff, size_t count, int datatype,
               int root, intptr_t stream):
         with nogil:
             status = _ncclBcast(<void*>buff, count,


### PR DESCRIPTION
In the `cupy_backends/cuda/libs/nccl.pyx`, all functions except `broadcast` use `int` as the type of `count`, others are all `size_t`. I think this is a typo, which prevent broadcasting larger arrays.