### PR TITLE
CI: Do not run full CI on CUDA 12.0/12.1/12.2 + Windows

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -127,6 +127,10 @@ function Main {
     if (-Not $is_pull_request) {
         $Env:CUPY_TEST_FULL_COMBINATION = "1"
     }
+    # Skip full test for these CUDA versions as compilation seems so slow
+    if (($cuda -eq "12.0") -or ($cuda -eq "12.1") -or ($cuda -eq "12.2")) {
+        $Env:CUPY_TEST_FULL_COMBINATION = "0"
+    }
 
     # Install dependency for cuDNN 8.3+
     echo ">> Installing zlib"


### PR DESCRIPTION
It seems that on these platforms the compilation is extremely slow that could not complete the full combination tests within reasonable resources.

Here is the latest CI results for the recent commit in the `main` branch: https://ci.preferred.jp/p/dashboard_by_commit_id?commit_id=d44993a49f920f6e53812791ad2e85bbc04b76fd
![image](https://github.com/user-attachments/assets/7382b16e-5d80-4847-b5fb-1be914d7610f)

I attempted several approaches (#8949 etc.) but couldn't find the root cause. The CUDA 12.3.0 release notes mentions the compiler performance improvement, so I guess this got fixed somehow in the recent versions of CUDA.
https://docs.nvidia.com/cuda/archive/12.3.0/cuda-toolkit-release-notes/index.html#cuda-compilers

> * Improved compile time in some common scenarios:
>   * Extended split compilation to cubin for LTO.
>   * Turned on concurrent NVVM processing by default, with documented fallback to serialized compilation.
>   * Reduced NVRTC compile time for small programs via moving CUDA C++ builtin function declarations into compiler.
>   * Moved cuda_fp16.h and cuda_bf16.h into compiler bitcode.

