### PR TITLE
Use `testing.with_requires` to skip broken tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -381,6 +381,7 @@ class _TestRBFInterpolator:
         d = xp.zeros(1)
         self.build(scp, y, d, kernel='thin_plate_spline')
 
+    @testing.with_requires("scipy<1.13")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=UserWarning)
     @pytest.mark.parametrize('kernel',
                              [kl for kl in _NAME_TO_MIN_DEGREE])

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2139,6 +2139,7 @@ class TestCsrMatrixDiagonal:
         testing.assert_array_equal(scipy_a.indices, cupyx_a.indices)
         testing.assert_array_equal(scipy_a.indptr, cupyx_a.indptr)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     def test_setdiag(self, dtype):
         scipy_a, cupyx_a = self._make_matrix(dtype)
@@ -2152,6 +2153,7 @@ class TestCsrMatrixDiagonal:
                 x = numpy.ones((x_len,), dtype=dtype)
                 self._test_setdiag(scipy_a, cupyx_a, x, k)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     def test_setdiag_scalar(self, dtype):
         scipy_a, cupyx_a = self._make_matrix(dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -110,7 +110,7 @@ class TestSetitemIndexing:
                             _get_index_combos(1)):
             self._run(maj, min, data=x)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     def test_set_zero_dim_bool_mask(self):
 
         zero_dim_data = [numpy.array(5), cupy.array(5)]
@@ -278,12 +278,8 @@ class TestSetitemIndexing:
         self._run(slice(10, 2, 5), slice(None))
         self._run(slice(10, 0, 10), slice(None))
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     def test_fancy_setting_bool(self):
-        # Unfortunately, boolean setting is implemented slightly
-        # differently between Scipy 1.4 and 1.5. Using the most
-        # up-to-date version in CuPy.
-
         for maj in _get_index_combos(
                 [[True], [False], [False], [True], [True], [True]]):
             self._run(maj, data=5)
@@ -507,9 +503,7 @@ class TestBoolMaskIndexing(IndexingTestBase):
     n_rows = 3
     n_cols = 5
 
-    # In older environments (e.g., py35, scipy 1.4), scipy sparse arrays are
-    # crashing when indexed with native Python boolean list.
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_bool_mask(self, xp, sp, dtype):
@@ -518,6 +512,7 @@ class TestBoolMaskIndexing(IndexingTestBase):
         _check_shares_memory(xp, sp, a, res)
         return res
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_numpy_bool_mask(self, xp, sp, dtype):
@@ -527,6 +522,7 @@ class TestBoolMaskIndexing(IndexingTestBase):
         _check_shares_memory(xp, sp, a, res)
         return res
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_cupy_bool_mask(self, xp, sp, dtype):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
@@ -38,6 +38,7 @@ class TestLogsumexp:
         a = xp.array([[100, 1000], [1e10, 1e-10]])
         return scp.special.logsumexp(a, axis=-1, keepdims=True)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_array_inputs(self, xp, scp, dtype):
@@ -46,6 +47,7 @@ class TestLogsumexp:
         a = testing.shaped_random((100, 1000), xp, dtype=dtype)
         return scp.special.logsumexp(a)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_sign_argument(self, xp, scp, dtype):
@@ -60,6 +62,7 @@ class TestLogsumexp:
         b = xp.array([1, -1]).astype(dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims(self, xp, scp, dtype):
@@ -69,6 +72,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 1, 1, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis(self, xp, scp, dtype):
@@ -76,6 +80,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 2, 3, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, axis=2, b=b, return_sign=True)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis_2d(self, xp, scp, dtype):
@@ -90,6 +95,7 @@ class TestLogsumexp:
         b = xp.array([1, 0], dtype=dtype)
         return scp.special.logsumexp(a, b=b)
 
+    @testing.with_requires("scipy<1.13")
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_b_multi_dims(self, xp, scp, dtype):


### PR DESCRIPTION
Related to #8621 .

MEMO: I simplified the version ranges a bit because `scipy` 1.4 is already EOL.