### PR TITLE
Deprecate `cupyx.scipy.linalg.kron`

### DIFF
--- a/cupyx/scipy/linalg/_special_matrices.py
+++ b/cupyx/scipy/linalg/_special_matrices.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import cupy
 from cupy import _core
@@ -178,6 +179,12 @@ def kron(a, b):
 
     .. seealso:: :func:`scipy.linalg.kron`
     """
+    warnings.warn(
+        '`cupyx.scipy.linalg.kron` has been deprecated in CuPy v14 and will '
+        'be removed in the near future. Please use `cupy.kron` instead.',
+        DeprecationWarning,
+    )
+
     o = cupy.outer(a, b)
     o = o.reshape(a.shape + b.shape)
     return cupy.concatenate(cupy.concatenate(o, axis=1), axis=1)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from cupy import testing
 import cupyx.scipy.linalg  # NOQA
@@ -62,6 +63,8 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
     def test_special_matrix(self, xp, scp):
+        if self.function == "kron":
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
         function = getattr(scp.linalg, self.function)
         return function(*[self._get_arg(xp, arg) for arg in self.args])
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -63,10 +63,14 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
     def test_special_matrix(self, xp, scp):
-        if self.function == "kron":
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
         function = getattr(scp.linalg, self.function)
-        return function(*[self._get_arg(xp, arg) for arg in self.args])
+
+        if self.function == "kron":
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=DeprecationWarning)
+                return function(*[self._get_arg(xp, arg) for arg in self.args])
+        else:
+            return function(*[self._get_arg(xp, arg) for arg in self.args])
 
 
 @testing.parameterize(*(


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

`scipy.linalg.kron` is deprecated in favour of `numpy.kron` in SciPy 1.15.
https://docs.scipy.org/doc/scipy-1.15.0/release/1.15.0-notes.html#deprecated-features-and-future-changes