### PR TITLE
Pass `locals` dict to `exec`

### DIFF
--- a/tests/typing_tests/test_run.py
+++ b/tests/typing_tests/test_run.py
@@ -10,10 +10,11 @@ def test_run(t: Path) -> None:
     with open(t) as f:
         lines = f.readlines()
 
+    exec_locals = {}
     for _lineno, _line in enumerate(lines, start=1):
         if "# E: " not in _line:
             try:
-                exec(_line)
+                exec(_line, None, exec_locals)
             except Exception:
                 print(f"{t}:{_lineno} {_line}")
                 raise


### PR DESCRIPTION
Following up #8953, fixes Python 3.13 CI failure

https://ci.preferred.jp/cupy.linux.cuda126/186849/#L28875
```
FAILED typing_tests/test_run.py::test_run[/tmp/tmp.frF0r0nEHN/tests/typing_tests/cupy_tests/creation_tests/test_basic.pyi]
```

The same reason as https://github.com/cupy/cupy-release-tools/pull/397#discussion_r1959125638
