### PR TITLE
Improve performance of `cupyx.scipy.ndimage.binary_fill_holes`

### DIFF
--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -363,7 +363,8 @@ def binary_erosion(input, structure=None, iterations=1, mask=None, output=None,
 
     .. seealso:: :func:`scipy.ndimage.binary_erosion`
     """
-    structure, _, _ = _prep_structure(structure, input.ndim)
+    axes = _util._check_axes(axes, input.ndim)
+    structure, _, _ = _prep_structure(structure, len(axes))
     return _binary_erosion(input, structure, iterations, mask, output,
                            border_value, origin, 0, brute_force, axes=axes)
 
@@ -415,9 +416,9 @@ def binary_dilation(input, structure=None, iterations=1, mask=None,
 
     .. seealso:: :func:`scipy.ndimage.binary_dilation`
     """
-    structure, structure_shape, symmetric = _prep_structure(structure,
-                                                            input.ndim)
     axes = _util._check_axes(axes, input.ndim)
+    structure, structure_shape, symmetric = _prep_structure(structure,
+                                                            len(axes))
     origin = _util._fix_sequence_arg(origin, len(axes), 'origin', int)
     # no point in flipping if already symmetric
     if not symmetric:
@@ -480,7 +481,8 @@ def binary_opening(input, structure=None, iterations=1, output=None, origin=0,
 
     .. seealso:: :func:`scipy.ndimage.binary_opening`
     """
-    structure, _, _ = _prep_structure(structure, input.ndim)
+    axes = _util._check_axes(axes, input.ndim)
+    structure, _, _ = _prep_structure(structure, len(axes))
     tmp = binary_erosion(input, structure, iterations, mask, None,
                          border_value, origin, brute_force, axes=axes)
     return binary_dilation(tmp, structure, iterations, mask, output,
@@ -537,7 +539,8 @@ def binary_closing(input, structure=None, iterations=1, output=None, origin=0,
 
     .. seealso:: :func:`scipy.ndimage.binary_closing`
     """
-    structure, _, _ = _prep_structure(structure, input.ndim)
+    axes = _util._check_axes(axes, input.ndim)
+    structure, _, _ = _prep_structure(structure, len(axes))
     tmp = binary_dilation(input, structure, iterations, mask, None,
                           border_value, origin, brute_force, axes=axes)
     return binary_erosion(tmp, structure, iterations, mask, output,

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -649,7 +649,7 @@ def binary_propagation(input, structure=None, mask=None, output=None,
                            origin, brute_force=True, axes=axes)
 
 
-def _binary_fill_holes_non_iterative(input, output=None):
+def _binary_fill_holes_non_iterative(input, structure=None, output=None):
     """Non-iterative method for hole filling.
 
     This algorithm is based on inverting the input and then using `label` to
@@ -673,7 +673,9 @@ def _binary_fill_holes_non_iterative(input, output=None):
 
     # assign unique labels the background and holes
     inverse_binary_mask = ~binary_mask
-    inverse_labels, _ = _measurements.label(inverse_binary_mask)
+    inverse_labels, _ = _measurements.label(
+        inverse_binary_mask, structure=structure
+    )
 
     # After inversion, what was originally the background will now be the
     # first foreground label encountered. This is ensured due to the
@@ -741,12 +743,13 @@ def binary_fill_holes(input, structure=None, output=None, origin=0, *,
     filter_all_axes = axes == tuple(range(input.ndim))
     if isinstance(origin, int):
         origin = (origin,) * len(axes)
-    if structure is None and all(o == 0 for o in origin) and filter_all_axes:
-        return _binary_fill_holes_non_iterative(input, output=output)
+    if all(o == 0 for o in origin) and filter_all_axes:
+        return _binary_fill_holes_non_iterative(
+            input, structure=structure, output=output)
     elif filter_all_axes:
         warnings.warn(
-            'It is recommended to keep the default structure=None and '
-            'origin=0, so that a faster non-iterative algorithm can be used.'
+            'It is recommended to keep the default origin=0 so that a faster '
+            'non-iterative algorithm can be used.'
         )
     mask = cupy.logical_not(input)
     tmp = cupy.zeros(mask.shape, bool)

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -587,12 +587,12 @@ def binary_hit_or_miss(input, structure1=None, structure2=None, output=None,
 
     .. seealso:: :func:`scipy.ndimage.binary_hit_or_miss`
     """
-    if structure1 is None:
-        structure1 = generate_binary_structure(input.ndim, 1)
-    if structure2 is None:
-        structure2 = cupy.logical_not(structure1)
     axes = _util._check_axes(axes, input.ndim)
     num_axes = len(axes)
+    if structure1 is None:
+        structure1 = generate_binary_structure(num_axes, 1)
+    if structure2 is None:
+        structure2 = cupy.logical_not(structure1)
     origin1 = _util._fix_sequence_arg(origin1, num_axes, 'origin1', int)
     if origin2 is None:
         origin2 = origin1

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -743,7 +743,7 @@ def binary_fill_holes(input, structure=None, output=None, origin=0, *,
         origin = (origin,) * len(axes)
     if structure is None and all(o == 0 for o in origin) and filter_all_axes:
         return _binary_fill_holes_non_iterative(input, output=output)
-    else:
+    elif filter_all_axes:
         warnings.warn(
             'It is recommended to keep the default structure=None and '
             'origin=0, so that a faster non-iterative algorithm can be used.'

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -694,6 +694,13 @@ def _binary_fill_holes_non_iterative(input, structure=None, output=None):
     if output is None:
         output = cupy.ascontiguousarray(temp)
     else:
+        # handle output argument as in _binary_erosion
+        if isinstance(output, cupy.ndarray):
+            if output.dtype.kind == 'c':
+                raise TypeError('Complex output type not supported')
+        else:
+            output = bool
+        output = _util._get_output(output, input)
         output[:] = temp
     return output
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -501,8 +501,8 @@ class TestBinaryErosionAndDilation:
     testing.product({  # cases with boolean input and output
         'x_dtype': [bool],
         'border_value': [0],
-        'connectivity': [1],
-        'origin': [(0, 1)],
+        'connectivity': [1, None],
+        'origin': [(0, 0), (0, 1)],
         'shape': [(16, 15), (5, 7, 9)],
         'axes': [(0, 1), (0, -1), (-2, -1), (1,)],
         'density': [0.1, 0.5, 0.9],
@@ -519,11 +519,17 @@ class TestBinaryMorphologyAxes:
         ndim = len(self.shape)
         kwargs = {}
         if self.axes is None:
-            structure = scp.ndimage.generate_binary_structure(
-                ndim, self.connectivity)
+            if self.connectivity is None:
+                structure = None
+            else:
+                structure = scp.ndimage.generate_binary_structure(
+                    ndim, self.connectivity)
         else:
-            structure = scp.ndimage.generate_binary_structure(
-                len(self.axes), self.connectivity)
+            if self.connectivity is None:
+                structure = None
+            else:
+                structure = scp.ndimage.generate_binary_structure(
+                    len(self.axes), self.connectivity)
         if len(self.origin) > len(self.axes):
             self.origin = [self.origin[ax] for ax in self.axes]
 


### PR DESCRIPTION
This MR is built on top of a bug fix from https://github.com/cupy/cupy/pull/8954, so please review that one first.

partially resolves #8867 (it does not fix the slow performance of iterative binary morphology, but provides a way to perform `binary_fill_holes` without needing to use iteration)

## Benchmarks
see https://github.com/cupy/cupy/issues/8867#issuecomment-2659471046

