### PR TITLE
Fix illegal memory access in LinearNDInterpolator

### DIFF
--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -2948,6 +2948,7 @@ RealType*           coords
                 }
 
                 if(!isInTri) {
+                    if (nextNearest == -1) break;
                     nearest = triOpp[nextNearest];
                     visited[off + 1] = nextNearest;
                 }


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/8933.

`nextNearest` can become `-1` when the all opposites of `nearest` are visited. This PR stops the search for the closest points and concludes that there is no triangle covering the query point in such a case.
cc: @andfoy 