### PR TITLE
Disable contiguous_check for some `signal.cont2discrete` tests

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_cont2discrete.py
@@ -46,7 +46,7 @@ class TestC2D:
                                  method='impulse')
         return ad, bd, cd, dd, dt
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_gbt(self, xp, scp):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)
@@ -61,7 +61,7 @@ class TestC2D:
                                  method='gbt', alpha=alpha)
         return ad, bd, cd, dd, dt
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_euler(self, xp, scp):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)
@@ -74,7 +74,7 @@ class TestC2D:
                                  method='euler')
         return ad, bd, cd, dd, dt
 
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_backward_diff(self, xp, scp):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)
@@ -88,7 +88,7 @@ class TestC2D:
         return ad, bd, cd, dd, dt
 
     @pytest.mark.parametrize('dt_requested', [0.5, 1.0 / 3.0])
-    @testing.numpy_cupy_allclose(scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
     def test_bilinear(self, xp, scp, dt_requested):
         ac = xp.eye(2)
         bc = xp.full((2, 1), 0.5)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

The difference of contiguity between SciPy and CuPy stems from the return value of `xp.linalg.solve`. `lapack.gesv` handles F-contiguous ndarrays, it is difficult to resolve this difference without performance degradation.