### PR TITLE
Drop unneeded `bytes` copy of `CUPY_CACHE_KEY`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -71,7 +71,7 @@ cdef extern from *:
     const char* cupy_cache_key  # set at build time
 
 
-CUPY_CACHE_KEY = bytes(cupy_cache_key).decode()
+CUPY_CACHE_KEY = cupy_cache_key.decode()
 
 
 # If rop of cupy.ndarray is called, cupy's op is the last chance.


### PR DESCRIPTION
Cython knows how to [`decode` a `const char*` directly to `str`]( https://cython.readthedocs.io/en/latest/src/tutorial/strings.html#decoding-bytes-to-text ) without needing to create a `bytes` object. So this drops the use of `bytes` here when constructing the Python value of `CUPY_CACHE_KEY`.

xref: https://github.com/cupy/cupy/pull/8919#discussion_r1940412605

cc @leofang