### PR TITLE
[v13] Skip test_log_expit SciPy 1.7

### DIFF
--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -25,7 +25,7 @@ class _TestBase:
     def test_expit(self):
         self.check_unary_lower_precision('expit')
 
-    @testing.with_requires("scipy<1.14")
+    @testing.with_requires("scipy>=1.8.0rc0", "scipy<1.14")
     def test_log_expit(self):
         self.check_unary_lower_precision('log_expit')
 


### PR DESCRIPTION
https://github.com/cupy/cupy/pull/8554 deleted `@testing.with_requires('scipy>=1.8.0rc0')`, but CuPy v13 still have support for SciPy 1.7.
