### PR TITLE
Skip tests if `scipy` is not installed

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_max_len_seq.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_max_len_seq.py
@@ -10,7 +10,7 @@ import numpy as np
 try:
     import scipy.signal  # NOQA
 except ImportError:
-    pass
+    scipy = None
 
 
 @testing.with_requires('scipy')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
@@ -9,7 +9,7 @@ try:
     import scipy.signal  # NOQA
     import scipy.signal.windows  # NOQA
 except ImportError:
-    pass
+    scipy = None
 
 import numpy as np
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -11,7 +11,7 @@ import cupyx.scipy.signal  # NOQA
 try:
     import scipy.signal  # NOQA
 except ImportError:
-    pass
+    scipy = None
 
 
 @pytest.mark.xfail(

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
@@ -11,6 +11,7 @@ except ImportError:
     pass
 
 
+@testing.with_requires("scipy")
 class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_qmf(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
@@ -12,7 +12,7 @@ try:
     import scipy.signal.windows as cpu_windows  # NOQA
     import scipy.fft  # NOQA
 except ImportError:
-    pass
+    cpu_windows = None
 
 
 window_funcs = [
@@ -39,6 +39,7 @@ window_funcs = [
 ]
 
 
+@testing.with_requires("scipy")
 class TestBartHann:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15, atol=1e-15)
     def test_basic(self, xp, scp):
@@ -48,6 +49,7 @@ class TestBartHann:
         return w1, w2, w3
 
 
+@testing.with_requires("scipy")
 class TestBartlett:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15, atol=1e-15)
     def test_basic(self, xp, scp):
@@ -57,6 +59,7 @@ class TestBartlett:
         return w1, w2, w3
 
 
+@testing.with_requires("scipy")
 class TestBlackman:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15, atol=1e-15)
     def test_basic(self, xp, scp):
@@ -66,6 +69,7 @@ class TestBlackman:
                 scp.signal.windows.blackman(7, True))
 
 
+@testing.with_requires("scipy")
 class TestBlackmanHarris:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15, atol=1e-15)
     def test_basic(self, xp, scp):
@@ -75,6 +79,7 @@ class TestBlackmanHarris:
                 scp.signal.windows.blackmanharris(7, sym=True))
 
 
+@testing.with_requires("scipy")
 class TestTaylor:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-15, atol=1e-15)
     def test_normalized(self, xp, scp):
@@ -131,6 +136,7 @@ class TestTaylor:
         return PSLL, BW_3dB, BW_18dB
 
 
+@testing.with_requires("scipy")
 class TestBohman:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -139,6 +145,7 @@ class TestBohman:
                 scp.signal.windows.bohman(6, False))
 
 
+@testing.with_requires("scipy")
 class TestBoxcar:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -147,6 +154,7 @@ class TestBoxcar:
                 scp.signal.windows.boxcar(6, False))
 
 
+@testing.with_requires("scipy")
 class TestChebWin:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -204,6 +212,7 @@ exponential_data = {
 }
 
 
+@testing.with_requires("scipy")
 @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
 def test_exponential(xp, scp):
     for args, valid in exponential_data.items():
@@ -214,6 +223,7 @@ def test_exponential(xp, scp):
             return win
 
 
+@testing.with_requires("scipy")
 class TestFlatTop:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -223,6 +233,7 @@ class TestFlatTop:
                 scp.signal.windows.flattop(7, True),)
 
 
+@testing.with_requires("scipy")
 class TestGaussian:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -232,6 +243,7 @@ class TestGaussian:
                 scp.signal.windows.gaussian(6, 3, False),)
 
 
+@testing.with_requires("scipy")
 class TestGeneralCosine:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -240,6 +252,7 @@ class TestGeneralCosine:
                                                   sym=False),)
 
 
+@testing.with_requires("scipy")
 class TestGeneralHamming:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -248,6 +261,7 @@ class TestGeneralHamming:
                 scp.signal.windows.general_hamming(6, 0.75, sym=True),)
 
 
+@testing.with_requires("scipy")
 class TestHamming:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -257,6 +271,7 @@ class TestHamming:
                 scp.signal.windows.hamming(7, sym=True),)
 
 
+@testing.with_requires("scipy")
 class TestHann:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -266,6 +281,7 @@ class TestHann:
                 scp.signal.windows.hann(7),)
 
 
+@testing.with_requires("scipy")
 class TestKaiser:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -276,7 +292,7 @@ class TestKaiser:
                 scp.signal.windows.kaiser(6, 2.7, False),)
 
 
-@testing.with_requires('scipy >= 1.10')
+@testing.with_requires('scipy>=1.10')
 class TestKaiserBesselDerived:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -306,6 +322,7 @@ class TestKaiserBesselDerived:
         return 42
 
 
+@testing.with_requires("scipy")
 class TestNuttall:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -315,6 +332,7 @@ class TestNuttall:
                 scp.signal.windows.nuttall(7, True),)
 
 
+@testing.with_requires("scipy")
 class TestParzen:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -323,6 +341,7 @@ class TestParzen:
                 scp.signal.windows.parzen(6, False),)
 
 
+@testing.with_requires("scipy")
 class TestTriang:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -354,6 +373,7 @@ tukey_data = [
 ]
 
 
+@testing.with_requires("scipy")
 class TestTukey:
     @pytest.mark.parametrize('args', tukey_data)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
@@ -372,6 +392,7 @@ dpss_data = [
 
 
 @pytest.mark.skip('This has not been implemented yet in CuPy')
+@testing.with_requires("scipy")
 class TestDPSS:
     @pytest.mark.parametrize('args', tukey_data)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
@@ -417,7 +438,7 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
 
-@testing.with_requires("scipy >= 1.10")
+@testing.with_requires("scipy>=1.10")
 class TestLanczos:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -440,6 +461,7 @@ class TestLanczos:
             assert len(windows.lanczos(n, sym=True)) == n
 
 
+@testing.with_requires("scipy")
 class TestGetWindow:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_boxcar(self, xp, scp):
@@ -520,6 +542,7 @@ class TestGetWindow:
 
 
 @pytest.mark.parametrize('window_info', window_funcs)
+@testing.with_requires("scipy")
 @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
 def test_windowfunc_basics(window_info, xp, scp):
     window_name, params = window_info
@@ -568,6 +591,7 @@ def test_windowfunc_basics(window_info, xp, scp):
 
 
 @pytest.mark.parametrize('windows', [cu_windows, cpu_windows])
+@testing.with_requires("scipy")
 def test_needs_params(windows):
     for winstr in ['kaiser', 'ksr', 'kaiser_bessel_derived', 'kbd',
                    'gaussian', 'gauss', 'gss',
@@ -579,13 +603,14 @@ def test_needs_params(windows):
         assert_raises(ValueError, windows.get_window, winstr, 7)
 
 
-@testing.with_requires("scipy >= 1.10")
+@testing.with_requires("scipy>=1.10")
 @pytest.mark.parametrize('windows', [cu_windows, cpu_windows])
 def test_needs_params_2(windows):
     for winstr in ['kaiser_bessel_derived']:
         assert_raises(ValueError, windows.get_window, winstr, 7)
 
 
+@testing.with_requires("scipy")
 @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
 def test_not_needs_params(xp, scp):
     for winstr in ['barthann',

--- a/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
+++ b/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
@@ -3,9 +3,8 @@ import pytest
 import numpy
 try:
     import scipy
-    scipy_available = True
 except ImportError:
-    scipy_available = False
+    pass
 
 import cupy
 import cupyx.signal

--- a/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
+++ b/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
@@ -1,7 +1,11 @@
 import pytest
 
 import numpy
-import scipy
+try:
+    import scipy
+    scipy_available = True
+except ImportError:
+    scipy_available = False
 
 import cupy
 import cupyx.signal

--- a/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
+++ b/tests/cupyx_tests/signal_tests/filtering_tests/test_filtering.py
@@ -23,6 +23,7 @@ def linspace_data_gen(start, stop, n, endpoint=False, dtype=numpy.float64):
 @pytest.mark.parametrize('dtype', [cupy.float32, cupy.float64])
 @pytest.mark.parametrize("num_samps", [2**14, 2**18])
 @pytest.mark.parametrize("filter_len", [8, 32, 128])
+@testing.with_requires("scipy")
 def test_firfilter(dtype, num_samps, filter_len):
     cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
     cpu_filter, _ = scipy.signal.butter(filter_len, 0.5)
@@ -34,6 +35,7 @@ def test_firfilter(dtype, num_samps, filter_len):
 
 @pytest.mark.parametrize('dtype', [cupy.float32, cupy.float64])
 @pytest.mark.parametrize("filter_len", [8, 32, 128])
+@testing.with_requires("scipy")
 def test_firfilter_zi(dtype, filter_len):
     cpu_filter, _ = scipy.signal.butter(filter_len, 0.5)
     gpu_filter = cupy.asarray(cpu_filter, dtype=dtype)
@@ -48,6 +50,7 @@ def test_firfilter_zi(dtype, filter_len):
 @pytest.mark.parametrize("num_samps", [2**14, 2**18])
 @pytest.mark.parametrize("filter_len", [8, 32, 128])
 @pytest.mark.parametrize("padtype", ["odd", "even", "constant"])
+@testing.with_requires("scipy")
 def test_firfilter2(dtype, num_samps, filter_len, padtype):
     cpu_sig, gpu_sig = linspace_data_gen(0, 10, num_samps, endpoint=False)
     cpu_filter, _ = scipy.signal.butter(filter_len, 0.5)
@@ -147,11 +150,13 @@ def channelize_poly_cpu(x, h, n_chans):
 @pytest.mark.parametrize("num_samps", [2**12])
 @pytest.mark.parametrize("filt_samps", [2048])
 @pytest.mark.parametrize("n_chan", [64, 128, 256])
+@testing.with_requires("scipy")
 def test_channelize_poly(dtype, num_samps, filt_samps, n_chan):
     cpu_sig = testing.shaped_random((num_samps,), xp=numpy, dtype=dtype)
     gpu_sig = testing.shaped_random((num_samps,), xp=cupy, dtype=dtype)
     cpu_filt = testing.shaped_random((filt_samps,), xp=numpy, dtype=dtype)
     gpu_filt = testing.shaped_random((filt_samps,), xp=cupy, dtype=dtype)
+    # Use scipy inside channelize_poly_cpu
     cpu_output = channelize_poly_cpu(cpu_sig, cpu_filt, n_chan)
     gpu_output = cupyx.signal.channelize_poly(gpu_sig, gpu_filt, n_chan)
     testing.assert_allclose(gpu_output, cpu_output, atol=5e-3, rtol=5e-3)

--- a/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
+++ b/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
@@ -1,6 +1,10 @@
 import numpy
 import pytest
-import scipy
+try:
+    import scipy
+    scipy_available = True
+except ImportError:
+    scipy_available = False
 
 import cupy
 from cupy import testing

--- a/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
+++ b/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
@@ -56,6 +56,7 @@ tol = {
 @pytest.mark.parametrize('window', [None, 'hamming', numpy.negative])
 @testing.for_dtypes('fdFD')
 @testing.numpy_cupy_allclose(rtol=tol, contiguous_check=False)
+@testing.with_requires("scipy")
 def test_pulse_compression(xp, normalize, window, dtype):
     x = testing.shaped_random((8, 700), xp=xp, dtype=dtype)
     template = testing.shaped_random((100,), xp=xp, dtype=dtype)
@@ -64,12 +65,14 @@ def test_pulse_compression(xp, normalize, window, dtype):
         return signal.pulse_compression(x, template, normalize, window)
     else:
         assert xp is numpy
+        # May use scipy inside _numpy_pulse_compression
         return _numpy_pulse_compression(x, template, normalize, window)
 
 
 @pytest.mark.parametrize('window', [None, 'hamming', numpy.negative])
 @testing.for_dtypes('fdFD')
 @testing.numpy_cupy_allclose(rtol=tol, contiguous_check=False)
+@testing.with_requires("scipy")
 def test_pulse_doppler(xp, window, dtype):
     x = testing.shaped_random((8, 700), xp=xp, dtype=dtype)
 
@@ -77,6 +80,7 @@ def test_pulse_doppler(xp, window, dtype):
         return signal.pulse_doppler(x, window)
     else:
         assert xp is numpy
+        # May use scipy inside _numpy_pulse_doppler
         return _numpy_pulse_doppler(x, window)
 
 
@@ -93,6 +97,7 @@ def test_cfar_alpha(dtype):
     "size,gc,rc", [(100, 1, 5), (11, 2, 3), (100, 10, 20)])
 @testing.for_float_dtypes(no_float16=True)
 @testing.numpy_cupy_allclose(rtol=2e-6, type_check=False)
+@testing.with_requires("scipy")
 def test_ca_cfar1d(xp, dtype, size, gc, rc):
     array = testing.shaped_random((size,), xp=xp, dtype=dtype)
     if xp is cupy:
@@ -118,6 +123,7 @@ def test_ca_cfar1d_failures(size, gc, rc):
     "shape,gc,rc", [((10, 10), (1, 1), (2, 2)), ((10, 100), (1, 10), (2, 20))])
 @testing.for_float_dtypes(no_float16=True)
 @testing.numpy_cupy_allclose(rtol=2e-6, type_check=False)
+@testing.with_requires("scipy")
 def test_ca_cfar2d(xp, dtype, shape, gc, rc):
     array = testing.shaped_random(shape, xp=xp, dtype=dtype)
     if xp is cupy:

--- a/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
+++ b/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
@@ -2,9 +2,8 @@ import numpy
 import pytest
 try:
     import scipy
-    scipy_available = True
 except ImportError:
-    scipy_available = False
+    pass
 
 import cupy
 from cupy import testing


### PR DESCRIPTION
### Description of changes

- Use `try ... except ImportError ...` to detect `scipy` without crashing `pytest`
- Add `testing.with_requires("scipy")`