### PR TITLE
Fix handling of pinned memory

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2797,6 +2797,7 @@ cdef _ndarray_base _array_default(
     cdef intptr_t ptr_h = <intptr_t>(a_cpu.ctypes.data)
     if pinned_memory.is_memory_pinned(ptr_h):
         a.data.copy_from_host_async(ptr_h, nbytes, stream)
+        pinned_memory._add_to_watch_list(stream.record(), a_cpu)
     else:
         # The input numpy array does not live on pinned memory, so we allocate
         # an extra buffer and copy from it to avoid potential data race, see

--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -330,6 +330,7 @@ cdef class PinnedMemoryPool:
 
     cpdef free_all_blocks(self):
         """Release free all blocks."""
+        _watcher.check_and_release()
         rlock.lock_fastrlock(self._lock, -1, True)
         try:
             self._free.clear()


### PR DESCRIPTION
Closes #8789.

- Keep reference to source when doing async H2D copy to avoid lifetime hazard.
- Check for event completion in `free_all_blocks` to free more blocks that are no longer in use.
