### PR TITLE
Disable contiguous_check for COO/dense matmul test

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -632,7 +632,7 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.dot(x)
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_dot_dense_matrix(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
@@ -811,7 +811,7 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m * x
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_mul_dense_matrix(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
@@ -874,7 +874,7 @@ class TestCooMatrixScipyComparison:
         x = xp.array(2, dtype=self.dtype)
         return x * m
 
-    @testing.numpy_cupy_allclose(sp_name='sp')
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_rmul_dense_matrix(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         x = xp.arange(12).reshape(4, 3).astype(self.dtype)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

In SciPy 1.15, the result of the matrix product of COO sparse matrices and dense matrices is returned in a C-contiguous array, which is different from the behaviour in SciPy 1.14 and earlier. However, for performance reasons, CuPy should continue to return a non-contiguous array.