### PR TITLE
Catch `ValueError`

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -336,7 +336,7 @@ class TestCooMatrixInit:
 
     def test_invalid_format(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
-            with pytest.raises(TypeError):
+            with pytest.raises((TypeError, ValueError)):
                 sp.coo_matrix(
                     (self.data(xp), self.row(xp)), shape=self.shape)
 


### PR DESCRIPTION
This PR partially cherry-picks e9f921f .

See #8621 for why it's necessary.