### PR TITLE
Update precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,58 +2,60 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    # Git
-    -   id: check-added-large-files
-    -   id: no-commit-to-branch
+      # Git
+      - id: check-added-large-files
+      - id: no-commit-to-branch
         name: "ensure no direct commit to main/vXX branch"
         args: [--branch, "main", --pattern, "v\\d+"]
-    -   id: check-case-conflict
-    # Contents
-    -   id: mixed-line-ending
-    -   id: fix-byte-order-marker
-    -   id: check-yaml
+      - id: check-case-conflict
+      # Contents
+      - id: mixed-line-ending
+      - id: fix-byte-order-marker
+      - id: check-yaml
 
--   repo: https://github.com/pre-commit/mirrors-autopep8
+  - repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v2.0.2
     hooks:
-    -   id: autopep8
+      - id: autopep8
 
--   repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
-    -   id: flake8
+      - id: flake8
         # use config from setup.cfg
-    -   id: flake8
+      - id: flake8
         name: flake8 (cython)
         types: ["cython"]
         args: [--config, ".flake8.cython", "--force-check"]
         additional_dependencies: [flake8-force]
 
--   repo: https://github.com/MarcoGorelli/cython-lint
+  - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.15.0
     hooks:
-    -   id: cython-lint
+      - id: cython-lint
         args: ["--max-line-length", "79"]
 
--   repo: https://github.com/pre-commit/mirrors-mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.4.1
     hooks:
-    -   id: mypy
+      - id: mypy
         # Keep in sync with the list in setup.cfg
         files: "^(cupy|cupyx|cupy_backends|.github|.pfnci)/"
-        additional_dependencies: [numpy, types-setuptools==57.4.14, types-PyYAML]
-    -   id: mypy
+        additional_dependencies:
+          [numpy, types-setuptools==57.4.14, types-PyYAML]
+      - id: mypy
         name: "mypy (install)"
         files: "^install/"
         args: [--config-file, "install/mypy.ini"]
-        additional_dependencies: [numpy, types-setuptools==57.4.14, types-PyYAML]
+        additional_dependencies:
+          [numpy, types-setuptools==57.4.14, types-PyYAML]
 
--   repo: local
+  - repo: local
     hooks:
-    -   id: ci-generate
+      - id: ci-generate
         name: "check CI files are up-to-date (.pfnci/generate.py)"
         files: .pfnci/
         entry: .pfnci/generate.py --dry-run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
       - id: fix-byte-order-marker
       - id: check-yaml
 
-  - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.2
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.3.1
     hooks:
       - id: autopep8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       # Git
       - id: check-added-large-files
@@ -22,7 +22,7 @@ repos:
       - id: autopep8
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         # use config from setup.cfg
@@ -33,13 +33,13 @@ repos:
         additional_dependencies: [flake8-force]
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.15.0
+    rev: v0.16.2
     hooks:
       - id: cython-lint
         args: ["--max-line-length", "79"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.11.2
     hooks:
       - id: mypy
         # Keep in sync with the list in setup.cfg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,14 +44,12 @@ repos:
       - id: mypy
         # Keep in sync with the list in setup.cfg
         files: "^(cupy|cupyx|cupy_backends|.github|.pfnci)/"
-        additional_dependencies:
-          [numpy, types-setuptools==57.4.14, types-PyYAML]
+        additional_dependencies: [numpy, types-setuptools, types-PyYAML]
       - id: mypy
         name: "mypy (install)"
         files: "^install/"
         args: [--config-file, "install/mypy.ini"]
-        additional_dependencies:
-          [numpy, types-setuptools==57.4.14, types-PyYAML]
+        additional_dependencies: [numpy, types-setuptools, types-PyYAML]
 
   - repo: local
     hooks:

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -259,7 +259,7 @@ class _OpsRegister:
             # find the typecasting rules
             op = self._determine_from_signature(signature)
         elif dtype is not None:
-            if type(dtype) == tuple:
+            if isinstance(dtype, tuple):
                 # TODO(ecastill) support dtype tuples
                 raise RuntimeError('dtype with tuple is not yet supported')
             op = self._determine_from_dtype(dtype)
@@ -630,10 +630,10 @@ class _GUFunc:
         args, ret_dtype, func = self._ops_register.determine_dtype(
             args, dtype, casting, signature)
 
-        if not type(self._signature) == str:
+        if not isinstance(self._signature, str):
             raise TypeError('`signature` has to be of type string')
 
-        if outs is not None and type(outs) != tuple:
+        if outs is not None and not isinstance(outs, tuple):
             if isinstance(outs, cupy.ndarray):
                 outs = (outs,)
             else:
@@ -643,7 +643,7 @@ class _GUFunc:
 
         input_coredimss = self._input_coredimss
         output_coredimss = self._output_coredimss
-        if outs is not None and type(outs) != tuple:
+        if outs is not None and not isinstance(outs, tuple):
             raise TypeError('`outs` must be a tuple')
         # Axes
         input_axes, output_axes = _validate_normalize_axes(

--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -856,7 +856,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *,
         raise ValueError(
             f'Shapes of x {x.shape} and w {w.shape} are incompatible')
     if method != "qr":
-        raise ValueError(f"{method = } is not supported.")
+        raise ValueError(f"{method=} is not supported.")
     if any(x[1:] - x[:-1] < 0):
         raise ValueError("Expect x to be a 1D non-decreasing sequence.")
 

--- a/cupyx/scipy/interpolate/_fitpack_repro.py
+++ b/cupyx/scipy/interpolate/_fitpack_repro.py
@@ -58,7 +58,7 @@ def fpcheck(x, t, k):
 
     if x.ndim != 1 or t.ndim != 1:
         raise ValueError(
-            f"Expect `x` and `t` be 1D sequences. Got {x = } and {t = }"
+            f"Expect `x` and `t` be 1D sequences. Got {x=} and {t=}"
         )
 
     m = x.shape[0]
@@ -69,35 +69,35 @@ def fpcheck(x, t, k):
     # c      1) k+1 <= n-k-1 <= m
     if not (k + 1 <= nk1 <= m):
         raise ValueError(
-            f"Need k+1 <= n-k-1 <= m. Got {m = }, {n = } and {k = }."
+            f"Need k+1 <= n-k-1 <= m. Got {m=}, {n=} and {k=}."
         )
 
     # check condition no 2
     # c      2) t(1) <= t(2) <= ... <= t(k+1)
     # c         t(n-k) <= t(n-k+1) <= ... <= t(n)
     if (t[:k+1] > t[1:k+2]).any():
-        raise ValueError(f"First k knots must be ordered; got {t = }.")
+        raise ValueError(f"First k knots must be ordered; got {t=}.")
 
     if (t[nk1:] < t[nk1-1:-1]).any():
-        raise ValueError(f"Last k knots must be ordered; got {t = }.")
+        raise ValueError(f"Last k knots must be ordered; got {t=}.")
 
     # c  check condition no 3
     # c      3) t(k+1) < t(k+2) < ... < t(n-k)
     if (t[k+1:n-k] <= t[k:n-k-1]).any():
-        raise ValueError(f"Internal knots must be distinct. Got {t = }.")
+        raise ValueError(f"Internal knots must be distinct. Got {t=}.")
 
     # c  check condition no 4
     # c      4) t(k+1) <= x(i) <= t(n-k)
     # NB: FITPACK's fpchec only checks x[0] & x[-1], so we follow.
     if (x[0] < t[k]) or (x[-1] > t[n-k-1]):
-        raise ValueError(f"Out of bounds: {x = } and {t = }.")
+        raise ValueError(f"Out of bounds: {x=} and {t=}.")
 
     # c  check condition no 5
     # c      5) the conditions specified by schoenberg and whitney must hold
     # c         for at least one subset of data points, i.e. there must be a
     # c         subset of data points y(j) such that
     # c             t(j) < y(j) < t(j+k+1), j=1,2,...,n-k-1
-    mesg = f"Schoenberg-Whitney condition is violated with {t = } and {x =}."
+    mesg = f"Schoenberg-Whitney condition is violated with {t =} and {x =}."
 
     if (x[0] >= t[k+1]) or (x[-1] <= t[n-k-2]):
         raise ValueError(mesg)
@@ -226,33 +226,33 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric):
     else:
         w = cupy.asarray(w, dtype=float)
         if w.ndim != 1:
-            raise ValueError(f"{w.ndim = } not implemented yet.")
+            raise ValueError(f"{w.ndim=} not implemented yet.")
         if (w < 0).any():
             raise ValueError("Weights must be non-negative")
 
     if y.ndim == 0 or y.ndim > 2:
-        raise ValueError(f"{y.ndim = } not supported (must be 1 or 2.)")
+        raise ValueError(f"{y.ndim=} not supported (must be 1 or 2.)")
 
     parametric = bool(parametric)
     if parametric:
         if y.ndim != 2:
             raise ValueError(
-                f"{y.ndim = } != 2 not supported with {parametric =}."
+                f"{y.ndim=} != 2 not supported with {parametric=}."
             )
     else:
         if y.ndim != 1:
             raise ValueError(
-                f"{y.ndim = } != 1 not supported with {parametric =}."
+                f"{y.ndim=} != 1 not supported with {parametric=}."
             )
         # all _impl functions expect y.ndim = 2
         y = y[:, None]
 
     if w.shape[0] != x.shape[0]:
-        raise ValueError(f"Weights is incompatible: {w.shape =} != {x.shape}.")
+        raise ValueError(f"Weights is incompatible: {w.shape=} != {x.shape}.")
 
     if x.shape[0] != y.shape[0]:
         raise ValueError(
-            f"Data is incompatible: {x.shape = } and {y.shape = }."
+            f"Data is incompatible: {x.shape=} and {y.shape=}."
         )
     if x.ndim != 1 or (x[1:] < x[:-1]).any():
         raise ValueError("Expect `x` to be an ordered 1D sequence.")
@@ -260,7 +260,7 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric):
     k = operator.index(k)
 
     if s < 0:
-        raise ValueError(f"`s` must be non-negative. Got {s = }")
+        raise ValueError(f"`s` must be non-negative. Got {s=}")
 
     if xb is None:
         xb = min(x)
@@ -375,7 +375,7 @@ def _generate_knots_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0,
     else:
         if nest < 2*(k + 1):
             raise ValueError(
-                f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}."
+                f"`nest` too small: {nest=} < 2*(k+1) = {2*(k+1)}."
             )
 
     nmin = 2*(k + 1)    # the number of knots for an LSQ polynomial approx
@@ -581,13 +581,13 @@ class F:
         self.k = k
         w = cupy.ones_like(x, dtype=float) if w is None else w
         if w.ndim != 1:
-            raise ValueError(f"{w.ndim = } != 1.")
+            raise ValueError(f"{w.ndim=} != 1.")
         self.w = w
         self.s = s
 
         if y.ndim != 2:
             raise ValueError(
-                f"F: expected y.ndim == 2, got {y.ndim = } instead.")
+                f"F: expected y.ndim == 2, got {y.ndim=} instead.")
 
         # ### precompute what we can ###
 
@@ -608,7 +608,7 @@ class F:
         nc = t.shape[0] - k - 1
         nz = k + 1
         if R.shape[1] != nz:
-            raise ValueError(f"Internal error: {R.shape[1] =} != {k+1 =}.")
+            raise ValueError(f"Internal error: {R.shape[1]=} != {k+1=}.")
 
         # r.h.s. of the augmented system
         z = cupy.zeros((b.shape[0], Y.shape[1]), dtype=float)
@@ -810,7 +810,7 @@ def _make_splrep_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None,
     else:
         if nest < 2*(k + 1):
             raise ValueError(
-                f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}."
+                f"`nest` too small: {nest=} < 2*(k+1) = {2*(k+1)}."
             )
         if t is not None:
             raise ValueError("Either supply `t` or `nest`.")

--- a/cupyx/scipy/interpolate/_ndbspline.py
+++ b/cupyx/scipy/interpolate/_ndbspline.py
@@ -497,7 +497,7 @@ class NdBSpline:
             k = (k,) * ndim
 
         if len(k) != ndim:
-            raise ValueError(f"{len(t) = } != {len(k) = }.")
+            raise ValueError(f"{len(t)=} != {len(k)=}.")
 
         self.k = tuple(operator.index(ki) for ki in k)
         self.t = tuple(cupy.ascontiguousarray(ti, dtype=float) for ti in t)
@@ -577,10 +577,10 @@ class NdBSpline:
             nu = cupy.asarray(nu, dtype=cupy.int32)
             if nu.ndim != 1 or nu.shape[0] != ndim:
                 raise ValueError(
-                    f"invalid number of derivative orders {nu = } for "
+                    f"invalid number of derivative orders {nu=} for "
                     f"ndim = {len(self.t)}.")
             if cupy.any(nu < 0).item():
-                raise ValueError(f"derivatives must be positive, got {nu = }")
+                raise ValueError(f"derivatives must be positive, got {nu=}")
 
         # prepare xi : shape (..., m1, ..., md) -> (1, m1, ..., md)
         xi = cupy.asarray(xi, dtype=float)
@@ -661,7 +661,7 @@ class NdBSpline:
         if len(t) != ndim:
             raise ValueError(
                 f"Data and knots are inconsistent: len(t) = {len(t)} for "
-                f" {ndim = }."
+                f" {ndim=}."
             )
         try:
             len(k)

--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -327,7 +327,7 @@ class RegularGridInterpolator:
         if nu is not None and method not in self._SPLINE_METHODS_ndbspl:
             raise ValueError(
                 f"Can only compute derivatives for methods "
-                f"{self._SPLINE_METHODS_ndbspl}, got {method =}."
+                f"{self._SPLINE_METHODS_ndbspl}, got {method=}."
             )
 
         xi, xi_shape, ndim, nans, out_of_bounds = self._prepare_xi(xi)

--- a/cupyx/scipy/signal/_iir_filter_conversions.py
+++ b/cupyx/scipy/signal/_iir_filter_conversions.py
@@ -1951,7 +1951,7 @@ def _find_nat_freq(stopb, passb, gpass, gstop, filter_type, filter_kind):
         nat = ((stopb ** 2 - passb[0] * passb[1]) /
                (stopb * (passb[0] - passb[1])))
     else:
-        raise ValueError(f"should not happen: {filter_type =}.")
+        raise ValueError(f"should not happen: {filter_type=}.")
 
     nat = min(cupy.abs(nat))
     return nat, passb

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -495,7 +495,7 @@ def upfirdn(
     if mode is None:
         mode = "constant"  # For backwards compatibility
     if mode != "constant" or cval != 0:
-        raise NotImplementedError(f"{mode = } and {cval =} not implemented.")
+        raise NotImplementedError(f"{mode=} and {cval=} not implemented.")
 
     ufd = _UpFIRDn(h, x.dtype, int(up), int(down))
     # This is equivalent to (but faster than) using cp.apply_along_axis

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -339,7 +339,6 @@ def _make_fast_matvec(A):
     from cupy_backends.cuda.libs import cusparse as _cusparse
     from cupyx import cusparse
 
-    matvec = None
     if _csr.isspmatrix_csr(A) and cusparse.check_availability('spmv'):
         handle = device.get_cusparse_handle()
         op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -366,7 +366,8 @@ def _make_fast_matvec(A):
                 beta.ctypes.data, desc_y.desc, cuda_dtype, alg, buff.data.ptr)
             return y
 
-    return matvec
+        return matvec
+    return None
 
 
 def _make_compute_hu(V):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ exclude = *.git*, *.eggs*, *cupy/array_api*, *tests/cupy_tests/array_api_tests*,
 per-file-ignores =
     # ignore long lines containing arrays of numerical constants
     cupyx/scipy/special/_gammainc.py:E501
+# Prohibit type comparison
+extend-ignore = E721
 
 [mypy]
 # Keep in sync with the list in .pre-commit-config.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,6 @@ exclude = *.git*, *.eggs*, *cupy/array_api*, *tests/cupy_tests/array_api_tests*,
 per-file-ignores =
     # ignore long lines containing arrays of numerical constants
     cupyx/scipy/special/_gammainc.py:E501
-# Prohibit type comparison
-extend-ignore = E721
 
 [mypy]
 # Keep in sync with the list in .pre-commit-config.yaml

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,12 @@ extras_require = {
     ],
     # TODO(kmaehashi): remove stylecheck and update the contribution guide
     'stylecheck': [
-        'autopep8==1.5.5',
-        'flake8==3.8.4',
+        'autopep8==2.3.1',
+        'flake8==7.1.1',
         'pbr==5.5.1',
-        'pycodestyle==2.6.0',
 
-        'mypy==1.4.1',
-        'types-setuptools==57.4.14',
+        'mypy==1.11.2',
+        'types-setuptools',
     ],
     'test': [
         # 4.2 <= pytest < 6.2 is slow collecting tests and times out on CI.

--- a/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
@@ -48,7 +48,7 @@ def check_fusion(
             check_array(actual, expected, **check_array_kwargs)
 
         elif isinstance(expected, (list, tuple)):
-            assert type(actual) == type(expected)
+            assert type(actual) is type(expected)
             for item_actual, item_expected in zip(actual, expected):
                 check(xp, item_actual, item_expected)
 

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -387,7 +387,8 @@ class TestProduct:
     )
     @testing.numpy_cupy_allclose()
     def test_kron_accepts_numbers_as_arguments(self, a, b, xp):
-        args = [xp.array(arg) if type(arg) == list else arg for arg in [a, b]]
+        args = [xp.array(arg) if isinstance(arg, list)
+                else arg for arg in [a, b]]
         return xp.kron(*args)
 
 

--- a/tests/cupy_tests/test_type_routines.py
+++ b/tests/cupy_tests/test_type_routines.py
@@ -43,7 +43,7 @@ class TestCommonType(unittest.TestCase):
     @testing.numpy_cupy_equal()
     def test_common_type_empty(self, xp):
         ret = xp.common_type()
-        assert type(ret) == type
+        assert type(ret) is type
         return ret
 
     @testing.for_all_dtypes(no_bool=True)
@@ -51,7 +51,7 @@ class TestCommonType(unittest.TestCase):
     def test_common_type_single_argument(self, xp, dtype):
         array = _generate_type_routines_input(xp, dtype, 'array')
         ret = xp.common_type(array)
-        assert type(ret) == type
+        assert type(ret) is type
         return ret
 
     @testing.for_all_dtypes_combination(
@@ -61,7 +61,7 @@ class TestCommonType(unittest.TestCase):
         array1 = _generate_type_routines_input(xp, dtype1, 'array')
         array2 = _generate_type_routines_input(xp, dtype2, 'array')
         ret = xp.common_type(array1, array2)
-        assert type(ret) == type
+        assert type(ret) is type
         return ret
 
     @testing.for_all_dtypes()

--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -341,7 +341,7 @@ class TestFallbackArray(unittest.TestCase):
     @numpy_fallback_equal()
     def test_type_assert(self, xp):
         a = xp.array([1, 2, 3])
-        return type(a) == xp.ndarray
+        return isinstance(a, xp.ndarray)
 
     @numpy_fallback_equal()
     def test_base(self, xp):


### PR DESCRIPTION
This PR updates pre-commit CI for better style checking.

### Description of changes

- Upgrade hooks in `.pre-commit-config.yaml`
- Remove deprecated `mirrors-autopep8`
- Unpin `types-setuptools` because `setuptools` itself is not pinned
- Fix linter warnings
  - ~Ignoring rule E721 for now~
- Change/upgrade stylecheck deps. (deprecated)
  - Drop `pycodestyle` as it's shipped with `autopep8` 