### PR TITLE
Support empty tuple indexing for sparse matrix

### DIFF
--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -596,6 +596,8 @@ def _unpack_index(index):
             row, col = index
         elif len(index) == 1:
             row, col = index[0], slice(None)
+        elif len(index) == 0:
+            row, col = slice(None), slice(None)
         else:
             raise IndexError('invalid number of indices')
     else:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -455,7 +455,7 @@ def _check_bounds(indices, n_rows, n_cols, **kwargs):
         ]
     )
 }) if _check_bounds(**params)])
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestArrayIndexing(IndexingTestBase):
 
     @skip_HIP_0_size_matrix()
@@ -469,6 +469,7 @@ class TestArrayIndexing(IndexingTestBase):
         return res
 
     @skip_HIP_0_size_matrix()
+    @testing.with_requires('scipy>=1.15.0')
     @testing.for_dtypes('fdFD')
     @testing.for_dtypes('il', name='ind_dtype')
     @testing.numpy_cupy_array_equal(
@@ -481,6 +482,7 @@ class TestArrayIndexing(IndexingTestBase):
         return res
 
     @skip_HIP_0_size_matrix()
+    @testing.with_requires('scipy>=1.15.0')
     @testing.for_dtypes('fdFD')
     @testing.for_dtypes('il', name='ind_dtype')
     @testing.numpy_cupy_array_equal(


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

https://docs.scipy.org/doc/scipy-1.15.0/release/1.15.0-notes.html#scipy-sparse-improvements