### PR TITLE
Add `special.sph_harm_y` and deprecate `special.sph_harm`

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -83,6 +83,7 @@ from cupyx.scipy.special._erf import erfcinv  # NOQA
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA
 from cupyx.scipy.special._sph_harm import sph_harm  # NOQA
+from cupyx.scipy.special._sph_harm import sph_harm_y  # NOQA
 
 # Other special functions
 from cupyx.scipy.special._binom import binom  # NOQA

--- a/cupyx/scipy/special/_sph_harm.py
+++ b/cupyx/scipy/special/_sph_harm.py
@@ -5,6 +5,8 @@ SciPy Cython file:
 https://github.com/scipy/scipy/blob/master/scipy/special/sph_harm.pxd
 """
 
+import warnings
+
 from cupy import _core
 
 from cupyx.scipy.special._poch import poch_definition
@@ -71,7 +73,7 @@ __device__ complex<double> sph_harmonic(int m, int n, double theta, double phi)
 )
 
 
-sph_harm = _core.create_ufunc(
+_sph_harm = _core.create_ufunc(
     "cupyx_scipy_lpmv",
     ("iiff->F", "iidd->D", "llff->F", "lldd->D"),
     "out0 = out0_type(sph_harmonic(in0, in1, in2, in3));",
@@ -82,3 +84,17 @@ sph_harm = _core.create_ufunc(
 
     """,
 )
+
+
+def sph_harm(m, n, theta, phi, out=None):
+    """Spherical Harmonic.
+
+    .. seealso:: :meth:`scipy.special.sph_harm`
+
+    """
+
+    warnings.warn(DeprecationWarning(
+        "`cupyx.scipy.special.sph_harm` is deprecated in CuPy v14 "
+        "and are planned to be removed in the future."))
+
+    return _sph_harm(m, n, theta, phi, out=out)

--- a/cupyx/scipy/special/_sph_harm.py
+++ b/cupyx/scipy/special/_sph_harm.py
@@ -98,3 +98,14 @@ def sph_harm(m, n, theta, phi, out=None):
         "and are planned to be removed in the future."))
 
     return _sph_harm(m, n, theta, phi, out=out)
+
+
+def sph_harm_y(n, m, theta, phi, *, diff_n=0):
+    """Spherical Harmonic.
+
+    .. seealso:: :meth:`scipy.special.sph_harm`
+    """
+    if diff_n != 0:
+        raise NotImplementedError("Derivatives not implemented.")
+
+    return _sph_harm(m, n, phi, theta)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -28,6 +28,7 @@ class TestBasic():
         theta, phi = xp.meshgrid(theta, phi)
         return scp.special.sph_harm(m, n, theta, phi)
 
+    @testing.with_requires("scipy>=1.15.0")
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-7, atol=1e-10)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -18,9 +18,10 @@ def _get_harmonic_list(degree_max):
 @testing.with_requires("scipy")
 class TestBasic():
 
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])
-    @numpy_cupy_allclose(scipy_name="scp")
+    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-7, atol=1e-10)
     def test_sph_harm(self, xp, scp, dtype, m, n):
         theta = xp.linspace(0, 2 * cp.pi)
         phi = xp.linspace(0, cp.pi)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -27,3 +27,12 @@ class TestBasic():
         phi = xp.linspace(0, cp.pi)
         theta, phi = xp.meshgrid(theta, phi)
         return scp.special.sph_harm(m, n, theta, phi)
+
+    @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
+    @testing.for_dtypes(["e", "f", "d"])
+    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-7, atol=1e-10)
+    def test_sph_harm_y(self, xp, scp, dtype, m, n):
+        theta = xp.linspace(0, cp.pi)
+        phi = xp.linspace(0, 2 * cp.pi)
+        theta, phi = xp.meshgrid(theta, phi)
+        return scp.special.sph_harm_y(n, m, theta, phi)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

`scipy.special.sph_harm` has been deprecated in favor of `scipy.special.sph_harm_y`.

https://docs.scipy.org/doc/scipy-1.15.0/release/1.15.0-notes.html#deprecated-features-and-future-changes
