### PR TITLE
Introducing CuPy Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Matrix](https://img.shields.io/matrix/cupy_community:gitter.im?server_fqdn=matrix.org)](https://gitter.im/cupy/community)
 [![Twitter](https://img.shields.io/twitter/follow/CuPy_Team?label=%40CuPy_Team)](https://twitter.com/CuPy_Team)
 [![Medium](https://img.shields.io/badge/Medium-CuPy-teal)](https://medium.com/cupy-team)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20CuPy%20Guru-006BFF)](https://gurubase.io/g/cupy)
 
 [**Website**](https://cupy.dev/)
 | [**Install**](https://docs.cupy.dev/en/stable/install.html)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CuPy Guru](https://gurubase.io/g/cupy) to Gurubase. CuPy Guru uses the data from this repo and data from the [docs](https://docs.cupy.dev/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "CuPy Guru", which highlights that CuPy now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CuPy Guru in Gurubase, just let me know that's totally fine.
