### PR TITLE
Update cupyx.scipy.special functions for SciPy 1.15

### DIFF
--- a/cupyx/scipy/special/_basic.py
+++ b/cupyx/scipy/special/_basic.py
@@ -49,8 +49,8 @@ log1p = _core.create_ufunc(
 
 cbrt = _core.create_ufunc(
     'cupyx_scipy_special_cbrt',
-    (('f->f', 'out0 = cbrtf(in0)'), 'd->d'),
-    'out0 = cbrt(in0)',
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = cbrtf(in0)'), 'd->d'),
+    'out0 = cbrt(double(in0))',
     doc='''Cube root.
 
     .. seealso:: :meth:`scipy.special.cbrt`
@@ -93,7 +93,8 @@ expm1 = _core.create_ufunc(
 exprel = _core.create_ufunc(
     'cupyx_scipy_special_exprel',
     (
-        ('l->d', 'out0 = abs(in0) >= 1e-16 ? expm1(double(in0)) / in0 : 1'),
+        ('l->d', 'out0 = in0 != 0 ? expm1(double(in0)) / in0 : 1'),
+        ('L->d', 'out0 = in0 != 0 ? expm1(double(in0)) / in0 : 1'),
         ('e->d', 'out0 = abs(in0) >= 1e-16 ? expm1(double(in0)) / in0 : 1'),
         'f->f',
         'd->d',
@@ -152,7 +153,7 @@ __device__ static double cosm1(double x)
 """
 
 cosm1 = _core.create_ufunc(
-    'cupyx_scipy_special_cosm1', ('f->f', 'd->d'),
+    'cupyx_scipy_special_cosm1', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
     'out0 = cosm1(in0)',
     preamble=cosm1_implementation,
     doc='''Computes ``cos(x) - 1``.
@@ -167,7 +168,7 @@ pi180_preamble = """
 
 cosdg = _core.create_ufunc(
     'cupyx_scipy_special_cosdg',
-    (('f->f', 'out0 = cosf(PI180 * in0)'), 'd->d'),
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = cosf(PI180 * in0)'), 'd->d'),
     'out0 = cos(PI180 * in0)',
     preamble=pi180_preamble,
     doc='''Cosine of x with x in degrees.
@@ -179,7 +180,7 @@ cosdg = _core.create_ufunc(
 
 sindg = _core.create_ufunc(
     'cupyx_scipy_special_sindg',
-    (('f->f', 'out0 = sinf(PI180 * in0)'), 'd->d'),
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = sinf(PI180 * in0)'), 'd->d'),
     'out0 = sin(PI180 * in0)',
     preamble=pi180_preamble,
     doc='''Sine of x with x in degrees.
@@ -262,7 +263,7 @@ __device__ static double tancot(double xx, int cotflg)
 """
 
 tandg = _core.create_ufunc(
-    'cupyx_scipy_special_tandg', ('f->f', 'd->d'),
+    'cupyx_scipy_special_tandg', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
     'out0 = tandg(in0)',
     preamble=tancot_implementation,
     doc='''Tangent of x with x in degrees.
@@ -273,7 +274,7 @@ tandg = _core.create_ufunc(
 
 
 cotdg = _core.create_ufunc(
-    'cupyx_scipy_special_cotdg', ('f->f', 'd->d'),
+    'cupyx_scipy_special_cotdg', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
     'out0 = cotdg(in0)',
     preamble=tancot_implementation,
     doc='''Cotangent of x with x in degrees.
@@ -295,8 +296,9 @@ __device__ T radian(T d, T m, T s)
 """
 
 radian = _core.create_ufunc(
-    'cupyx_scipy_special_radian', ('fff->f', 'ddd->d'),
-    'out0 = radian(in0, in1, in2)',
+    'cupyx_scipy_special_radian',
+    ('lll->d', 'LLL->d', 'eee->d', 'fff->f', 'ddd->d'),
+    'out0 = radian(out0_type(in0), out0_type(in1), out0_type(in2))',
     preamble=radian_implementation,
     doc='''Degrees, minutes, seconds to radians:
 

--- a/cupyx/scipy/special/_bessel.py
+++ b/cupyx/scipy/special/_bessel.py
@@ -10,8 +10,8 @@ from cupy import _core
 from cupyx.scipy.special._gamma import chbevl_implementation
 
 j0 = _core.create_ufunc(
-    'cupyx_scipy_special_j0', ('f->f', 'd->d'),
-    'out0 = j0(in0)',
+    'cupyx_scipy_special_j0', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = j0(out0_type(in0))',
     doc='''Bessel function of the first kind of order 0.
 
     .. seealso:: :meth:`scipy.special.j0`
@@ -20,8 +20,8 @@ j0 = _core.create_ufunc(
 
 
 j1 = _core.create_ufunc(
-    'cupyx_scipy_special_j1', ('f->f', 'd->d'),
-    'out0 = j1(in0)',
+    'cupyx_scipy_special_j1', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = j1(out0_type(in0))',
     doc='''Bessel function of the first kind of order 1.
 
     .. seealso:: :meth:`scipy.special.j1`
@@ -30,8 +30,8 @@ j1 = _core.create_ufunc(
 
 
 y0 = _core.create_ufunc(
-    'cupyx_scipy_special_y0', ('f->f', 'd->d'),
-    'out0 = y0(in0)',
+    'cupyx_scipy_special_y0', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = y0(out0_type(in0))',
     doc='''Bessel function of the second kind of order 0.
 
     .. seealso:: :meth:`scipy.special.y0`
@@ -40,8 +40,8 @@ y0 = _core.create_ufunc(
 
 
 y1 = _core.create_ufunc(
-    'cupyx_scipy_special_y1', ('f->f', 'd->d'),
-    'out0 = y1(in0)',
+    'cupyx_scipy_special_y1', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = y1(out0_type(in0))',
     doc='''Bessel function of the second kind of order 1.
 
     .. seealso:: :meth:`scipy.special.y1`
@@ -73,8 +73,8 @@ yn = _core.create_ufunc(
 
 
 i0 = _core.create_ufunc(
-    'cupyx_scipy_special_i0', ('f->f', 'd->d'),
-    'out0 = cyl_bessel_i0(in0)',
+    'cupyx_scipy_special_i0', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = cyl_bessel_i0(out0_type(in0))',
     doc='''Modified Bessel function of order 0.
 
     .. seealso:: :meth:`scipy.special.i0`
@@ -83,8 +83,8 @@ i0 = _core.create_ufunc(
 
 
 i0e = _core.create_ufunc(
-    'cupyx_scipy_special_i0e', ('f->f', 'd->d'),
-    'out0 = exp(-abs(in0)) * cyl_bessel_i0(in0)',
+    'cupyx_scipy_special_i0e', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = exp(-abs(out0_type(in0))) * cyl_bessel_i0(out0_type(in0))',
     doc='''Exponentially scaled modified Bessel function of order 0.
 
     .. seealso:: :meth:`scipy.special.i0e`
@@ -93,8 +93,8 @@ i0e = _core.create_ufunc(
 
 
 i1 = _core.create_ufunc(
-    'cupyx_scipy_special_i1', ('f->f', 'd->d'),
-    'out0 = cyl_bessel_i1(in0)',
+    'cupyx_scipy_special_i1', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = cyl_bessel_i1(out0_type(in0))',
     doc='''Modified Bessel function of order 1.
 
     .. seealso:: :meth:`scipy.special.i1`
@@ -103,8 +103,8 @@ i1 = _core.create_ufunc(
 
 
 i1e = _core.create_ufunc(
-    'cupyx_scipy_special_i1e', ('f->f', 'd->d'),
-    'out0 = exp(-abs(in0)) * cyl_bessel_i1(in0)',
+    'cupyx_scipy_special_i1e', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
+    'out0 = exp(-abs(out0_type(in0))) * cyl_bessel_i1(out0_type(in0))',
     doc='''Exponentially scaled modified Bessel function of order 1.
 
     .. seealso:: :meth:`scipy.special.i1e`
@@ -392,7 +392,7 @@ __device__ float k1f(float x){
 
 k0 = _core.create_ufunc(
     'cupyx_scipy_special_k0',
-    (('f->f', 'out0 = k0f(in0)'), 'd->d'),
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = k0f(in0)'), 'd->d'),
     'out0 = k0(in0)',
     preamble=k_preamble,
     doc='''Modified Bessel function of the second kind of order 0.
@@ -410,8 +410,8 @@ k0 = _core.create_ufunc(
 
 k0e = _core.create_ufunc(
     'cupyx_scipy_special_k0e',
-    (('f->f', 'out0 = expf(in0) * k0f(in0)'), 'd->d'),
-    'out0 = exp(in0) * k0(in0)',
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = expf(in0) * k0f(in0)'), 'd->d'),
+    'out0 = exp(out0_type(in0)) * k0(in0)',
     preamble=k_preamble,
     doc='''Exponentially scaled modified Bessel function K of order 0
 
@@ -428,7 +428,7 @@ k0e = _core.create_ufunc(
 
 k1 = _core.create_ufunc(
     'cupyx_scipy_special_k1',
-    (('f->f', 'out0 = k1f(in0)'), 'd->d'),
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = k1f(in0)'), 'd->d'),
     'out0 = k1(in0)',
     preamble=k_preamble,
     doc='''Modified Bessel function of the second kind of order 1.
@@ -446,8 +446,8 @@ k1 = _core.create_ufunc(
 
 k1e = _core.create_ufunc(
     'cupyx_scipy_special_k1e',
-    (('f->f', 'out0 = expf(in0) * k1f(in0)'), 'd->d'),
-    'out0 = exp(in0) * k1(in0)',
+    ('l->d', 'L->d', 'e->d', ('f->f', 'out0 = expf(in0) * k1f(in0)'), 'd->d'),
+    'out0 = exp(out0_type(in0)) * k1(in0)',
     preamble=k_preamble,
     doc='''Exponentially scaled modified Bessel function K of order 1
 

--- a/cupyx/scipy/special/_beta.py
+++ b/cupyx/scipy/special/_beta.py
@@ -390,7 +390,7 @@ __noinline__ __device__ double lbeta(double a, double b)
 
 beta = _core.create_ufunc(
     "cupyx_scipy_beta",
-    ("ff->f", "dd->d"),
+    ("ll->d", "LL->d", "ee->d", "ff->f", "dd->d"),
     "out0 = out0_type(beta(in0, in1));",
     preamble=(
         beta_preamble +
@@ -425,7 +425,7 @@ beta = _core.create_ufunc(
 
 betaln = _core.create_ufunc(
     "cupyx_scipy_betaln",
-    ("ff->f", "dd->d"),
+    ("ll->d", "LL->d", "ee->d", "ff->f", "dd->d"),
     "out0 = out0_type(lbeta(in0, in1));",
     preamble=(
         beta_preamble +

--- a/cupyx/scipy/special/_gamma.py
+++ b/cupyx/scipy/special/_gamma.py
@@ -5,9 +5,9 @@ from cupyx.scipy.special._loggamma import loggamma_definition
 _gamma_body = """
 
     if (isinf(in0) && in0 < 0) {
-        out0 = -1.0 / 0.0;
+        out0 = CUDART_NAN;
     } else if (in0 < 0. && in0 == floor(in0)) {
-        out0 = 1.0 / 0.0;
+        out0 = CUDART_NAN;
     } else {
         out0 = tgamma(in0);
     }
@@ -136,6 +136,9 @@ __device__ double rgamma(double x)
     double w, y, z;
     int sign;
 
+    if (isinf(x)) {
+        return 0.0;
+    }
     if (x > 34.84425627277176174) {
         return exp(-lgamma(x));
     }

--- a/cupyx/scipy/special/_gammaln.py
+++ b/cupyx/scipy/special/_gammaln.py
@@ -7,12 +7,12 @@ from cupy import _core
 
 
 gammaln = _core.create_ufunc(
-    'cupyx_scipy_special_gammaln', ('f->f', 'd->d'),
+    'cupyx_scipy_special_gammaln', ('l->d', 'e->d', 'f->f', 'd->d'),
     '''
-    if (isinf(in0) && in0 < 0) {
+    if (isinf(out0_type(in0)) && in0 < 0) {
         out0 = -1.0 / 0.0;
     } else {
-        out0 = lgamma(in0);
+        out0 = lgamma(out0_type(in0));
     }
     ''',
     doc="""Logarithm of the absolute value of the Gamma function.

--- a/cupyx/scipy/special/_gammasgn.py
+++ b/cupyx/scipy/special/_gammasgn.py
@@ -20,13 +20,13 @@ __device__ double gammasgn(double x)
     if (isnan(x)) {
       return x;
     }
-    if (x > 0) {
+    if (x >= 0) {
         return 1.0;
     }
     else {
         fx = floor(x);
         if (x - fx == 0.0) {
-            return 0.0;
+            return CUDART_NAN;
         }
         else if ((int)fx % 2) {
             return -1.0;
@@ -40,7 +40,7 @@ __device__ double gammasgn(double x)
 
 gammasgn = _core.create_ufunc(
     "cupyx_scipy_gammasgn",
-    ("f->f", "d->d"),
+    ("l->d", "L->d", "e->d", "f->f", "d->d"),
     "out0 = out0_type(gammasgn(in0));",
     preamble=gammasgn_definition,
     doc="""Elementwise function for scipy.special.gammasgn

--- a/cupyx/scipy/special/_logsumexp.py
+++ b/cupyx/scipy/special/_logsumexp.py
@@ -41,6 +41,9 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     scipy.special.logsumexp
 
     """
+    if a.dtype.kind in 'biu':
+        a = a.astype(cp.float64)
+
     if b is not None:
         a, b = cp.broadcast_arrays(a, b)
         if cp.any(b == 0):

--- a/cupyx/scipy/special/_spherical_bessel.py
+++ b/cupyx/scipy/special/_spherical_bessel.py
@@ -73,18 +73,14 @@ __device__ double spherical_yn_d_real(int n, double x) {
 
 _spherical_yn_real = _core.create_ufunc(
     "cupyx_scipy_spherical_yn_real",
-    (
-        "ie->d",
-        "if->f",
-        "id->d",
-    ),
+    ("id->d", "ld->d"),
     "out0 = out0_type(spherical_yn_real(in0, in1))",
     preamble=spherical_bessel_preamble,
 )
 
 _spherical_dyn_real = _core.create_ufunc(
     "cupyx_scipy_spherical_dyn_real",
-    ("if->f", "id->d"),
+    ("id->d", "ld->d"),
     "out0 = out0_type(spherical_yn_d_real(in0, in1));",
     preamble=spherical_bessel_preamble,
 )

--- a/cupyx/scipy/special/_zetac.py
+++ b/cupyx/scipy/special/_zetac.py
@@ -301,7 +301,7 @@ zetac_preamble = (polevl_definition+p1evl_definition +
                   _lanczos_preamble+zetac_definition)
 
 zetac = _core.create_ufunc(
-    'cupyx_scipy_special_zetac', ('f->f', 'd->d'),
+    'cupyx_scipy_special_zetac', ('l->d', 'L->d', 'e->d', 'f->f', 'd->d'),
     'out0 = zetac(in0)',
     preamble=zetac_preamble,
     doc="""Riemann zeta function minus 1.

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_basic.py
@@ -37,47 +37,48 @@ class TestLegendreFunctions:
 
     @pytest.mark.parametrize("order", [0, 1, 2, 3, 4])
     @pytest.mark.parametrize("degree", [0, 1, 2, 3, 4, 5, 10, 20, 30, 40, 50])
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=1e-12)
     def test_lpmv(self, xp, scp, dtype, order, degree):
-        vals = xp.linspace(-1, 1, 100, dtype=dtype)
+        vals = testing.shaped_linspace(-1, 1, 100, xp=xp, dtype=dtype)
         return scp.special.lpmv(order, degree, vals)
 
 
-@testing.with_requires("scipy")
+@testing.with_requires("scipy>=1.15")
 class TestBasic:
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp")
     def test_gammasgn(self, xp, scp, dtype):
-        vals = xp.linspace(-4, 4, 100, dtype=dtype)
+        vals = testing.shaped_linspace(-4, 4, 10, xp=xp, dtype=dtype)
         return scp.special.gammasgn(vals)
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes()
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-5)
     def test_log1p_linspace(self, xp, scp, dtype):
-        vals = xp.linspace(-100, 100, 1000, dtype=dtype)
+        vals = testing.shaped_linspace(-100, 100, 1000, xp=xp, dtype=dtype)
         dtype = xp.dtype(dtype)
         if dtype.kind == 'c':
             # broadcast to mix large and small real vs. imaginary
             vals = vals[::10, xp.newaxis] + 1j * vals[xp.newaxis, ::10]
         return xp.abs(scp.special.log1p(vals))
 
-    @testing.for_dtypes("efFdD")
+    @testing.for_all_dtypes()
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-5)
     def test_log1p_logspace(self, xp, scp, dtype):
         dtype = xp.dtype(dtype)
-        vals = xp.logspace(-10, 10, 1000, dtype=dtype)
+        vals = testing.shaped_linspace(-10, 10, 1000, xp=xp, dtype=dtype)
         if dtype.kind == 'c':
             # broadcast to mix large and small real vs. imaginary
             vals = vals[::10, xp.newaxis] + 1j * vals[xp.newaxis, ::10]
         return xp.abs(scp.special.log1p(vals))
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=rtol)
     def test_log1p_path2(self, xp, scp, dtype):
         # test values for code path corresponding to range [1/sqrt(2), sqrt(2)]
-        vals = xp.linspace(1 / math.sqrt(2), math.sqrt(2), 1000, dtype=dtype)
+        vals = testing.shaped_linspace(
+            1 / math.sqrt(2), math.sqrt(2), 1000, xp=xp, dtype=dtype)
         return scp.special.log1p(vals)
 
     def test_log1p_real(self):
@@ -90,26 +91,26 @@ class TestBasic:
         assert_array_equal(log1p(inf), inf)
 
     @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes()
     @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
                                                  cupy.float64: 1e-12})
     def test_xlogy(self, xp, scp, dtype, function):
         # only test with values > 0 to avoid NaNs
-        x = xp.linspace(-100, 100, 1000, dtype=dtype)
-        y = xp.linspace(0.001, 100, 1000, dtype=dtype)
+        x = testing.shaped_linspace(-100, 100, 1000, xp=xp, dtype=dtype)
+        y = testing.shaped_linspace(0.001, 100, 1000, xp=xp, dtype=dtype)
         if x.dtype.kind == 'c':
             x -= 1j * x
             y += 1j * y
         return getattr(scp.special, function)(x, y)
 
     @pytest.mark.parametrize("function", ["xlogy", "xlog1py"])
-    @testing.for_dtypes('efdFD')
+    @testing.for_all_dtypes()
     @numpy_cupy_allclose(scipy_name="scp", rtol={'default': 1e-3,
                                                  cupy.float64: 1e-12})
     def test_xlogy_zeros(self, xp, scp, dtype, function):
         # only test with values > 0 to avoid NaNs
         x = xp.zeros((1, 100), dtype=dtype)
-        y = xp.linspace(-10, 10, 100, dtype=dtype)
+        y = testing.shaped_linspace(-10, 10, 100, xp=xp, dtype=dtype)
         if y.dtype.kind == 'c':
             y += 1j * y
         return getattr(scp.special, function)(x, y)
@@ -122,48 +123,48 @@ class TestBasic:
         assert cupy.all(cupy.isnan(func(cupy.nan, y)))
         assert cupy.all(cupy.isnan(func(y, cupy.nan)))
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_exp2(self, xp, scp, dtype):
-        vals = xp.linspace(-100, 100, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-100, 100, 200, xp=xp, dtype=dtype)
         return scp.special.exp2(vals)
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_exp10(self, xp, scp, dtype):
         if xp.dtype(dtype).char == 'd':
-            vals = xp.linspace(-100, 100, 100, dtype=dtype)
+            vals = testing.shaped_linspace(-100, 100, 200, xp=xp, dtype=dtype)
         else:
             # Note: comparisons start to fail outside this range
             #       np.finfo(np.float32).max is 3.4028235e+38
-            vals = xp.linspace(-37, 37, 100, dtype=dtype)
+            vals = testing.shaped_linspace(-37, 37, 100, xp=xp, dtype=dtype)
         return scp.special.exp10(vals)
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes()
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_expm1(self, xp, scp, dtype):
-        vals = xp.linspace(-50, 50, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-50, 50, 200, xp=xp, dtype=dtype)
         if xp.dtype(dtype).kind == 'c':
             # broadcast to mix small and large real and imaginary parts
             vals = vals[:, xp.newaxis] + 1j * vals[xp.newaxis, :]
         return scp.special.expm1(vals)
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_cosm1(self, xp, scp, dtype):
-        vals = xp.linspace(-50, 50, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-50, 50, 200, xp=xp, dtype=dtype)
         return scp.special.cosm1(vals)
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_cosm1_close_to_zero(self, xp, scp, dtype):
-        vals = xp.linspace(-1e-8, 1e-8, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-1e-8, 1e-8, 200, xp=xp, dtype=dtype)
         return scp.special.cosm1(vals)
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_radian(self, xp, scp, dtype):
-        tmp = xp.linspace(-100, 100, 10, dtype=dtype)
+        tmp = testing.shaped_linspace(-100, 100, 10, xp=xp, dtype=dtype)
         d = tmp[:, xp.newaxis, xp.newaxis]
         m = tmp[xp.newaxis, : xp.newaxis]
         s = tmp[xp.newaxis, xp.newaxis, :]
@@ -175,15 +176,15 @@ class TestBasic:
                          atol={'default': 1e-6, cupy.float64: 1e-12},
                          rtol=1e-6)
     def test_trig_degrees(self, xp, scp, dtype, function):
-        vals = xp.linspace(-100, 100, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-100, 100, 200, xp=xp, dtype=dtype)
         # test at exact multiples of 45 degrees
         vals = xp.concatenate((vals, xp.arange(-360, 361, 45, dtype=dtype)))
         return getattr(scp.special, function)(vals)
 
-    @testing.for_dtypes("efd")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6)
     def test_cbrt(self, xp, scp, dtype):
-        vals = xp.linspace(-100, 100, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-100, 100, 200, xp=xp, dtype=dtype)
         return scp.special.cbrt(vals)
 
     # TODO: omit "e" since SciPy will promote to "f", but CuPy does not
@@ -192,7 +193,7 @@ class TestBasic:
     def test_round(self, xp, scp, dtype):
         vals = xp.concatenate(
             (
-                xp.linspace(-2, 2, 100, dtype=dtype),
+                testing.shaped_linspace(-2, 2, 100, xp=xp, dtype=dtype),
                 # test at half-integer locations
                 xp.asarray([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5], dtype=dtype),
             )
@@ -206,7 +207,7 @@ class TestBasic:
     @testing.for_dtypes("fd")
     @numpy_cupy_allclose(scipy_name="scp", rtol=1e-6, atol=1e-6)
     def test_sinc(self, xp, scp, dtype):
-        vals = xp.linspace(-100, 100, 200, dtype=dtype)
+        vals = testing.shaped_linspace(-100, 100, 200, xp=xp, dtype=dtype)
         return scp.special.sinc(vals)
 
     @testing.with_requires("numpy>=2.0")

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_bessel.py
@@ -5,10 +5,10 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestSpecial:
 
-    @testing.for_dtypes(['e', 'f', 'd'])
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-5, scipy_name='scp')
     def check_unary(self, name, xp, scp, dtype):
         import scipy.special  # NOQA
@@ -63,7 +63,7 @@ class TestSpecial:
         return scp.special.yn(n[:, xp.newaxis], a[xp.newaxis, :])
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestFusionSpecial(unittest.TestCase):
 
     @testing.for_dtypes(['e', 'f', 'd'])
@@ -115,7 +115,6 @@ class TestFusionSpecial(unittest.TestCase):
     def test_k1e(self):
         self.check_unary('k1e')
 
-    @testing.with_requires("scipy>=1.14")
     @testing.for_dtypes(['e', 'f', 'd'])
     @testing.numpy_cupy_allclose(rtol=1e-5, scipy_name='scp')
     def test_chbevl_dependent_fusion(self, dtype, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_beta.py
@@ -13,10 +13,10 @@ def _get_logspace_max(dtype):
     elif dtype.char == 'f':
         return 30
     elif dtype.char == 'e':
-        return 5
+        return 4
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestBeta:
 
     @pytest.mark.parametrize('function', ['beta', 'betaln'])
@@ -35,7 +35,7 @@ class TestBeta:
         cupy.cuda.runtime.runtimeGetVersion() < 5_00_00000,
         reason='ROCm/HIP fails in ROCm 4.x')
     @pytest.mark.parametrize('function', ['beta', 'betaln'])
-    @testing.for_float_dtypes()
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_linspace(self, xp, scp, dtype, function):
         import scipy.special  # NOQA
@@ -43,7 +43,7 @@ class TestBeta:
         func = getattr(scp.special, function)
         # TODO: Some choices of start/stop value can give mismatched location
         #       of +inf or -inf values.
-        x = xp.linspace(-20, 21, 50, dtype=dtype)
+        x = testing.shaped_linspace(-20, 21, 50, xp=xp, dtype=dtype)
         return func(x[:, xp.newaxis], x[xp.newaxis, :])
 
     @pytest.mark.parametrize('function', ['beta', 'betaln'])
@@ -111,7 +111,7 @@ class TestBetaInc:
         return scp.special.betaincinv(a, b, x)
 
     @pytest.mark.parametrize('function', ['betainc', 'betaincinv'])
-    @testing.for_float_dtypes()
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_linspace(self, xp, scp, dtype, function):
         import scipy.special  # NOQA
@@ -119,7 +119,7 @@ class TestBetaInc:
         func = getattr(scp.special, function)
         # TODO: Some choices of start/stop value can give mismatched location
         #       of +inf or -inf values.
-        tmp = xp.linspace(-20, 21, 10, dtype=dtype)
+        tmp = testing.shaped_linspace(-20, 21, 10, xp=xp, dtype=dtype)
         a = tmp[:, xp.newaxis, xp.newaxis]
         b = tmp[xp.newaxis, :, xp.newaxis]
         x = xp.linspace(0, 1, 5, dtype=dtype)[xp.newaxis, xp.newaxis, :]

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_binom.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_binom.py
@@ -51,5 +51,5 @@ class TestBinom:
     def test_nan_inf(self, xp, scp, dtype):
         import scipy.special  # NOQA
         a = xp.array([-numpy.inf, numpy.nan, numpy.inf, 0, -1,
-                      1e8, 5e7], dtype=dtype)
+                      3e3, 1e4]).astype(dtype)
         return scp.special.binom(a[:, xp.newaxis], a[xp.newaxis, :])

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_convex_analysis.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_convex_analysis.py
@@ -18,7 +18,7 @@ class TestSpecialConvex(unittest.TestCase):
         testing.assert_allclose(cupyx.scipy.special.huber(2, 2.5),
                                 2 * (2.5 - 0.5 * 2))
 
-    @testing.for_float_dtypes()
+    @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_huber(self, xp, scp, dtype):
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -42,7 +42,7 @@ class TestDigamma(unittest.TestCase):
         return scp.special.digamma(dtype(1.5))
 
     @testing.with_requires('scipy>=1.1.0')
-    @testing.for_all_dtypes()
+    @testing.for_dtypes("efdFD")
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_exprel.py
@@ -21,41 +21,43 @@ rtol = {
 }
 
 
-@testing.with_requires("scipy>=1.14")
+@testing.with_requires("scipy>=1.15")
 class Testexprel:
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_float_dtypes()
     @numpy_cupy_allclose(scipy_name="scp")
     def test_exprel(self, xp, scp, dtype):
-        return scp.special.exprel(-1)
+        return scp.special.exprel(xp.array(-1, dtype=dtype))
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_2(self, xp, scp, dtype):
-        return scp.special.exprel(1)
+        return scp.special.exprel(xp.array(1, dtype=dtype))
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_large_values(self, xp, scp, dtype):
-        return scp.special.exprel(720)
+        if xp.dtype(dtype).char in 'bB':
+            return xp.array(0)  # Skip to avoid overflow
+        return scp.special.exprel(xp.array(720, dtype=dtype))
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_small_value(self, xp, scp, dtype):
-        return scp.special.exprel(1e-17)
+        return scp.special.exprel(xp.array(1e-17, dtype=dtype))
 
-    @testing.for_dtypes("efdFD")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_zero_values(self, xp, scp, dtype):
-        return scp.special.exprel(0.0)
+        return scp.special.exprel(xp.array(0, dtype=dtype))
 
-    @testing.for_dtypes("edf")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_array_inputs(self, xp, scp, dtype):
         n = testing.shaped_arange((5, 1, 2), xp, dtype) * 0.001
         return scp.special.exprel(n)
 
-    @testing.for_dtypes("edf")
+    @testing.for_all_dtypes(no_complex=True)
     @numpy_cupy_allclose(scipy_name="scp", atol=atol, rtol=rtol)
     def test_exprel_array_inputs_2(self, xp, scp, dtype):
         n = testing.shaped_random((5, 3), xp, dtype) * 0.001

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
@@ -6,7 +6,7 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.with_requires("scipy>=1.14")
+@testing.with_requires("scipy>=1.15")
 class TestGamma:
 
     @pytest.mark.parametrize('function', ['gamma', 'loggamma', 'rgamma'])
@@ -51,7 +51,7 @@ class TestGamma:
 
     # skip on SciPy < 1.5 due to: https://github.com/scipy/scipy/issues/11315
     @pytest.mark.parametrize('function', ['gamma', 'loggamma', 'rgamma'])
-    @testing.for_all_dtypes()
+    @testing.for_dtypes("efdFD")
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
     @testing.with_requires('scipy>=1.5.0')
     def test_inf_and_nan(self, xp, scp, dtype, function):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gammaln.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gammaln.py
@@ -7,7 +7,7 @@ from cupy import testing
 import cupyx.scipy.special  # NOQA
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestGammaln:
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestLogsumexp:
 
     @testing.for_all_dtypes(no_bool=True)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -45,7 +45,7 @@ class TestPolygamma(unittest.TestCase):
     @pytest.mark.xfail(
         platform.machine() == "aarch64",
         reason="aarch64 scipy does not match cupy/x86 see Scipy #20159")
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_spherical_bessel.py
@@ -9,21 +9,21 @@ except ImportError:
     pass
 
 
-@testing.with_requires("scipy>=1.14")
+@testing.with_requires("scipy>=1.15")
 class TestSphericalBessel:
 
-    @testing.for_dtypes('i', name='order_dtype')
+    @testing.for_dtypes('il', name='order_dtype')
     @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_spherical_yn_inf_and_nan(self, xp, scp, dtype, order_dtype):
         n = xp.arange(0, 100, dtype=order_dtype)
         a = xp.array([numpy.nan, numpy.inf, -numpy.inf], dtype=dtype)
         return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])
 
-    @testing.for_dtypes('i', name='order_dtype')
-    @testing.for_float_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-12, rtol=1e-12, scipy_name='scp')
+    @testing.for_dtypes('il', name='order_dtype')
+    @testing.for_all_dtypes(no_bool=True, no_complex=True)
+    @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_spherical_yn_linspace(self, xp, scp, dtype, order_dtype):
-        n = xp.arange(0, 10, dtype=order_dtype)
-        a = xp.linspace(-10, 10, 100, dtype=dtype)
+        n = testing.shaped_arange((10,), xp=xp, dtype=order_dtype)
+        a = testing.shaped_linspace(-10, 10, 100, xp=xp, dtype=dtype)
         return scp.special.spherical_yn(n[xp.newaxis, :], a[:, xp.newaxis])

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_zeta.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_zeta.py
@@ -35,7 +35,7 @@ class TestZeta(unittest.TestCase):
 
         return scp.special.zeta(dtype(2.), dtype(1.5))
 
-    @testing.for_all_dtypes(no_complex=True)
+    @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):
         import scipy.special  # NOQA

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_zetac.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_zetac.py
@@ -10,7 +10,7 @@ except ImportError:
     pass
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy>=1.15')
 class TestZetac(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/8866.

- Fix for test failures caused by dtype mismatch
- Minor fix for inf/nan handling
- Enhanced tests for more comprehensive input dtype coverage
- Fix tests to suppress overflow warning