### PR TITLE
Fix typo in _cretate_frame_tree

### DIFF
--- a/cupy/cuda/memory_hooks/line_profile.py
+++ b/cupy/cuda/memory_hooks/line_profile.py
@@ -54,13 +54,13 @@ class LineProfileHook(memory_hook.MemoryHook):
 
     # callback
     def malloc_preprocess(self, device_id, size, mem_size):
-        self._cretate_frame_tree(used_bytes=mem_size)
+        self._create_frame_tree(used_bytes=mem_size)
 
     # callback
     def alloc_preprocess(self, device_id, mem_size):
-        self._cretate_frame_tree(acquired_bytes=mem_size)
+        self._create_frame_tree(acquired_bytes=mem_size)
 
-    def _cretate_frame_tree(self, used_bytes=0, acquired_bytes=0):
+    def _create_frame_tree(self, used_bytes=0, acquired_bytes=0):
         self._root.used_bytes += used_bytes
         self._root.acquired_bytes += acquired_bytes
         parent = self._root


### PR DESCRIPTION
Corrected spelling for `_create_frame_tree` function of `LineProfileHook`. Previous name was `_cretate_frame_tree` with a superfluous `t`.