### PR TITLE
[v13] Regenerate coverage matrix

### DIFF
--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -3579,7 +3579,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - cutensor,cub
-     - 28
+     - 30
      - 
      - 
      - 


### PR DESCRIPTION
Fix the static-check CI failure. The coverage table became outdated due to merge order of pull requests.