### PR TITLE
Remove ndarray.ptp from fallback tests

### DIFF
--- a/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
+++ b/tests/cupyx_tests/fallback_mode_tests/test_fallback.py
@@ -353,7 +353,6 @@ class TestFallbackArray(unittest.TestCase):
 @testing.parameterize(
     {'func': 'min', 'shape': (5,), 'args': (), 'kwargs': {}},
     {'func': 'argmax', 'shape': (5, 3), 'args': (), 'kwargs': {'axis': 0}},
-    {'func': 'ptp', 'shape': (3, 3), 'args': (), 'kwargs': {'axis': 1}},
     {'func': 'compress', 'shape': (3, 2), 'args': ([False, True],),
      'kwargs': {'axis': 0}}
 )


### PR DESCRIPTION
`numpy.ndarray.ptp` was removed in NumPy 2.0.