### PR TITLE
Fix csr_matrix.minimum/maximum dtype promotion rule

### DIFF
--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -295,7 +295,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
 
     def _maximum_minimum(self, other, cupy_op, op_name, dense_check):
         if _util.isscalarlike(other):
-            other = cupy.asarray(other, dtype=self.dtype)
+            other = cupy.asarray(other)
             if dense_check(other):
                 dtype = self.dtype
                 # Note: This is a work-around to make the output dtype the same
@@ -310,10 +310,11 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 new_array = cupy_op(self.todense(), other)
                 return csr_matrix(new_array)
             else:
+                dtype = cupy.result_type(self.dtype, other)
                 self.sum_duplicates()
                 new_data = cupy_op(self.data, other)
                 return csr_matrix((new_data, self.indices, self.indptr),
-                                  shape=self.shape, dtype=self.dtype)
+                                  shape=self.shape, dtype=dtype)
         elif _util.isdense(other):
             self.sum_duplicates()
             other = cupy.atleast_2d(other)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1929,25 +1929,16 @@ class TestCsrMatrixMaximumMinimum:
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_plus(self, xp, sp):
-        if (self.a_dtype in ('float32', 'complex64')):
-            pytest.xfail(reason="XXX: np2.0: weak promotion")
-
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         return getattr(a, self.opt)(0.5)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_minus(self, xp, sp):
-        if (self.a_dtype in ('float32', 'complex64')):
-            pytest.xfail(reason="XXX: np2.0: weak promotion")
-
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         return getattr(a, self.opt)(-0.5)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_zero(self, xp, sp):
-        if self.a_dtype in ('float32', 'complex64'):
-            pytest.xfail(reason="XXX: np2.0: weak promotion")
-
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         return getattr(a, self.opt)(0)
 
@@ -2088,18 +2079,21 @@ class TestCsrMatrixComparison:
         b = self._make_sp_matrix_col(self.b_dtype, xp, sp).toarray()
         return self._compare(a, b)
 
+    @testing.with_requires('numpy>=2.0')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_plus(self, xp, sp):
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         with self._assert_warns_efficiency(sp, 0.5):
             return self._compare(a, 0.5)
 
+    @testing.with_requires('numpy>=2.0')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_minus(self, xp, sp):
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         with self._assert_warns_efficiency(sp, -0.5):
             return self._compare(a, -0.5)
 
+    @testing.with_requires('numpy>=2.0')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_zero(self, xp, sp):
         if self.opt in ('_le_', '_ge_'):


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8306.