### PR TITLE
cupyx.scipy.distance: initialize output array with empty instead of zeros

### DIFF
--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -114,7 +114,7 @@ _METRICS_NAMES = list(_METRICS.keys())
 def check_soft_dependencies():
     if not cuvs_available:
         if not pylibraft_available:
-            raise RuntimeError('cuVS >= 24.12 or pylibraft < '
+            raise RuntimeError('cuVS >= 25.02 or pylibraft < '
                                '24.12 should be installed to use this feature')
 
 

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -114,7 +114,7 @@ _METRICS_NAMES = list(_METRICS.keys())
 def check_soft_dependencies():
     if not cuvs_available:
         if not pylibraft_available:
-            raise RuntimeError('cuVS >= 25.02 or pylibraft < '
+            raise RuntimeError('cuVS >= 24.12 or pylibraft < '
                                '24.12 should be installed to use this feature')
 
 

--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -142,7 +142,7 @@ def minkowski(u, v, p):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "minkowski", p)
 
@@ -173,7 +173,7 @@ def canberra(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "canberra")
 
@@ -204,7 +204,7 @@ def chebyshev(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "chebyshev")
 
@@ -236,7 +236,7 @@ def cityblock(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "cityblock")
 
@@ -272,7 +272,7 @@ def correlation(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "correlation")
 
@@ -305,7 +305,7 @@ def cosine(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "cosine")
 
@@ -340,7 +340,7 @@ def hamming(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "hamming")
 
@@ -371,7 +371,7 @@ def euclidean(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "euclidean")
 
@@ -406,7 +406,7 @@ def jensenshannon(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "jensenshannon")
 
@@ -441,7 +441,7 @@ def russellrao(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "russellrao")
 
@@ -473,7 +473,7 @@ def sqeuclidean(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "sqeuclidean")
 
@@ -506,7 +506,7 @@ def hellinger(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
 
     pairwise_distance(u, v, output_arr, "hellinger")
 
@@ -541,7 +541,7 @@ def kl_divergence(u, v):
         raise ValueError('u and v must have the same layout '
                          '(u.order=%s, v.order=%s' % (u_order, v_order))
 
-    output_arr = cupy.zeros((1, 1), dtype=u.dtype, order=u_order)
+    output_arr = cupy.empty((1, 1), dtype=u.dtype, order=u_order)
     pairwise_distance(u, v, output_arr, "kl_divergence")
 
     return output_arr[0, 0]
@@ -625,7 +625,7 @@ def cdist(XA, XB, metric='euclidean', out=None, **kwargs):
         mstr = metric.lower()
         metric_info = _METRIC_ALIAS.get(mstr, None)
         if metric_info is not None:
-            output_arr = out if out is not None else cupy.zeros((mA, mB),
+            output_arr = out if out is not None else cupy.empty((mA, mB),
                                                                 dtype=XA.dtype,
                                                                 order=XA_order)
             pairwise_distance(XA, XB, output_arr, metric, p=p)


### PR DESCRIPTION
cc @cjnolet , @jakirkham 

This MR is to avoid overhead of explicitly writing zeros into the output array before calling the cuVS/raft `pairwise_distance` function. Unit tests continue to pass when I tried this locally.

Checking in cuVS and raft sources, it seems
- cuVS defaults to [empty-initialized `out` array](https://github.com/rapidsai/cuvs/blob/v25.02.00/python/cuvs/cuvs/distance/distance.pyx)
- at least since RAFT 22.12, it also uses an [empty `out` array](https://github.com/rapidsai/raft/blob/v24.10.00/python/pylibraft/pylibraft/distance/pairwise_distance.pyx#L181) by default.

Given that, I think this is likely safe to merge for CuPy 14.x.

---

Aside from the performance issue, I found that the recommendation of "cuVS>=24.12" does not work for 24.12 (25.02 worked as expected): see 
https://github.com/cupy/cupy/pull/8970#issuecomment-2667149022