### PR TITLE
Fix NumPy 2.x CI failures

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -260,9 +260,9 @@ from cupy._manipulation.join import column_stack  # NOQA
 from cupy._manipulation.join import concatenate  # NOQA
 from cupy._manipulation.join import dstack  # NOQA
 from cupy._manipulation.join import hstack  # NOQA
+from cupy._manipulation.join import row_stack  # NOQA
 from cupy._manipulation.join import stack  # NOQA
 from cupy._manipulation.join import vstack  # NOQA
-from cupy._manipulation.join import vstack as row_stack  # NOQA
 
 # NumPy 2.0 alias
 concat = concatenate

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -1,5 +1,4 @@
 # distutils: language = c++
-import warnings
 import string
 
 import numpy
@@ -58,10 +57,8 @@ cdef tuple _ndarray_nonzero(_ndarray_base self):
     if ndim >= 1:
         return tuple([dst[:, i] for i in range(ndim)])
     else:
-        warnings.warn(
-            'calling nonzero on 0d arrays is deprecated',
-            DeprecationWarning)
-        return cupy.zeros(dst.shape[0], numpy.int64),
+        raise ValueError("Calling nonzero on 0d arrays is not allowed. "
+                         "Use cp.atleast_1d(scalar).nonzero() instead.")
 
 
 # TODO(kataoka): Rename the function because `_ndarray_base` does not have

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -134,8 +134,6 @@ cdef _ndarray_base _ndarray_cumprod(_ndarray_base self, axis, dtype, out):
 
 
 cdef _ndarray_base _ndarray_clip(_ndarray_base self, a_min, a_max, out):
-    if a_min is None and a_max is None:
-        raise ValueError('array_clip: must set either max or min')
     kind = self.dtype.kind
     if a_min is None:
         if kind == 'f':

--- a/cupy/_manipulation/join.py
+++ b/cupy/_manipulation/join.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cupy
 from cupy import _core
 
@@ -128,6 +130,16 @@ def vstack(tup, *, dtype=None, casting='same_kind'):
     """
     return concatenate([cupy.atleast_2d(m) for m in tup], 0,
                        dtype=dtype, casting=casting)
+
+
+def row_stack(tup, *, dtype=None, casting='same_kind'):
+    warnings.warn(
+        "`row_stack` alias is deprecated. "
+        "Use `cp.vstack` directly.",
+        DeprecationWarning,
+        stacklevel=1
+    )
+    return vstack(tup, dtype=dtype, casting=casting)
 
 
 def stack(tup, axis=0, out=None, *, dtype=None, casting='same_kind'):

--- a/cupy/_manipulation/rearrange.py
+++ b/cupy/_manipulation/rearrange.py
@@ -127,7 +127,7 @@ def roll(a, shift, axis=None):
                 '\'shift\' and \'axis\' should be scalars or 1D sequences')
         shifts = {ax: 0 for ax in range(a.ndim)}
         for sh, ax in broadcasted:
-            shifts[ax] += sh
+            shifts[ax] += int(sh)
 
         rolls = [((slice(None), slice(None)),)] * a.ndim
         for ax, offset in shifts.items():

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -503,6 +503,7 @@ class TestJoin:
         # may raise TypeError or ComplexWarning
         return xp.stack((a, b), dtype=dtype2, casting=casting)
 
+    @testing.with_requires("numpy>=2.0")
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')
     @testing.numpy_cupy_array_equal()
@@ -510,22 +511,23 @@ class TestJoin:
         a = testing.shaped_arange((4, 3), xp, dtype1)
         b = testing.shaped_arange((3,), xp, dtype2)
         c = testing.shaped_arange((2, 3), xp, dtype1)
-        return xp.row_stack((a, b, c))
+        with pytest.warns(DeprecationWarning):
+            return xp.row_stack((a, b, c))
 
     def test_row_stack_wrong_ndim1(self):
         a = cupy.zeros(())
         b = cupy.zeros((3,))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
             cupy.row_stack((a, b))
 
     def test_row_stack_wrong_ndim2(self):
         a = cupy.zeros((3, 2, 3))
         b = cupy.zeros((3, 2))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
             cupy.row_stack((a, b))
 
     def test_row_stack_wrong_shape(self):
         a = cupy.zeros((3, 2))
         b = cupy.zeros((4, 3))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
             cupy.row_stack((a, b))

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -45,12 +45,14 @@ class TestRoll(unittest.TestCase):
 
 class TestRollTypeError(unittest.TestCase):
 
+    @testing.with_requires("numpy>=2.1")
     def test_roll_invalid_shift_castable(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)
             # Weird but works due to `int` call
             xp.roll(x, '0', axis=0)
 
+    @testing.with_requires("numpy>=2.1")
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -45,14 +45,14 @@ class TestRoll(unittest.TestCase):
 
 class TestRollTypeError(unittest.TestCase):
 
-    @testing.with_requires("numpy>=2.1")
+    @testing.with_requires("numpy>=2.1.2")
     def test_roll_invalid_shift_castable(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)
             # Weird but works due to `int` call
             xp.roll(x, '0', axis=0)
 
-    @testing.with_requires("numpy>=2.1")
+    @testing.with_requires("numpy>=2.1.2")
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -45,11 +45,17 @@ class TestRoll(unittest.TestCase):
 
 class TestRollTypeError(unittest.TestCase):
 
+    def test_roll_invalid_shift_castable(self):
+        for xp in (numpy, cupy):
+            x = testing.shaped_arange((5, 2), xp)
+            # Weird but works due to `int` call
+            xp.roll(x, '0', axis=0)
+
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)
-            with pytest.raises(TypeError):
-                xp.roll(x, '0', axis=0)
+            with pytest.raises(ValueError):
+                xp.roll(x, 'a', axis=0)
 
     def test_roll_invalid_axis_type(self):
         for xp in (numpy, cupy):

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -107,12 +107,12 @@ class TestMisc:
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.clip(3, None)
 
+    @testing.with_requires("numpy>=2.0")
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
-    def test_clip_min_max_none(self, dtype):
-        for xp in (numpy, cupy):
-            a = testing.shaped_arange((2, 3, 4), xp, dtype)
-            with pytest.raises(ValueError):
-                a.clip(None, None)
+    @testing.numpy_cupy_array_equal()
+    def test_clip_min_max_none(self, xp, dtype):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.clip(None, None)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -171,9 +171,12 @@ class TestMisc:
         a = xp.array([2, 3, 4], dtype=dtype)
         return xp.fabs(a)
 
+    @testing.with_requires("numpy>=2.0")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_fabs_negative(self, xp, dtype):
+        if numpy.issubdtype(dtype, numpy.unsignedinteger):
+            pytest.skip("trying to set negative value to unsigned integer")
         a = xp.array([-2.0, -4.0, 0.0, 4.0], dtype=dtype)
         return xp.fabs(a)
 

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -109,7 +109,7 @@ class TestRandint2(unittest.TestCase):
 
 class TestRandintDtype(unittest.TestCase):
 
-    @pytest.mark.xfail(reason="XXX: np2.0: comparisons broken in numpy 1.26")
+    @testing.with_requires("numpy>=2.0")
     @testing.for_dtypes([
         numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.int32])
     def test_dtype(self, dtype):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -369,12 +369,18 @@ class TestNonzero:
 @testing.with_requires('numpy>=1.17.0')
 class TestNonzeroZeroDimension:
 
+    @testing.with_requires("numpy>=2.1")
+    @testing.for_all_dtypes()
+    def test_nonzero(self, dtype):
+        array = cupy.array(self.array, dtype=dtype)
+        with pytest.raises(ValueError):
+            cupy.nonzero(array)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_nonzero(self, xp, dtype):
+    def test_nonzero_explicit(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
-        with testing.assert_warns(DeprecationWarning):
-            return xp.nonzero(array)
+        return xp.nonzero(xp.atleast_1d(array))
 
 
 @testing.parameterize(


### PR DESCRIPTION
Related to #8565 .

This PR partly fixes https://ci.preferred.jp/cupy.linux.cuda126/176161/ .

### Fixed

- `cupy_tests/manipulation_tests/test_join.py::TestJoin::test_row_stack`
- `cupy_tests/manipulation_tests/test_rearrange.py::TestRollTypeError::test_roll_invalid_shift`
- `cupy_tests/math_tests/test_misc.py::TestMisc::test_clip_min_max_none`
- `cupy_tests/math_tests/test_misc.py::TestMisc::test_fabs_negative`
- `cupy_tests/random_tests/test_sample.py::TestRandintDtype::test_dtype`
- `cupy_tests/sorting_tests/test_search.py::TestNonzeroZeroDimension::test_nonzero` (x2)	