### PR TITLE
Enable `ruff` rule `UP`

### DIFF
--- a/.github/workflows/scripts/flexci_dispatcher.py
+++ b/.github/workflows/scripts/flexci_dispatcher.py
@@ -10,7 +10,7 @@ import json
 import os
 import re
 import sys
-from typing import Any, Dict, Optional, Set
+from typing import Any, Optional
 import urllib.request
 
 import github
@@ -23,8 +23,8 @@ def _log(msg: str) -> None:
 
 
 def _forward_to_flexci(
-        event_name: str, payload: Dict[str, Any], secret: str,
-        projects: Set[str], base_url: str) -> bool:
+        event_name: str, payload: dict[str, Any], secret: str,
+        projects: set[str], base_url: str) -> bool:
     """
     Submits the GitHub webhook payload to FlexCI.
     """
@@ -58,8 +58,8 @@ def _forward_to_flexci(
 
 
 def _fill_commit_status(
-        event_name: str, payload: Dict[str, Any], token: str,
-        projects: Set[str], context_prefix: str, base_url: str) -> None:
+        event_name: str, payload: dict[str, Any], token: str,
+        projects: set[str], context_prefix: str, base_url: str) -> None:
     gh_repo = github.Github(token).get_repo(payload['repository']['full_name'])
     if event_name == 'push':
         sha = payload['after']
@@ -94,7 +94,7 @@ def _fill_commit_status(
             state='success', description='Skipped', context=context)
 
 
-def extract_requested_tags(comment: str) -> Optional[Set[str]]:
+def extract_requested_tags(comment: str) -> Optional[set[str]]:
     """
     Returns the set of test tags requested in the comment.
     """
@@ -197,8 +197,8 @@ def main(argv: Any) -> int:
         _log(f'Invalid event name: {event_name}')
         return 1
 
-    projects_dispatch: Set[str] = set()
-    projects_skip: Set[str] = set()
+    projects_dispatch: set[str] = set()
+    projects_skip: set[str] = set()
     for project, tags in project_tags.items():
         dispatch = (len(set(tags) & requested_tags) != 0)
         if dispatch:

--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -8,7 +8,7 @@ import sys
 
 import yaml
 
-from typing import Any, Dict, List, Mapping, Tuple
+from typing import Any, Mapping
 
 
 SchemaType = Mapping[str, Any]
@@ -22,7 +22,7 @@ class Matrix:
         }
         self._rec.update(record)
 
-    def env(self) -> Dict[str, Any]:
+    def env(self) -> dict[str, Any]:
         envvars = {}
         for k, v in self._rec.items():
             if not k.startswith('env:') or v is None:
@@ -215,7 +215,7 @@ class LinuxGenerator:
         lines.append('')
         return '\n'.join(lines)
 
-    def _additional_packages(self, kind: str) -> List[str]:
+    def _additional_packages(self, kind: str) -> list[str]:
         assert kind in ('apt', 'yum')
         matrix = self.matrix
         if matrix.cuda is not None:
@@ -344,11 +344,11 @@ class LinuxGenerator:
 
 
 class CoverageGenerator:
-    def __init__(self, schema: SchemaType, matrixes: List[Matrix]):
+    def __init__(self, schema: SchemaType, matrixes: list[Matrix]):
         self.schema = schema
         self.matrixes = matrixes
 
-    def generate_rst(self) -> Tuple[str, List[str]]:
+    def generate_rst(self) -> tuple[str, list[str]]:
         # Generate a matrix table.
         table = [
             ['Param', '', '#', 'Test'] + [''] * (len(self.matrixes) - 1),
@@ -418,7 +418,7 @@ class CoverageGenerator:
 
 
 class TagGenerator:
-    def __init__(self, matrixes: List[Matrix]):
+    def __init__(self, matrixes: list[Matrix]):
         self.matrixes = matrixes
 
     def generate(self) -> str:
@@ -464,7 +464,7 @@ def validate_schema(schema: SchemaType) -> None:
                             f'while parsing schema {key}:{value}')
 
 
-def validate_matrixes(schema: SchemaType, matrixes: List[Matrix]) -> None:
+def validate_matrixes(schema: SchemaType, matrixes: list[Matrix]) -> None:
     # Validate overall consistency
     project_seen = set()
     system_target_seen = set()
@@ -530,7 +530,7 @@ def validate_matrixes(schema: SchemaType, matrixes: List[Matrix]) -> None:
                         f'not supported by {key} {value}')
 
 
-def expand_inherited_matrixes(matrixes: List[Matrix]) -> None:
+def expand_inherited_matrixes(matrixes: list[Matrix]) -> None:
     prj2mat = {m.project: m for m in matrixes}
     for matrix in matrixes:
         if matrix._inherits is None:
@@ -548,7 +548,7 @@ def log(msg: str, visible: bool = True) -> None:
         print(msg)
 
 
-def parse_args(argv: List[str]) -> Any:
+def parse_args(argv: list[str]) -> Any:
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', '--schema', type=str, default=None)
     parser.add_argument('-m', '--matrix', type=str, default=None)
@@ -558,7 +558,7 @@ def parse_args(argv: List[str]) -> Any:
     return parser.parse_args()
 
 
-def main(argv: List[str]) -> int:
+def main(argv: list[str]) -> int:
     options = parse_args(argv)
 
     basedir = os.path.abspath(os.path.dirname(argv[0]))

--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -8,7 +8,8 @@ import sys
 
 import yaml
 
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 
 SchemaType = Mapping[str, Any]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -10,6 +10,10 @@ extend-exclude = [
 
 [lint]
 select = ["E", "F", "W", "UP"]
+extend-ignore = [
+  "UP031", # printf-string-formatting
+  "UP032", # f-string
+]
 
 [lint.per-file-ignores]
 "cupyx/scipy/special/_gammainc.py" = [

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,7 +9,7 @@ extend-exclude = [
 ]
 
 [lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "UP"]
 
 [lint.per-file-ignores]
 "cupyx/scipy/special/_gammainc.py" = [

--- a/cupy/_core/_codeblock.py
+++ b/cupy/_core/_codeblock.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 _CodeType = Any  # TODO(asi1024): Correct type annotation
 
@@ -11,8 +11,8 @@ class CodeBlock:
         self._head = '' if head == '' else head + ' '
         self._codes = codes
 
-    def _to_str_list(self, indent_width: int = 0) -> List[str]:
-        codes: List[str] = []
+    def _to_str_list(self, indent_width: int = 0) -> list[str]:
+        codes: list[str] = []
         codes.append(' ' * indent_width + self._head + '{')
         for code in self._codes:
             next_indent_width = indent_width + 2

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -19,7 +19,7 @@ _OUTPUT_ARGUMENTS = '{0:}(?:,{0:})*'.format(
     _ARGUMENT
 )  # Use `'{0:}(?:,{0:})*,?'` if gufunc-
 # signature should be allowed for length 1 tuple returns
-_SIGNATURE = '^{0:}->{1:}$'.format(_INPUT_ARGUMENTS, _OUTPUT_ARGUMENTS)
+_SIGNATURE = '^{:}->{:}$'.format(_INPUT_ARGUMENTS, _OUTPUT_ARGUMENTS)
 
 
 def _parse_gufunc_signature(signature):

--- a/cupy/_creation/ranges.py
+++ b/cupy/_creation/ranges.py
@@ -326,7 +326,7 @@ def meshgrid(*xi, **kwargs):
     return meshes_br
 
 
-class nd_grid(object):
+class nd_grid:
     """Construct a multi-dimensional "meshgrid".
 
     ``grid = nd_grid()`` creates an instance which will return a mesh-grid

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -11,7 +11,7 @@ import platform
 import re
 import shutil
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 import warnings
 
 
@@ -268,14 +268,14 @@ def get_cupy_cuda_lib_path():
     return os.path.abspath(cupy_cuda_lib_path)
 
 
-def get_preload_config() -> Optional[Dict[str, Any]]:
+def get_preload_config() -> Optional[dict[str, Any]]:
     global _preload_config
     if _preload_config is None:
         _preload_config = _get_json_data('_wheel.json')
     return _preload_config
 
 
-def _get_json_data(name: str) -> Optional[Dict[str, Any]]:
+def _get_json_data(name: str) -> Optional[dict[str, Any]]:
     config_path = os.path.join(
         get_cupy_install_path(), 'cupy', '.data', name)
     if not os.path.exists(config_path):
@@ -383,7 +383,7 @@ def _preload_library(lib):
                 _log(f'Library {lib} could not be preloaded: {e}')
 
 
-def _parse_version(version: str) -> Tuple[int, int, int]:
+def _parse_version(version: str) -> tuple[int, int, int]:
     parts = re.split(r'[^\d]', version, maxsplit=3)
     major = int(parts[0])
     minor = int(parts[1]) if len(parts) >= 2 else 0
@@ -391,7 +391,7 @@ def _parse_version(version: str) -> Tuple[int, int, int]:
     return major, minor, patch
 
 
-def _get_cutensor_from_wheel(version: str, cuda: str) -> List[str]:
+def _get_cutensor_from_wheel(version: str, cuda: str) -> list[str]:
     """
     Returns the list of shared library path candidates for cuTENSOR
     installed via Pip (cutensor-cuXX package).
@@ -460,7 +460,7 @@ You can install the library by:
 ''')
 
 
-def _get_include_dir_from_conda_or_wheel(major: int, minor: int) -> List[str]:
+def _get_include_dir_from_conda_or_wheel(major: int, minor: int) -> list[str]:
     # FP16 headers from CUDA 12.2+ depends on headers from CUDA Runtime.
     # See https://github.com/cupy/cupy/issues/8466.
     if major < 12 or (major == 12 and minor < 2):

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -12,7 +12,7 @@ def _get_input_type(arg):
         return numpy.dtype(type(arg)).char
 
 
-class vectorize(object):
+class vectorize:
     """Generalized function class.
 
     .. seealso:: :class:`numpy.vectorize`

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -11,7 +11,7 @@ from cupy._creation import from_data
 from cupy._manipulation import join
 
 
-class AxisConcatenator(object):
+class AxisConcatenator:
     """Translates slice objects to concatenation along an axis.
 
     For detailed documentation on usage, see :func:`cupy.r_`.

--- a/cupy/_indexing/generate.py
+++ b/cupy/_indexing/generate.py
@@ -81,7 +81,7 @@ class AxisConcatenator:
 class CClass(AxisConcatenator):
 
     def __init__(self):
-        super(CClass, self).__init__(-1, ndmin=2, trans1d=0)
+        super().__init__(-1, ndmin=2, trans1d=0)
 
 
 c_ = CClass()
@@ -114,7 +114,7 @@ array([[1, 2, 3, 0, 0, 4, 5, 6]], dtype=int32)
 class RClass(AxisConcatenator):
 
     def __init__(self):
-        super(RClass, self).__init__()
+        super().__init__()
 
 
 r_ = RClass()

--- a/cupy/_io/npz.py
+++ b/cupy/_io/npz.py
@@ -8,7 +8,7 @@ import cupy
 _support_allow_pickle = (numpy.lib.NumpyVersion(numpy.__version__) >= '1.10.0')
 
 
-class NpzFile(object):
+class NpzFile:
 
     def __init__(self, npz_file):
         self.npz_file = npz_file

--- a/cupy/_statistics/order.py
+++ b/cupy/_statistics/order.py
@@ -190,7 +190,7 @@ def _quantile_unchecked(a, q, axis=None, out=None,
         zerod = False
     if q.ndim > 1:
         raise ValueError('Expected q to have a dimension of 1.\n'
-                         'Actual: {0} != 1'.format(q.ndim))
+                         'Actual: {} != 1'.format(q.ndim))
     if isinstance(axis, int):
         axis = axis,
     if keepdims:
@@ -242,7 +242,7 @@ def _quantile_unchecked(a, q, axis=None, out=None,
         pass
     else:
         raise ValueError('Unexpected interpolation method.\n'
-                         'Actual: \'{0}\' not in (\'linear\', \'lower\', '
+                         'Actual: \'{}\' not in (\'linear\', \'lower\', '
                          '\'higher\', \'midpoint\')'.format(method))
 
     if indices.dtype == cupy.int32:

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -24,7 +24,7 @@ from cupy_backends.cuda.libs import nvrtc  # NOQA
 _available = None
 
 
-class _UnavailableModule():
+class _UnavailableModule:
     available = False
 
     def __init__(self, name):

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -665,7 +665,7 @@ class CompileException(Exception):
         self.name = name
         self.options = options
         self.backend = backend
-        super(CompileException, self).__init__()
+        super().__init__()
 
     def __reduce__(self):
         return (type(self), (self._msg, self.source, self.name,

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -70,11 +70,11 @@ def _run_cc(cmd, cwd, backend, log_stream=None):
             log_stream.write(log)
         return log
     except subprocess.CalledProcessError as e:
-        msg = ('`{0}` command returns non-zero exit status. \n'
-               'command: {1}\n'
-               'return-code: {2}\n'
+        msg = ('`{}` command returns non-zero exit status. \n'
+               'command: {}\n'
+               'return-code: {}\n'
                'stdout/stderr: \n'
-               '{3}'.format(backend,
+               '{}'.format(backend,
                             e.cmd,
                             e.returncode,
                             e.output))
@@ -782,9 +782,9 @@ def compile_using_hipcc(source, options, arch, log_stream=None):
         if not os.path.isfile(out_path):
             raise HIPCCException(
                 '`hipcc` command does not generate output file. \n'
-                'command: {0}\n'
+                'command: {}\n'
                 'stdout/stderr: \n'
-                '{1}'.format(cmd, output))
+                '{}'.format(cmd, output))
         with open(out_path, 'rb') as f:
             return f.read()
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -696,7 +696,7 @@ class CompileException(Exception):
         f.flush()
 
 
-class _NVRTCProgram(object):
+class _NVRTCProgram:
 
     def __init__(self, src, name='default_program', headers=(),
                  include_names=(), name_expressions=None, method='ptx'):

--- a/cupy/cuda/memory_hooks/line_profile.py
+++ b/cupy/cuda/memory_hooks/line_profile.py
@@ -114,7 +114,7 @@ class LineProfileHook(memory_hook.MemoryHook):
             self._print_frame(child, depth=depth + 1, file=file)
 
 
-class StackFrame(object):
+class StackFrame:
     """Compatibility layer for outputs of traceback.extract_stack().
 
     Attributes:
@@ -134,7 +134,7 @@ class StackFrame(object):
             self.name = obj.name
 
 
-class MemoryFrame(object):
+class MemoryFrame:
     """A single stack frame along with sum of memory usage at the frame.
 
     Attributes:

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -25,7 +25,7 @@ _UINT32_MAX = 0xffffffff
 _UINT64_MAX = 0xffffffffffffffff
 
 
-class RandomState(object):
+class RandomState:
 
     """Portable container of a pseudo-random number generator.
 

--- a/cupy/testing/_condition.py
+++ b/cupy/testing/_condition.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 
-class QuietTestRunner(object):
+class QuietTestRunner:
 
     def run(self, suite):
         result = unittest.TestResult()

--- a/cupy/testing/_condition.py
+++ b/cupy/testing/_condition.py
@@ -39,7 +39,7 @@ def repeat_with_success_at_least(times, min_success):
             results = []
 
             def fail():
-                msg = '\nFail: {0}, Success: {1}'.format(
+                msg = '\nFail: {}, Success: {}'.format(
                     failure_counter, success_counter)
                 if len(results) > 0:
                     first = results[0]

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -2,7 +2,6 @@ import functools
 import inspect
 import os
 import random
-from typing import Tuple, Type
 import traceback
 import unittest
 import warnings
@@ -22,7 +21,7 @@ from cupy.testing._pytest_impl import is_available
 if is_available():
     import _pytest.outcomes
     _is_pytest_available = True
-    _skip_classes: Tuple[Type, ...] = (
+    _skip_classes: tuple[type, ...] = (
         unittest.SkipTest, _pytest.outcomes.Skipped)
 else:
     _is_pytest_available = False

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -23,7 +23,7 @@ def _eval_or_error(func, errors):
         return repr(e)
 
 
-class _InstallInfo(object):
+class _InstallInfo:
 
     # TODO(niboshi): Add is_binary_distribution
 

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -14,7 +14,7 @@ from cupy import _util
 import cupyx.scipy.sparse
 
 
-class MatDescriptor(object):
+class MatDescriptor:
 
     def __init__(self, descriptor):
         self.descriptor = descriptor
@@ -1268,7 +1268,7 @@ def _dtype_to_IndexType(dtype):
         raise TypeError
 
 
-class BaseDescriptor(object):
+class BaseDescriptor:
 
     def __init__(self, descriptor, get=None, destroyer=None):
         self.desc = descriptor

--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -502,7 +502,7 @@ class _SparseNCCLCommunicator:
         # We get the elements from the array and send them
         # so that other process can create receiving arrays for it
         # However, this exchange synchronizes the gpus
-        sizes_shape = shape + tuple((a.size for a in arrays))
+        sizes_shape = shape + tuple(a.size for a in arrays)
         return sizes_shape
 
     @classmethod

--- a/cupyx/distributed/array/_array.py
+++ b/cupyx/distributed/array/_array.py
@@ -1,5 +1,6 @@
 from itertools import chain
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Optional
+from collections.abc import Iterable
 
 import numpy
 from numpy.typing import ArrayLike

--- a/cupyx/distributed/array/_chunk.py
+++ b/cupyx/distributed/array/_chunk.py
@@ -1,6 +1,7 @@
 import contextlib
 from itertools import chain
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Optional, Union
+from collections.abc import Iterator
 
 import numpy
 

--- a/cupyx/distributed/array/_data_transfer.py
+++ b/cupyx/distributed/array/_data_transfer.py
@@ -1,6 +1,7 @@
 import contextlib
 import dataclasses
-from typing import Any, Iterable, Iterator
+from typing import Any
+from collections.abc import Iterable, Iterator
 
 from cupy._core.core import ndarray
 import cupy._creation.from_data as _creation_from_data

--- a/cupyx/distributed/array/_elementwise.py
+++ b/cupyx/distributed/array/_elementwise.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Sequence
+from collections.abc import Sequence
 from itertools import chain
 
 import cupy

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -1,4 +1,5 @@
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 import warnings
 
 import cupy

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -5,7 +5,8 @@ import linecache
 import numbers
 import re
 import sys
-from typing import Any, Optional, Sequence, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
+from collections.abc import Sequence
 import warnings
 import types
 

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -350,15 +350,13 @@ def _transpile_function_internal(
         # TODO(asi1024): Support for `ast.ClassDef`.
         raise NotImplementedError('Not supported: {}'.format(type(func)))
     if len(func.decorator_list) > 0:
-        if sys.version_info >= (3, 9):
-            # Code path for Python versions that support `ast.unparse`.
-            for deco in func.decorator_list:
-                deco_code = ast.unparse(deco)
-                if not any(word in deco_code
-                           for word in ['rawkernel', 'vectorize']):
-                    warnings.warn(
-                        f'Decorator {deco_code} may not supported in JIT.',
-                        RuntimeWarning)
+        for deco in func.decorator_list:
+            deco_code = ast.unparse(deco)
+            if not any(word in deco_code
+                       for word in ['rawkernel', 'vectorize']):
+                warnings.warn(
+                    f'Decorator {deco_code} may not supported in JIT.',
+                    RuntimeWarning)
     arguments = func.args
     if arguments.vararg is not None:
         raise NotImplementedError('`*args` is not supported currently.')

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -5,7 +5,7 @@ import linecache
 import numbers
 import re
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Optional, Sequence, TypeVar, Union
 import warnings
 import types
 
@@ -157,11 +157,11 @@ class Generated:
 
     def __init__(self) -> None:
         # list of str
-        self.codes: List[str] = []
+        self.codes: list[str] = []
         # (function, in_types) => Optional(function_name, return_type)
         self.device_function: \
-            Dict[Tuple[Any, Tuple[_cuda_types.TypeBase, ...]],
-                 Tuple[str, _cuda_types.TypeBase]] = {}
+            dict[tuple[Any, tuple[_cuda_types.TypeBase, ...]],
+                 tuple[str, _cuda_types.TypeBase]] = {}
         # whether to use cooperative launch
         self.enable_cg = False
         # whether to include cooperative_groups.h
@@ -245,7 +245,7 @@ def _transpile_func_obj(func, attributes, mode, in_types, ret_type, generated):
     return name, env.ret_type
 
 
-def _indent(lines: List[str], spaces: str = '  ') -> List[str]:
+def _indent(lines: list[str], spaces: str = '  ') -> list[str]:
     return [spaces + line for line in lines]
 
 
@@ -275,16 +275,16 @@ class Environment:
     def __init__(
             self,
             mode: str,
-            consts: Dict[str, Constant],
-            params: Dict[str, Data],
+            consts: dict[str, Constant],
+            params: dict[str, Data],
             ret_type: _cuda_types.TypeBase,
             generated: Generated,
     ):
         self.mode = mode
         self.consts = consts
         self.params = params
-        self.locals: Dict[str, Data] = {}
-        self.decls: Dict[str, Data] = {}
+        self.locals: dict[str, Data] = {}
+        self.decls: dict[str, Data] = {}
         self.ret_type = ret_type
         self.generated = generated
         self.count = 0
@@ -500,7 +500,7 @@ __device__ {out_type} {ufunc_name}({params}) {{
 
 
 def _transpile_stmts(
-        stmts: List[ast.stmt],
+        stmts: list[ast.stmt],
         is_toplevel: bool,
         env: Environment,
 ) -> _CodeType:
@@ -731,7 +731,7 @@ def _transpile_expr_internal(
     if isinstance(expr, ast.Call):
         func = _transpile_expr(expr.func, env)
         args = [_transpile_expr(x, env) for x in expr.args]
-        kwargs: Dict[str, Union[Constant, Data]] = {}
+        kwargs: dict[str, Union[Constant, Data]] = {}
         for kw in expr.keywords:
             assert kw.arg is not None
             kwargs[kw.arg] = _transpile_expr(kw.value, env)

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -1,5 +1,6 @@
 import ast
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Optional
+from collections.abc import Mapping
 
 import numpy
 import numpy.typing as npt

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Any, Callable, Mapping, Optional, Tuple, Type
+from typing import Any, Callable, Mapping, Optional
 
 import numpy
 import numpy.typing as npt
@@ -39,7 +39,7 @@ _scalar_gt = _core.create_comparison('scalar_less', '>')
 _scalar_gte = _core.create_comparison('scalar_less', '>=')
 
 
-_py_ops: Mapping[Type[ast.AST], Callable[..., Any]] = {
+_py_ops: Mapping[type[ast.AST], Callable[..., Any]] = {
     ast.And: lambda x, y: x and y,
     ast.Or: lambda x, y: x or y,
     ast.Add: operator.add,
@@ -66,7 +66,7 @@ _py_ops: Mapping[Type[ast.AST], Callable[..., Any]] = {
 }
 
 
-_numpy_ops: Mapping[Type[ast.AST], cupy.ufunc] = {
+_numpy_ops: Mapping[type[ast.AST], cupy.ufunc] = {
     ast.And: ops.logical_and,
     ast.Or: ops.logical_or,
     ast.Add: arithmetic.add,
@@ -93,11 +93,11 @@ _numpy_ops: Mapping[Type[ast.AST], cupy.ufunc] = {
 }
 
 
-def get_pyfunc(op_type: Type[ast.AST]) -> Callable[..., Any]:
+def get_pyfunc(op_type: type[ast.AST]) -> Callable[..., Any]:
     return _py_ops[op_type]
 
 
-def get_ufunc(mode: str, op_type: Type[ast.AST]) -> cupy.ufunc:
+def get_ufunc(mode: str, op_type: type[ast.AST]) -> cupy.ufunc:
     if mode == 'numpy':
         return _numpy_ops[op_type]
     if mode == 'cuda':
@@ -145,7 +145,7 @@ def _cuda_can_cast(from_dtype: npt.DTypeLike, to_dtype: npt.DTypeLike) -> bool:
 
 def guess_routine(
         ufunc: cupy.ufunc,
-        in_types: Tuple[numpy.dtype, ...],
+        in_types: tuple[numpy.dtype, ...],
         dtype: Optional[numpy.dtype],
         mode: str,
 ) -> cupy._core._kernel._Op:

--- a/cupyx/jit/_cuda_types.py
+++ b/cupyx/jit/_cuda_types.py
@@ -1,4 +1,5 @@
-from typing import Mapping, Optional, Sequence, Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
+from collections.abc import Mapping, Sequence
 
 import numpy
 import numpy.typing as npt

--- a/cupyx/scipy/fft/_helper.py
+++ b/cupyx/scipy/fft/_helper.py
@@ -1,9 +1,8 @@
-from typing import Dict, List, Tuple
 
 import math
 
 
-_next_fast_len_cache: Dict[Tuple[int, List[int]], int] = {}
+_next_fast_len_cache: dict[tuple[int, list[int]], int] = {}
 
 
 def _next_fast_len_impl(n, primes):

--- a/cupyx/scipy/fftpack/_fft.py
+++ b/cupyx/scipy/fftpack/_fft.py
@@ -91,8 +91,8 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         if n == 1:
             axis1D = axes[0]
             if axis1D >= a.ndim or axis1D < -a.ndim:
-                err = 'The chosen axis ({0}) exceeds the number of '\
-                      'dimensions of a ({1})'.format(axis1D, a.ndim)
+                err = 'The chosen axis ({}) exceeds the number of '\
+                      'dimensions of a ({})'.format(axis1D, a.ndim)
                 raise ValueError(err)
         elif n > 3:
             raise ValueError('Only up to three axes is supported')

--- a/cupyx/scipy/interpolate/_cubic.py
+++ b/cupyx/scipy/interpolate/_cubic.py
@@ -45,7 +45,7 @@ def prepare_input(x, y, axis, dydx=None):
     if x.shape[0] < 2:
         raise ValueError("`x` must contain at least 2 elements.")
     if x.shape[0] != y.shape[axis]:
-        raise ValueError("The length of `y` along `axis`={0} doesn't "
+        raise ValueError("The length of `y` along `axis`={} doesn't "
                          "match the length of `x`".format(axis))
 
     if not cupy.all(cupy.isfinite(x)):

--- a/cupyx/scipy/interpolate/_rbfinterp.py
+++ b/cupyx/scipy/interpolate/_rbfinterp.py
@@ -718,7 +718,7 @@ class RBFInterpolator:
         nnei = len(y)
 
         # in each chunk we consume the same space we already occupy
-        chunksize = memory_budget // ((self.powers.shape[0] + nnei)) + 1
+        chunksize = memory_budget // (self.powers.shape[0] + nnei) + 1
         if chunksize <= nx:
             out = cp.empty((nx, self.d.shape[1]), dtype=float)
             for i in range(0, nx, chunksize):

--- a/cupyx/scipy/ndimage/_pba_2d.py
+++ b/cupyx/scipy/ndimage/_pba_2d.py
@@ -68,7 +68,7 @@ def get_pba2d_src(block_size_2d=64, marker=-32768, pixel_int2_t="short2"):
         make_pixel_func=make_pixel_func
     )
     kernel_directory = os.path.join(os.path.dirname(__file__), "cuda")
-    with open(os.path.join(kernel_directory, "pba_kernels_2d.h"), "rt") as f:
+    with open(os.path.join(kernel_directory, "pba_kernels_2d.h")) as f:
         pba2d_kernels = "\n".join(f.readlines())
 
     pba2d_code += pba2d_kernels

--- a/cupyx/scipy/ndimage/_pba_3d.py
+++ b/cupyx/scipy/ndimage/_pba_3d.py
@@ -76,7 +76,7 @@ def get_pba3d_src(block_size_3d=32, marker=-2147483648, max_int=2147483647,
     else:
         pba3d_code += pba3d_defines_encode_32bit
     kernel_directory = os.path.join(os.path.dirname(__file__), "cuda")
-    with open(os.path.join(kernel_directory, "pba_kernels_3d.h"), "rt") as f:
+    with open(os.path.join(kernel_directory, "pba_kernels_3d.h")) as f:
         pba3d_kernels = "\n".join(f.readlines())
     pba3d_code += pba3d_kernels
     return pba3d_code

--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -254,7 +254,7 @@ def compute_root_from_lambda(lamb):
     omega = np.arctan(np.sqrt((144 * lamb - 1.0) / xi))
     tmp2 = np.sqrt(xi)
     r = ((24 * lamb - 1 - tmp2) / (24 * lamb) *
-         np.sqrt((48*lamb + 24 * lamb * tmp)) / tmp2)
+         np.sqrt(48*lamb + 24 * lamb * tmp) / tmp2)
     return r, omega
 
 

--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -1095,7 +1095,7 @@ def istft(
         if len(win.shape) != 1:
             raise ValueError("window must be 1-D")
         if win.shape[0] != nperseg:
-            raise ValueError("window must have length of {0}".format(nperseg))
+            raise ValueError("window must have length of {}".format(nperseg))
 
     ifunc = cupy.fft.irfft if input_onesided else cupy.fft.ifft
     xsubs = ifunc(Zxx, axis=-2, n=nfft)[..., :nperseg, :]

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -325,7 +325,7 @@ def _spectral_helper(
 
     if boundary not in boundary_funcs:
         raise ValueError(
-            "Unknown boundary option '{0}', must be one of: {1}".format(
+            "Unknown boundary option '{}', must be one of: {}".format(
                 boundary, list(boundary_funcs.keys())
             )
         )

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -338,7 +338,7 @@ def _get_tpb_bpg():
     return threadsperblock, blockspergrid
 
 
-class _UpFIRDn(object):
+class _UpFIRDn:
     def __init__(self, h, x_dtype, up, down):
         """Helper for resampling"""
         h = cupy.asarray(h)

--- a/cupyx/scipy/signal/windows/_windows.py
+++ b/cupyx/scipy/signal/windows/_windows.py
@@ -26,7 +26,6 @@ from CuSignal under terms of the MIT license.
 # DEALINGS IN THE SOFTWARE.
 
 import warnings
-from typing import Set
 
 import cupy
 import numpy as np
@@ -2207,7 +2206,7 @@ for k, v in _win_equiv_raw.items():
         _win_equiv[key] = v[0]
 
 # Keep track of which windows need additional parameters
-_needs_param: Set[str] = set()
+_needs_param: set[str] = set()
 for k, v in _win_equiv_raw.items():
     if v[1]:
         _needs_param.update(k)

--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -23,7 +23,7 @@ except ImportError:
 # TODO(asi1024): Implement _spbase
 
 
-class spmatrix(object):
+class spmatrix:
 
     """Base class of all sparse matrixes.
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -143,7 +143,7 @@ def _non_zero_cmp(mat, am, zero, m):
             zero_ind)
 
 
-class _minmax_mixin(object):
+class _minmax_mixin:
     """Mixin for min and max methods.
     These are not implemented for dia_matrix, hence the separate class.
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -177,8 +177,8 @@ class _minmax_mixin:
 
     def _min_or_max(self, axis, out, min_or_max, explicit):
         if out is not None:
-            raise ValueError(("Sparse matrices do not support "
-                              "an 'out' parameter."))
+            raise ValueError("Sparse matrices do not support "
+                              "an 'out' parameter.")
 
         _sputils.validateaxis(axis)
 

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -338,7 +338,7 @@ _csr_sample_values_kern = _core.ElementwiseKernel(
 ''', 'cupyx_scipy_sparse_csr_sample_values_kern')
 
 
-class IndexMixin(object):
+class IndexMixin:
     """
     This class provides common dispatching and validation logic for indexing.
     """

--- a/cupyx/scipy/sparse/_sputils.py
+++ b/cupyx/scipy/sparse/_sputils.py
@@ -74,9 +74,9 @@ def validateaxis(axis):
         # dimensions, so let's make it explicit that they are not
         # allowed to be passed in
         if isinstance(axis, tuple):
-            raise TypeError(("Tuples are not accepted for the 'axis' "
+            raise TypeError("Tuples are not accepted for the 'axis' "
                              "parameter. Please pass in one of the "
-                             "following: {-2, -1, 0, 1, None}."))
+                             "following: {-2, -1, 0, 1, None}.")
 
         axis_type = type(axis)
 

--- a/cupyx/scipy/sparse/linalg/_interface.py
+++ b/cupyx/scipy/sparse/linalg/_interface.py
@@ -34,9 +34,9 @@ rmatmat=None)
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
             # Operate as _CustomLinearOperator factory.
-            return super(LinearOperator, cls).__new__(_CustomLinearOperator)
+            return super().__new__(_CustomLinearOperator)
         else:
-            obj = super(LinearOperator, cls).__new__(cls)
+            obj = super().__new__(cls)
 
             if (type(obj)._matvec == LinearOperator._matvec
                     and type(obj)._matmat == LinearOperator._matmat):
@@ -261,7 +261,7 @@ class _CustomLinearOperator(LinearOperator):
 
     def __init__(self, shape, matvec, rmatvec=None, matmat=None,
                  dtype=None, rmatmat=None):
-        super(_CustomLinearOperator, self).__init__(dtype, shape)
+        super().__init__(dtype, shape)
 
         self.args = ()
 
@@ -276,7 +276,7 @@ class _CustomLinearOperator(LinearOperator):
         if self.__matmat_impl is not None:
             return self.__matmat_impl(X)
         else:
-            return super(_CustomLinearOperator, self)._matmat(X)
+            return super()._matmat(X)
 
     def _matvec(self, x):
         return self.__matvec_impl(x)
@@ -291,7 +291,7 @@ class _CustomLinearOperator(LinearOperator):
         if self.__rmatmat_impl is not None:
             return self.__rmatmat_impl(X)
         else:
-            return super(_CustomLinearOperator, self)._rmatmat(X)
+            return super()._rmatmat(X)
 
     def _adjoint(self):
         return _CustomLinearOperator(shape=(self.shape[1], self.shape[0]),
@@ -307,7 +307,7 @@ class _AdjointLinearOperator(LinearOperator):
 
     def __init__(self, A):
         shape = (A.shape[1], A.shape[0])
-        super(_AdjointLinearOperator, self).__init__(
+        super().__init__(
             dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
@@ -330,7 +330,7 @@ class _TransposedLinearOperator(LinearOperator):
 
     def __init__(self, A):
         shape = (A.shape[1], A.shape[0])
-        super(_TransposedLinearOperator, self).__init__(
+        super().__init__(
             dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
@@ -368,7 +368,7 @@ class _SumLinearOperator(LinearOperator):
             raise ValueError('cannot add %r and %r: shape mismatch'
                              % (A, B))
         self.args = (A, B)
-        super(_SumLinearOperator, self).__init__(_get_dtype([A, B]), A.shape)
+        super().__init__(_get_dtype([A, B]), A.shape)
 
     def _matvec(self, x):
         return self.args[0].matvec(x) + self.args[1].matvec(x)
@@ -395,7 +395,7 @@ class _ProductLinearOperator(LinearOperator):
         if A.shape[1] != B.shape[0]:
             raise ValueError('cannot multiply %r and %r: shape mismatch'
                              % (A, B))
-        super(_ProductLinearOperator, self).__init__(_get_dtype([A, B]),
+        super().__init__(_get_dtype([A, B]),
                                                      (A.shape[0], B.shape[1]))
         self.args = (A, B)
 
@@ -423,7 +423,7 @@ class _ScaledLinearOperator(LinearOperator):
         if not cupy.isscalar(alpha):
             raise ValueError('scalar expected as alpha')
         dtype = _get_dtype([A], [type(alpha)])
-        super(_ScaledLinearOperator, self).__init__(dtype, A.shape)
+        super().__init__(dtype, A.shape)
         self.args = (A, alpha)
 
     def _matvec(self, x):
@@ -452,7 +452,7 @@ class _PowerLinearOperator(LinearOperator):
         if not _util.isintlike(p) or p < 0:
             raise ValueError('non-negative integer expected as p')
 
-        super(_PowerLinearOperator, self).__init__(_get_dtype([A]), A.shape)
+        super().__init__(_get_dtype([A]), A.shape)
         self.args = (A, p)
 
     def _power(self, fun, x):
@@ -480,7 +480,7 @@ class _PowerLinearOperator(LinearOperator):
 
 class MatrixLinearOperator(LinearOperator):
     def __init__(self, A):
-        super(MatrixLinearOperator, self).__init__(A.dtype, A.shape)
+        super().__init__(A.dtype, A.shape)
         self.A = A
         self.__adj = None
         self.args = (A,)
@@ -511,7 +511,7 @@ class _AdjointMatrixOperator(MatrixLinearOperator):
 
 class IdentityOperator(LinearOperator):
     def __init__(self, shape, dtype=None):
-        super(IdentityOperator, self).__init__(dtype, shape)
+        super().__init__(dtype, shape)
 
     def _matvec(self, x):
         return x

--- a/cupyx/scipy/sparse/linalg/_interface.py
+++ b/cupyx/scipy/sparse/linalg/_interface.py
@@ -6,7 +6,7 @@ from cupyx.scipy import sparse
 from cupyx.scipy.sparse import _util
 
 
-class LinearOperator(object):
+class LinearOperator:
     """LinearOperator(shape, matvec, rmatvec=None, matmat=None, dtype=None, \
 rmatmat=None)
 

--- a/cupyx/scipy/sparse/linalg/_norm.py
+++ b/cupyx/scipy/sparse/linalg/_norm.py
@@ -35,7 +35,7 @@ def norm(x, ord=None, axis=None):
     """
 
     if not cupyx.scipy.sparse.issparse(x):
-        raise TypeError(("input is not sparse. use cupy.linalg.norm"))
+        raise TypeError("input is not sparse. use cupy.linalg.norm")
 
     # Check the default case first and handle it immediately.
     if axis is None and ord in (None, 'fro', 'f'):

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -525,7 +525,7 @@ def spsolve(A, b):
         return cupyx.cusolver.csrlsvqr(A, b)
 
 
-class SuperLU():
+class SuperLU:
 
     def __init__(self, obj):
         """LU factorization of a sparse matrix.

--- a/cupyx/tools/_hipsparse_stub_mapper.py
+++ b/cupyx/tools/_hipsparse_stub_mapper.py
@@ -1,6 +1,5 @@
 import urllib.request
 import sys
-from typing import Tuple
 
 
 # Take cupy_backends/stub/cupy_cusparse.h and generate
@@ -34,7 +33,7 @@ hip_versions = ("3.5.0", "3.7.0", "3.8.0", "3.9.0", "4.0.0", "4.2.0")
 
 
 # typedefs
-typedefs: Tuple[str, ...]
+typedefs: tuple[str, ...]
 typedefs = ('cusparseIndexBase_t', 'cusparseStatus_t', 'cusparseHandle_t',
             'cusparseMatDescr_t', 'csrsv2Info_t', 'csrsm2Info_t',
             'csric02Info_t', 'bsric02Info_t', 'csrilu02Info_t',

--- a/cupyx/tools/_hipsparse_stub_mapper.py
+++ b/cupyx/tools/_hipsparse_stub_mapper.py
@@ -343,8 +343,8 @@ def main(hip_h, cu_h, stubs, hip_version, init):
                     hip_stub_h.append("#endif")
             else:
                 hip_stub_h.append(
-                    (line[:line.find('return')+6]
-                     + ' HIPSPARSE_STATUS_NOT_SUPPORTED;'))
+                    line[:line.find('return')+6]
+                     + ' HIPSPARSE_STATUS_NOT_SUPPORTED;')
 
         elif 'return' in line:
             if 'CUSPARSE_STATUS' in line:

--- a/cupyx/tools/_hipsparse_stub_mapper.py
+++ b/cupyx/tools/_hipsparse_stub_mapper.py
@@ -367,12 +367,12 @@ def main(hip_h, cu_h, stubs, hip_version, init):
 
 
 if __name__ == '__main__':
-    with open('cupy_backends/stub/cupy_cusparse.h', 'r') as f:
+    with open('cupy_backends/stub/cupy_cusparse.h') as f:
         stubs = f.read()
 
     init = False
     for cu_ver in cu_versions:
-        with open(cusparse_h.format(cu_ver), 'r') as f:
+        with open(cusparse_h.format(cu_ver)) as f:
             cu_h = f.read()
 
         x = 0

--- a/examples/gemm/utils.py
+++ b/examples/gemm/utils.py
@@ -2,7 +2,7 @@ import cupy as cp
 
 
 def read_code(code_filename, params):
-    with open(code_filename, 'r') as f:
+    with open(code_filename) as f:
         code = f.read()
     for k, v in params.items():
         code = '#define ' + k + ' ' + str(v) + '\n' + code

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -3,7 +3,7 @@ import os
 import os.path
 import subprocess
 import sys
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import setuptools
 import setuptools.command.build_ext
@@ -15,9 +15,9 @@ from cupy_builder._compiler import DeviceCompilerUnix, DeviceCompilerWin32
 
 
 def filter_files_by_extension(
-        sources: List[str],
+        sources: list[str],
         extension: str,
-) -> Tuple[List[str], List[str]]:
+) -> tuple[list[str], list[str]]:
     sources_selected = []
     sources_others = []
     for src in sources:
@@ -31,7 +31,7 @@ def filter_files_by_extension(
 def compile_device_code(
         ctx: Context,
         ext: setuptools.Extension
-) -> Tuple[List[str], List[str]]:
+) -> tuple[list[str], list[str]]:
     """Compiles device code ("*.cu").
 
     This method invokes the device compiler (nvcc/hipcc) to build object
@@ -72,7 +72,7 @@ def _get_timestamp(path: str) -> float:
     return max(stat.st_atime, stat.st_mtime, stat.st_ctime)
 
 
-def dumpbin_dependents(dumpbin: str, path: str) -> List[str]:
+def dumpbin_dependents(dumpbin: str, path: str) -> list[str]:
     args = [dumpbin, '/nologo', '/dependents', path]
     try:
         p = subprocess.run(args, stdout=subprocess.PIPE)
@@ -108,7 +108,7 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
         }
 
         # Compile-time constants to be used in Cython code
-        compile_time_env: Dict[str, Any] = {}
+        compile_time_env: dict[str, Any] = {}
 
         # Enable CUDA Python.
         # TODO: add `cuda` to `setup_requires` only when this flag is set

--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -5,7 +5,7 @@ import platform
 import shutil
 import sys
 import subprocess
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from setuptools import Extension
 
@@ -13,7 +13,7 @@ from cupy_builder._context import Context
 import cupy_builder.install_build as build
 
 
-def _nvcc_gencode_options(cuda_version: int) -> List[str]:
+def _nvcc_gencode_options(cuda_version: int) -> list[str]:
     """Returns NVCC GPU code generation options."""
 
     if sys.argv == ['setup.py', 'develop']:
@@ -164,16 +164,16 @@ class DeviceCompilerBase:
     def __init__(self, ctx: Context):
         self._context = ctx
 
-    def _get_preprocess_options(self, ext: Extension) -> List[str]:
+    def _get_preprocess_options(self, ext: Extension) -> list[str]:
         # https://setuptools.pypa.io/en/latest/deprecated/distutils/apiref.html#distutils.core.Extension
         # https://github.com/pypa/setuptools/blob/v60.0.0/setuptools/_distutils/command/build_ext.py#L524-L526
         incdirs = ext.include_dirs[:]
-        macros: List[Any] = ext.define_macros[:]
+        macros: list[Any] = ext.define_macros[:]
         for undef in ext.undef_macros:
             macros.append((undef,))
         return distutils.ccompiler.gen_preprocess_options(macros, incdirs)
 
-    def spawn(self, commands: List[str]) -> None:
+    def spawn(self, commands: list[str]) -> None:
         print('Command:', commands)
         subprocess.check_call(commands)
 
@@ -271,7 +271,7 @@ class DeviceCompilerWin32(DeviceCompilerBase):
                   'setuptools.msvc could not be imported')
             return None
 
-        vctools: List[str] = setuptools.msvc.EnvironmentInfo(
+        vctools: list[str] = setuptools.msvc.EnvironmentInfo(
             platform.machine()).VCTools
         for path in vctools:
             cl_exe = os.path.join(path, 'cl.exe')

--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -3,7 +3,7 @@ import glob
 import hashlib
 import os
 import sys
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional
 
 import cupy_builder
 
@@ -12,7 +12,7 @@ def _get_env_bool(name: str, default: bool, env: Mapping[str, str]) -> bool:
     return env[name] != '0' if name in env else default
 
 
-def _get_env_path(name: str, env: Mapping[str, str]) -> List[str]:
+def _get_env_path(name: str, env: Mapping[str, str]) -> list[str]:
     paths = env.get(name, None)
     if paths is None:
         return []
@@ -23,7 +23,7 @@ class Context:
     def __init__(
             self, source_root: str, *,
             _env: Mapping[str, str] = os.environ,
-            _argv: List[str] = sys.argv):
+            _argv: list[str] = sys.argv):
         self.source_root = source_root
 
         self.use_cuda_python = _get_env_bool(
@@ -37,8 +37,8 @@ class Context:
         self.package_name: str = cmdopts.cupy_package_name
         self.long_description_path: Optional[str] = (
             cmdopts.cupy_long_description)
-        self.wheel_libs: List[str] = cmdopts.cupy_wheel_lib
-        self.wheel_includes: List[str] = cmdopts.cupy_wheel_include
+        self.wheel_libs: list[str] = cmdopts.cupy_wheel_lib
+        self.wheel_includes: list[str] = cmdopts.cupy_wheel_include
         self.wheel_metadata_path: Optional[str] = (
             cmdopts.cupy_wheel_metadata)
         self.no_rpath: bool = cmdopts.cupy_no_rpath
@@ -78,7 +78,7 @@ class Context:
         self.win32_cl_exe_path: Optional[str] = None
 
 
-def parse_args(argv: List[str]) -> Tuple[Any, List[str]]:
+def parse_args(argv: list[str]) -> tuple[Any, list[str]]:
     parser = argparse.ArgumentParser(add_help=False)
 
     parser.add_argument(

--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -3,7 +3,8 @@ import glob
 import hashlib
 import os
 import sys
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
+from collections.abc import Mapping
 
 import cupy_builder
 

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -148,7 +148,7 @@ _cuda_files = [
 
 # Libraries required for cudart_static
 _cudart_static_libs = (
-    (['pthread', 'rt', 'dl'] if sys.platform == 'linux' else [])
+    ['pthread', 'rt', 'dl'] if sys.platform == 'linux' else []
 )
 
 

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List
+from typing import Any
 
 import cupy_builder.install_build as build
 import cupy_builder.install_utils as utils
@@ -18,17 +18,17 @@ class Feature:
         self.required = False
 
         # List of Cython modules.
-        self.modules: List[str] = []
+        self.modules: list[str] = []
 
         # C/C++ headers required for the feature.
         # This is used only for testing availability of the feature.
-        self.includes: List[str] = []
+        self.includes: list[str] = []
 
         # Libraries (shared/static) on the search path to be linked.
-        self.libraries: List[str] = []
+        self.libraries: list[str] = []
 
         # Static libraries (manually searched) to be linked.
-        self.static_libraries: List[str] = []
+        self.static_libraries: list[str] = []
 
         # Version of the feature.
         self._version: Any = self._UNDETERMINED
@@ -61,7 +61,7 @@ class Feature:
         return getattr(self, key)
 
 
-def _from_dict(d: Dict[str, Any], ctx: Context) -> Feature:
+def _from_dict(d: dict[str, Any], ctx: Context) -> Feature:
     # Define a feature from dict.
     # TODO(kmaehashi): Remove this transient function.
     f = Feature(ctx)
@@ -152,7 +152,7 @@ _cudart_static_libs = (
 )
 
 
-def get_features(ctx: Context) -> Dict[str, Feature]:
+def get_features(ctx: Context) -> dict[str, Feature]:
     # We handle nvtx (and likely any other future support) here, because
     # the HIP stubs (hip/cupy_*.h) would cause many symbols
     # to leak into all these modules even if unused. It's easier for all of

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -364,7 +364,7 @@ def check_compute_capabilities(compiler, settings):
             library_dirs=settings['library_dirs'])
         _compute_capabilities = set([int(o) for o in out.split()])
     except Exception as e:
-        utils.print_warning('Cannot check compute capability\n{0}'.format(e))
+        utils.print_warning('Cannot check compute capability\n{}'.format(e))
         return False
 
     return True
@@ -388,7 +388,7 @@ def check_thrust_version(compiler, settings):
         }
         ''', include_dirs=settings['include_dirs'])
     except Exception as e:
-        utils.print_warning('Cannot check Thrust version\n{0}'.format(e))
+        utils.print_warning('Cannot check Thrust version\n{}'.format(e))
         return False
 
     _thrust_version = int(out)
@@ -420,7 +420,7 @@ def check_cudnn_version(compiler, settings):
         ''', include_dirs=settings['include_dirs'])
 
     except Exception as e:
-        utils.print_warning('Cannot check cuDNN version\n{0}'.format(e))
+        utils.print_warning('Cannot check cuDNN version\n{}'.format(e))
         return False
 
     _cudnn_version = int(out)
@@ -476,7 +476,7 @@ def check_nccl_version(compiler, settings):
                             define_macros=settings['define_macros'])
 
     except Exception as e:
-        utils.print_warning('Cannot include NCCL\n{0}'.format(e))
+        utils.print_warning('Cannot include NCCL\n{}'.format(e))
         return False
 
     _nccl_version = int(out)
@@ -564,9 +564,9 @@ def check_cub_version(compiler, settings):
                     out += int(local_patch[0]) + int(local_patch[1])
             else:
                 raise RuntimeError('Cannot determine CUB version from git tag'
-                                   '\n{0}'.format(e))
+                                   '\n{}'.format(e))
         except Exception as e:
-            utils.print_warning('Cannot determine CUB version\n{0}'.format(e))
+            utils.print_warning('Cannot determine CUB version\n{}'.format(e))
             # 0: CUB is not built (makes no sense), -1: built with unknown ver
             out = -1
 
@@ -652,7 +652,7 @@ def check_cutensor_version(compiler, settings):
         ''', include_dirs=settings['include_dirs'])
 
     except Exception as e:
-        utils.print_warning('Cannot check cuTENSOR version\n{0}'.format(e))
+        utils.print_warning('Cannot check cuTENSOR version\n{}'.format(e))
         return False
 
     _cutensor_version = int(out)
@@ -691,7 +691,7 @@ def check_cusparselt_version(compiler, settings):
         ''', include_dirs=settings['include_dirs'])
 
     except Exception as e:
-        utils.print_warning('Cannot check cuSPARSELt version\n{0}'.format(e))
+        utils.print_warning('Cannot check cuSPARSELt version\n{}'.format(e))
         return False
 
     _cusparselt_version = int(out)
@@ -794,7 +794,7 @@ def build_shlib(compiler, source, libraries=(),
                                      extra_postargs=postargs,
                                      target_lang='c++')
         except Exception as e:
-            msg = 'Cannot build a stub file.\nOriginal error: {0}'.format(e)
+            msg = 'Cannot build a stub file.\nOriginal error: {}'.format(e)
             raise Exception(msg)
 
 
@@ -823,7 +823,7 @@ def build_and_run(compiler, source, libraries=(),
                                      extra_postargs=postargs,
                                      target_lang='c++')
         except Exception as e:
-            msg = 'Cannot build a stub file.\nOriginal error: {0}'.format(e)
+            msg = 'Cannot build a stub file.\nOriginal error: {}'.format(e)
             raise Exception(msg)
 
         try:
@@ -831,5 +831,5 @@ def build_and_run(compiler, source, libraries=(),
             return out
 
         except Exception as e:
-            msg = 'Cannot execute a stub file.\nOriginal error: {0}'.format(e)
+            msg = 'Cannot execute a stub file.\nOriginal error: {}'.format(e)
             raise Exception(msg)

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -10,7 +10,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List, Set
 
 import cupy_builder
 import cupy_builder.install_utils as utils
@@ -89,7 +88,7 @@ def get_cuda_path():
     return _cuda_path
 
 
-def get_nvcc_path() -> List[str]:
+def get_nvcc_path() -> list[str]:
     nvcc = os.environ.get('NVCC', None)
     if nvcc:
         return shlex.split(nvcc)
@@ -110,7 +109,7 @@ def get_nvcc_path() -> List[str]:
         return None
 
 
-def get_hipcc_path() -> List[str]:
+def get_hipcc_path() -> list[str]:
     hipcc = os.environ.get('HIPCC', None)
     if hipcc:
         return shlex.split(hipcc)
@@ -238,7 +237,7 @@ def _match_output_lines(output_lines, regexs):
     return None
 
 
-def get_compiler_base_options(compiler_path: List[str]) -> List[str]:
+def get_compiler_base_options(compiler_path: list[str]) -> list[str]:
     """Returns base options for nvcc compiler.
 
     """
@@ -371,7 +370,7 @@ def check_compute_capabilities(compiler, settings):
     return True
 
 
-def get_compute_capabilities(formatted: bool = False) -> Set[int]:
+def get_compute_capabilities(formatted: bool = False) -> set[int]:
     return _compute_capabilities
 
 

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -540,9 +540,12 @@ def check_cub_version(compiler, settings):
             cupy_cub_include = os.path.join(
                 cupy_builder.get_context().source_root,
                 "third_party/cccl")
-            a = subprocess.run(' '.join(['git', 'describe', '--tags']),
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               shell=True, cwd=cupy_cub_include)
+            a = subprocess.run(
+                " ".join(["git", "describe", "--tags"]),
+                capture_output=True,
+                shell=True,
+                cwd=cupy_cub_include,
+            )
             if a.returncode == 0:
                 tag = a.stdout.decode()[:-1]
 
@@ -594,9 +597,12 @@ def check_jitify_version(compiler, settings):
             "third_party/jitify")
         # Unfortunately Jitify does not have any identifiable name (branch,
         # tag, etc), so we must use the commit here
-        a = subprocess.run(' '.join(['git', 'rev-parse', '--short', 'HEAD']),
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                           shell=True, cwd=cupy_jitify_include)
+        a = subprocess.run(
+            " ".join(["git", "rev-parse", "--short", "HEAD"]),
+            capture_output=True,
+            shell=True,
+            cwd=cupy_jitify_include,
+        )
         if a.returncode == 0:
             out = a.stdout.decode()[:-1]  # unlike elsewhere, out is a str here
         else:

--- a/install/cupy_builder/install_utils.py
+++ b/install/cupy_builder/install_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional
+from typing import Optional
 
 
 def print_warning(*lines: str) -> None:
@@ -9,11 +9,11 @@ def print_warning(*lines: str) -> None:
     print('**************************************************')
 
 
-def get_path(key: str) -> List[str]:
+def get_path(key: str) -> list[str]:
     return os.environ.get(key, '').split(os.pathsep)
 
 
-def search_on_path(filenames: List[str]) -> Optional[str]:
+def search_on_path(filenames: list[str]) -> Optional[str]:
     for p in get_path('PATH'):
         for filename in filenames:
             full = os.path.join(p, filename)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
@@ -7,7 +7,7 @@ import cupy
 from cupy import testing
 
 
-class CreateMock(object):
+class CreateMock:
 
     def __init__(self, target):
         self.target = eval(target)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
@@ -424,7 +424,7 @@ class TestFusionMultiDevice(unittest.TestCase):
         return out1, out2
 
 
-class TestFusionInvalid():
+class TestFusionInvalid:
 
     def test_branch(self):
         @cupy.fuse()

--- a/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
@@ -6,7 +6,7 @@ from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-class CreateMock(object):
+class CreateMock:
 
     def __init__(self, target):
         self.target = eval(target)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -77,7 +77,7 @@ class TestFusionArrayContents(FusionUnaryUfuncTestBase):
 
     def generate_inputs(self, xp, has_nan, dtype):
         if numpy.dtype(dtype).kind not in ('f', 'c'):
-            return super(TestFusionArrayContents, self).generate_inputs(
+            return super().generate_inputs(
                 xp, dtype)
 
         nan = numpy.nan

--- a/tests/cupy_tests/core_tests/test_gufuncs.py
+++ b/tests/cupy_tests/core_tests/test_gufuncs.py
@@ -166,7 +166,7 @@ class TestGUFuncDtype:
             testing.assert_allclose(z, x)
 
 
-class TestGUFuncOrder():
+class TestGUFuncOrder:
 
     @pytest.mark.parametrize('order', ['C', 'F', 'K'])
     @testing.numpy_cupy_array_equal(strides_check=True)
@@ -196,7 +196,7 @@ class TestGUFuncOrder():
             assert z.flags.f_contiguous
 
 
-class TestGUFuncSignatures():
+class TestGUFuncSignatures:
     def test_signatures(self):
         dtypes = 'fdihq'
         dtypes_access = {d: None for d in dtypes}

--- a/tests/cupy_tests/core_tests/test_include.py
+++ b/tests/cupy_tests/core_tests/test_include.py
@@ -36,7 +36,7 @@ __device__ void kernel() {
 class TestIncludesCompileCUDA:
     def _get_cuda_archs(self):
         cuda_ver = cupy.cuda.runtime.runtimeGetVersion()
-        to_exclude = set((int(a) for a in cupy.cuda.compiler._tegra_archs))
+        to_exclude = set(int(a) for a in cupy.cuda.compiler._tegra_archs)
         if cuda_ver < 11000:
             # CUDA 10.2 (Tegra excluded)
             archs = (30, 35, 50, 52, 60, 61, 70, 75)

--- a/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_cuda_array_interface.py
@@ -10,7 +10,7 @@ from cupy import testing
 # TODO(leofang): test PTDS in this file
 
 
-class DummyObjectWithCudaArrayInterface(object):
+class DummyObjectWithCudaArrayInterface:
 
     def __init__(self, a, ver=3):
         self.a = a

--- a/tests/cupy_tests/core_tests/test_scan.py
+++ b/tests/cupy_tests/core_tests/test_scan.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import unittest
 
 import cupy

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -685,7 +685,7 @@ class TestCudaArrayInterfaceBigArray(unittest.TestCase):
 
 @pytest.mark.skipif(
     cupy.cuda.runtime.is_hip, reason='HIP does not support this')
-class DummyObjectWithCudaArrayInterface(object):
+class DummyObjectWithCudaArrayInterface:
     def __init__(self, a, ver, include_strides=False, mask=None, stream=None):
         assert ver in tuple(range(max_cuda_array_interface_version+1))
         self.a = None

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -938,7 +938,7 @@ class TestAllocatorDisabled(unittest.TestCase):
         self._check_pool_not_used()
 
 
-class PythonAllocator(object):
+class PythonAllocator:
     def __init__(self):
         self.malloc_called = False
         self.free_called = False

--- a/tests/cupy_tests/cuda_tests/test_texture.py
+++ b/tests/cupy_tests/cuda_tests/test_texture.py
@@ -175,7 +175,7 @@ class TestTexture:
 
         if (self.mem_type == 'linear' and dim != 1) or \
            (self.mem_type == 'pitch2D' and dim != 2):
-            pytest.skip('The test case {0} is inapplicable for {1} and thus '
+            pytest.skip('The test case {} is inapplicable for {} and thus '
                         'skipped.'.format(self.dimensions, self.mem_type))
 
         # generate input data and allocate output buffer

--- a/tests/cupy_tests/fft_tests/test_cache.py
+++ b/tests/cupy_tests/fft_tests/test_cache.py
@@ -362,8 +362,8 @@ class TestPlanCache(unittest.TestCase):
         curr_size += 1
         curr_memsize += node1.plan.work_area.mem.size
         stdout = intercept_stdout(cache.show_info)
-        assert '{0} / {1} (counts)'.format(curr_size, size) in stdout
-        assert '{0} / {1} (bytes)'.format(curr_memsize, memsize) in stdout
+        assert '{} / {} (counts)'.format(curr_size, size) in stdout
+        assert '{} / {} (bytes)'.format(curr_memsize, memsize) in stdout
         assert str(node1) in stdout
 
         a = testing.shaped_random((1024,), cupy, cupy.complex64)
@@ -373,8 +373,8 @@ class TestPlanCache(unittest.TestCase):
         curr_size += 1
         curr_memsize += node2.plan.work_area.mem.size
         stdout = intercept_stdout(cache.show_info)
-        assert '{0} / {1} (counts)'.format(curr_size, size) in stdout
-        assert '{0} / {1} (bytes)'.format(curr_memsize, memsize) in stdout
+        assert '{} / {} (counts)'.format(curr_size, size) in stdout
+        assert '{} / {} (bytes)'.format(curr_memsize, memsize) in stdout
         assert str(node2) + '\n' + str(node1) in stdout
 
         # test deletion
@@ -384,8 +384,8 @@ class TestPlanCache(unittest.TestCase):
         curr_size -= 1
         curr_memsize -= node2.plan.work_area.mem.size
         stdout = intercept_stdout(cache.show_info)
-        assert '{0} / {1} (counts)'.format(curr_size, size) in stdout
-        assert '{0} / {1} (bytes)'.format(curr_memsize, memsize) in stdout
+        assert '{} / {} (counts)'.format(curr_size, size) in stdout
+        assert '{} / {} (bytes)'.format(curr_memsize, memsize) in stdout
         assert str(node2) not in stdout
 
     @multi_gpu_config(gpu_configs=[[0, 1], [1, 0]])

--- a/tests/cupy_tests/manipulation_tests/test_basic.py
+++ b/tests/cupy_tests/manipulation_tests/test_basic.py
@@ -186,7 +186,7 @@ class TestBasic:
 
 @testing.parameterize(
     *testing.product(
-        {'src': [float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j],
+        {'src': [3.2, 0, 4, -4, True, False, 1 + 1j],
          'dst_shape': [(), (0,), (1,), (1, 1), (2, 2)]}))
 class TestCopytoFromScalar:
 
@@ -250,7 +250,7 @@ class TestCopytoFromNumpyScalar:
 
 @pytest.mark.parametrize('shape', [(3, 2), (0,)])
 @pytest.mark.parametrize('where', [
-    float(3.2), int(0), int(4), int(-4), True, False, 1 + 1j
+    3.2, 0, 4, -4, True, False, 1 + 1j
 ])
 @testing.for_all_dtypes()
 @testing.numpy_cupy_allclose()

--- a/tests/cupy_tests/testing_tests/test_loops.py
+++ b/tests/cupy_tests/testing_tests/test_loops.py
@@ -215,7 +215,7 @@ class TestCheckCupyNumpyError(unittest.TestCase):
             dummy_axis_error(self)
 
 
-class NumPyCuPyDecoratorBase(object):
+class NumPyCuPyDecoratorBase:
 
     def test_valid(self):
         decorator = getattr(testing, self.decorator)()
@@ -248,7 +248,7 @@ def cupy_error(_, xp):
         raise ValueError()
 
 
-class NumPyCuPyDecoratorBase2(object):
+class NumPyCuPyDecoratorBase2:
 
     def test_accept_error_numpy(self):
         decorator = getattr(testing, self.decorator)(accept_error=False)

--- a/tests/cupy_tests/testing_tests/test_parameterized.py
+++ b/tests/cupy_tests/testing_tests/test_parameterized.py
@@ -43,7 +43,7 @@ def f(x):
     return x
 
 
-class C(object):
+class C:
 
     def __repr__(self):
         return '<C object>'

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -134,7 +134,7 @@ class TestDctDst:
     )
 )
 @testing.with_requires('scipy>=1.12.0rc1')
-class TestDctnDstn():
+class TestDctnDstn:
 
     def _run_transform(self, dct_func, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -445,7 +445,7 @@ class TestRegularGridInterpolator:
         assert v.shape == (1, *trailing_points)
 
         # check the values, too : manually loop over the trailing dimensions
-        vs = cp.empty((values.shape[-2:]))
+        vs = cp.empty(values.shape[-2:])
         for i in range(values.shape[-2]):
             for j in range(values.shape[-1]):
                 interp = RegularGridInterpolator(points, values[..., i, j],
@@ -476,7 +476,7 @@ class TestRegularGridInterpolator:
         assert v.shape == (1, *trailing_points)
 
         # check the values, too : manually loop over the trailing dimensions
-        vs = cp.empty((values.shape[-2:]))
+        vs = cp.empty(values.shape[-2:])
         for i in range(values.shape[-2]):
             for j in range(values.shape[-1]):
                 interp = RegularGridInterpolator(points, values[..., i, j],

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -309,7 +309,7 @@ class TestFourierUniform:
     )
 )
 @testing.with_requires('scipy')
-class TestFourierEllipsoid():
+class TestFourierEllipsoid:
     def _test_real_nd(self, xp, scp, x, real_axis):
         if x.ndim == 1 and scipy_version < '1.5.3':
             # 1D case gives an incorrect result in SciPy < 1.5.3
@@ -379,7 +379,7 @@ class TestFourierEllipsoid():
 
 
 @testing.with_requires('scipy')
-class TestFourierEllipsoidInvalid():
+class TestFourierEllipsoidInvalid:
 
     # SciPy < 1.5 raises ValueError instead of AxisError
     @testing.with_requires('scipy>=1.5.0')

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -835,7 +835,7 @@ class TestZoom:
     'zoom': [(1, 1), (3, 5), (8, 2), (8, 8)],
     'mode': ['nearest', 'reflect', 'mirror', 'grid-wrap', 'grid-constant'],
 }))
-class TestZoomOrder0IntegerGrid():
+class TestZoomOrder0IntegerGrid:
 
     def test_zoom_grid_by_int_order0(self):
         # When grid_mode is True,  order 0 zoom should be the same as
@@ -858,7 +858,7 @@ class TestZoomOrder0IntegerGrid():
     'order': [0, 1, 2, 3, 4, 5],
     'grid_mode': [False, True],
 }))
-class TestZoomOutputSize1():
+class TestZoomOutputSize1:
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -372,7 +372,7 @@ class TestMeasurementsSelect:
     'shape': [(200,), (16, 20)],
 }))
 @testing.with_requires('scipy')
-class TestHistogram():
+class TestHistogram:
 
     def _make_image(self, shape, xp, dtype, scale):
         return testing.shaped_random(shape, xp, dtype=dtype, scale=scale)
@@ -413,7 +413,7 @@ class TestHistogram():
     'pass_positions': [True, False],
 }))
 @testing.with_requires('scipy')
-class TestLabeledComprehension():
+class TestLabeledComprehension:
 
     def _make_image(self, shape, xp, dtype, scale):
         if dtype == xp.bool_:

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
@@ -64,8 +64,7 @@ zf_checks = [check_zoom_fft, check_zoom_fft_2, check_zoom_fft_3, check_czt]
 
 def _gen_random_signal():
     lengths = testing.shaped_random((8, 200, 20))
-    for x in lengths:
-        yield x
+    yield from lengths
 
 
 @testing.with_requires("scipy >= 1.8.0")

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
@@ -292,7 +292,7 @@ class TestDecimate:
         rate = 120
         rates_to = [15, 20, 30, 40]  # q = 8, 6, 4, 3
 
-        t_tot = int(100)  # Need to let antialiasing filters settle
+        t_tot = 100  # Need to let antialiasing filters settle
         t = xp.arange(rate * t_tot + 1) / float(rate)
 
         # Sinusoids at 0.8*nyquist, windowed to avoid edge artifacts

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
@@ -19,7 +19,7 @@ class TestSpmatrix(unittest.TestCase):
             class DummySparseGPU(sparse.spmatrix):
 
                 def __init__(self, maxprint=50, shape=None, nnz=0):
-                    super(DummySparseGPU, self).__init__(maxprint)
+                    super().__init__(maxprint)
                     self._shape = shape
                     self._nnz = nnz
 
@@ -34,7 +34,7 @@ class TestSpmatrix(unittest.TestCase):
             class DummySparseCPU(scipy.sparse._base._spbase):
 
                 def __init__(self, maxprint=50, shape=None, nnz=0):
-                    super(DummySparseCPU, self).__init__(
+                    super().__init__(
                         None, maxprint=maxprint)
                     self._shape = shape
                     self._nnz = nnz

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -13,7 +13,7 @@ def _boundary_inputs(boundary, rtol, atol):
     return [left, boundary, right]
 
 
-class _TestBase(object):
+class _TestBase:
 
     def test_erf(self):
         self.check_unary('erf')

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gammainc.py
@@ -10,7 +10,7 @@ from cupy.testing import assert_allclose, assert_array_equal
 INVALID_POINTS = [(1, -1), (0, 0), (-1, 1), (cp.nan, 1), (1, cp.nan)]
 
 
-class TestGammainc(object):
+class TestGammainc:
     @pytest.mark.skipif(
         cp.cuda.runtime.is_hip and
         cp.cuda.runtime.runtimeGetVersion() < 5_00_00000,
@@ -108,7 +108,7 @@ class TestGammainc(object):
         assert_allclose(x, y, rtol=1e-10)
 
 
-class TestGammaincc(object):
+class TestGammaincc:
     @pytest.mark.parametrize("a, x", INVALID_POINTS)
     def test_domain(self, a, x):
         assert cp.isnan(sc.gammaincc(a, x))

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -16,7 +16,7 @@ def _get_harmonic_list(degree_max):
 
 
 @testing.with_requires("scipy")
-class TestBasic():
+class TestBasic:
 
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])


### PR DESCRIPTION
This PR enables the `UP` rules, which bans deprecated/outdated codes.

### MEMO

`UP031` and `UP032` are ignored for now because diffs. would be too large with them.