### PR TITLE
Fix `cupyx.scipy.spatial.distance`'s `cdist` for RAPIDS 24.12 compatibility

### DIFF
--- a/.pfnci/linux/tests/cuda-rapids.Dockerfile
+++ b/.pfnci/linux/tests/cuda-rapids.Dockerfile
@@ -1,11 +1,11 @@
-ARG BASE_IMAGE="rapidsai/base:25.02a-cuda12.5-py3.11"
+ARG BASE_IMAGE="rapidsai/base:25.02-cuda12.8-py3.11"
 FROM ${BASE_IMAGE}
 
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qqy update && \
-    apt-get -qqy install build-essential cuda-toolkit-12-5 ccache git curl
+    apt-get -qqy install build-essential cuda-toolkit-12-8 ccache git curl
 
 ENV CUDA_PATH "/usr/local/cuda"
 ENV PATH "/usr/lib/ccache:${PATH}"

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -114,8 +114,8 @@ _METRICS_NAMES = list(_METRICS.keys())
 def check_soft_dependencies():
     if not cuvs_available:
         if not pylibraft_available:
-            raise RuntimeError('cuVS >= 24.12 or pylibraft < '
-                               '24.12 should be installed to use this feature')
+            raise RuntimeError('cuVS >= 25.02 or pylibraft < '
+                               '25.02 should be installed to use this feature')
 
 
 def minkowski(u, v, p):

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -628,7 +628,7 @@ def cdist(XA, XB, metric='euclidean', out=None, **kwargs):
             output_arr = out if out is not None else cupy.zeros((mA, mB),
                                                                 dtype=XA.dtype,
                                                                 order=XA_order)
-            pairwise_distance(XA, XB, output_arr, metric, p=p)
+            pairwise_distance(XA, XB, output_arr, metric, p)
             return output_arr
         else:
             raise ValueError('Unknown Distance Metric: %s' % mstr)

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -114,8 +114,8 @@ _METRICS_NAMES = list(_METRICS.keys())
 def check_soft_dependencies():
     if not cuvs_available:
         if not pylibraft_available:
-            raise RuntimeError('cuVS >= 25.02 or pylibraft < '
-                               '25.02 should be installed to use this feature')
+            raise RuntimeError('cuVS >= 24.12 or pylibraft < '
+                               '24.12 should be installed to use this feature')
 
 
 def minkowski(u, v, p):


### PR DESCRIPTION
Fixes a bug in `cupyx.scipy.spatial.distance`'s implementation of `cdist`, which relies on RAPIDS. The current implementation was broken with RAPIDS 24.12 due to a bug in RAPIDS. This includes a fix to workaround the RAPIDS 24.12 bug and remain compatible with RAPIDS pre-24.12 and 25.02+. 

Also update RAPIDS CI testing to use released RAPIDS 25.02 Docker images (instead of nightlies).

Note: RAPIDS dropped CUDA 12.5 images and replaced them with CUDA 12.8.

ref: https://docs.rapids.ai/notices/rsn0042/

cc @cjnolet @grlee77