### PR TITLE
Fix some NumPy 2.x CI failures (cupyx)

### DIFF
--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -727,9 +727,9 @@ def _arg_wlen_as_expected(value):
         value = -1
     elif 1 < value:
         # Round up to a positive integer
-        if not cupy.can_cast(value, cupy.int64, "safe"):
+        if isinstance(value, float):
             value = math.ceil(value)
-        value = int(value)
+        value = cupy.intp(value)
     else:
         raise ValueError('`wlen` must be larger than 1, was {}'
                          .format(value))

--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -727,8 +727,7 @@ def _arg_wlen_as_expected(value):
         value = -1
     elif 1 < value:
         # Round up to a positive integer
-        if isinstance(value, float):
-            value = math.ceil(value)
+        value = math.ceil(value)
         value = cupy.intp(value)
     else:
         raise ValueError('`wlen` must be larger than 1, was {}'

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
@@ -199,7 +199,7 @@ class TestBasic:
         )
         return scp.special.round(vals)
 
-    @pytest.mark.xfail(reason="XXX: np2.0: f32/f64 dtypes differ")
+    @testing.with_requires("numpy>=2.0")
     # Exclude 'e' here because of deficiency in the NumPy/SciPy
     # implementation for float16 dtype. This was also noted in
     # cupy_tests/math_tests/test_special.py
@@ -209,7 +209,7 @@ class TestBasic:
         vals = xp.linspace(-100, 100, 200, dtype=dtype)
         return scp.special.sinc(vals)
 
-    @pytest.mark.xfail(reason="XXX: np2.0: f32/f64 dtypes differ")
+    @testing.with_requires("numpy>=2.0")
     # TODO: Should we make all int dtypes convert to float64 and test for that?
     #       currently int8->float16, int16->float32, etc... but for
     #       numpy.sinc/scipy.special.sinc any int type becomes float64.

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -117,6 +117,10 @@ class TestPosv(unittest.TestCase):
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_posv(self, xp, dtype):
+        if (self.nrhs is None
+                and numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0"):
+            pytest.skip("numpy.linalg.solve changes behavior")
+
         # TODO: cusolver does not support nrhs > 1 for potrsBatched
         if len(self.shape) > 2 and self.nrhs and self.nrhs > 1:
             pytest.skip('cusolver does not support nrhs > 1 for potrsBatched')

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -114,13 +114,19 @@ class TestPosv(unittest.TestCase):
         if not cusolver.check_availability('potrsBatched'):
             pytest.skip('potrsBatched is not available')
 
+    @staticmethod
+    def _solve(a, b):
+        if (
+            numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            or a.shape[:-1] != b.shape
+        ):
+            return numpy.linalg.solve(a, b)
+        b = b[..., numpy.newaxis]
+        return numpy.linalg.solve(a, b)[..., 0]
+
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_posv(self, xp, dtype):
-        if (self.nrhs is None
-                and numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0"):
-            pytest.skip("numpy.linalg.solve changes behavior")
-
         # TODO: cusolver does not support nrhs > 1 for potrsBatched
         if len(self.shape) > 2 and self.nrhs and self.nrhs > 1:
             pytest.skip('cusolver does not support nrhs > 1 for potrsBatched')
@@ -134,7 +140,7 @@ class TestPosv(unittest.TestCase):
         if xp == cupy:
             return lapack.posv(a, b)
         else:
-            return numpy.linalg.solve(a, b)
+            return self._solve(a, b)
 
     def _create_posdef_matrix(self, xp, shape, dtype):
         n = shape[-1]


### PR DESCRIPTION
Related to #8565  , #8690 and #8695 .

This PR also partly fixes https://ci.preferred.jp/cupy.linux.cuda126/176161/ .

### Fixed

- `cupyx_tests/scipy_tests/signal_tests/test_peak_finding.py::TestPeakProminences::test_wlen`
- `cupyx_tests/scipy_tests/signal_tests/test_peak_finding.py::TestFindPeaks::test_wlen_smaller_plateau`
- `cupyx_tests/scipy_tests/special_tests/test_basic.py::TestBasic::test_sinc`
- `cupyx_tests/scipy_tests/special_tests/test_basic.py::TestBasic::test_sinc_integer_valued`
- `cupyx_tests/test_lapack.py::TestPosv_param_0_{nrhs=None, shape=(3, 4, 2, 2)}::test_posv`
- `cupyx_tests/test_lapack.py::TestPosv_param_1_{nrhs=None, shape=(5, 3, 3)}::test_posv`