### PR TITLE
Switch from `.A` attribute to `.todense()` method

### DIFF
--- a/cupyx/scipy/sparse/linalg/_norm.py
+++ b/cupyx/scipy/sparse/linalg/_norm.py
@@ -89,9 +89,9 @@ def norm(x, ord=None, axis=None):
             raise ValueError('Invalid axis %r for an array with shape %r' %
                              (axis, x.shape))
         if ord == numpy.inf:
-            return abs(x).max(axis=a).A.ravel()
+            return abs(x).max(axis=a).todense().ravel()
         elif ord == -numpy.inf:
-            return abs(x).min(axis=a).A.ravel()
+            return abs(x).min(axis=a).todense().ravel()
         elif ord == 0:
             # Zero norm
             return (x != 0).astype(numpy.float32).sum(axis=a).ravel().astype(

--- a/cupyx/scipy/sparse/linalg/_norm.py
+++ b/cupyx/scipy/sparse/linalg/_norm.py
@@ -89,9 +89,9 @@ def norm(x, ord=None, axis=None):
             raise ValueError('Invalid axis %r for an array with shape %r' %
                              (axis, x.shape))
         if ord == numpy.inf:
-            return abs(x).max(axis=a).todense().ravel()
+            return abs(x).max(axis=a).toarray().ravel()
         elif ord == -numpy.inf:
-            return abs(x).min(axis=a).todense().ravel()
+            return abs(x).min(axis=a).toarray().ravel()
         elif ord == 0:
             # Zero norm
             return (x != 0).astype(numpy.float32).sum(axis=a).ravel().astype(


### PR DESCRIPTION
The sparse matrix `.A` attribute is deprecated in SciPy (and [removed in 1.14.0]( https://docs.scipy.org/doc/scipy-1.14.1/release/1.14.0-notes.html#expired-deprecations )) and is sometimes used with NumPy & SciPy in the tests. So swap it out for the `.todense()` method, which is not deprecated. The behavior and results should be the same. This just avoids deprecation warnings or errors from SciPy.

xref: https://github.com/scipy/scipy/pull/14822
xref: https://github.com/scipy/scipy/pull/20499