### PR TITLE
Make `cupy.linalg.solve` compatible with `numpy` v2

### DIFF
--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -38,7 +38,6 @@ def solve(a, b):
     from cupyx import lapack
     from cupy.cublas import batched_gesv, get_batched_gesv_limit
 
-    # TODO(kataoka): Move the checks to the beginning
     _util._assert_cupy_array(a, b)
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -49,11 +49,13 @@ def solve(a, b):
     if b.ndim == 1:
         if a.shape[-1] != b.size:
             raise ValueError(
-                "a must have (..., M, M) shape and b must have (M,) for one-dimensional b")
+                "a must have (..., M, M) shape and b must have (M,) "
+                "for one-dimensional b")
         b = cupy.broadcast_to(b, a.shape[:-1])
     elif a.shape[:-1] != b.shape[:-1]:
         raise ValueError(
-            "a must have (..., M, M) shape and b must have (..., M, K) for multidimensional b")
+            "a must have (..., M, M) shape and b must have (..., M, K) "
+            "for multidimensional b")
 
     if a.ndim > 2 and a.shape[-1] <= get_batched_gesv_limit():
         # Note: There is a low performance issue in batched_gesv when matrix is

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -19,7 +19,7 @@ def solve(a, b):
 
     Args:
         a (cupy.ndarray): The matrix with dimension ``(..., M, M)``.
-        b (cupy.ndarray): The matrix with dimension ``(..., M)`` or
+        b (cupy.ndarray): The matrix with dimension ``(M,)`` or
             ``(..., M, K)``.
 
     Returns:
@@ -38,24 +38,27 @@ def solve(a, b):
     from cupyx import lapack
     from cupy.cublas import batched_gesv, get_batched_gesv_limit
 
-    if a.ndim > 2 and a.shape[-1] <= get_batched_gesv_limit():
-        # Note: There is a low performance issue in batched_gesv when matrix is
-        # large, so it is not used in such cases.
-        return batched_gesv(a, b)
-
     # TODO(kataoka): Move the checks to the beginning
     _util._assert_cupy_array(a, b)
     _util._assert_stacked_2d(a)
     _util._assert_stacked_square(a)
 
-    # TODO(kataoka): Support broadcast
-    if not (
-        (a.ndim == b.ndim or a.ndim == b.ndim + 1)
-        and a.shape[:-1] == b.shape[:a.ndim - 1]
-    ):
+    # Newly added to make it compatible with numpy 2
+    if b.ndim == 0:
+        raise ValueError("b must have at least one dimension")
+    if b.ndim == 1:
+        if a.shape[-1] != b.size:
+            raise ValueError(
+                "a must have (..., M, M) shape and b must have (M,) for one-dimensional b")
+        b = cupy.broadcast_to(b, a.shape[:-1])
+    elif a.shape[:-1] != b.shape[:-1]:
         raise ValueError(
-            'a must have (..., M, M) shape and b must have (..., M) '
-            'or (..., M, K)')
+            "a must have (..., M, M) shape and b must have (..., M, K) for multidimensional b")
+
+    if a.ndim > 2 and a.shape[-1] <= get_batched_gesv_limit():
+        # Note: There is a low performance issue in batched_gesv when matrix is
+        # large, so it is not used in such cases.
+        return batched_gesv(a, b)
 
     dtype, out_dtype = _util.linalg_common_type(a, b)
     if b.size == 0:

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -44,14 +44,14 @@ class TestSolve(unittest.TestCase):
     def test_solve(self):
         self.check_x((4, 4), (4,))
         self.check_x((5, 5), (5, 2))
-        self.check_x((2, 4, 4), (2, 4,))
         self.check_x((2, 5, 5), (2, 5, 2))
-        self.check_x((2, 3, 2, 2), (2, 3, 2,))
         self.check_x((2, 3, 3, 3), (2, 3, 3, 2))
         self.check_x((0, 0), (0,))
         self.check_x((0, 0), (0, 2))
-        self.check_x((0, 2, 2), (0, 2,))
         self.check_x((0, 2, 2), (0, 2, 3))
+        # Allowed since numpy 2
+        self.check_x((2, 3, 3), (3,))
+        self.check_x((2, 5, 3, 3), (3,))
 
     def check_shape(self, a_shape, b_shape, error_type):
         for xp in (numpy, cupy):
@@ -72,9 +72,13 @@ class TestSolve(unittest.TestCase):
         self.check_shape((3, 3), (2,), ValueError)
         self.check_shape((3, 3), (2, 2), ValueError)
         self.check_shape((3, 3, 4), (3,), numpy.linalg.LinAlgError)
-        self.check_shape((2, 3, 3), (3,), ValueError)
         self.check_shape((3, 3), (0,), ValueError)
         self.check_shape((0, 3, 4), (3,), numpy.linalg.LinAlgError)
+        self.check_shape((3, 3), (), ValueError)
+        # Not allowed since numpy 2
+        self.check_shape((0, 2, 2), (0, 2,), ValueError)
+        self.check_shape((2, 4, 4), (2, 4,), ValueError)
+        self.check_shape((2, 3, 2, 2), (2, 3, 2,), ValueError)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -41,7 +41,7 @@ class TestSolve(unittest.TestCase):
         cupy.testing.assert_array_equal(b_copy, b)
         return result
 
-    @testing.with_requires("numpy>=2")
+    @testing.with_requires("numpy>=2.0")
     def test_solve(self):
         self.check_x((4, 4), (4,))
         self.check_x((5, 5), (5, 2))
@@ -68,7 +68,7 @@ class TestSolve(unittest.TestCase):
         # LinAlgError("Singular matrix") is not raised
         return xp.linalg.solve(a, b)
 
-    @testing.with_requires("numpy>=2")
+    @testing.with_requires("numpy>=2.0")
     def test_invalid_shape(self):
         self.check_shape((2, 3), (4,), numpy.linalg.LinAlgError)
         self.check_shape((3, 3), (2,), ValueError)

--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -41,6 +41,7 @@ class TestSolve(unittest.TestCase):
         cupy.testing.assert_array_equal(b_copy, b)
         return result
 
+    @testing.with_requires("numpy>=2")
     def test_solve(self):
         self.check_x((4, 4), (4,))
         self.check_x((5, 5), (5, 2))
@@ -67,6 +68,7 @@ class TestSolve(unittest.TestCase):
         # LinAlgError("Singular matrix") is not raised
         return xp.linalg.solve(a, b)
 
+    @testing.with_requires("numpy>=2")
     def test_invalid_shape(self):
         self.check_shape((2, 3), (4,), numpy.linalg.LinAlgError)
         self.check_shape((3, 3), (2,), ValueError)


### PR DESCRIPTION
Related to #8306 .


### Description of changes

Now shape of `b` (right hand side) must be either `(M,)` or `(..., M, K)` rather than `(..., M)` or `(..., M, K)` (`numpy` v1).

See https://numpy.org/doc/stable/reference/generated/numpy.linalg.solve.html#numpy.linalg.solve for details.