### PR TITLE
[ROCm 6.2.2] Conditionally define CUDA_SUCCESS only if it's not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ htmlcov/
 .pytest_cache/
 cupy/.data/
 cupy/cuda/thrust.h
+
+# Ignore generated files
+cupy/_core/numpy_allocator.h

--- a/cupy_backends/hip/cupy_hip_common.h
+++ b/cupy_backends/hip/cupy_hip_common.h
@@ -15,7 +15,10 @@ extern "C" {
 
 typedef int CUdevice;
 typedef hipError_t CUresult;
+// Conditionally define CUDA_SUCCESS only if it's not defined
+#ifndef CUDA_SUCCESS
 const CUresult CUDA_SUCCESS = static_cast<CUresult>(0);
+#endif
 enum CUjit_option {};
 enum CUjitInputType {};
 enum CUarray_format {};


### PR DESCRIPTION
To fix the following compilation error when building for AMD GPUs:

```log
  In file included from cupy_backends/cuda/libs/cusolver.cpp:847:
  In file included from cupy_backends/cuda/libs/../../cupy_lapack.h:12:
  In file included from cupy_backends/cuda/libs/../../hip/cupy_rocsolver.h:4:
  In file included from cupy_backends/cuda/libs/../../hip/cupy_hip.h:4:
  cupy_backends/cuda/libs/../../hip/cupy_hip_common.h:18:16: error: redefinition of 'hipSuccess' as different kind of symbol
     18 | const CUresult CUDA_SUCCESS = static_cast<CUresult>(0);
        |                ^
rocm/6.2.2/include/hip/amd_detail/amd_hip_runtime.h:111:22: note: expanded from macro 'CUDA_SUCCESS'
    111 | #define CUDA_SUCCESS hipSuccess
        |                      ^
rocm/6.2.2/include/hip/hip_runtime_api.h:288:5: note: previous definition is here
    288 |     hipSuccess = 0,  ///< Successful completion.
        |     ^
```
