### PR TITLE
Use relative path of header files to generate cache key

### DIFF
--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -66,7 +66,8 @@ class Context:
         hasher = hashlib.sha1(usedforsecurity=False)
         for include_file in include_files:
             with open(include_file, 'rb') as f:
-                hasher.update(include_file.encode())
+                relpath = os.path.relpath(include_file, source_root)
+                hasher.update(relpath.encode())
                 hasher.update(f.read())
                 hasher.update(b'\x00')
         cache_key = hasher.hexdigest()


### PR DESCRIPTION
Previously, the cache key was calculated based on the absolute path + content of each header file. This PR changes the logic to use relative path + content instead.

This does not affect end-user use case at all. In the CI environment, source tree is checked out to a temporary directory whose name changes every time. This causes kernel cache to be invalidated every time since #8919.