### PR TITLE
Use `/bigobj` on Windows build

### DIFF
--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -253,7 +253,9 @@ class DeviceCompilerWin32(DeviceCompilerBase):
         # to build CuPy because some Python versions were built using it.
         # REF: https://wiki.python.org/moin/WindowsCompilers
         postargs += ['-allow-unsupported-compiler']
-        postargs += ['-Xcompiler', '/MD', '-D_USE_MATH_DEFINES']
+        # "/bigobj" to silence `fatal error C1128: number of sections exceeded
+        # object file format limit`
+        postargs += ['-Xcompiler', '/MD /bigobj', '-D_USE_MATH_DEFINES']
         # Bumping C++ standard from C++14 to C++17 for "if constexpr"
         num_threads = int(os.environ.get('CUPY_NUM_NVCC_THREADS', '2'))
         postargs += ['--std=c++17',


### PR DESCRIPTION
In the [release-tools CI](https://ci.preferred.jp/cupy-release-tools.win/186048/#L11407) I found CUB build is failing with error:

```
C:\Windows\TEMP\tmpxft_00000fac_00000000-10_cupy_cub.compute_120.cudafe1.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

This fixes the issue by passing `/bigobj`.

(Note: Windows CI in the CuPy repository cannot detect this because it [only builds for the native device](https://github.com/cupy/cupy/blob/9ec2184716a2dc05c3e11d856a981d061dd563bf/.pfnci/windows/test.ps1#L78) as there's no `ccache nvcc` on Windows)