### PR TITLE
Fix sosfilt state output shape when ndim < 2

### DIFF
--- a/cupyx/scipy/signal/_iir_utils.py
+++ b/cupyx/scipy/signal/_iir_utils.py
@@ -727,7 +727,8 @@ def apply_iir_sos(x, sos, axis=-1, zi=None, dtype=None, block_sz=1024,
 
     if zi is not None:
         zi_out = zi_out.reshape(zi_shape)
-        zi_out = cupy.moveaxis(zi_out, -1, axis)
+        if len(zi_shape) > 2:
+            zi_out = cupy.moveaxis(zi_out, -1, axis)
         if not zi_out.flags.c_contiguous:
             zi_out = zi_out.copy()
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -814,6 +814,13 @@ class TestSosFilt:
         out, _ = scp.signal.sosfilt(sos, x, zi=zi)
         return out
 
+    def test_sosfilt_zi_sosfilt(self):
+        sos = cupyx.scipy.signal.butter(6, 0.2, output='sos')
+        zi = cupyx.scipy.signal.sosfilt_zi(sos)
+        _, zf = cupyx.scipy.signal.sosfilt(
+            sos, cupy.ones(40, dtype=cupy.float64), zi=zi)
+        testing.assert_allclose(zi, zf)
+
 
 @testing.with_requires('scipy')
 class TestDetrend:


### PR DESCRIPTION
See https://github.com/scipy/scipy/pull/21713#discussion_r1802139152

This PR ensures that `sosfilt` returns the stage state in the correct shape when the input is not 2-dimensional. This was causing compatibility issues when testing against SciPy