### PR TITLE
Accept `OverflowError` in `TestCopytoFromScalar` for NumPy v2

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -193,14 +193,14 @@ class TestBasic:
 class TestCopytoFromScalar:
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    @testing.numpy_cupy_allclose(accept_error=(TypeError, OverflowError))
     def test_copyto(self, xp, dtype):
         dst = xp.ones(self.dst_shape, dtype=dtype)
         xp.copyto(dst, self.src)
         return dst
 
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    @testing.numpy_cupy_allclose(accept_error=(TypeError, OverflowError))
     def test_copyto_where(self, xp, dtype):
         dst = xp.ones(self.dst_shape, dtype=dtype)
         mask = (testing.shaped_arange(


### PR DESCRIPTION
Related to #8306 .

Make tests aware of `OverflowError` raised when casting negative numbers to unsigned types.