### PR TITLE
Use `testing.with_requires` to skip broken tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -384,7 +384,7 @@ class _TestRBFInterpolator:
         d = xp.zeros(1)
         self.build(scp, y, d, kernel='thin_plate_spline')
 
-    @pytest.mark.skip("XXX: NP2.0: scipy does not emit the warning")
+    @testing.with_requires("scipy<1.13")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=UserWarning)
     @pytest.mark.parametrize('kernel',
                              [kl for kl in _NAME_TO_MIN_DEGREE

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2159,8 +2159,7 @@ class TestCsrMatrixDiagonal:
         testing.assert_array_equal(scipy_a.indices, cupyx_a.indices)
         testing.assert_array_equal(scipy_a.indptr, cupyx_a.indptr)
 
-    @pytest.mark.xfail(scipy_113_or_later,
-                       reason="XXX: np2.0: weak promotion")
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     def test_setdiag(self, dtype):
         scipy_a, cupyx_a = self._make_matrix(dtype)
@@ -2174,8 +2173,7 @@ class TestCsrMatrixDiagonal:
                 x = numpy.ones((x_len,), dtype=dtype)
                 self._test_setdiag(scipy_a, cupyx_a, x, k)
 
-    @pytest.mark.xfail(scipy_113_or_later,
-                       reason="XXX: np2.0: weak promotion")
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     def test_setdiag_scalar(self, dtype):
         scipy_a, cupyx_a = self._make_matrix(dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -3,6 +3,7 @@ import itertools
 
 import numpy
 import pytest
+
 try:
     import scipy.sparse
 except ImportError:
@@ -116,8 +117,7 @@ class TestSetitemIndexing:
                             _get_index_combos(1)):
             self._run(maj, min, data=x)
 
-    @pytest.mark.xfail(scipy_113_or_later, reason="XXX: scipy1.13")
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     def test_set_zero_dim_bool_mask(self):
 
         zero_dim_data = [numpy.array(5), cupy.array(5)]
@@ -285,14 +285,8 @@ class TestSetitemIndexing:
         self._run(slice(10, 2, 5), slice(None))
         self._run(slice(10, 0, 10), slice(None))
 
-    @pytest.mark.xfail(scipy_113_or_later,
-                       reason="XXX: scipy 1.13")
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     def test_fancy_setting_bool(self):
-        # Unfortunately, boolean setting is implemented slightly
-        # differently between Scipy 1.4 and 1.5. Using the most
-        # up-to-date version in CuPy.
-
         for maj in _get_index_combos(
                 [[True], [False], [False], [True], [True], [True]]):
             self._run(maj, data=5)
@@ -516,41 +510,29 @@ class TestBoolMaskIndexing(IndexingTestBase):
     n_rows = 3
     n_cols = 5
 
-    # In older environments (e.g., py35, scipy 1.4), scipy sparse arrays are
-    # crashing when indexed with native Python boolean list.
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_bool_mask(self, xp, sp, dtype):
-
-        if self.indices == ([True, False, True], [True, False, True]):
-            pytest.xfail(reason="XXX: np2.0: scipy 1.13 sparse raises")
-
         a = self._make_matrix(sp, dtype)
         res = a[self.indices]
         _check_shares_memory(xp, sp, a, res)
         return res
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_numpy_bool_mask(self, xp, sp, dtype):
-
-        if self.indices == ([True, False, True], [True, False, True]):
-            pytest.xfail(reason="XXX: np2.0: scipy 1.13 sparse raises")
-
         a = self._make_matrix(sp, dtype)
         indices = self._make_indices(numpy)
         res = a[indices]
         _check_shares_memory(xp, sp, a, res)
         return res
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_cupy_bool_mask(self, xp, sp, dtype):
-
-        if self.indices == ([True, False, True], [True, False, True]):
-            pytest.xfail(reason="XXX: np2.0: scipy 1.13 sparse raises")
-
         a = self._make_matrix(sp, dtype)
         indices = self._make_indices(xp)
         res = a[indices]

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
@@ -38,7 +38,7 @@ class TestLogsumexp:
         a = xp.array([[100, 1000], [1e10, 1e-10]])
         return scp.special.logsumexp(a, axis=-1, keepdims=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_array_inputs(self, xp, scp, dtype):
@@ -47,7 +47,7 @@ class TestLogsumexp:
         a = testing.shaped_random((100, 1000), xp, dtype=dtype)
         return scp.special.logsumexp(a)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_sign_argument(self, xp, scp, dtype):
@@ -62,7 +62,7 @@ class TestLogsumexp:
         b = xp.array([1, -1]).astype(dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims(self, xp, scp, dtype):
@@ -72,7 +72,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 1, 1, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis(self, xp, scp, dtype):
@@ -80,7 +80,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 2, 3, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, axis=2, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis_2d(self, xp, scp, dtype):
@@ -95,7 +95,7 @@ class TestLogsumexp:
         b = xp.array([1, 0], dtype=dtype)
         return scp.special.logsumexp(a, b=b)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_b_multi_dims(self, xp, scp, dtype):


### PR DESCRIPTION
Related to #8621 .

MEMO: I simplified the version ranges a bit because `scipy` 1.4 is already EOL.