### PR TITLE
Add self-hosted CI

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,0 +1,84 @@
+name: Self-Hosted CI
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  CI_REPO_OWNER: 'cupy'
+  CI_REPO_NAME: 'self-hosted-ci'
+
+jobs:
+  pre-dispatch:
+    if: github.repository_owner == 'cupy'
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pull-request.outputs.head_sha }}
+      merge_commit_sha: ${{ steps.pull-request.outputs.merge_commit_sha }}
+    steps:
+    # TODO Support workflow_dispatch and push.
+    - name: 'Handle Pull Request Comments'
+      id: pull-request
+      if: |
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        ( github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' )
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // Check if the comment contain "/test rocm" request.
+          const lines = context.payload.comment.body.split('\n');
+          if (!lines.some(line => line.trim().startsWith('/test ') && line.includes('rocm'))) {
+            console.log('Dispatch not requested in pull request comment.');
+            return;
+          }
+
+          // Get the merge commit SHA.
+          for (let i = 0; i < 10; i++) {
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const mergeable = pr.data.mergeable;
+            if (mergeable === null) {
+              console.log('Waiting for GitHub to determine mergeability...');
+              await new Promise(r => setTimeout(r, 1000));
+              continue;
+            }
+            if (mergeable === true) {
+              const head_sha = pr.data.head.sha;
+              const merge_commit_sha = pr.data.merge_commit_sha;
+              core.setOutput('head_sha', head_sha);
+              core.setOutput('merge_commit_sha', merge_commit_sha);
+              console.log(`Target HEAD commit ${head_sha}, merge commit ${merge_commit_sha}`);
+            } else {
+              core.setFailed('The pull request is not mergeable.');
+            }
+            break;
+          }
+
+  dispatch:
+    needs: pre-dispatch
+    if: ${{ needs.pre-dispatch.outputs.head_sha != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Generate Token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.GH_APP_SELF_HOSTED_CI_ID }}
+        private-key: ${{ secrets.GH_APP_SELF_HOSTED_CI_PEM }}
+        owner: ${{ env.CI_REPO_OWNER }}
+        repositories: ${{ env.CI_REPO_NAME }}
+    - name: Dispach Self-Hosted CI
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        repository: ${{ env.CI_REPO_OWNER }}/${{ env.CI_REPO_NAME }}
+        event-type: rocm-5-3
+        token: ${{ steps.generate-token.outputs.token }}
+        client-payload: |
+          {
+            "head_sha": "${{ needs.pre-dispatch.outputs.head_sha }}",
+            "merge_commit_sha": "${{ needs.pre-dispatch.outputs.merge_commit_sha }}",
+            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }


### PR DESCRIPTION
Add CI that uses on-premise self-hosted GitHub Actions runners.
This replaces the Jenkins CI.

### How it works

1. The workflow in `cupy/cupy` repository (added in this PR) triggers when a new comment is added to pull-request.
2. If the comment contains `/test ... rocm ...` line, dispatch the CI request to [`cupy/self-hosted-ci`](https://github.com/cupy/self-hosted-ci/) repository.
3. CI runs on self-hosted runners registered to `cupy/self-hosted-ci` repository with [this workflow](https://github.com/cupy/self-hosted-ci/blob/main/.github/workflows/ci.yml).

This complicated setup is required to use self-hosted on-premise GitHub Actions runners securely in public repositories.