### PR TITLE
CI: support "skip-ci" label

### DIFF
--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -1,10 +1,10 @@
 name: "FlexCI"
 
 on:
-  push:
-    branches: ["main", "v[0-9]+", "hotfix-*"]
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: read
@@ -18,7 +18,9 @@ jobs:
             (github.event_name == 'issue_comment' &&
              github.event.issue.pull_request &&
              contains(github.event.comment.body, '/test ')) ||
-            (github.event_name == 'push')
+            (github.event_name == 'pull_request_target' &&
+             github.event.pull_request.merged &&
+             !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
         )
     runs-on: ubuntu-22.04
 
@@ -34,7 +36,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event_name == 'push' && github.ref || steps.base.outputs.pr_base_ref }}
+        ref: ${{ github.event_name == 'issue_comment' && steps.base.outputs.pr_base_ref || github.event.pull_request.merge_commit_sha }}
 
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This PR introduces "skip-ci" label support, which omits triggering full CIs when merging a PR.
