### PR TITLE
Broaden usage of C++17

### DIFF
--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -36,7 +36,8 @@ cdef function.Function _create_cub_reduction_function(
         #    license issue we can't yet bundle bf16 headers. CUB offers us a
         #    band-aid solution to avoid including the latter (NVIDIA/cub#478,
         #    nvbugs 3641496).
-        options += ('--std=c++11', '-DCUB_DISABLE_BF16_SUPPORT')
+        # 3. Recent CCCL versions need C++17.
+        options += ('--std=c++17', '-DCUB_DISABLE_BF16_SUPPORT')
 
     cdef str backend
     if runtime._is_hip_environment:

--- a/cupy/_functional/vectorize.py
+++ b/cupy/_functional/vectorize.py
@@ -95,7 +95,7 @@ class vectorize(object):
             kern = _core.ElementwiseKernel(
                 in_params, out_params, body, 'cupy_vectorize',
                 preamble=result.code,
-                options=('-DCUPY_JIT_MODE', '--std=c++14'),
+                options=('-DCUPY_JIT_MODE', '--std=c++17'),
             )
             self._kernel_cache[itypes] = kern
 


### PR DESCRIPTION
Follow up on this discussion in PR: https://github.com/cupy/cupy/pull/8951

Switch more C++14 flags to C++17.

This should help with compilation issues we have seen (like Windows CUDA 11.2).