### PR TITLE
Use `functools.cache` and `pytest.warns`

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1,3 +1,4 @@
+import functools
 import string
 import warnings
 
@@ -501,14 +502,14 @@ cdef class ParameterInfo:
             ]))
 
 
-@_util.memoize()
+@functools.cache
 def _get_param_info(str s, is_const):
     if len(s) == 0:
         return ()
     return tuple([ParameterInfo(i, is_const) for i in s.strip().split(',')])
 
 
-@_util.memoize()
+@functools.cache
 def _decide_params_type(in_params, out_params, in_args_dtype, out_args_dtype):
     return _decide_params_type_core(in_params, out_params, in_args_dtype,
                                     out_args_dtype)
@@ -689,7 +690,7 @@ cdef list _get_out_args_with_params(
     return out_args
 
 
-@_util.memoize()
+@functools.cache
 def _get_elementwise_kernel_code(
         tuple arginfos, _TypeMap type_map,
         tuple params, str operation, str name,

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -1,3 +1,5 @@
+import functools
+
 from cpython cimport sequence
 
 from cupy._core cimport _carray
@@ -687,7 +689,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             self._input_expr, self._output_expr, self.preamble, ())
 
 
-@_util.memoize()
+@functools.cache
 def _SimpleReductionKernel_get_cached_function_code(
         map_expr, reduce_expr, post_map_expr, reduce_type,
         params, arginfos, _kernel._TypeMap type_map,
@@ -880,7 +882,7 @@ cdef class ReductionKernel(_AbstractReductionKernel):
             self.preamble, self.options)
 
 
-@_util.memoize()
+@functools.cache
 def _ReductionKernel_get_cached_function_code(
         nin, nout, params, arginfos, _kernel._TypeMap type_map,
         name, block_size, reduce_type, identity, map_expr, reduce_expr,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import hashlib
 import math
 import os
@@ -91,7 +92,7 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
         raise OSError(msg.format(backend))
 
 
-@_util.memoize()
+@functools.cache
 def _get_extra_path_for_msvc():
     cl_exe = shutil.which('cl.exe')
     if cl_exe:
@@ -159,7 +160,7 @@ def _get_nvrtc_version():
 _tegra_archs = ('32', '53', '62', '72', '87')
 
 
-@_util.memoize()
+@functools.cache
 def _get_max_compute_capability():
     major, minor = _get_nvrtc_version()
     if major < 11:
@@ -179,7 +180,7 @@ def _get_max_compute_capability():
     return nvrtc_max_compute_capability
 
 
-@_util.memoize()
+@functools.cache
 def _get_extra_include_dir_opts():
     major, minor = _get_nvrtc_version()
     return tuple(

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -1,11 +1,11 @@
 # distutils: language = c++
 
+import functools
 import threading
 
 from cupy._core import syncdetect
 from cupy_backends.cuda.api cimport runtime
 from cupy_backends.cuda.api import runtime as runtime_module
-from cupy import _util
 
 
 cdef object _thread_local = threading.local()
@@ -102,7 +102,7 @@ cdef bint _enable_peer_access(int device, int peer) except -1:
     return True
 
 
-@_util.memoize()
+@functools.cache
 def _get_attributes(device_id):
     """Return a dict containing all device attributes."""
     d = {}

--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -12,7 +12,7 @@ _reduce = functools.reduce
 _prod = cupy._core.internal.prod
 
 
-@cupy._util.memoize()
+@functools.cache
 def _output_dtype(dtype, value_type):
     if value_type != 'R2C':
         if dtype in [np.float16, np.float32]:

--- a/cupy/linalg/_einsum_cutn.py
+++ b/cupy/linalg/_einsum_cutn.py
@@ -1,3 +1,4 @@
+import functools
 import threading
 import warnings
 
@@ -8,7 +9,6 @@ except ImportError:
     cuquantum = cutensornet = None
 
 import cupy
-from cupy import _util
 from cupy._core import _accelerator
 from cupy.cuda.device import Handle
 
@@ -16,7 +16,7 @@ from cupy.cuda.device import Handle
 _tls = threading.local()
 
 
-@_util.memoize()
+@functools.cache
 def _is_cuqnt_22_11_or_higher():
     ver = [int(i) for i in cuquantum.__version__.split('.')]
     if (ver[0] > 22) or (ver[0] == 22 and ver[1] >= 11):

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -163,7 +163,7 @@ def _get_avail_version_from_spec(x):
     return x
 
 
-@_util.memoize()
+@_functools.cache
 def check_availability(name):
     if not _runtime.is_hip:
         available_version = _available_cusparse_version

--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -1,3 +1,5 @@
+import functools
+
 import numpy
 
 import cupy
@@ -1171,7 +1173,7 @@ __device__ void sort(X *array, int size) {{
 }}'''
 
 
-@cupy._util.memoize()
+@functools.cache
 def _get_shell_gap(filter_size):
     gap = 1
     while gap < filter_size:

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -35,7 +35,7 @@ class TestProdSequence(unittest.TestCase):
 class TestGetSize:
 
     def test_none(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             assert internal.get_size(None) == ()
 
     def check_collection(self, a):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -26,7 +26,7 @@ def wrap_take(array, *args, **kwargs):
 class TestNdarrayInit(unittest.TestCase):
 
     def test_shape_none(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             a = cupy.ndarray(None)
         assert a.shape == ()
 

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -10,7 +10,7 @@ from cupy import _util
 def astype_without_warning(x, dtype, *args, **kwargs):
     dtype = numpy.dtype(dtype)
     if x.dtype.kind == 'c' and dtype.kind not in ['b', 'c']:
-        with testing.assert_warns(ComplexWarning):
+        with pytest.warns(ComplexWarning):
             return x.astype(dtype, *args, **kwargs)
     else:
         return x.astype(dtype, *args, **kwargs)

--- a/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_unary_op.py
@@ -12,7 +12,7 @@ class TestArrayBoolOp(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_bool_empty(self, dtype):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             assert not bool(cupy.array((), dtype=dtype))
 
     def test_bool_scalar_bool(self):

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -47,7 +47,7 @@ class TestBasic:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_empty_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             a = xp.empty(None, dtype=dtype, order=order)
         a.fill(0)
         return a
@@ -201,7 +201,7 @@ class TestBasic:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_zeros_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             return xp.zeros(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -535,7 +535,7 @@ class TestSingleDeviceMemoryPool(unittest.TestCase):
         p1 = self.pool.malloc(self.unit * 4)
         ptr1 = p1.ptr
         del p1
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             self.pool.free_all_free()
         p2 = self.pool.malloc(self.unit * 4)
         assert ptr1 != p2.ptr
@@ -731,14 +731,14 @@ class TestMemoryPool(unittest.TestCase):
             assert self.pool.n_free_blocks() == 0
             mem.free()
             assert self.pool.n_free_blocks() == 1
-            with testing.assert_warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning):
                 self.pool.free_all_free()
             assert self.pool.n_free_blocks() == 0
 
     def test_free_all_free_without_malloc(self):
         with cupy.cuda.Device():
             # call directly without malloc.
-            with testing.assert_warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning):
                 self.pool.free_all_free()
             assert self.pool.n_free_blocks() == 0
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -373,7 +373,7 @@ class TestNonzeroZeroDimension:
     @testing.numpy_cupy_array_equal()
     def test_nonzero(self, xp, dtype):
         array = xp.array(self.array, dtype=dtype)
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             return xp.nonzero(array)
 
 

--- a/tests/cupy_tests/statistics_tests/test_correlation.py
+++ b/tests/cupy_tests/statistics_tests/test_correlation.py
@@ -72,7 +72,7 @@ class TestCov(unittest.TestCase):
     def check_warns(self, a_shape, y_shape=None, rowvar=True, bias=False,
                     ddof=None, xp=None, dtype=None,
                     fweights=None, aweights=None):
-        with testing.assert_warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning):
             a, y = self.generate_input(a_shape, y_shape, xp, dtype)
             return xp.cov(a, y, rowvar, bias, ddof,
                           fweights, aweights, dtype=dtype)

--- a/tests/cupy_tests/testing_tests/test_loops.py
+++ b/tests/cupy_tests/testing_tests/test_loops.py
@@ -51,7 +51,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
     }
 
     def test_both_success(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_both_success(self, xp):
                 pass
@@ -60,7 +60,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_both_success(self)
 
     def test_cupy_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_cupy_error(self, xp):
                 if xp is cupy:
@@ -70,7 +70,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_cupy_error(self)
 
     def test_numpy_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_numpy_error(self, xp):
                 if xp is numpy:
@@ -80,7 +80,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_numpy_error(self)
 
     def test_cupy_numpy_different_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_cupy_numpy_different_error(self, xp):
                 if xp is cupy:
@@ -95,7 +95,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_cupy_numpy_different_error(self)
 
     def test_cupy_derived_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_cupy_derived_error(self, xp):
                 if xp is cupy:
@@ -106,7 +106,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         dummy_cupy_derived_error(self)  # Assert no exceptions
 
     def test_numpy_derived_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_numpy_derived_error(self, xp):
                 if xp is cupy:
@@ -122,7 +122,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_numpy_derived_error(self)
 
     def test_same_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises(accept_error=Exception)
             def dummy_same_error(self, xp):
                 raise Exception(self.tbs.get(xp))
@@ -130,7 +130,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
         dummy_same_error(self)
 
     def test_cupy_derived_unaccept_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises(accept_error=ValueError)
             def dummy_cupy_derived_unaccept_error(self, xp):
                 if xp is cupy:
@@ -146,7 +146,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_cupy_derived_unaccept_error(self)
 
     def test_numpy_derived_unaccept_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises(accept_error=ValueError)
             def dummy_numpy_derived_unaccept_error(self, xp):
                 if xp is cupy:
@@ -162,7 +162,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_numpy_derived_unaccept_error(self)
 
     def test_forbidden_error(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises(accept_error=False)
             def dummy_forbidden_error(self, xp):
                 raise Exception(self.tbs.get(xp))
@@ -173,7 +173,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_forbidden_error(self)
 
     def test_axis_error_different_type(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_axis_error(self, xp):
                 if xp is cupy:
@@ -187,7 +187,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_axis_error(self)
 
     def test_axis_error_value_different_type(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_axis_error(self, xp):
                 if xp is cupy:
@@ -201,7 +201,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_axis_error(self)
 
     def test_axis_error_index_different_type(self):
-        with testing.assert_warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             @testing.numpy_cupy_raises()
             def dummy_axis_error(self, xp):
                 if xp is cupy:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2027,7 +2027,7 @@ class TestCsrMatrixComparison:
     @contextlib.contextmanager
     def _assert_warns_efficiency(self, sp, scalar_rhs=None):
         if scalar_rhs is None and self._compare(0, 0):
-            with testing.assert_warns(sp.SparseEfficiencyWarning):
+            with pytest.warns(sp.SparseEfficiencyWarning):
                 yield
         elif scalar_rhs is not None and self._compare(0, scalar_rhs):
             if sp is sparse:  # cupy
@@ -2036,7 +2036,7 @@ class TestCsrMatrixComparison:
                 with self._ignore_efficiency_warning():
                     yield
             else:  # scipy
-                with testing.assert_warns(sp.SparseEfficiencyWarning):
+                with pytest.warns(sp.SparseEfficiencyWarning):
                     yield
         else:
             yield

--- a/tests/cupyx_tests/test_optimize.py
+++ b/tests/cupyx_tests/test_optimize.py
@@ -135,7 +135,7 @@ class TestOptimize(unittest.TestCase):
             filepath = directory + '/optimize_params'
 
             # non-existing file, readonly=True
-            with testing.assert_warns(UserWarning):
+            with pytest.warns(UserWarning):
                 with cupyx.optimizing.optimize(path=filepath, readonly=True):
                     cupy.sum(cupy.arange(2))
 


### PR DESCRIPTION
Closes #8691 .


### Changes

- Replace `_util.memoize()` (no per-device cache option) with `functools.cache`
  - This resolves circular import between `_util.pyx` and `device.pyx` 
- Replace `testing.assert_warns` with `pytest.warns`