### PR TITLE
Fix return type of `cupy.where` for scalar arguments for NumPy 2.0

### DIFF
--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -166,10 +166,6 @@ _where_ufunc = _core.create_ufunc(
     'cupy_where',
     ('???->?', '?bb->b', '?BB->B', '?hh->h', '?HH->H', '?ii->i', '?II->I',
      '?ll->l', '?LL->L', '?qq->q', '?QQ->Q', '?ee->e', '?ff->f',
-     # On CUDA 6.5 these combinations don't work correctly (on CUDA >=7.0, it
-     # works).
-     # See issue #551.
-     '?hd->d', '?Hd->d',
      '?dd->d', '?FF->F', '?DD->D'),
     'out0 = in0 ? in1 : in2')
 
@@ -209,7 +205,7 @@ def where(condition, x=None, y=None):
     if fusion._is_fusing():
         return fusion._call_ufunc(_where_ufunc, condition, x, y)
 
-    return _where_ufunc(condition.astype('?'), x, y)
+    return _where_ufunc(condition.astype('?', copy=False), x, y)
 
 
 def argwhere(a):

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -209,9 +209,6 @@ def where(condition, x=None, y=None):
     if fusion._is_fusing():
         return fusion._call_ufunc(_where_ufunc, condition, x, y)
 
-    x = cupy.asarray(x)
-    y = cupy.asarray(y)
-
     return _where_ufunc(condition.astype('?'), x, y)
 
 

--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -319,6 +319,31 @@ class TestWhereTwoArrays:
         return xp.where(cond, x, y)
 
 
+@testing.with_requires("numpy>=2.0")
+@testing.parameterize(
+    {'scalar_value': 1},
+    {'scalar_value': 1.0},
+    {'scalar_value': 1 + 2j},
+)
+class TestWhereArrayAndScalar:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_where_array_scalar(self, xp, dtype):
+        cond = testing.shaped_random((2, 3, 4), xp, xp.bool_)
+        x = testing.shaped_random((2, 3, 4), xp, dtype, seed=0)
+        y = self.scalar_value
+        return xp.where(cond, x, y)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_where_scalar_array(self, xp, dtype):
+        cond = testing.shaped_random((2, 3, 4), xp, xp.bool_)
+        x = self.scalar_value
+        y = testing.shaped_random((2, 3, 4), xp, dtype, seed=0)
+        return xp.where(cond, x, y)
+
+
 @testing.parameterize(
     {'cond_shape': (2, 3, 4)},
     {'cond_shape': (4,)},


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306.