### PR TITLE
add axes support for additional functions in cupyx.scipy.ndimage (from SciPy 1.15.0)

### DIFF
--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -927,6 +927,7 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
         # expand origins ,footprint and structure if num_axes < input.ndim
         ftprnt = _util._expand_footprint(input.ndim, axes, ftprnt)
         origins = _util._expand_origin(input.ndim, axes, origin)
+        modes = tuple(_util._expand_mode(input.ndim, axes, modes))
 
     if structure is not None:
         structure = _util._expand_footprint(

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -152,7 +152,7 @@ def generate_binary_structure(rank, connectivity):
 
 
 def _binary_erosion(input, structure, iterations, mask, output, border_value,
-                    origin, invert, brute_force=True):
+                    origin, invert, brute_force=True, *, axes=None):
     try:
         iterations = operator.index(iterations)
     except TypeError:
@@ -160,8 +160,11 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
 
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
+    ndim = input.ndim
+    axes = _util._check_axes(axes, ndim)
+    num_axes = len(axes)
     if structure is None:
-        structure = generate_binary_structure(input.ndim, 1)
+        structure = generate_binary_structure(num_axes, 1)
         all_weights_nonzero = input.ndim == 1
         center_is_true = True
         structure_shape = structure.shape
@@ -175,13 +178,19 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
         structure_shape = structure.shape
         # transfer to CPU for use in determining if it is fully dense
         # structure_cpu = cupy.asnumpy(structure)
-        if structure.ndim != input.ndim:
+        if structure.ndim != num_axes:
             raise RuntimeError(
                 'structure and input must have same dimensionality')
         if not structure.flags.c_contiguous:
             structure = cupy.ascontiguousarray(structure)
         if structure.size < 1:
             raise RuntimeError('structure must not be empty')
+
+    if num_axes < ndim:
+        structure = _util._expand_footprint(
+            ndim, axes, structure, footprint_name="structure"
+        )
+        structure_shape = structure.shape
 
     if mask is not None:
         if mask.shape != input.shape:
@@ -191,7 +200,9 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
         masked = True
     else:
         masked = False
-    origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
+    origin = _util._fix_sequence_arg(origin, num_axes, 'origin', int)
+    if num_axes < ndim:
+        origin = _util._expand_origin(ndim, axes, origin)
 
     if isinstance(output, cupy.ndarray):
         if output.dtype.kind == 'c':
@@ -304,7 +315,7 @@ def _prep_structure(structure, ndim):
 
 
 def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
-                   border_value=0, origin=0, brute_force=False):
+                   border_value=0, origin=0, brute_force=False, *, axes=None):
     """Multidimensional binary erosion with a given structuring element.
 
     Binary erosion is a mathematical morphology operation used for image
@@ -313,10 +324,14 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
     Args:
         input(cupy.ndarray): The input binary array_like to be eroded.
             Non-zero (True) elements form the subset to be eroded.
-        structure(cupy.ndarray, optional): The structuring element used for the
-            erosion. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None).
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the erosion. Non-zero elements are considered
+            true. If no structuring element is provided an element is
+            generated with a square connectivity equal to one. If a tuple of
+            integers is provided, a structuring element of the specified shape
+            is used (all elements true). If an integer is provided, the
+            structuring element will have the same size along all axes.
+            (Default value = None).
         iterations(int, optional): The erosion is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the erosion is
             repeated until the result does not change anymore. Only an integer
@@ -335,6 +350,9 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
             candidates to be updated (eroded) in the current iteration; if
             True all pixels are considered as candidates for erosion,
             regardless of what happened in the previous iteration.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of binary erosion.
@@ -347,20 +365,25 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
     """
     structure, _, _ = _prep_structure(structure, input.ndim)
     return _binary_erosion(input, structure, iterations, mask, output,
-                           border_value, origin, 0, brute_force)
+                           border_value, origin, 0, brute_force, axes=axes)
 
 
 def binary_dilation(input, structure=None, iterations=1, mask=None,
-                    output=None, border_value=0, origin=0, brute_force=False):
+                    output=None, border_value=0, origin=0, brute_force=False,
+                    *, axes=None):
     """Multidimensional binary dilation with the given structuring element.
 
     Args:
         input(cupy.ndarray): The input binary array_like to be dilated.
             Non-zero (True) elements form the subset to be dilated.
-        structure(cupy.ndarray, optional): The structuring element used for the
-            dilation. Non-zero elements are considered True. If no structuring
-            element is provided an element is generated with a square
-            connectivity equal to one. (Default value = None).
+        structure(cupy.ndarray or tuple or int, optional): The structuring
+            element used for the dilation. Non-zero elements are considered
+            true. If no structuring element is provided an element is
+            generated with a square connectivity equal to one. If a tuple of
+            integers is provided, a structuring element of the specified shape
+            is used (all elements true). If an integer is provided, the
+            structuring element will have the same size along all axes.
+            (Default value = None).
         iterations(int, optional): The dilation is repeated ``iterations``
             times (one, by default). If iterations is less than 1, the dilation
             is repeated until the result does not change anymore. Only an
@@ -379,6 +402,9 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
             candidates to be updated (dilated) in the current iteration; if
             True all pixels are considered as candidates for dilation,
             regardless of what happened in the previous iteration.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of binary dilation.
@@ -391,7 +417,8 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
     """
     structure, structure_shape, symmetric = _prep_structure(structure,
                                                             input.ndim)
-    origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
+    axes = _util._check_axes(axes, input.ndim)
+    origin = _util._fix_sequence_arg(origin, len(axes), 'origin', int)
     # no point in flipping if already symmetric
     if not symmetric:
         structure = structure[tuple([slice(None, None, -1)] * structure.ndim)]
@@ -400,11 +427,11 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
         if not structure_shape[ii] & 1:
             origin[ii] -= 1
     return _binary_erosion(input, structure, iterations, mask, output,
-                           border_value, origin, 1, brute_force)
+                           border_value, origin, 1, brute_force, axes=axes)
 
 
 def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
-                   mask=None, border_value=0, brute_force=False):
+                   mask=None, border_value=0, brute_force=False, *, axes=None):
     """
     Multidimensional binary opening with the given structuring element.
 
@@ -415,13 +442,13 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
         input(cupy.ndarray): The input binary array to be opened.
             Non-zero (True) elements form the subset to be opened.
         structure(cupy.ndarray or tuple or int, optional): The structuring
-            element used for the erosion. Non-zero elements are considered
-            True. If no structuring element is provided an element is generated
-            with a square connectivity equal to one. (Default value = None). If
-            a tuple of integers is provided, a structuring element of the
-            specified shape is used (all elements True). If an integer is
-            provided, the structuring element will have the same size along all
-            axes.
+            element used for the opening. Non-zero elements are considered
+            true. If no structuring element is provided an element is
+            generated with a square connectivity equal to one. If a tuple of
+            integers is provided, a structuring element of the specified shape
+            is used (all elements true). If an integer is provided, the
+            structuring element will have the same size along all axes.
+            (Default value = None).
         iterations(int, optional): The opening is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the opening is
             repeated until the result does not change anymore. Only an integer
@@ -440,6 +467,9 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
             candidates to be updated (dilated) in the current iteration; if
             True all pixels are considered as candidates for opening,
             regardless of what happened in the previous iteration.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of binary opening.
@@ -452,13 +482,13 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
     """
     structure, _, _ = _prep_structure(structure, input.ndim)
     tmp = binary_erosion(input, structure, iterations, mask, None,
-                         border_value, origin, brute_force)
+                         border_value, origin, brute_force, axes=axes)
     return binary_dilation(tmp, structure, iterations, mask, output,
-                           border_value, origin, brute_force)
+                           border_value, origin, brute_force, axes=axes)
 
 
 def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
-                   mask=None, border_value=0, brute_force=False):
+                   mask=None, border_value=0, brute_force=False, *, axes=None):
     """
     Multidimensional binary closing with the given structuring element.
 
@@ -469,13 +499,13 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
         input(cupy.ndarray): The input binary array to be closed.
             Non-zero (True) elements form the subset to be closed.
         structure(cupy.ndarray or tuple or int, optional): The structuring
-            element used for the erosion. Non-zero elements are considered
-            True. If no structuring element is provided an element is generated
-            with a square connectivity equal to one. (Default value = None). If
-            a tuple of integers is provided, a structuring element of the
-            specified shape is used (all elements True). If an integer is
-            provided, the structuring element will have the same size along all
-            axes.
+            element used for the closing. Non-zero elements are considered
+            true. If no structuring element is provided an element is
+            generated with a square connectivity equal to one. If a tuple of
+            integers is provided, a structuring element of the specified shape
+            is used (all elements true). If an integer is provided, the
+            structuring element will have the same size along all axes.
+            (Default value = None).
         iterations(int, optional): The closing is repeated ``iterations`` times
             (one, by default). If iterations is less than 1, the closing is
             repeated until the result does not change anymore. Only an integer
@@ -494,6 +524,9 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
             candidates to be updated (dilated) in the current iteration; if
             True all pixels are considered as candidates for closing,
             regardless of what happened in the previous iteration.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of binary closing.
@@ -506,13 +539,13 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
     """
     structure, _, _ = _prep_structure(structure, input.ndim)
     tmp = binary_dilation(input, structure, iterations, mask, None,
-                          border_value, origin, brute_force)
+                          border_value, origin, brute_force, axes=axes)
     return binary_erosion(tmp, structure, iterations, mask, output,
-                          border_value, origin, brute_force)
+                          border_value, origin, brute_force, axes=axes)
 
 
 def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
-                       origin1=0, origin2=None):
+                       origin1=0, origin2=None, *, axes=None):
     """
     Multidimensional binary hit-or-miss transform.
 
@@ -537,6 +570,9 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
             second part of the structuring element ``structure2``, by default 0
             for a centered structure. If a value is provided for ``origin1``
             and not for ``origin2``, then ``origin2`` is set to ``origin1``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: Hit-or-miss transform of ``input`` with the given
@@ -552,17 +588,19 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
         structure1 = generate_binary_structure(input.ndim, 1)
     if structure2 is None:
         structure2 = cupy.logical_not(structure1)
-    origin1 = _util._fix_sequence_arg(origin1, input.ndim, 'origin1', int)
+    axes = _util._check_axes(axes, input.ndim)
+    num_axes = len(axes)
+    origin1 = _util._fix_sequence_arg(origin1, num_axes, 'origin1', int)
     if origin2 is None:
         origin2 = origin1
     else:
-        origin2 = _util._fix_sequence_arg(origin2, input.ndim, 'origin2', int)
+        origin2 = _util._fix_sequence_arg(origin2, num_axes, 'origin2', int)
 
     tmp1 = _binary_erosion(input, structure1, 1, None, None, 0, origin1, 0,
-                           False)
+                           False, axes=axes)
     inplace = isinstance(output, cupy.ndarray)
     result = _binary_erosion(input, structure2, 1, None, output, 0, origin2, 1,
-                             False)
+                             False, axes=axes)
     if inplace:
         cupy.logical_not(output, output)
         cupy.logical_and(tmp1, output, output)
@@ -572,7 +610,7 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
 
 
 def binary_propagation(input, structure=None, mask=None, output=None,
-                       border_value=0, origin=0):
+                       border_value=0, origin=0, *, axes=None):
     """
     Multidimensional binary propagation with the given structuring element.
 
@@ -590,6 +628,9 @@ def binary_propagation(input, structure=None, mask=None, output=None,
         border_value (int, optional): Value at the border in the output array.
             The value is cast to 0 or 1.
         origin (int or tuple of ints, optional): Placement of the filter.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray : Binary propagation of ``input`` inside ``mask``.
@@ -601,10 +642,11 @@ def binary_propagation(input, structure=None, mask=None, output=None,
     .. seealso:: :func:`scipy.ndimage.binary_propagation`
     """
     return binary_dilation(input, structure, -1, mask, output, border_value,
-                           origin, brute_force=True)
+                           origin, brute_force=True, axes=axes)
 
 
-def binary_fill_holes(input, structure=None, output=None, origin=0):
+def binary_fill_holes(input, structure=None, output=None, origin=0, *,
+                      axes=None):
     """Fill the holes in binary objects.
 
     Args:
@@ -619,6 +661,9 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
             is created.
         origin (int, tuple of ints, optional): Position of the structuring
             element.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: Transformation of the initial image ``input`` where holes
@@ -636,17 +681,17 @@ def binary_fill_holes(input, structure=None, output=None, origin=0):
     # TODO (grlee77): set brute_force=False below once implemented
     if inplace:
         binary_dilation(tmp, structure, -1, mask, output, 1, origin,
-                        brute_force=True)
+                        brute_force=True, axes=axes)
         cupy.logical_not(output, output)
     else:
         output = binary_dilation(tmp, structure, -1, mask, None, 1, origin,
-                                 brute_force=True)
+                                 brute_force=True, axes=axes)
         cupy.logical_not(output, output)
         return output
 
 
 def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
-                 mode='reflect', cval=0.0, origin=0):
+                 mode='reflect', cval=0.0, origin=0, *, axes=None):
     """Calculates a greyscale erosion.
 
     Args:
@@ -671,6 +716,9 @@ def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of greyscale erosion.
@@ -682,11 +730,13 @@ def grey_erosion(input, size=None, footprint=None, structure=None, output=None,
         raise ValueError('size, footprint or structure must be specified')
 
     return _filters._min_or_max_filter(input, size, footprint, structure,
-                                       output, mode, cval, origin, 'min', None)
+                                       output, mode, cval, origin, 'min',
+                                       axes=axes)
 
 
 def grey_dilation(input, size=None, footprint=None, structure=None,
-                  output=None, mode='reflect', cval=0.0, origin=0):
+                  output=None, mode='reflect', cval=0.0, origin=0, *,
+                  axes=None):
     """Calculates a greyscale dilation.
 
     Args:
@@ -711,6 +761,9 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of greyscale dilation.
@@ -727,7 +780,8 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
         footprint = cupy.array(footprint)
         footprint = footprint[tuple([slice(None, None, -1)] * footprint.ndim)]
 
-    origin = _util._fix_sequence_arg(origin, input.ndim, 'origin', int)
+    axes = _util._check_axes(axes, input.ndim)
+    origin = _util._fix_sequence_arg(origin, len(axes), 'origin', int)
     for i in range(len(origin)):
         origin[i] = -origin[i]
         if footprint is not None:
@@ -742,11 +796,13 @@ def grey_dilation(input, size=None, footprint=None, structure=None,
             origin[i] -= 1
 
     return _filters._min_or_max_filter(input, size, footprint, structure,
-                                       output, mode, cval, origin, 'max', None)
+                                       output, mode, cval, origin, 'max',
+                                       axes=axes)
 
 
 def grey_closing(input, size=None, footprint=None, structure=None,
-                 output=None, mode='reflect', cval=0.0, origin=0):
+                 output=None, mode='reflect', cval=0.0, origin=0, *,
+                 axes=None):
     """Calculates a multi-dimensional greyscale closing.
 
     Args:
@@ -771,6 +827,9 @@ def grey_closing(input, size=None, footprint=None, structure=None,
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of greyscale closing.
@@ -780,14 +839,14 @@ def grey_closing(input, size=None, footprint=None, structure=None,
     if (size is not None) and (footprint is not None):
         warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
-    tmp = grey_dilation(input, size, footprint, structure, None, mode, cval,
-                        origin)
-    return grey_erosion(tmp, size, footprint, structure, output, mode, cval,
-                        origin)
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp = grey_dilation(input, size, footprint, structure, None, **kwargs)
+    return grey_erosion(tmp, size, footprint, structure, output, **kwargs)
 
 
 def grey_opening(input, size=None, footprint=None, structure=None,
-                 output=None, mode='reflect', cval=0.0, origin=0):
+                 output=None, mode='reflect', cval=0.0, origin=0, *,
+                 axes=None):
     """Calculates a multi-dimensional greyscale opening.
 
     Args:
@@ -812,6 +871,9 @@ def grey_opening(input, size=None, footprint=None, structure=None,
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The result of greyscale opening.
@@ -821,10 +883,9 @@ def grey_opening(input, size=None, footprint=None, structure=None,
     if (size is not None) and (footprint is not None):
         warnings.warn('ignoring size because footprint is set', UserWarning,
                       stacklevel=2)
-    tmp = grey_erosion(input, size, footprint, structure, None, mode, cval,
-                       origin)
-    return grey_dilation(tmp, size, footprint, structure, output, mode, cval,
-                         origin)
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp = grey_erosion(input, size, footprint, structure, None, **kwargs)
+    return grey_dilation(tmp, size, footprint, structure, output, **kwargs)
 
 
 def morphological_gradient(
@@ -836,6 +897,8 @@ def morphological_gradient(
     mode='reflect',
     cval=0.0,
     origin=0,
+    *,
+    axes=None,
 ):
     """
     Multidimensional morphological gradient.
@@ -866,23 +929,23 @@ def morphological_gradient(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The morphological gradient of the input.
 
     .. seealso:: :func:`scipy.ndimage.morphological_gradient`
     """
-    tmp = grey_dilation(
-        input, size, footprint, structure, None, mode, cval, origin
-    )
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp = grey_dilation(input, size, footprint, structure, None, **kwargs)
     if isinstance(output, cupy.ndarray):
-        grey_erosion(
-            input, size, footprint, structure, output, mode, cval, origin
-        )
+        grey_erosion(input, size, footprint, structure, output, **kwargs)
         return cupy.subtract(tmp, output, output)
     else:
         return tmp - grey_erosion(
-            input, size, footprint, structure, None, mode, cval, origin
+            input, size, footprint, structure, None, **kwargs
         )
 
 
@@ -895,6 +958,8 @@ def morphological_laplace(
     mode='reflect',
     cval=0.0,
     origin=0,
+    *,
+    axes=None,
 ):
     """
     Multidimensional morphological laplace.
@@ -922,26 +987,24 @@ def morphological_laplace(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: The morphological laplace of the input.
 
     .. seealso:: :func:`scipy.ndimage.morphological_laplace`
     """
-    tmp1 = grey_dilation(
-        input, size, footprint, structure, None, mode, cval, origin
-    )
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp1 = grey_dilation(input, size, footprint, structure, None, **kwargs)
     if isinstance(output, cupy.ndarray):
-        grey_erosion(
-            input, size, footprint, structure, output, mode, cval, origin
-        )
+        grey_erosion(input, size, footprint, structure, output, **kwargs)
         cupy.add(tmp1, output, output)
         cupy.subtract(output, input, output)
         return cupy.subtract(output, input, output)
     else:
-        tmp2 = grey_erosion(
-            input, size, footprint, structure, None, mode, cval, origin
-        )
+        tmp2 = grey_erosion(input, size, footprint, structure, None, **kwargs)
         cupy.add(tmp1, tmp2, tmp2)
         cupy.subtract(tmp2, input, tmp2)
         cupy.subtract(tmp2, input, tmp2)
@@ -957,6 +1020,8 @@ def white_tophat(
     mode='reflect',
     cval=0.0,
     origin=0,
+    *,
+    axes=None,
 ):
     """
     Multidimensional white tophat filter.
@@ -983,6 +1048,9 @@ def white_tophat(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarray: Result of the filter of ``input`` with ``structure``.
@@ -993,12 +1061,9 @@ def white_tophat(
         warnings.warn(
             'ignoring size because footprint is set', UserWarning, stacklevel=2
         )
-    tmp = grey_erosion(
-        input, size, footprint, structure, None, mode, cval, origin
-    )
-    tmp = grey_dilation(
-        tmp, size, footprint, structure, output, mode, cval, origin
-    )
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp = grey_erosion(input, size, footprint, structure, None, **kwargs)
+    tmp = grey_dilation(tmp, size, footprint, structure, output, **kwargs)
     if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
         cupy.bitwise_xor(input, tmp, out=tmp)
     else:
@@ -1015,6 +1080,8 @@ def black_tophat(
     mode='reflect',
     cval=0.0,
     origin=0,
+    *,
+    axes=None,
 ):
     """
     Multidimensional black tophat filter.
@@ -1041,6 +1108,9 @@ def black_tophat(
             placement of the filter, relative to the center of the current
             element of the input. Default of 0 is equivalent to
             ``(0,)*input.ndim``.
+        axes (tuple of int or None): The axes over which to apply the filter.
+            If None, `input` is filtered along all axes. If an `origin` tuple
+            is provided, its length must match the number of axes.
 
     Returns:
         cupy.ndarry : Result of the filter of ``input`` with ``structure``.
@@ -1051,12 +1121,9 @@ def black_tophat(
         warnings.warn(
             'ignoring size because footprint is set', UserWarning, stacklevel=2
         )
-    tmp = grey_dilation(
-        input, size, footprint, structure, None, mode, cval, origin
-    )
-    tmp = grey_erosion(
-        tmp, size, footprint, structure, output, mode, cval, origin
-    )
+    kwargs = dict(mode=mode, cval=cval, origin=origin, axes=axes)
+    tmp = grey_dilation(input, size, footprint, structure, None, **kwargs)
+    tmp = grey_erosion(tmp, size, footprint, structure, output, **kwargs)
     if input.dtype == numpy.bool_ and tmp.dtype == numpy.bool_:
         cupy.bitwise_xor(tmp, input, out=tmp)
     else:

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -123,6 +123,47 @@ def _get_inttype(input):
     return 'int' if nbytes < (1 << 31) else 'ptrdiff_t'
 
 
+def _expand_origin(ndim_image, axes, origin):
+    num_axes = len(axes)
+    origins = _fix_sequence_arg(origin, num_axes, 'origin', int)
+    if num_axes < ndim_image:
+        # set origin = 0 for any axes not being filtered
+        origins_temp = [
+            0,
+        ] * ndim_image
+        for o, ax in zip(origins, axes):
+            origins_temp[ax] = o
+        origins = origins_temp
+    return origins
+
+
+def _expand_footprint(ndim_image, axes, footprint, footprint_name='footprint'):
+    num_axes = len(axes)
+    if num_axes < ndim_image:
+        if footprint.ndim != num_axes:
+            raise RuntimeError(
+                f'{footprint_name}.ndim ({footprint.ndim}) '
+                f'must match len(axes) ({num_axes})'
+            )
+
+        footprint = cupy.expand_dims(
+            footprint, tuple(ax for ax in range(ndim_image) if ax not in axes)
+        )
+    return footprint
+
+
+def _expand_mode(ndim_image, axes, mode):
+    num_axes = len(axes)
+    if not isinstance(mode, str) and isinstance(mode, Iterable):
+        # set mode = 'constant' for any axes not being filtered
+        modes = _fix_sequence_arg(mode, num_axes, 'mode', str)
+        modes_temp = ['constant'] * ndim_image
+        for m, ax in zip(modes, axes):
+            modes_temp[ax] = m
+        mode = modes_temp
+    return mode
+
+
 def _generate_boundary_condition_ops(mode, ix, xsize, int_t="int",
                                      float_ix=False):
     min_func = "fmin" if float_ix else "min"

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -500,7 +500,7 @@ class TestFilterFastAxes(FilterTestCaseBase):
         })
     )
 ))
-@testing.with_requires('scipy>=1.15')
+@testing.with_requires('scipy>=1.15.0rc1')
 class TestFilterFastAxesSciPy15(FilterTestCaseBase):
 
     def _hip_skip_invalid_condition(self):
@@ -679,10 +679,10 @@ class TestGenericFilter(FilterTestCaseBase):
         'dtype': [numpy.uint16, numpy.float64],
         'axes': [(0, 1), (-2, -1), (0, -1)],
         'mode': ['constant', 'reflect'],
-        })
-    )
+    })
 )
-@testing.with_requires('scipy>=1.15')
+)
+@testing.with_requires('scipy>=1.15.0rc1')
 class TestGenericFilterAxes(FilterTestCaseBase):
 
     _func_or_kernels = {

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -110,7 +110,16 @@ class FilterTestCaseBase:
 
         if self.filter in ('convolve', 'correlate'):
             if getattr(self, "axes", None) is None:
-                kshape = self._kshape[:self._ndim]
+                # keep 0 values as-is, retain only first _ndim non-zero values
+                # (necessary for intended test from )
+                kshape = []
+                num_non_zero = 0
+                for v in self._kshape:
+                    if num_non_zero < self._ndim or v == 0:
+                        kshape.append(v)
+                    if v != 0:
+                        num_non_zero += 1
+                kshape = tuple(kshape)
             else:
                 if numpy.isscalar(self.axes):
                     self.axes = (self.axes,)
@@ -162,15 +171,6 @@ class FilterTestCaseBase:
         if self.filter in ('uniform_filter1d', 'generic_filter1d',
                            'minimum_filter1d', 'maximum_filter1d'):
             return self.ksize
-
-        if self.filter in ('uniform_filter'):
-            if getattr(self, "axes", None) is None:
-                kshape = self._kshape[:self._ndim]
-            else:
-                if numpy.isscalar(self.axes):
-                    self.axes = (self.axes,)
-                kshape = [self._kshape[ax] for ax in self.axes]
-            return kshape
 
         # gaussian_filter*, prewitt, sobel, *laplace, and *_gradient_magnitude
         # all have no 'weights' or similar argument so return None

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -382,7 +382,7 @@ class TestFilterFast(FilterTestCaseBase):
             'filter': ['gaussian_filter'],
             'sigma': [1.5, 2.25, (1.5, 2.25, 1.0, 3.0)],
             'radius': [None, 2, (1, 2, 3, 4)],
-            'mode': [('reflect', 'nearest', 'mirror', 'wrap')],
+            'mode': [('reflect', 'nearest', 'mirror', 'constant', 'wrap')],
             'truncate': [2.75],
         }) +
         testing.product({
@@ -407,7 +407,7 @@ class TestFilterFast(FilterTestCaseBase):
             'filter': ['maximum_filter', 'minimum_filter'],
             'origin': [0, (0, 1, 1, 0)],
             'ksize': [(3, 3, 4, 5)],
-            'mode': [('reflect', 'nearest', 'constant', 'wrap')],
+            'mode': [('reflect', 'nearest', 'mirror', 'constant', 'wrap')],
             'cval': [0, 2],
             'footprint': [False],
         }) +
@@ -424,7 +424,7 @@ class TestFilterFast(FilterTestCaseBase):
             'filter': ['uniform_filter'],
             'origin': [0, (0, 1, 1, 0)],
             'kshape': [(3, 5, 3, 5)],
-            'mode': [('reflect', 'constant', 'mirror', 'nearest')],
+            'mode': [('reflect', 'constant', 'mirror', 'nearest', 'wrap')],
             'cval': [0, 2],
         }),
         # common arguments for all filters to test axes

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -512,7 +512,7 @@ class TestBinaryErosionAndDilation:
         'output': [None]}
     )
 ))
-@testing.with_requires('scipy>=1.15')
+@testing.with_requires('scipy>=1.15.0rc1')
 class TestBinaryMorphologyAxes:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -821,7 +821,7 @@ class TestWhiteTophatAndBlackTopHat:
                    'morphological_gradient', 'white_tophat', 'black_tophat']
     })
 ))
-@testing.with_requires('scipy>=1.15')
+@testing.with_requires('scipy>=1.15.0rc1')
 class TestGreyMorphologyAxes:
 
     def _filter(self, xp, scp, x):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -498,6 +498,56 @@ class TestBinaryErosionAndDilation:
 
 
 @testing.parameterize(*(
+    testing.product({  # cases with boolean input and output
+        'x_dtype': [bool],
+        'border_value': [0],
+        'connectivity': [1],
+        'origin': [(0, 1)],
+        'shape': [(16, 15), (5, 7, 9)],
+        'axes': [(0, 1), (0, -1), (-2, -1), (1,)],
+        'density': [0.1, 0.5, 0.9],
+        'filter': ['binary_erosion', 'binary_dilation', 'binary_opening',
+                   'binary_closing', 'binary_hit_or_miss',
+                   'binary_propagation', 'binary_fill_holes'],
+        'output': [None]}
+    )
+))
+@testing.with_requires('scipy>=1.15')
+class TestBinaryMorphologyAxes:
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        ndim = len(self.shape)
+        kwargs = {}
+        if self.axes is None:
+            structure = scp.ndimage.generate_binary_structure(
+                ndim, self.connectivity)
+        else:
+            structure = scp.ndimage.generate_binary_structure(
+                len(self.axes), self.connectivity)
+        if len(self.origin) > len(self.axes):
+            self.origin = [self.origin[ax] for ax in self.axes]
+
+        if self.filter not in ["binary_hit_or_miss", "binary_fill_holes"]:
+            kwargs["border_value"] = self.border_value
+
+        if self.filter == "binary_hit_or_miss":
+            kwargs["origin1"] = self.origin
+            kwargs["origin2"] = self.origin
+        else:
+            kwargs["origin"] = self.origin
+        return filter(x, structure, axes=self.axes, **kwargs)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_binary_morphology_axes(self, xp, scp):
+        if self.x_dtype == self.output:
+            pytest.skip('redundant')
+        rstate = numpy.random.RandomState(5)
+        x = rstate.randn(*self.shape) > self.density
+        x = xp.asarray(x, dtype=self.x_dtype)
+        return self._filter(xp, scp, x)
+
+
+@testing.parameterize(*(
     testing.product({
         'x_dtype': [numpy.int8, numpy.float32],
         'shape': [(16, 24)],
@@ -753,4 +803,49 @@ class TestWhiteTophatAndBlackTopHat:
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         if self.x_dtype == self.output:
             pytest.skip('redundant')
+        return self._filter(xp, scp, x)
+
+
+@testing.parameterize(*(
+    testing.product({
+        'shape': [(8, 9), (3, 4, 7, 8)],
+        'size': [3],
+        'axes': [(0, 1), (0, -1), (-2, -1)],
+        'footprint': [None, 'random'],
+        'structure': [None, 'random'],
+        'mode': ['reflect'],
+        'cval': [0.0],
+        'x_dtype': [numpy.int16, numpy.float32],
+        'filter': ['grey_erosion', 'grey_dilation', 'grey_opening',
+                   'grey_closing', 'morphological_laplace',
+                   'morphological_gradient', 'white_tophat', 'black_tophat']
+    })
+))
+@testing.with_requires('scipy>=1.15')
+class TestGreyMorphologyAxes:
+
+    def _filter(self, xp, scp, x):
+        filter = getattr(scp.ndimage, self.filter)
+        num_axes = len(self.axes)
+        origin = (-1, 1, -1, 1)[:num_axes]
+        if self.footprint is None:
+            footprint = None
+        else:
+            shape = (self.size, ) * num_axes
+            r = testing.shaped_random(shape, xp, scale=1)
+            footprint = xp.where(r < .5, 1, 0)
+            if not footprint.any():
+                footprint = xp.ones(shape)
+        if self.structure is None:
+            structure = None
+        else:
+            shape = (self.size, ) * num_axes
+            structure = testing.shaped_random(shape, xp, dtype=xp.int32)
+        return filter(x, size=self.size, footprint=footprint,
+                      structure=structure, mode=self.mode, cval=self.cval,
+                      origin=origin, axes=self.axes)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_grey_morphology_axes(self, xp, scp):
+        x = testing.shaped_random(self.shape, xp, self.x_dtype)
         return self._filter(xp, scp, x)


### PR DESCRIPTION
This MR adds `axes` kwarg support to several remaining filter functions and all binary and grayscale morphology functions. These correspond to upstream features merged for SciPy 1.15.0.

- Implements scipy/scipy#20811
- Implements scipy/scipy#21549

The new tests were verified to pass locally when using SciPy **1.15.0rc2**
