### PR TITLE
Fix buffer protocol to raise TypeError when it is not meant to be supported

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -409,7 +409,7 @@ cdef class _ndarray_base:
         # TODO(leofang): use flags
         if (not is_ump_supported(self.data.device_id)
                 or not self.is_host_accessible()):
-            raise RuntimeError(
+            raise TypeError(
                 'Accessing a CuPy ndarry on CPU is not allowed except when '
                 'using system memory (on HMM or ATS enabled systems, need to '
                 'set CUPY_ENABLE_UMP=1) or managed memory')


### PR DESCRIPTION
In Python it seems `TypeError` is expected:
```python
>>> memoryview(123)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: memoryview: a bytes-like object is required, not 'int'
```
which was discovered by @ZzEeKkAa offline. cc @gmarkall for vis
