### PR TITLE
[v13] Backport the changes introduced in #8690

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -503,6 +503,7 @@ class TestJoin:
         # may raise TypeError or ComplexWarning
         return xp.stack((a, b), dtype=dtype2, casting=casting)
 
+    @testing.with_requires("numpy<2.0")
     @testing.for_all_dtypes(name='dtype1')
     @testing.for_all_dtypes(name='dtype2')
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_rearrange.py
+++ b/tests/cupy_tests/manipulation_tests/test_rearrange.py
@@ -45,6 +45,7 @@ class TestRoll(unittest.TestCase):
 
 class TestRollTypeError(unittest.TestCase):
 
+    @testing.with_requires("numpy<2.0")
     def test_roll_invalid_shift(self):
         for xp in (numpy, cupy):
             x = testing.shaped_arange((5, 2), xp)

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -107,6 +107,7 @@ class TestMisc:
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return a.clip(3, None)
 
+    @testing.with_requires("numpy<2.0")
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     def test_clip_min_max_none(self, dtype):
         for xp in (numpy, cupy):
@@ -171,6 +172,7 @@ class TestMisc:
         a = xp.array([2, 3, 4], dtype=dtype)
         return xp.fabs(a)
 
+    @testing.with_requires("numpy<2.0")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_fabs_negative(self, xp, dtype):

--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -109,6 +109,7 @@ class TestRandint2(unittest.TestCase):
 
 class TestRandintDtype(unittest.TestCase):
 
+    @testing.with_requires("numpy<2.0")
     @testing.for_dtypes([
         numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.int32])
     def test_dtype(self, dtype):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -366,7 +366,7 @@ class TestNonzero:
     {'array': numpy.array(0)},
     {'array': numpy.array(1)},
 )
-@testing.with_requires('numpy>=1.17.0')
+@testing.with_requires('numpy>=1.17.0,<2.0')
 class TestNonzeroZeroDimension:
 
     @testing.for_all_dtypes()


### PR DESCRIPTION
This PR adds `testing.with_requires("numpy<2.0")` to ensure that v13 branch passes the test even without the changes made in #8690 .