### PR TITLE
Raise VisibleDeprecationWarning for wavelet functions

### DIFF
--- a/cupyx/scipy/signal/_wavelets.py
+++ b/cupyx/scipy/signal/_wavelets.py
@@ -62,7 +62,7 @@ def qmf(hk):
         Coefficients of high-pass filter.
 
     """
-    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
+    warnings.warn(_deprecate_msg, cupy.exceptions.VisibleDeprecationWarning)
 
     hk = cupy.asarray(hk)
     return _qmf_kernel(hk, size=len(hk))
@@ -142,7 +142,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     with it.
 
     """
-    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
+    warnings.warn(_deprecate_msg, cupy.exceptions.VisibleDeprecationWarning)
 
     return _morlet_kernel(w, s, complete, size=M)
 
@@ -203,7 +203,7 @@ def ricker(points, a):
     >>> plt.show()
 
     """
-    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
+    warnings.warn(_deprecate_msg, cupy.exceptions.VisibleDeprecationWarning)
 
     return _ricker_kernel(a, size=int(points))
 
@@ -294,7 +294,7 @@ def morlet2(M, s, w=5):
         cmap='viridis', shading='gouraud')
     >>> plt.show()
     """
-    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
+    warnings.warn(_deprecate_msg, cupy.exceptions.VisibleDeprecationWarning)
 
     return _morlet2_kernel(w, s, size=int(M))
 
@@ -350,7 +350,7 @@ def cwt(data, wavelet, widths):
     >>> plt.show()
 
     """  # NOQA
-    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
+    warnings.warn(_deprecate_msg, cupy.exceptions.VisibleDeprecationWarning)
 
     if cupy.asarray(wavelet(1, 1)).dtype.char in "FDG":
         dtype = cupy.complex128

--- a/cupyx/scipy/signal/_wavelets.py
+++ b/cupyx/scipy/signal/_wavelets.py
@@ -36,7 +36,7 @@ _deprecate_msg = (
     "Following the change in SciPy 1.12, all wavelet functions have been "
     "deprecated in CuPy v14 and are planned to be removed in the future. "
     "To request continued support of the features, "
-    "please leave a comment at https://github.com/cupy/cupy/pull/8061."
+    "please leave a comment at https://github.com/cupy/cupy/issues/8864."
 )
 
 

--- a/cupyx/scipy/signal/_wavelets.py
+++ b/cupyx/scipy/signal/_wavelets.py
@@ -62,7 +62,7 @@ def qmf(hk):
         Coefficients of high-pass filter.
 
     """
-    warnings.warn(_deprecate_msg, DeprecationWarning)
+    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
 
     hk = cupy.asarray(hk)
     return _qmf_kernel(hk, size=len(hk))
@@ -142,7 +142,7 @@ def morlet(M, w=5.0, s=1.0, complete=True):
     with it.
 
     """
-    warnings.warn(_deprecate_msg, DeprecationWarning)
+    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
 
     return _morlet_kernel(w, s, complete, size=M)
 
@@ -203,7 +203,7 @@ def ricker(points, a):
     >>> plt.show()
 
     """
-    warnings.warn(_deprecate_msg, DeprecationWarning)
+    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
 
     return _ricker_kernel(a, size=int(points))
 
@@ -294,7 +294,7 @@ def morlet2(M, s, w=5):
         cmap='viridis', shading='gouraud')
     >>> plt.show()
     """
-    warnings.warn(_deprecate_msg, DeprecationWarning)
+    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
 
     return _morlet2_kernel(w, s, size=int(M))
 
@@ -350,7 +350,7 @@ def cwt(data, wavelet, widths):
     >>> plt.show()
 
     """  # NOQA
-    warnings.warn(_deprecate_msg, DeprecationWarning)
+    warnings.warn(_deprecate_msg, np.exceptions.VisibleDeprecationWarning)
 
     if cupy.asarray(wavelet(1, 1)).dtype.char in "FDG":
         dtype = cupy.complex128

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy.exceptions
 import pytest
 
 from cupy import testing
@@ -11,12 +12,14 @@ except ImportError:
     pass
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy<1.15")
 class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_qmf(self, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.qmf([1, 1])
 
     @pytest.mark.skip(reason='daub is not available on cupyx.scipy.signal')
@@ -25,6 +28,8 @@ class TestWavelets:
     def test_daub(self, p, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.daub(p)
 
     @pytest.mark.skip(reason='cascade is not available on cupyx.scipy.signal')
@@ -34,6 +39,8 @@ class TestWavelets:
     def test_cascade(self, J, i, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             lpcoef = scp.signal.daub(i)
             x, phi, psi = scp.signal.cascade(lpcoef, J)
         return x, phi, psi
@@ -55,12 +62,16 @@ class TestWavelets:
     def test_morlet(self, args, kwargs, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet(*args, **kwargs)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2(self, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet2(1.0, 0.5)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
@@ -68,6 +79,8 @@ class TestWavelets:
     def test_morlet2_length(self, length, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet2(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -75,6 +88,8 @@ class TestWavelets:
         points = 100
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             w = scp.signal.morlet2(points, 2.0)
             y = scp.signal.morlet2(3, s=1/(2*xp.pi), w=2)
         return w, y
@@ -83,6 +98,8 @@ class TestWavelets:
     def test_ricker(self, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(1.0, 1)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
@@ -90,6 +107,8 @@ class TestWavelets:
     def test_ricker_length(self, length, xp, scp):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -97,6 +116,8 @@ class TestWavelets:
         points = 100
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(points, 2.0)
 
     @pytest.mark.parametrize('a', [5, 10, 15, 20, 30])
@@ -106,6 +127,8 @@ class TestWavelets:
         points = 99
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(points, a)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -119,6 +142,8 @@ class TestWavelets:
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.cwt(test_data, delta_wavelet, widths)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -129,4 +154,6 @@ class TestWavelets:
         widths = [1, 3, 4, 5, 10]
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter(
+                'ignore', numpy.exceptions.VisibleDeprecationWarning)
             return scp.signal.cwt(test_data, scp.signal.ricker, widths)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
@@ -1,8 +1,5 @@
-import warnings
-
 import pytest
 
-import cupy.exceptions
 from cupy import testing
 import cupyx.scipy.signal  # NOQA
 
@@ -12,34 +9,27 @@ except ImportError:
     pass
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.filterwarnings('ignore::cupy.exceptions.VisibleDeprecationWarning')
 @testing.with_requires("scipy<1.15")
 class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_qmf(self, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.qmf([1, 1])
+        return scp.signal.qmf([1, 1])
 
     @pytest.mark.skip(reason='daub is not available on cupyx.scipy.signal')
     @pytest.mark.parametrize('p', list(range(1, 15)))
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_daub(self, p, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.daub(p)
+        return scp.signal.daub(p)
 
     @pytest.mark.skip(reason='cascade is not available on cupyx.scipy.signal')
     @pytest.mark.parametrize('J', list(range(1, 7)))
     @pytest.mark.parametrize('i', list(range(1, 5)))
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cascade(self, J, i, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            lpcoef = scp.signal.daub(i)
-            x, phi, psi = scp.signal.cascade(lpcoef, J)
+        lpcoef = scp.signal.daub(i)
+        x, phi, psi = scp.signal.cascade(lpcoef, J)
         return x, phi, psi
 
     @pytest.mark.parametrize('args,kwargs', [
@@ -57,68 +47,44 @@ class TestWavelets:
     ])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet(self, args, kwargs, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.morlet(*args, **kwargs)
+        return scp.signal.morlet(*args, **kwargs)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2(self, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.morlet2(1.0, 0.5)
+        return scp.signal.morlet2(1.0, 0.5)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2_length(self, length, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.morlet2(length, 1.0)
+        return scp.signal.morlet2(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2_points(self, xp, scp):
         points = 100
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            w = scp.signal.morlet2(points, 2.0)
-            y = scp.signal.morlet2(3, s=1/(2*xp.pi), w=2)
+        w = scp.signal.morlet2(points, 2.0)
+        y = scp.signal.morlet2(3, s=1/(2*xp.pi), w=2)
         return w, y
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker(self, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.ricker(1.0, 1)
+        return scp.signal.ricker(1.0, 1)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker_length(self, length, xp, scp):
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.ricker(length, 1.0)
+        return scp.signal.ricker(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker_points(self, xp, scp):
         points = 100
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.ricker(points, 2.0)
+        return scp.signal.ricker(points, 2.0)
 
     @pytest.mark.parametrize('a', [5, 10, 15, 20, 30])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker_zeros(self, a, xp, scp):
         # Check zeros
         points = 99
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.ricker(points, a)
+        return scp.signal.ricker(points, a)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cwt_delta(self, xp, scp):
@@ -129,10 +95,7 @@ class TestWavelets:
         def delta_wavelet(s, t):
             return xp.array([1])
 
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.cwt(test_data, delta_wavelet, widths)
+        return scp.signal.cwt(test_data, delta_wavelet, widths)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cwt_ricker(self, xp, scp):
@@ -140,7 +103,4 @@ class TestWavelets:
         test_data = xp.sin(xp.pi * xp.arange(0, len_data) / 10.0)
         # Check proper shape on output
         widths = [1, 3, 4, 5, 10]
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                'ignore', cupy.exceptions.VisibleDeprecationWarning)
-            return scp.signal.cwt(test_data, scp.signal.ricker, widths)
+        return scp.signal.cwt(test_data, scp.signal.ricker, widths)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_wavelets.py
@@ -1,8 +1,8 @@
 import warnings
 
-import numpy.exceptions
 import pytest
 
+import cupy.exceptions
 from cupy import testing
 import cupyx.scipy.signal  # NOQA
 
@@ -17,9 +17,8 @@ class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_qmf(self, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.qmf([1, 1])
 
     @pytest.mark.skip(reason='daub is not available on cupyx.scipy.signal')
@@ -27,9 +26,8 @@ class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_daub(self, p, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.daub(p)
 
     @pytest.mark.skip(reason='cascade is not available on cupyx.scipy.signal')
@@ -38,9 +36,8 @@ class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_cascade(self, J, i, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             lpcoef = scp.signal.daub(i)
             x, phi, psi = scp.signal.cascade(lpcoef, J)
         return x, phi, psi
@@ -61,35 +58,31 @@ class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet(self, args, kwargs, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet(*args, **kwargs)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2(self, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet2(1.0, 0.5)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2_length(self, length, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.morlet2(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_morlet2_points(self, xp, scp):
         points = 100
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             w = scp.signal.morlet2(points, 2.0)
             y = scp.signal.morlet2(3, s=1/(2*xp.pi), w=2)
         return w, y
@@ -97,27 +90,24 @@ class TestWavelets:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker(self, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(1.0, 1)
 
     @pytest.mark.parametrize('length', [5, 11, 15, 51, 101])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker_length(self, length, xp, scp):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(length, 1.0)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_ricker_points(self, xp, scp):
         points = 100
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(points, 2.0)
 
     @pytest.mark.parametrize('a', [5, 10, 15, 20, 30])
@@ -126,9 +116,8 @@ class TestWavelets:
         # Check zeros
         points = 99
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.ricker(points, a)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -141,9 +130,8 @@ class TestWavelets:
             return xp.array([1])
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.cwt(test_data, delta_wavelet, widths)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
@@ -153,7 +141,6 @@ class TestWavelets:
         # Check proper shape on output
         widths = [1, 3, 4, 5, 10]
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
             warnings.simplefilter(
-                'ignore', numpy.exceptions.VisibleDeprecationWarning)
+                'ignore', cupy.exceptions.VisibleDeprecationWarning)
             return scp.signal.cwt(test_data, scp.signal.ricker, widths)


### PR DESCRIPTION
The wavelet functions `scipy.signal` have been removed in SciPy 1.15.
https://docs.scipy.org/doc/scipy/release/1.15.0-notes.html#expired-deprecations

Discussion: https://github.com/cupy/cupy/issues/8864.