### PR TITLE
Make `cupyx.scipy` submodule imports lazy

### DIFF
--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -1,5 +1,4 @@
 import cupy
-import cupyx.scipy.fft
 
 from cupy import _core
 from cupy._core import _routines_math as _math
@@ -92,6 +91,7 @@ def _fft_convolve(a1, a2, mode):
 
     dtype = cupy.result_type(a1, a2)
     n1, n2 = a1.shape[-1], a2.shape[-1]
+    import cupyx.scipy.fft
     out_size = cupyx.scipy.fft.next_fast_len(n1 + n2 - 1)
     fa1 = fft(a1, out_size)
     fa2 = fft(a2, out_size)

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -5,7 +5,6 @@ import numpy
 
 import cupy
 from cupy.exceptions import RankWarning
-import cupyx.scipy.fft
 
 
 def _wraps_polyroutine(func):
@@ -175,6 +174,7 @@ def _polypow(x, n):
         else:
             fft, ifft = cupy.fft.rfft, cupy.fft.irfft
         out_size = (x.size - 1) * n + 1
+        import cupyx.scipy.fft
         size = cupyx.scipy.fft.next_fast_len(out_size)
         fx = fft(x, size)
         fy = cupy.power(fx, n, fx)

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -1,5 +1,5 @@
-import sys
 import warnings
+
 
 def __getattr__(name):
     import cupyx.scipy.sparse
@@ -8,4 +8,4 @@ def __getattr__(name):
         warnings.warn(msg, DeprecationWarning)
         return getattr(cupyx.scipy.sparse, name)
     raise AttributeError(
-         "module 'cupy.sparse' has no attribute {!r}".format(name))
+        "module 'cupy.sparse' has no attribute {!r}".format(name))

--- a/cupy/sparse/__init__.py
+++ b/cupy/sparse/__init__.py
@@ -1,22 +1,11 @@
 import sys
 import warnings
 
-import cupyx.scipy.sparse
-
-
-# Raise a `DeprecationWarning` for `cupy.sparse` submodule when its functions
-# are called. We could raise the warning on importing the submodule, but we
-# use module level `__getattr__` function here as the submodule is also
-# imported in cupy/__init__.py. Unfortunately, module level `__getattr__` is
-# supported on Python 3.7 and higher, so we need to keep the explicit import
-# list for older Python.
-if (3, 7) <= sys.version_info:
-    def __getattr__(name):
-        if hasattr(cupyx.scipy.sparse, name):
-            msg = 'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.'
-            warnings.warn(msg, DeprecationWarning)
-            return getattr(cupyx.scipy.sparse, name)
-        raise AttributeError(
-            "module 'cupy.sparse' has no attribute {!r}".format(name))
-else:
-    from cupyx.scipy.sparse import *  # NOQA
+def __getattr__(name):
+    import cupyx.scipy.sparse
+    if hasattr(cupyx.scipy.sparse, name):
+        msg = 'cupy.sparse is deprecated. Use cupyx.scipy.sparse instead.'
+        warnings.warn(msg, DeprecationWarning)
+        return getattr(cupyx.scipy.sparse, name)
+    raise AttributeError(
+         "module 'cupy.sparse' has no attribute {!r}".format(name))

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -13,7 +13,6 @@ import numpy
 
 import cupy
 import cupyx
-import cupyx.scipy.sparse
 from cupy._core import internal
 from cupy.testing._pytest_impl import is_available
 
@@ -170,7 +169,7 @@ def shaped_random(
 
 
 def shaped_sparse_random(
-        shape, sp=cupyx.scipy.sparse, dtype=numpy.float32,
+        shape, sp=None, dtype=numpy.float32,
         density=0.01, format='coo', seed=0):
     """Returns an array filled with random values.
 
@@ -186,6 +185,9 @@ def shaped_sparse_random(
         The sparse matrix with given shape, array module,
     """
     import scipy.sparse
+    import cupyx.scipy.sparse
+    if sp is None:
+        sp = cupyx.scipy.sparse
     n_rows, n_cols = shape
     numpy.random.seed(seed)
     a = scipy.sparse.random(n_rows, n_cols, density).astype(dtype)

--- a/cupy/testing/_helper.py
+++ b/cupy/testing/_helper.py
@@ -12,7 +12,6 @@ from unittest import mock
 import numpy
 
 import cupy
-import cupyx
 from cupy._core import internal
 from cupy.testing._pytest_impl import is_available
 

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -14,7 +14,6 @@ from cupy.exceptions import AxisError
 from cupy.testing import _array
 from cupy.testing import _parameterized
 import cupyx
-import cupyx.scipy.sparse
 
 from cupy.testing._pytest_impl import is_available
 
@@ -64,6 +63,7 @@ def _call_func_cupy(impl, args, kw, name, sp_name, scipy_name):
 
     # Run cupy
     if sp_name:
+        import cupyx.scipy.sparse
         kw[sp_name] = cupyx.scipy.sparse
     if scipy_name:
         kw[scipy_name] = cupyx.scipy
@@ -382,6 +382,7 @@ def _convert_output_to_ndarray(c_out, n_out, sp_name, check_sparse_format):
     Returns:
         The tuple of cupy.ndarray and numpy.ndarray.
     """
+    import cupyx.scipy.sparse
     if sp_name is not None and cupyx.scipy.sparse.issparse(c_out):
         # Sparse output case.
         import scipy.sparse

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -13,7 +13,6 @@ import cupy
 from cupy.exceptions import AxisError
 from cupy.testing import _array
 from cupy.testing import _parameterized
-import cupyx
 
 from cupy.testing._pytest_impl import is_available
 

--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -42,6 +42,7 @@ def get_array_module(*args):
 _submodules = ['fft', 'fftpack', 'interpolate', 'linalg', 'ndimage', 'signal',
                'sparse', 'spatial', 'special', 'stats']
 
+
 def __getattr__(name):
     if name in _submodules:
         return _importlib.import_module(f'cupyx.scipy.{name}')

--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -1,4 +1,5 @@
 import sys as _sys
+import importlib as _importlib
 
 from cupy._core import ndarray as _ndarray
 
@@ -34,3 +35,20 @@ def get_array_module(*args):
         if isinstance(arg, (_ndarray, _spmatrix)):
             return _cupyx_scipy
     return _scipy
+
+
+# support lazy importing from cupyx.scipy
+
+_submodules = ['fft', 'fftpack', 'interpolate', 'linalg', 'ndimage', 'signal',
+               'sparse', 'spatial', 'special', 'stats']
+
+def __getattr__(name):
+    if name in _submodules:
+        return _importlib.import_module(f'cupyx.scipy.{name}')
+    else:
+        try:
+            return globals()[name]
+        except KeyError:
+            raise AttributeError(
+                f"Module 'cupyx.scipy' has no attribute '{name}'"
+            )

--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -1,7 +1,6 @@
 import sys as _sys
 
 from cupy._core import ndarray as _ndarray
-from cupyx.scipy.sparse._base import spmatrix as _spmatrix
 
 
 try:
@@ -29,6 +28,8 @@ def get_array_module(*args):
         types of the arguments.
 
     """
+    from cupyx.scipy.sparse._base import spmatrix as _spmatrix
+
     for arg in args:
         if isinstance(arg, (_ndarray, _spmatrix)):
             return _cupyx_scipy


### PR DESCRIPTION
closes https://github.com/cupy/cupy/issues/8336

Two changes:

First, formerly, `import cupyx` eagerly imported `cupyx.scipy.fft`, `linalg` and `scpecial`. This led to strange effects downstream: `import cupyx` made `cupyx.scipy.special` available but not `cupyx.scipy.ndimage`.
Fix this by moving corresponding imports from the module level to call sites.

Second, implement a module `__getattr__` for `cupyx.scipy`, so that for all cupyx.scipy submodules the following works:

```
>>> import cupyx
>>> cupyx.scipy.ndimage.convolve
<function convolve at 0x7f4445220c20>
```