### PR TITLE
fix nanargmin and nanargmax's parameter order and pass optional parameters

### DIFF
--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -57,9 +57,9 @@ def nanargmax(a, axis=None, dtype=None, out=None, keepdims=False):
     .. seealso:: :func:`numpy.nanargmax`
     """
     if a.dtype.kind in 'biu':
-        return argmax(a, axis=axis)
+        return argmax(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
-    return _statistics._nanargmax(a, axis, dtype, out, keepdims)
+    return _statistics._nanargmax(a, axis, out, dtype, keepdims)
 
 
 def argmin(a, axis=None, dtype=None, out=None, keepdims=False):
@@ -112,9 +112,9 @@ def nanargmin(a, axis=None, dtype=None, out=None, keepdims=False):
     .. seealso:: :func:`numpy.nanargmin`
     """
     if a.dtype.kind in 'biu':
-        return argmin(a, axis=axis)
+        return argmin(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
-    return _statistics._nanargmin(a, axis, dtype, out, keepdims)
+    return _statistics._nanargmin(a, axis, out, dtype, keepdims)
 
 
 def nonzero(a):

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -523,6 +523,22 @@ class TestNanArgMin:
         a = testing.shaped_random((0, 1), xp, dtype)
         return xp.nanargmin(a, axis=1)
 
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_nanargmin_out_float_dtype(self, xp, dtype):
+        a = xp.array([[0.]])
+        b = xp.empty((1), dtype="int64")
+        xp.nanargmin(a, axis=1, out=b)
+        return b
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_nanargmin_out_int_dtype(self, xp, dtype):
+        a = xp.array([1, 0])
+        b = xp.empty((), dtype="int64")
+        xp.nanargmin(a, out=b)
+        return b
+
 
 class TestNanArgMax:
 
@@ -613,6 +629,22 @@ class TestNanArgMax:
     def test_nanargmax_zero_size_axis1(self, xp, dtype):
         a = testing.shaped_random((0, 1), xp, dtype)
         return xp.nanargmax(a, axis=1)
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_allclose()
+    def test_nanargmax_out_float_dtype(self, xp, dtype):
+        a = xp.array([[0.]])
+        b = xp.empty((1), dtype="int64")
+        xp.nanargmax(a, axis=1, out=b)
+        return b
+
+    @testing.for_all_dtypes(no_complex=True)
+    @testing.numpy_cupy_array_equal()
+    def test_nanargmax_out_int_dtype(self, xp, dtype):
+        a = xp.array([0, 1])
+        b = xp.empty((), dtype="int64")
+        xp.nanargmax(a, out=b)
+        return b
 
 
 @testing.parameterize(*testing.product(


### PR DESCRIPTION
Closes https://github.com/cupy/cupy/issues/8782.  Closes https://github.com/cupy/cupy/issues/8784. This PR (1) fixes nanargmin and nanargmax's parameter order and (2) passes optional parameters to `argmin` and `argmax` for `biu`-type ndarrays.