### PR TITLE
Use `platform.machine()` instead of `platform.processor()`

### DIFF
--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -705,7 +705,7 @@ def get_cusparselt_version(formatted=False):
 def conda_get_target_name():
     out = None
     if PLATFORM_LINUX:
-        plat = platform.processor()
+        plat = platform.machine()
         if plat == "aarch64":
             out = "sbsa-linux"
         else:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -260,7 +260,7 @@ class TestFilter(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
-        if self.dtype == numpy.uint8 and platform.processor() == "aarch64":
+        if self.dtype == numpy.uint8 and platform.machine() == "aarch64":
             pytest.skip(
                 "aarch64 scipy does not match cupy/x86 see Scipy #20158")
         self._hip_skip_invalid_condition()

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -318,7 +318,7 @@ class TestFirls:
         # assert_raises(ValueError, firls, 11, [0.1, 0.2], [0, 0], [-1])
 
     @pytest.mark.xfail(
-        platform.processor() == "aarch64",
+        platform.machine() == "aarch64",
         reason="aarch64 scipy does not match cupy/x86 see Scipy #20160")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-12)
     def test_firls(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -574,7 +574,7 @@ class TestPlacePoles:
 
     @pytest.mark.xfail(
         sys.platform.startswith('win32')
-        or platform.processor() == "aarch64",
+        or platform.machine() == "aarch64",
         reason='passes locally, fails on windows CI, aarch64')
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_real_2(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -43,7 +43,7 @@ class TestPolygamma(unittest.TestCase):
             dtype(2.), dtype(1.5)).astype(numpy.float32)
 
     @pytest.mark.xfail(
-        platform.processor() == "aarch64",
+        platform.machine() == "aarch64",
         reason="aarch64 scipy does not match cupy/x86 see Scipy #20159")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')


### PR DESCRIPTION
See #8654. Follows-up #8655.
