### PR TITLE
CI: Fix apt repository URL for Ubuntu 22.04

### DIFF
--- a/.pfnci/linux/update-cuda-driver.sh
+++ b/.pfnci/linux/update-cuda-driver.sh
@@ -12,8 +12,8 @@ if dpkg -s "cuda-drivers-${CUDA_DRIVER_VERSION}" && ls /dev/nvidiactl ; then
     killall Xorg || true
     nvidia-smi -pm 0
 
-    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
     apt-get purge -qqy "cuda-drivers*" "*nvidia*-${CUDA_DRIVER_VERSION}"
     apt-get install -qqy "cuda-drivers"
 


### PR DESCRIPTION
CI image is based on Ubuntu 22.04 and should have used the appropriate apt repository. This fixes CI failures currently happening, e.g. https://ci.preferred.jp/cupy.linux.cuda126/177020/
