### PR TITLE
Use CCCL 2.8.x branch + Use `CUPY_CACHE_KEY` in hash keys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/cccl"]
 	path = third_party/cccl
-	url = https://github.com/NVIDIA/cccl.git
+	url = https://github.com/cupy/cccl.git
 [submodule "third_party/jitify"]
 	path = third_party/jitify
 	url = https://github.com/NVIDIA/jitify.git

--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -3125,7 +3125,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - cutensor
-     - 🚨
+     - 2
      - 
      - 
      - 
@@ -3146,8 +3146,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
-     - 
-     - 
+     - ✅
+     - ✅
      - 
      - 
      - 
@@ -3207,7 +3207,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - cutensor,cub
-     - 28
+     - 26
      - 
      - 
      - 
@@ -3228,8 +3228,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
-     - ✅
-     - ✅
+     - 
+     - 
      - ✅
      - ✅
      - ✅

--- a/.pfnci/linux/tests/cuda123.multi.sh
+++ b/.pfnci/linux/tests/cuda123.multi.sh
@@ -9,7 +9,7 @@ ACTIONS="$(dirname $0)/actions"
 
 export NVCC="ccache nvcc"
 
-export CUPY_ACCELERATORS="cutensor,cub"
+export CUPY_ACCELERATORS="cutensor"
 
 "$ACTIONS/build.sh"
 export OMPI_ALLOW_RUN_AS_ROOT=1

--- a/.pfnci/linux/tests/cuda123.sh
+++ b/.pfnci/linux/tests/cuda123.sh
@@ -9,7 +9,7 @@ ACTIONS="$(dirname $0)/actions"
 
 export NVCC="ccache nvcc"
 
-export CUPY_ACCELERATORS="cutensor,cub"
+export CUPY_ACCELERATORS="cutensor"
 
 "$ACTIONS/build.sh"
 "$ACTIONS/unittest.sh" "not slow and not multi_gpu"

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -322,7 +322,7 @@
   mpi4py: null
   cython: "0.29"
   cuda-python: null
-  env:CUPY_ACCELERATORS: "cutensor,cub"
+  env:CUPY_ACCELERATORS: "cutensor"
   test: "unit"
 
 # CUDA 12.3 (Multi-GPU) | Linux
@@ -332,6 +332,7 @@
   target: "cuda123.multi"
   mpi4py: "3"
   test: "unit-multi"
+  env:CUPY_ACCELERATORS: "cutensor"
 
 # CUDA 12.4 | Linux
 - project: "cupy.linux.cuda124"

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -52,6 +52,7 @@ function ActivateCUDA($version) {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V12_2
     } elseif ($version -eq "12.3") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V12_3
+        $Env:CUPY_ACCELERATORS = ""
     } elseif ($version -eq "12.4") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V12_4
     } elseif ($version -eq "12.5") {

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -60,6 +60,20 @@ from cupy.exceptions import ComplexWarning
 NUMPY_1x = numpy.__version__ < '2'
 
 
+cdef extern from *:
+    """
+    #define _str_(s) #s
+    #define _xstr_(s) _str_(s)
+    const char* cupy_cache_key = _xstr_(CUPY_CACHE_KEY);
+    #undef _xstr_
+    #undef _str_
+    """
+    const char* cupy_cache_key  # set at build time
+
+
+CUPY_CACHE_KEY = bytes(cupy_cache_key).decode()
+
+
 # If rop of cupy.ndarray is called, cupy's op is the last chance.
 # If op of cupy.ndarray is called and the `other` is cupy.ndarray, too,
 # it is safe to call cupy's op.

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -155,6 +155,12 @@ def _get_nvrtc_version():
     return _nvrtc_version
 
 
+@_util.memoize()
+def _get_cupy_cache_key():
+    from cupy._core import core
+    return core.CUPY_CACHE_KEY
+
+
 # Known archs for Tegra/Jetson/Xavier/etc
 _tegra_archs = ('32', '53', '62', '72', '87')
 
@@ -580,7 +586,8 @@ def _compile_with_cache_cuda(
         base = _preprocess('', options, arch, backend)
         _empty_file_preprocess_cache[env] = base
 
-    key_src = '%s %s %s %s' % (env, base, source, extra_source)
+    key_src = '%s %s %s %s %s' % (
+        env, base, source, extra_source, _get_cupy_cache_key())
     key_src = key_src.encode('utf-8')
     name = _hash_hexdigest(key_src) + '.cubin'
 

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -149,7 +149,7 @@ class TestBoxcox_llf:
         not sys.platform.startswith('linux'),
         reason="Return value of scipy.stats.boxcox_llf has large error")
     @testing.with_requires('scipy>=1.13')
-    @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
+    @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-12, rtol=rtol)
     def test_instability_around_zero(self, xp, scp):
         data = xp.asarray([2003, 1950, 1997, 2000, 2009], dtype=numpy.float64)
         return scp.stats.boxcox_llf(1e-8, data)


### PR DESCRIPTION
Follow-up of #8899. Close #8588.

This PR switches to use the [2.8.x](https://github.com/NVIDIA/cccl/tree/branch/2.8.x) branch, as discussed in https://github.com/cupy/cupy/pull/8899#issuecomment-2626174099. Currently I manually backported https://github.com/NVIDIA/cccl/pull/3644 on top of it, using the existing `cupy/cccl` fork. If it gets done tomorrow we can switch back.