### PR TITLE
Fix scipy.spmatrix.sign for complex dtype inputs

### DIFF
--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -380,7 +380,13 @@ class _minmax_mixin(object):
 def _install_ufunc(func_name):
 
     def f(self):
-        ufunc = getattr(cupy, func_name)
+        if func_name == "sign":
+            # scipy.sparse_matrix.sign behaves compatible with
+            # numpy.sign in NumPy 1.x series.
+            ufunc = cupy._math.misc._legacy_sign
+        else:
+            ufunc = getattr(cupy, func_name)
+
         result = ufunc(self.data)
         return self._with_data(result)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -1107,8 +1107,6 @@ class TestUfunc:
 
     @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
     def test_ufun(self, xp, sp):
-        if self.ufunc == "sign" and numpy.dtype(self.dtype).kind == 'c':
-            pytest.xfail(reason="XXX: np2.0: should behave as legacy sign")
         x = _make(xp, sp, self.dtype)
         x.data *= 0.1
         func = getattr(x, self.ufunc)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -1402,8 +1402,6 @@ class TestUfunc:
 
     @testing.numpy_cupy_allclose(sp_name='sp', atol=1e-5)
     def test_ufun(self, xp, sp):
-        if self.ufunc == "sign" and numpy.dtype(self.dtype).kind == 'c':
-            pytest.xfail(reason="XXX: np2.0: should behave as legacy sign")
         x = _make(xp, sp, self.dtype)
         x.data *= 0.1
         func = getattr(x, self.ufunc)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306.