### PR TITLE
Resolve import loop

### DIFF
--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -6,7 +6,7 @@ import os
 import warnings
 
 import cupy
-from cupy.cuda cimport device
+from cupy_backends.cuda.api import runtime
 
 
 DEF CYTHON_BUILD_VER = CUPY_CYTHON_VERSION
@@ -54,7 +54,7 @@ def memoize(bint for_each_device=False):
             cdef int id = -1
             cdef dict m = memo
             if for_each_device:
-                id = device.get_device_id()
+                id = runtime.getDevice()
             if len(kwargs):
                 arg_key = (id, args, frozenset(kwargs.items()))
             else:

--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -6,7 +6,7 @@ import os
 import warnings
 
 import cupy
-from cupy_backends.cuda.api import runtime
+from cupy_backends.cuda.api cimport runtime
 
 
 DEF CYTHON_BUILD_VER = CUPY_CYTHON_VERSION


### PR DESCRIPTION
This PR resolves the circular import between `cupy/_util.pyx` and `cupy/cuda/device.pyx`.