### PR TITLE
Set `numpy._set_promotion_state("weak")` only for test with NumPy 1.x

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,8 @@ import pytest
 
 # enable NEP 50 weak promotion rules
 import numpy
-numpy._set_promotion_state("weak")
+if numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0":
+    numpy._set_promotion_state("weak")
 
 # Enable `testdir` fixture to test `cupy.testing`.
 # `pytest_plugins` cannot be locally configured. See also


### PR DESCRIPTION
Fix https://ci.preferred.jp/cupy.linux.cuda-head/180775/.

`numpy._set_promotion_state` was removed in NumPy 2.2.