### PR TITLE
Fix CUDA Python CI

### DIFF
--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -665,7 +665,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 11.6
-     - 3
+     - 2
      - 
      - 
      - 
@@ -701,7 +701,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - ✅
+     - 
      - 
      - 
    * - 
@@ -747,7 +747,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 11.8
-     - 7
+     - 8
      - 
      - 
      - 
@@ -783,7 +783,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
-     - 
+     - ✅
      - ✅
      - ✅
    * - 

--- a/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda11x-cuda-python.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:11.6.2-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:11.8.0-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -623,7 +623,7 @@
   tags: ["@push", "full", "mini", "cuda-python"]
   system: "linux"
   os: "ubuntu:20.04"
-  cuda: "11.6"
+  cuda: "11.8"
   rocm: null
   nccl: "2.16"
   cutensor: "2.0"


### PR DESCRIPTION
It seems CUDA Python build does not work well with CUDA 11.6, so bump to CUDA 11.8.
(maybe starting https://pypi.org/project/cuda-python/11.8.5.post1/ ?)

https://ci.preferred.jp/cupy.linux.cuda11x-cuda-python/178207/

```
error: use of enum ‘cudaLaunchAttributeID’ without previous declaration
```

`cudaLaunchAttributeID` is new in CUDA 11.8 so that might be related.

cc/ @leofang
