### PR TITLE
Fix possible source of flaky test: unexpected division by zero

### DIFF
--- a/cupyx/scipy/interpolate/_bspline.py
+++ b/cupyx/scipy/interpolate/_bspline.py
@@ -95,7 +95,7 @@ __global__ void d_boor(
     double* hh = h + k + 1;
 
     int ind, j, n;
-    double xa, xb, w;
+    double xa, xb, dba, w;
 
     if(mode == COMPUTE_LINEAR && interval < 0) {
         for(j = 0; j < num_c; j++) {
@@ -119,11 +119,12 @@ __global__ void d_boor(
             ind = interval + n;
             xb = t[ind];
             xa = t[ind - j];
-            if (xb == xa) {
+            dba = xb - xa;
+            if (dba == 0.0) {
                 h[n] = 0.0;
                 continue;
             }
-            w = hh[n - 1]/(xb - xa);
+            w = hh[n - 1]/dba;
             h[n - 1] += w*(xb - xp);
             h[n] = w*(xp - xa);
         }
@@ -142,11 +143,12 @@ __global__ void d_boor(
             ind = interval + n;
             xb = t[ind];
             xa = t[ind - j];
-            if (xb == xa) {
+            dba = xb - xa;
+            if (dba == 0.0) {
                 h[mu] = 0.0;
                 continue;
             }
-            w = ((double) j) * hh[n - 1]/(xb - xa);
+            w = ((double) j) * hh[n - 1]/dba;
             h[n - 1] -= w;
             h[n] = w;
         }


### PR DESCRIPTION
Maybe related to #7240 .

### Problem

Floating-point number can satisfy **BOTH** `a != b` and `b - a == 0`.

```py
import cupy as cp

# 1.1754944e-38
a = cp.finfo(cp.float32).smallest_normal
# 1.1754945e-38
b = cp.nextafter(a, 1)

assert a != b
assert b - a == 0
```

This PR resolves possible division-by-zero error by computing `xb - xa` in advance.