### PR TITLE
Remove "Type promotion" section from user guide

### DIFF
--- a/docs/source/user_guide/difference.rst
+++ b/docs/source/user_guide/difference.rst
@@ -99,22 +99,6 @@ If you want to use scalar values, cast the returned arrays explicitly.
   True
 
 
-Type promotion
-~~~~~~~~~~~~~~
-
-CuPy automatically promotes dtypes of :class:`cupy.ndarray` s in a function with two or more operands, the result dtype is determined by the dtypes of the inputs.
-This is different from NumPy's rule on type promotion, when operands contain zero-dimensional arrays.
-Zero-dimensional :class:`numpy.ndarray` s are treated as if they were scalar values if they appear in operands of NumPy's function,
-This may affect the dtype of its output, depending on the values of the "scalar" inputs.
-
-  >>> (np.array(3, dtype=np.int32) * np.array([1., 2.], dtype=np.float32)).dtype
-  dtype('float32')
-  >>> (np.array(300000, dtype=np.int32) * np.array([1., 2.], dtype=np.float32)).dtype
-  dtype('float64')
-  >>> (cupy.array(3, dtype=np.int32) * cupy.array([1., 2.], dtype=np.float32)).dtype
-  dtype('float64')
-
-
 Matrix type (:class:`numpy.matrix`)
 -----------------------------------
 


### PR DESCRIPTION
Since the NumPy 2.x series adopted the NEP 50 type promotion rules, it is no longer necessary to refer to specific values to determine the dtype of the return value. Now CuPy can aim for full compatibility with NumPy's type promotion rules.

NEP50: https://numpy.org/neps/nep-0050-scalar-promotion.html