### PR TITLE
Skip some signal tests for TypeError for inputs of `np.longlong` dtype

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -344,7 +344,7 @@ class TestOrderFilter:
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     def test_order_filter(self, xp, scp, dtype):
-        if dtype == xp.longlong and "1.15.0" <= scipy_version <= "1.15.1":
+        if dtype == xp.longlong and "1.15.0" <= scipy_version < "1.16.0":
             # https://github.com/scipy/scipy/issues/22368
             return xp.array([])  # Skip
         a = testing.shaped_random(self.a, xp, dtype)
@@ -379,7 +379,7 @@ class TestMedFilt:
         atol=1e-8, rtol=1e-8, scipy_name='scp',
         accept_error=ValueError)  # for even kernels
     def test_medfilt(self, xp, scp, dtype):
-        if dtype == xp.longlong and "1.15.0" <= scipy_version <= "1.15.1":
+        if dtype == xp.longlong and "1.15.0" <= scipy_version < "1.16.0":
             # https://github.com/scipy/scipy/issues/22368
             return xp.array([])  # Skip
         if sys.platform == 'win32':

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -11,6 +11,7 @@ import cupyx.scipy.signal
 
 try:
     import scipy.signal  # NOQA
+    scipy_version = np.lib.NumpyVersion(scipy.__version__)
 except ImportError:
     pass
 
@@ -343,6 +344,9 @@ class TestOrderFilter:
     @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
                                  accept_error=ValueError)  # for even kernels
     def test_order_filter(self, xp, scp, dtype):
+        if dtype == xp.longlong and "1.15.0" <= scipy_version <= "1.15.1":
+            # https://github.com/scipy/scipy/issues/22368
+            return xp.array([])  # Skip
         a = testing.shaped_random(self.a, xp, dtype)
         d = self.domain
         d = d[:a.ndim] if isinstance(d, tuple) else (d,)*a.ndim
@@ -375,6 +379,9 @@ class TestMedFilt:
         atol=1e-8, rtol=1e-8, scipy_name='scp',
         accept_error=ValueError)  # for even kernels
     def test_medfilt(self, xp, scp, dtype):
+        if dtype == xp.longlong and "1.15.0" <= scipy_version <= "1.15.1":
+            # https://github.com/scipy/scipy/issues/22368
+            return xp.array([])  # Skip
         if sys.platform == 'win32':
             pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
         volume = testing.shaped_random(self.volume, xp, dtype)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

https://github.com/scipy/scipy/issues/22368

In SciPy 1.15.1,
```py
>>> import numpy
>>> import scipy
>>> volume = numpy.arange(10, dtype='q')
>>> scipy.signal.medfilt(volume)
TypeError: Unsupported array type

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../.pyenv/versions/3.11.11/lib/python3.11/site-packages/scipy/signal/_signaltools.py", line 1599, in medfilt
    result = ndimage.rank_filter(volume, size // 2, size=kernel_size,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../.pyenv/versions/3.11.11/lib/python3.11/site-packages/scipy/ndimage/_filters.py", line 1630, in rank_filter
    return _rank_filter(input, rank, size, footprint, output, mode, cval,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../.pyenv/versions/3.11.11/lib/python3.11/site-packages/scipy/ndimage/_filters.py", line 1575, in _rank_filter
    _rank_filter_1d.rank_filter(x, rank, footprint.size, x_out, mode, cval,
SystemError: <built-in function rank_filter> returned a result with an exception set
```

In SciPy 1.14.1,
```py
>>> import numpy
>>> import scipy
>>> volume = numpy.arange(10, dtype='q')
>>> scipy.signal.medfilt(volume)
array([0, 1, 2, 3, 4, 5, 6, 7, 8, 8])
```