### PR TITLE
Fix bspline kernel to avoid out of bounds error

### DIFF
--- a/cupyx/scipy/interpolate/_bspline.py
+++ b/cupyx/scipy/interpolate/_bspline.py
@@ -57,7 +57,7 @@ __global__ void find_interval(
     int default_value = left - 1 < k ? k : left - 1;
     int result = found ? mid + 1 : default_value + 1;
 
-    while(xp >= *&t[result] && result != n) {
+    while(result != n && xp >= *&t[result]) {
         result++;
     }
 


### PR DESCRIPTION
`result != n` must be evaluated before `xp >= *&t[result]`.