### PR TITLE
Skip a test for invalid scipy return value of invalid COO matmul

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -652,6 +652,7 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.dot(x)
 
+    @testing.with_requires("scipy!=1.15.0", "scipy!=1.15.1")
     def test_dot_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

Skip `test_dot_unsupported` for https://github.com/scipy/scipy/issues/22347.