### PR TITLE
Disable typecheck with NumPy v1 in CI

### DIFF
--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -299,7 +299,8 @@ def _make_decorator(check_func, name, type_check, contiguous_check,
                 for cupy_r, numpy_r in zip(cupy_result, numpy_result)]
 
             # Check dtypes
-            if type_check:
+            if (type_check
+                    and numpy.lib.NumpyVersion(numpy.__version__) >= "2.0.0"):
                 for cupy_r, numpy_r in cupy_numpy_result_ndarrays:
                     if cupy_r.dtype != numpy_r.dtype:
                         raise AssertionError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,6 @@ import sys
 import pytest
 
 
-# enable NEP 50 weak promotion rules
-import numpy
-numpy._set_promotion_state("weak")
-
 # Enable `testdir` fixture to test `cupy.testing`.
 # `pytest_plugins` cannot be locally configured. See also
 # https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306 and https://github.com/cupy/cupy/issues/8514.