### PR TITLE
Fix splines tests to remove unexpected skips

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
@@ -18,8 +18,7 @@ class TestSymIIROrder:
     @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120])
     @pytest.mark.parametrize(
         'precision', [-1, 2, 1.5, 1.0, 0.5, 0.25, 0.1, 2e-3, 1e-3])
-    @testing.for_all_dtypes_combination(
-        no_float16=True, no_bool=True, names=('dtype',))
+    @testing.for_all_dtypes(no_float16=True, no_bool=True)
     @testing.numpy_cupy_allclose(
         atol=1e-5, rtol=1e-5, scipy_name='scp', accept_error=True)
     def test_symiirorder1(self, size, precision, dtype, xp, scp):
@@ -41,13 +40,10 @@ class TestSymIIROrder:
     @pytest.mark.parametrize(
         'omega', ['zero', 'pi', 'random']
     )
-    @testing.for_all_dtypes_combination(
-        no_float16=True, no_complex=True, no_bool=True, names=('dtype',))
+    @testing.for_dtypes('d')  # XXX: np2.0: f32/f64 dtypes differ
     @testing.numpy_cupy_allclose(
         atol=2e-5, rtol=2e-5, scipy_name='scp', accept_error=True)
     def test_symiirorder2(self, size, precision, omega, dtype, xp, scp):
-        if xp.dtype(dtype).kind in {'i', 'u'}:
-            pytest.skip()
         if (
             runtime.is_hip and driver.get_build_version() < 5_00_00000
         ):
@@ -64,8 +60,5 @@ class TestSymIIROrder:
 
         r = testing.shaped_random((1,), xp, scale=1)[0]
         x = testing.shaped_random((size,), xp, dtype=dtype)
-
-        if x.dtype == 'float32':
-            pytest.xfail(reason="XXX: np2.0: f32/f64 dtypes differ")
 
         return scp.signal.symiirorder2(x, r, omega, precision)


### PR DESCRIPTION
`for_all_dtypes_combination` does not check all combinations of dtype unless `CUPY_TEST_FULL_COMBINATION="1"` is set.