### PR TITLE
[backport] Fix dtype rule of boxcox_llf for SciPy 1.15

### DIFF
--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -60,7 +60,7 @@ def _compute(xp, scp, lmb, data):
     return result, _dtype(data.dtype, xp)
 
 
-@testing.with_requires('scipy<1.12.0rc1')
+@testing.with_requires('scipy<1.15')
 class TestBoxcox_llf:
 
     @testing.for_all_dtypes(no_bool=True)


### PR DESCRIPTION
Backport of #8913 by @asi1024