### PR TITLE
Fix `cupyx.scipy.special.logsumexp` for NumPy 2.0

### DIFF
--- a/cupyx/scipy/special/_logsumexp.py
+++ b/cupyx/scipy/special/_logsumexp.py
@@ -47,7 +47,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
             a = a + 0.  # promote to at least float
             a[b == 0] = -cp.inf
 
-    a_max = cp.max(a, axis=axis, keepdims=True)
+    a_max = cp.max(a.real, axis=axis, keepdims=True)
 
     if a_max.ndim > 0:
         a_max[~cp.isfinite(a_max)] = 0
@@ -61,8 +61,11 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     s = cp.sum(tmp, axis=axis, keepdims=keepdims)
     if return_sign:
-        sgn = cp.sign(s)
-        s *= sgn
+        if s.dtype.char == 'c':
+            sgn = s / cp.where(s == 0, 1, cp.abs(s))
+        else:
+            sgn = cp.sign(s)
+        s = cp.abs(s)
     out = cp.log(s)
 
     if not keepdims:

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
@@ -38,7 +38,7 @@ class TestLogsumexp:
         a = xp.array([[100, 1000], [1e10, 1e-10]])
         return scp.special.logsumexp(a, axis=-1, keepdims=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('scipy>=1.13')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_array_inputs(self, xp, scp, dtype):
@@ -47,7 +47,7 @@ class TestLogsumexp:
         a = testing.shaped_random((100, 1000), xp, dtype=dtype)
         return scp.special.logsumexp(a)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_sign_argument(self, xp, scp, dtype):
@@ -62,7 +62,7 @@ class TestLogsumexp:
         b = xp.array([1, -1]).astype(dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims(self, xp, scp, dtype):
@@ -72,7 +72,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 1, 1, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis(self, xp, scp, dtype):
@@ -80,7 +80,7 @@ class TestLogsumexp:
         b = testing.shaped_random((1, 2, 3, 4), xp, dtype=dtype)
         return scp.special.logsumexp(a, axis=2, b=b, return_sign=True)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_sign_multi_dims_axis_2d(self, xp, scp, dtype):
@@ -95,7 +95,7 @@ class TestLogsumexp:
         b = xp.array([1, 0], dtype=dtype)
         return scp.special.logsumexp(a, b=b)
 
-    @pytest.mark.skip(reason="XXX: NP2.0: log wrong branch in 1.26.x")
+    @testing.with_requires('scipy>=1.13')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_b_multi_dims(self, xp, scp, dtype):


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306.
Blocked by https://github.com/cupy/cupy/pull/8835.