### PR TITLE
Add notice about `cupy.array_api` removal

### DIFF
--- a/docs/source/reference/array_api.rst
+++ b/docs/source/reference/array_api.rst
@@ -1,6 +1,11 @@
 Python Array API Support
 ========================
 
+.. note::
+   ``cupy.array_api`` will be removed in CuPy v14 because its NumPy counterpart ``numpy.array_api`` has been removed.
+   The root module ``cupy.*`` is now compatible with the Array API specification as it mirrors the NumPy v2 API.
+   Use the `Array API compatibility library <https://data-apis.org/array-api-compat/>`_ to develop applications compatible with various array libraries, including CuPy, NumPy, and PyTorch.
+
 The `Python array API standard <https://data-apis.org/array-api/2021.12/>`_ aims to provide a coherent set of
 APIs for array and tensor libraries developed by the community to build upon. This solves the API fragmentation
 issue across the community by offering concrete function signatures, semantics and scopes of coverage, enabling

--- a/docs/source/reference/array_api_array.rst
+++ b/docs/source/reference/array_api_array.rst
@@ -1,6 +1,11 @@
 Array API Compliant Object
 ==========================
 
+.. note::
+   ``cupy.array_api`` will be removed in CuPy v14 because its NumPy counterpart ``numpy.array_api`` has been removed.
+   The root module ``cupy.*`` is now compatible with the Array API specification as it mirrors the NumPy v2 API.
+   Use the `Array API compatibility library <https://data-apis.org/array-api-compat/>`_ to develop applications compatible with various array libraries, including CuPy, NumPy, and PyTorch.
+
 :class:`~cupy.array_api._array_object.Array` is a wrapper class built upon :class:`cupy.ndarray`
 to enforce strict compliance with the array API standard. See the
 `documentation <https://data-apis.org/array-api/latest/API_specification/array_object.html>`_

--- a/docs/source/reference/array_api_functions.rst
+++ b/docs/source/reference/array_api_functions.rst
@@ -1,6 +1,11 @@
 Array API Functions
 ===================
 
+.. note::
+   ``cupy.array_api`` will be removed in CuPy v14 because its NumPy counterpart ``numpy.array_api`` has been removed.
+   The root module ``cupy.*`` is now compatible with the Array API specification as it mirrors the NumPy v2 API.
+   Use the `Array API compatibility library <https://data-apis.org/array-api-compat/>`_ to develop applications compatible with various array libraries, including CuPy, NumPy, and PyTorch.
+
 This section is a full list of implemented APIs. For the detailed documentation, see the
 `array API specification <https://data-apis.org/array-api/latest/API_specification/index.html>`_.
 


### PR DESCRIPTION
context: https://github.com/cupy/cupy/issues/8470#issuecomment-2285383328.

Closes #8470 and #8747.

cc/ @leofang
