### PR TITLE
Avoid hardcoding index dtypes as int32 for CS matrices

### DIFF
--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -257,12 +257,13 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
             if len(data) != len(indices):
                 raise ValueError('indices and data should have the same size')
-            
+
             # Select index dtype large enough to hold array data
             maxval = None
             if shape is not None and 0 not in shape:
                 maxval = max(shape)
-            idx_dtype = _sputils.get_index_dtype((indptr, indices), maxval=maxval, check_contents=True)
+            idx_dtype = _sputils.get_index_dtype(
+                (indptr, indices), maxval=maxval, check_contents=True)
 
         elif _base.isdense(arg1):
             if arg1.ndim > 2:


### PR DESCRIPTION
Hi community! This is my first time getting involved with cupy. 
My team encountered issue #8731, where sparse matrices whose indices exceed the int32 maxval should have their indices cast to int64 to avoid overflow.

These changes add an additional check to the CS matrix constructor to check if the index dtype should be promoted, as opposed to hardcoding as int32 (shortcut 'i'). Fixes #8731. 

Happy to add tests for these overflow cases but they would require significant CUDA mem. 