### PR TITLE
Fix some NumPy 2.x CI failures (cont.)

### DIFF
--- a/cupy/_math/rounding.py
+++ b/cupy/_math/rounding.py
@@ -46,39 +46,110 @@ rint = ufunc.create_math_ufunc(
     ''')
 
 
-floor = ufunc.create_math_ufunc(
-    'floor', 1, 'cupy_floor',
-    '''Rounds each element of an array to its floor integer.
+floor = _core.create_ufunc(
+    "cupy_floor",
+    (
+        "?->?",
+        "b->b",
+        "B->B",
+        "h->h",
+        "H->H",
+        "i->i",
+        "I->I",
+        "l->l",
+        "L->L",
+        "q->q",
+        "Q->Q",
+        ("e->e", "out0 = floorf(in0)"),
+        ("f->f", "out0 = floorf(in0)"),
+        ("d->d", "out0 = floor(in0)"),
+    ),
+    "out0 = in0",
+    doc="""Rounds each element of an array to its floor integer.
 
-    .. seealso:: :data:`numpy.floor`
+        .. seealso:: :data:`numpy.floor`
 
-    ''', support_complex=False)
-
-
-ceil = ufunc.create_math_ufunc(
-    'ceil', 1, 'cupy_ceil',
-    '''Rounds each element of an array to its ceiling integer.
-
-    .. seealso:: :data:`numpy.ceil`
-
-    ''', support_complex=False)
+        """,
+)
 
 
-trunc = ufunc.create_math_ufunc(
-    'trunc', 1, 'cupy_trunc',
-    '''Rounds each element of an array towards zero.
+ceil = _core.create_ufunc(
+    "cupy_ceil",
+    (
+        "?->?",
+        "b->b",
+        "B->B",
+        "h->h",
+        "H->H",
+        "i->i",
+        "I->I",
+        "l->l",
+        "L->L",
+        "q->q",
+        "Q->Q",
+        ("e->e", "out0 = ceilf(in0)"),
+        ("f->f", "out0 = ceilf(in0)"),
+        ("d->d", "out0 = ceil(in0)"),
+    ),
+    "out0 = in0",
+    doc="""Rounds each element of an array to its ceiling integer.
+
+        .. seealso:: :data:`numpy.ceil`
+
+        """,
+)
+
+
+trunc = _core.create_ufunc(
+    "cupy_trunc",
+    (
+        "?->?",
+        "b->b",
+        "B->B",
+        "h->h",
+        "H->H",
+        "i->i",
+        "I->I",
+        "l->l",
+        "L->L",
+        "q->q",
+        "Q->Q",
+        ("e->e", "out0 = truncf(in0)"),
+        ("f->f", "out0 = truncf(in0)"),
+        ("d->d", "out0 = trunc(in0)"),
+    ),
+    "out0 = in0",
+    doc="""Rounds each element of an array towards zero.
 
     .. seealso:: :data:`numpy.trunc`
 
-    ''', support_complex=False)
+    """,
+)
 
 
 fix = _core.create_ufunc(
-    'cupy_fix', ('e->e', 'f->f', 'd->d'),
-    'out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)',
-    doc='''If given value x is positive, it return floor(x).
+    "cupy_fix",
+    (
+        "?->?",
+        "b->b",
+        "B->B",
+        "h->h",
+        "H->H",
+        "i->i",
+        "I->I",
+        "l->l",
+        "L->L",
+        "q->q",
+        "Q->Q",
+        ("e->e", "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)"),
+        ("f->f", "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)"),
+        ("d->d", "out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)"),
+    ),
+    "out0 = in0",
+    doc="""If given value x is positive, it return floor(x).
     Else, it return ceil(x).
 
     .. seealso:: :func:`numpy.fix`
 
-    ''')
+    """
+)

--- a/cupy/_math/rounding.py
+++ b/cupy/_math/rounding.py
@@ -46,80 +46,59 @@ rint = ufunc.create_math_ufunc(
     ''')
 
 
-floor = _core.create_ufunc(
+def create_rounding_ufunc(name, opf, op, doc):
+    return _core.create_ufunc(
+        name,
+        (
+            "?->?",
+            "b->b",
+            "B->B",
+            "h->h",
+            "H->H",
+            "i->i",
+            "I->I",
+            "l->l",
+            "L->L",
+            "q->q",
+            "Q->Q",
+            ("e->e", opf),
+            ("f->f", opf),
+            ("d->d", op),
+        ),
+        "out0 = in0",
+        doc=doc,
+    )
+
+
+floor = create_rounding_ufunc(
     "cupy_floor",
-    (
-        "?->?",
-        "b->b",
-        "B->B",
-        "h->h",
-        "H->H",
-        "i->i",
-        "I->I",
-        "l->l",
-        "L->L",
-        "q->q",
-        "Q->Q",
-        ("e->e", "out0 = floorf(in0)"),
-        ("f->f", "out0 = floorf(in0)"),
-        ("d->d", "out0 = floor(in0)"),
-    ),
-    "out0 = in0",
-    doc="""Rounds each element of an array to its floor integer.
+    "out0 = floorf(in0)",
+    "out0 = floor(in0)",
+    """Rounds each element of an array to its floor integer.
 
-        .. seealso:: :data:`numpy.floor`
+    .. seealso:: :data:`numpy.floor`
 
-        """,
+    """,
 )
 
 
-ceil = _core.create_ufunc(
+ceil = create_rounding_ufunc(
     "cupy_ceil",
-    (
-        "?->?",
-        "b->b",
-        "B->B",
-        "h->h",
-        "H->H",
-        "i->i",
-        "I->I",
-        "l->l",
-        "L->L",
-        "q->q",
-        "Q->Q",
-        ("e->e", "out0 = ceilf(in0)"),
-        ("f->f", "out0 = ceilf(in0)"),
-        ("d->d", "out0 = ceil(in0)"),
-    ),
-    "out0 = in0",
-    doc="""Rounds each element of an array to its ceiling integer.
+    "out0 = ceilf(in0)",
+    "out0 = ceil(in0)",
+    """Rounds each element of an array to its ceiling integer.
 
-        .. seealso:: :data:`numpy.ceil`
+    .. seealso:: :data:`numpy.ceil`
 
-        """,
+    """,
 )
 
 
-trunc = _core.create_ufunc(
+trunc = create_rounding_ufunc(
     "cupy_trunc",
-    (
-        "?->?",
-        "b->b",
-        "B->B",
-        "h->h",
-        "H->H",
-        "i->i",
-        "I->I",
-        "l->l",
-        "L->L",
-        "q->q",
-        "Q->Q",
-        ("e->e", "out0 = truncf(in0)"),
-        ("f->f", "out0 = truncf(in0)"),
-        ("d->d", "out0 = trunc(in0)"),
-    ),
-    "out0 = in0",
-    doc="""Rounds each element of an array towards zero.
+    "out0 = truncf(in0)",
+    "out0 = trunc(in0)",
+    """Rounds each element of an array towards zero.
 
     .. seealso:: :data:`numpy.trunc`
 
@@ -127,29 +106,14 @@ trunc = _core.create_ufunc(
 )
 
 
-fix = _core.create_ufunc(
+fix = create_rounding_ufunc(
     "cupy_fix",
-    (
-        "?->?",
-        "b->b",
-        "B->B",
-        "h->h",
-        "H->H",
-        "i->i",
-        "I->I",
-        "l->l",
-        "L->L",
-        "q->q",
-        "Q->Q",
-        ("e->e", "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)"),
-        ("f->f", "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)"),
-        ("d->d", "out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)"),
-    ),
-    "out0 = in0",
-    doc="""If given value x is positive, it return floor(x).
+    "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)",
+    "out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)",
+    """If given value x is positive, it return floor(x).
     Else, it return ceil(x).
 
     .. seealso:: :func:`numpy.fix`
 
-    """
+    """,
 )

--- a/cupy/_math/rounding.py
+++ b/cupy/_math/rounding.py
@@ -46,7 +46,7 @@ rint = ufunc.create_math_ufunc(
     ''')
 
 
-def create_rounding_ufunc(name, opf, op, doc):
+def create_rounding_ufunc(name, op, doc):
     return _core.create_ufunc(
         name,
         (
@@ -61,8 +61,8 @@ def create_rounding_ufunc(name, opf, op, doc):
             "L->L",
             "q->q",
             "Q->Q",
-            ("e->e", opf),
-            ("f->f", opf),
+            ("e->e", op),
+            ("f->f", op),
             ("d->d", op),
         ),
         "out0 = in0",
@@ -72,7 +72,6 @@ def create_rounding_ufunc(name, opf, op, doc):
 
 floor = create_rounding_ufunc(
     "cupy_floor",
-    "out0 = floorf(in0)",
     "out0 = floor(in0)",
     """Rounds each element of an array to its floor integer.
 
@@ -84,7 +83,6 @@ floor = create_rounding_ufunc(
 
 ceil = create_rounding_ufunc(
     "cupy_ceil",
-    "out0 = ceilf(in0)",
     "out0 = ceil(in0)",
     """Rounds each element of an array to its ceiling integer.
 
@@ -96,7 +94,6 @@ ceil = create_rounding_ufunc(
 
 trunc = create_rounding_ufunc(
     "cupy_trunc",
-    "out0 = truncf(in0)",
     "out0 = trunc(in0)",
     """Rounds each element of an array towards zero.
 
@@ -108,7 +105,6 @@ trunc = create_rounding_ufunc(
 
 fix = create_rounding_ufunc(
     "cupy_fix",
-    "out0 = (in0 >= 0.0) ? floorf(in0): ceilf(in0)",
     "out0 = (in0 >= 0.0) ? floor(in0): ceil(in0)",
     """If given value x is positive, it return floor(x).
     Else, it return ceil(x).

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -687,10 +687,10 @@ class RandomState(object):
                     'mx must be non-negative (actual: {})'.format(mx))
             elif mx <= _UINT32_MAX:
                 dtype = numpy.uint32
-                upper_limit = _UINT32_MAX - (1 << 32) % (mx + 1)
+                upper_limit = dtype(_UINT32_MAX - (1 << 32) % (mx + 1))
             elif mx <= _UINT64_MAX:
                 dtype = numpy.uint64
-                upper_limit = _UINT64_MAX - (1 << 64) % (mx + 1)
+                upper_limit = dtype(_UINT64_MAX - (1 << 64) % (mx + 1))
             else:
                 raise ValueError(
                     'mx must be within uint64 range (actual: {})'.format(mx))

--- a/tests/cupy_tests/math_tests/test_rounding.py
+++ b/tests/cupy_tests/math_tests/test_rounding.py
@@ -48,18 +48,22 @@ class TestRounding(unittest.TestCase):
         self.check_unary_negative('rint')
         self.check_unary_negative_complex('rint')
 
+    @testing.with_requires("numpy>=2.1")
     def test_floor(self):
         self.check_unary('floor')
         self.check_unary_complex_unsupported('floor')
 
+    @testing.with_requires("numpy>=2.1")
     def test_ceil(self):
         self.check_unary('ceil')
         self.check_unary_complex_unsupported('ceil')
 
+    @testing.with_requires("numpy>=2.1")
     def test_trunc(self):
         self.check_unary('trunc')
         self.check_unary_complex_unsupported('trunc')
 
+    @testing.with_requires("numpy>=2.1")
     def test_fix(self):
         self.check_unary('fix')
         self.check_unary_complex_unsupported('fix')

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -970,7 +970,6 @@ class TestRandint(RandomGeneratorTestCase):
         self.generate(6.7, size=(2, 3))
 
     def test_randint_int64_1(self):
-        # FIXME: May have subtle bug in function signature determination
         self.generate(2**34, 2**40, 3, dtype='q')
 
     def test_randint_array(self):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -969,10 +969,7 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_float2(self):
         self.generate(6.7, size=(2, 3))
 
-    @pytest.mark.xfail(numpy.__version__ < "2",
-                       reason='XXX: np 2.0: comparisons with OOB '
-                              'ints are broken in numpy < 2'
-                       )
+    @pytest.mark.xfail(reason="cupy does not support comparison with OOB ints")
     def test_randint_int64_1(self):
         self.generate(2**34, 2**40, 3, dtype='q')
 

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -969,8 +969,8 @@ class TestRandint(RandomGeneratorTestCase):
     def test_randint_float2(self):
         self.generate(6.7, size=(2, 3))
 
-    @pytest.mark.xfail(reason="cupy does not support comparison with OOB ints")
     def test_randint_int64_1(self):
+        # FIXME: May have subtle bug in function signature determination
         self.generate(2**34, 2**40, 3, dtype='q')
 
     def test_randint_array(self):

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -217,7 +217,12 @@ class TestMeanVar:
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_mean_all_float64_dtype(self, xp, dtype):
-        a = xp.full((2, 3, 4), 123456789, dtype=dtype)
+        fillvalue = 123456789
+        try:
+            dtype(fillvalue)
+        except OverflowError:
+            pytest.skip("fillvalue is out of range.")
+        a = xp.full((2, 3, 4), fillvalue, dtype=dtype)
         return xp.mean(a, dtype=numpy.float64)
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -217,12 +217,7 @@ class TestMeanVar:
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose()
     def test_mean_all_float64_dtype(self, xp, dtype):
-        fillvalue = 123456789
-        try:
-            dtype(fillvalue)
-        except OverflowError:
-            pytest.skip("fillvalue is out of range.")
-        a = xp.full((2, 3, 4), fillvalue, dtype=dtype)
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.mean(a, dtype=numpy.float64)
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupy_tests/testing_tests/test_helper.py
+++ b/tests/cupy_tests/testing_tests/test_helper.py
@@ -12,19 +12,19 @@ class TestPackageRequirements:
     def test_installed(self):
         assert testing.installed('cupy')
         assert testing.installed('cupy>9', 'numpy>=1.12')
-        assert testing.installed('numpy>=1.10,<=2.0')
-        assert not testing.installed('numpy>=2.0')
+        assert testing.installed('numpy>=1.10,<=3.0')
+        assert not testing.installed('numpy>=3.0')
         assert not testing.installed('numpy>1.10,<1.9')
         # This is a dummy package name that is unlikely to be installed
         assert not testing.installed('supercalifragilisticexpialidocious')
 
     def test_numpy_satisfies(self):
         assert testing.numpy_satisfies('>1.10')
-        assert not testing.numpy_satisfies('>=2.10')
+        assert not testing.numpy_satisfies('>=3.0')
 
-    @testing.with_requires('numpy>2.0')
+    @testing.with_requires('numpy>3.0')
     def test_with_requires(self):
-        assert False, 'this should not happen'
+        pytest.fail("this should not happen")
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Related to #8565 and #8690 .

This PR also partly fixes https://ci.preferred.jp/cupy.linux.cuda126/176161/ .

### Fixed

- `cupy_tests/statistics_tests/test_meanvar.py::TestMeanVar::test_mean_all_float64_dtype`
- `cupy_tests/testing_tests/test_helper.py::TestPackageRequirements::test_installed`
- `cupy_tests/testing_tests/test_helper.py::TestPackageRequirements::test_with_requires`
- `cupy_tests/random_tests/test_generator.py::TestRandint::test_randint_int64_1`
- `cupy_tests/math_tests/test_rounding.py::TestRounding::test_ceil`
- `cupy_tests/math_tests/test_rounding.py::TestRounding::test_floor`
- `cupy_tests/math_tests/test_rounding.py::TestRounding::test_trunc`
- `cupy_tests/math_tests/test_rounding.py::TestRounding::test_fix`

