### PR TITLE
Add cupyx.scipy.ndimage.find_objects

### DIFF
--- a/cupyx/scipy/ndimage/__init__.py
+++ b/cupyx/scipy/ndimage/__init__.py
@@ -36,6 +36,7 @@ from cupyx.scipy.ndimage._interpolation import spline_filter  # NOQA
 from cupyx.scipy.ndimage._interpolation import spline_filter1d  # NOQA
 from cupyx.scipy.ndimage._interpolation import zoom  # NOQA
 
+from cupyx.scipy.ndimage._measurements import find_objects  # NOQA
 from cupyx.scipy.ndimage._measurements import label  # NOQA
 from cupyx.scipy.ndimage._measurements import sum  # NOQA
 from cupyx.scipy.ndimage._measurements import sum_labels  # NOQA

--- a/cupyx/scipy/ndimage/_bbox_slices.pxd
+++ b/cupyx/scipy/ndimage/_bbox_slices.pxd
@@ -1,0 +1,9 @@
+from cython cimport fused_type
+
+
+ctypedef fused coord_index_type:
+    unsigned int
+    unsigned long long
+
+cpdef create_bbox_slice_tuple(coord_index_type[:, ::1] bbox,
+                              coord_index_type max_int)

--- a/cupyx/scipy/ndimage/_bbox_slices.pyx
+++ b/cupyx/scipy/ndimage/_bbox_slices.pyx
@@ -1,0 +1,28 @@
+# distutils: language = c++
+
+
+cpdef create_bbox_slice_tuple(coord_index_type[:, ::1] bbox,
+                              coord_index_type max_int):
+    """Support function for cupyx.scipy.ndimage.find_objects
+
+    Creates a list of slice tuples from an array of bounding box coordinates.
+    """
+    cdef list slices = []
+    cdef list slices_inner = []
+    cdef coord_index_type n = bbox.shape[0]
+    cdef coord_index_type i = 0
+    cdef int ndim = bbox.shape[1] // 2
+
+    for i in range(n):
+        if bbox[i, 0] == max_int:
+            # A value of max_int for the starting coordinate means label `i`
+            # was not present in the image. We store None in this case.
+            slices.append(None)
+        else:
+            # Append a slice tuple corresponding to the bounding box
+            slices_inner = []
+            for d in range(ndim):
+                slices_inner.append(slice(bbox[i, 2*d], bbox[i, 2*d + 1]))
+            slices.append(tuple(slices_inner))
+
+    return slices

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -6,6 +6,7 @@ import numpy
 import cupy
 from cupy import _core
 from cupy import _util
+from cupyx.scipy.ndimage._bbox_slices import create_bbox_slice_tuple
 
 
 def label(input, structure=None, output=None):
@@ -1584,11 +1585,5 @@ def find_objects(input, max_label=0):
 
     # Copy bounding box coordinates to the CPU to create Python slice objects
     bbox_coords_cpu = cupy.asnumpy(bbox_coords[:max_label, :])  # synchronize
-    bbox_slices = [
-        tuple(
-            slice(int(box[2 * d]), int(box[2 * d + 1]))
-            for d in range(ndim)
-        ) if box[0] != int_max else None
-        for box in bbox_coords_cpu
-    ]
+    bbox_slices = create_bbox_slice_tuple(bbox_coords_cpu, int_max)
     return bbox_slices

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 import numpy
@@ -1380,57 +1381,136 @@ def value_indices(arr, *, ignore_value=None, adaptive_index_dtype=False):
     return out
 
 
-def _unravel_loop_index(var_name, ndim, uint_t="unsigned int"):
+def _unravel_loop_index_declarations(var_name, ndim, uint_t="unsigned int"):
+    """Declare variables needed for unraveling the index to nd coordinates"""
+    if ndim == 1:
+        code = f"""
+        {uint_t} in_coord[1];"""
+        return code
+
+    code = f"""
+        // variables for unraveling a linear index to a coordinate array
+        {uint_t} in_coord[{ndim}];
+        {uint_t} temp_floor;"""
+    for d in range(ndim):
+        code += f"""
+        {uint_t} dim{d}_size = {var_name}.shape()[{d}];"""
+    return code
+
+
+def _unravel_loop_index(
+    var_name,
+    ndim,
+    uint_t="unsigned int",
+    raveled_index="i",
+    omit_declarations=False,
+):
     """
     declare a multi-index array in_coord and unravel the 1D index, i into it.
     This code assumes that the array is a C-ordered array.
     """
-
+    code = (
+        ""
+        if omit_declarations
+        else _unravel_loop_index_declarations(var_name, ndim, uint_t)
+    )
     if ndim == 1:
         code = f"""
-        {uint_t} in_coord[1];
-        in_coord[0] = i;\n"""
+        in_coord[0] = {raveled_index};\n"""
         return code
 
-    code = f"""
-        {uint_t} in_coord[{ndim}];
-        {uint_t} s, t, idx = i;"""
-    for j in range(ndim - 1, 0, -1):
+    code += f"{uint_t} temp_idx = {raveled_index};"
+    for d in range(ndim - 1, 0, -1):
         code += f"""
-        s = {var_name}.shape()[{j}];
-        t = idx / s;
-        in_coord[{j}] = idx - t * s;
-        idx = t;"""
+        temp_floor = temp_idx / dim{d}_size;
+        in_coord[{d}] = temp_idx - temp_floor * dim{d}_size;
+        temp_idx = temp_floor;"""
     code += """
-        in_coord[0] = idx;\n"""
+        in_coord[0] = temp_idx;"""
     return code
 
 
 @cupy.memoize(for_each_device=True)
-def get_bbox_coords_kernel(coord_dtype, ndim):
+def get_bbox_coords_kernel(coord_dtype, ndim, pixels_per_thread=32):
     coord_dtype = cupy.dtype(coord_dtype)
+
+    # maximum number of unique labels this thread might encounter
+    # (could use a smaller value for most datasets, but for safety assume
+    # every pixel in the window could have a separate label.)
+    max_unique = pixels_per_thread
 
     uint_t = (
         "unsigned int" if coord_dtype.itemsize <= 4 else "unsigned long long"
     )
 
+    # declare storage for local min/max of each label within the pixel window
     source = f"""
-        // empirically found that scipy's find_objects ignores negative values
-        if (image[i] > 0) {{
-            {uint_t} offset = 0;"""
-    source += _unravel_loop_index("image", ndim, uint_t=uint_t)
+    {uint_t} start_index = {pixels_per_thread}*i;
+    // bounding box variables
+    {uint_t} bbox_min[{ndim * max_unique}];
+    {uint_t} bbox_max[{ndim * max_unique}] = {{0}};
+    // initialize minimum coordinate to array size
+    for (unsigned int ii = 0; ii < {ndim * max_unique}; ii++) {{
+      bbox_min[ii] = image_size;
+    }}\n"""
+    source += _unravel_loop_index_declarations(
+        "image", ndim, uint_t=uint_t
+    )
+
+    # declare inner loop operation
+    inner_op = _unravel_loop_index(
+        "image",
+        ndim=ndim,
+        uint_t=uint_t,
+        raveled_index="ii",
+        omit_declarations=True,
+    )
+    for d in range(ndim):
+        inner_op += f"""
+          bbox_min[{ndim}*offset + {d}] = min(
+              in_coord[{d}], bbox_min[{ndim}*offset + {d}]);
+          bbox_max[{ndim}*offset + {d}] = max(
+              in_coord[{d}] + 1, bbox_max[{ndim}*offset + {d}]);"""
+
+    # Find min and max coordinates among the next pixels_per_thread pixels
+    source += f"""
+      X encountered_labels[{max_unique}] = {{0}};
+      X current_label;
+      X prev_label = image[start_index];
+      int offset = 0;
+      encountered_labels[0] = prev_label;
+      {uint_t} ii_max = min(start_index + {pixels_per_thread}, image_size);
+      for ({uint_t} ii = start_index; ii < ii_max; ii++) {{
+        current_label = image[ii];
+        if (current_label <= 0) {{ continue; }}
+        if (current_label != prev_label) {{
+            offset += 1;
+            prev_label = current_label;
+            encountered_labels[offset] = current_label;
+        }}
+        // inner loop operation for boundary box min/max
+        {inner_op}
+      }}\n"""
+
+    # Update the global min/max values with the min/max from the pixel group
+    source += """
+      for (unsigned int ii = 0; ii <= offset; ii++) {
+        X lab = encountered_labels[ii];
+        if (lab > 0) {"""
     for d in range(ndim):
         source += f"""
-            offset = (image[i] - 1) * {2 * ndim} + {2*d};
-            // store interleaved minima/maxima
-            atomicMin(&bbox[offset], in_coord[{d}]);
-            atomicMax(&bbox[offset + 1], in_coord[{d}] + 1);"""
+          atomicMin(&bbox[(lab - 1)*{2*ndim} + {2*d}],
+                    bbox_min[{ndim}*ii + {d}]);
+          atomicMax(&bbox[(lab - 1)*{2*ndim} + {2*d + 1}],
+                    bbox_max[{ndim}*ii + {d}]);"""
     source += """
-          }\n"""
+        }
+      }\n"""
 
-    inputs = "raw X image"
+    inputs = f"raw X image, raw {coord_dtype.name} image_size"
     outputs = f"raw {coord_dtype.name} bbox"
     name = f"cucim_bbox_{ndim}d_{coord_dtype.char}"
+    name += f"_batch{pixels_per_thread}"
     return cupy.ElementwiseKernel(
         inputs, outputs, source, name=name
     )
@@ -1477,8 +1557,14 @@ def find_objects(input, max_label=0):
         max_label = int(image.max())  # synchronize
 
     # choose 32 or 64-bit coordinate type for atomicMin and atomicMax
-    coord_dtype = cupy.uint32 if max(image.shape) < 2**32 else cupy.uint64
-    bbox_coords_kernel = get_bbox_coords_kernel(coord_dtype, image.ndim)
+    coord_dtype = cupy.uint32 if image.size < 2**32 else cupy.uint64
+
+    # Could potentially expose pixels per thread as a tuning parameter instead
+    # of using a fixed value here.
+    pixels_per_thread = 32
+    bbox_coords_kernel = get_bbox_coords_kernel(
+        coord_dtype, image.ndim, pixels_per_thread
+    )
 
     ndim = image.ndim
     # 0 is the correct initial value for coordinate maxima
@@ -1493,7 +1579,8 @@ def find_objects(input, max_label=0):
     if not image.flags.c_contiguous:
         image = cupy.ascontiguousarray(image)
 
-    bbox_coords_kernel(image, bbox_coords, size=image.size)
+    size = math.ceil(image.size / pixels_per_thread)
+    bbox_coords_kernel(image, image.size, bbox_coords, size=size)
 
     # Copy bounding box coordinates to the CPU to create Python slice objects
     bbox_coords_cpu = cupy.asnumpy(bbox_coords[:max_label, :])  # synchronize

--- a/cupyx/scipy/ndimage/_util.py
+++ b/cupyx/scipy/ndimage/_util.py
@@ -100,8 +100,8 @@ def _check_axes(axes, ndim):
     elif cupy.isscalar(axes):
         axes = (operator.index(axes),)
     elif isinstance(axes, Iterable):
+        axes = tuple(operator.index(ax) for ax in axes)
         for ax in axes:
-            axes = tuple(operator.index(ax) for ax in axes)
             if ax < -ndim or ax > ndim - 1:
                 raise AxisError(f"specified axis: {ax} is out of range")
         axes = tuple(ax % ndim if ax < 0 else ax for ax in axes)

--- a/docs/source/reference/scipy_ndimage.rst
+++ b/docs/source/reference/scipy_ndimage.rst
@@ -73,6 +73,7 @@ Measurements
 
    center_of_mass
    extrema
+   find_objects
    histogram
    label
    labeled_comprehension

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -144,6 +144,7 @@ _cuda_files = [
     'cupy.fft._callback',
     'cupy.lib._polynomial',
     'cupy._util',
+    'cupyx.scipy.ndimage._bbox_slices',
 ]
 
 # Libraries required for cudart_static


### PR DESCRIPTION
This MR implements the `find_objects` functions from SciPy. This function finds the Cartesian bounding boxes for all integer-labeled objects in an image as in the example image shown below:

![find_objects_bounding_boxes](https://github.com/user-attachments/assets/bbfb5105-eec9-47af-bac6-08aa43c27227)

So, conceptually the kernel is very simple and just needs to find the minimum and maximum coordinate index associated with each label value. In the first commit, a simple elementwise kernel was created for this. 

This was refined in a subsequent commit which updated the kernel to process multiple sequential pixels per GPU thread to reduce the overhead of atomic operations. This makes the kernel harder to read, but has substantial performance benefit (see benchmark results below)

A simple Cython function was also implemented to perform the final loop over the coordinates that creates the Python slice objects that are returned.

## Benchmarks

Benchmarks were run at a few different 2D and 3D image sizes, where for each size three different object densities were investigated. Examples of what these density images look like for the shape (512, 512) shape is shown here (they are created with a third-party `cucim.skimage.data.binary_blobs` function for generating blobs of various sizes/density):

![find_objects_volume_fractions](https://github.com/user-attachments/assets/b08dbc99-ba1a-42ea-a2cf-3ae8a34e8afd)

### Table of accelerations vs. scikit-image

#### For initial commit (1 pixel per GPU thread) and no Cython slice object creation

|   shape   |  num_labels   |   Duration (skimage)  |  Duration (cuCIM)  |  Acceleration  |
|-----------|---------------|-----------------------|--------------------|----------------|
| (512, 512) | 2747 | 0.00307 | 0.00555 | 0.55 |
| (512, 512) | 309 | 0.00103 | 0.00060 | 1.71 |
| (512, 512) | 41 | 0.00092 | 0.00029 | 3.19 |
| (3840, 2160) | 1558 | 0.02739 | 0.00573 | 4.78 |
| (3840, 2160) | 179 | 0.02504 | 0.00515 | 4.86 |
| (3840, 2160) | 26 | 0.02546 | 0.00629 | 4.05 |
| (192, 192, 192) | 7710 | 0.05011 | 0.02828 | 1.77 |
| (192, 192, 192) | 626 | 0.03022 | 0.00819 | 3.69 |
| (192, 192, 192) | 60 | 0.02493 | 0.00708 | 3.52 |


#### For intermediate version with multiple pixels per thread but no Cython code
|   shape   |  num_labels   |   Duration (skimage)  |  Duration (cuCIM)  |  Acceleration  |
|-----------|---------------|-----------------------|--------------------|----------------|
| (512, 512) | 2747 | 0.00419 | 0.00682 | 0.61 |
| (512, 512) | 309 | 0.00103 | 0.00062 | 1.67 |
| (512, 512) | 41 | 0.00092 | 0.00021 | 4.45 |
| (3840, 2160) | 1558 | 0.02723 | 0.00339 | 8.03 |
| (3840, 2160) | 179 | 0.02536 | 0.00085 | 29.98 |
| (3840, 2160) | 26 | 0.02540 | 0.00065 | 39.29 |
| (192, 192, 192) | 7710 | 0.05592 | 0.02811 | 1.99 |
| (192, 192, 192) | 626 | 0.03012 | 0.00248 | 12.17 |
| (192, 192, 192) | 60 | 0.02511 | 0.00105 | 23.90 |

This has greatly improved performance for the larger sizes and particularly when there are relatively few, large labeled regions.

#### For final version 
|   shape   |  num_labels   |   Duration (skimage)  |  Duration (cuCIM)  |  Acceleration  |
|-----------|---------------|-----------------------|--------------------|----------------|
| (512, 512) | 2747 | 0.00326 | 0.00276 | 1.18 |
| (512, 512) | 309 | 0.00104 | 0.00022 | 4.64 |
| (512, 512) | 41 | 0.00094 | 0.00014 | 6.83 |
| (3840, 2160) | 1558 | 0.02747 | 0.00205 | 13.41 |
| (3840, 2160) | 179 | 0.02569 | 0.00068 | 37.70 |
| (3840, 2160) | 26 | 0.02543 | 0.00066 | 38.43 |
| (192, 192, 192) | 7710 | 0.05193 | 0.01439 | 3.61 |
| (192, 192, 192) | 626 | 0.03057 | 0.00193 | 15.82 |
| (192, 192, 192) | 60 | 0.02512 | 0.00106 | 23.63 |

The Cython code provides complementary improvement to the smaller image cases, and particularly cases with a large number of regions.

### Tuning the internal `pixels_per_thread` parameter

The below shows results for the three shape (3840, 2160) cases for a variety of settings of the internal `pixels_per_thread` parameter. The hard-coded internal value of 24 was selected based on this.

![find_objects_pixels_per_thread](https://github.com/user-attachments/assets/5a2e335f-c9b8-43ae-8569-fec16197053e)

(zoomed view showing only the cases with 4 or more threads)
![find_objects_pixels_per_thread_zoomed](https://github.com/user-attachments/assets/8dab9245-e4d5-4a9e-bad1-207ec2db7b51)
