### PR TITLE
Fix test_interpnd for removed interpolate.interpnd namespace

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_interpnd.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_interpnd.py
@@ -1,4 +1,3 @@
-
 import cupy
 from cupy import testing
 import cupyx.scipy.interpolate  # NOQA
@@ -136,7 +135,7 @@ class TestEstimateGradients2DGlobal:
 
         tri = scp.spatial.Delaunay(x)
         z = func(x[:, 0], x[:, 1])
-        if xp is cupy:
+        if xp is cupy or np.lib.NumpyVersion(scipy.__version__) >= "1.15.0":
             grad_fn = scp.interpolate._interpnd.estimate_gradients_2d_global
         else:
             grad_fn = scp.interpolate.interpnd.estimate_gradients_2d_global


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.