### PR TITLE
`cupyx.scipy.spatial.distance.cdist` remove explicit zeroing of user-provided output array

### DIFF
--- a/cupyx/scipy/spatial/distance.py
+++ b/cupyx/scipy/spatial/distance.py
@@ -619,7 +619,6 @@ def cdist(XA, XB, metric='euclidean', out=None, **kwargs):
             out = out.astype('float32', copy=False)
         if out.shape != (mA, mB):
             cupy.resize(out, (mA, mB))
-        out[:] = 0.0
 
     if isinstance(metric, str):
         mstr = metric.lower()


### PR DESCRIPTION

sorry, I was out of office just before !8971 was merged and had missed addressing [this comment](https://github.com/cupy/cupy/pull/8971#issuecomment-2667149879)

This MR removes an unnecessary zeroing of user-provided `out` array in `cupyx.scipy.spatial.distance.cdist`

cc @jakirkham, @kmaehashi 