### PR TITLE
Replace `numpy.ComplexWarning` with `cupy.exceptions.ComplexWarning`

### DIFF
--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -643,7 +643,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
                 and numpy.dtype(op.in_types[0]).kind == 'f'):
             warnings.warn(
                 'Casting complex values to real discards the imaginary part',
-                numpy.ComplexWarning)
+                cupy.exceptions.ComplexWarning)
             in_args[0] = in_args[0].real
 
         type_map = _kernel._TypeMap((

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -299,7 +299,7 @@ class TestJoin:
         return xp.hstack((a, b), dtype=dtype2)
 
     @testing.with_requires('numpy>=1.24.0')
-    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.filterwarnings('error::cupy.exceptions.ComplexWarning')
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',
@@ -342,7 +342,7 @@ class TestJoin:
         return xp.vstack((a, b), dtype=dtype2)
 
     @testing.with_requires('numpy>=1.24.0')
-    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.filterwarnings('error::cupy.exceptions.ComplexWarning')
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',
@@ -486,7 +486,7 @@ class TestJoin:
         return xp.stack((a, b), dtype=dtype2)
 
     @testing.with_requires('numpy>=1.24.0')
-    @pytest.mark.filterwarnings('error::numpy.ComplexWarning')
+    @pytest.mark.filterwarnings('error::cupy.exceptions.ComplexWarning')
     @pytest.mark.parametrize('casting', [
         'no',
         'equiv',


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306.