### PR TITLE
Documented the arguments of cupyx.jit.rawkernel 

### DIFF
--- a/cupyx/jit/_interface.py
+++ b/cupyx/jit/_interface.py
@@ -169,6 +169,11 @@ class _JitRawKernel:
 
 def rawkernel(*, mode='cuda', device=False):
     """A decorator compiles a Python function into CUDA kernel.
+    Args:
+        mode ('numpy' or 'cuda'): The rule for typecast.
+        device (int or cupy.cuda.Device): Index of the device to be used. 
+        Be careful that the device ID (a.k.a. GPU ID) is zero origin. The 
+        current device is selected by default.
     """
     cupy._util.experimental('cupyx.jit.rawkernel')
 


### PR DESCRIPTION
Documentation for the issue: #8681 
```py
cupyx.jit.rawkernel(*, mode='cuda', device=False)
```
**Documentation added**
mode ('numpy' or 'cuda'): The rule for typecast.
device (int or cupy.cuda.Device): Index of the device to be used. Be careful that the device ID (a.k.a. GPU ID) is zero origin. The current device is selected by default.