### PR TITLE
Resolve intersect1d edge case

### DIFF
--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -160,6 +160,12 @@ def intersect1d(arr1, arr2, assume_unique=False, return_indices=False):
     numpy.intersect1d
 
     """
+    if arr1.size == 0 or arr2.size == 0:
+        if return_indices:
+            return cupy.array([]), -1, -1
+        else:
+            return cupy.array([])
+
     if not assume_unique:
         if return_indices:
             arr1, ind1 = cupy.unique(arr1, return_index=True)

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -261,6 +261,13 @@ class TestIntersect1d:
         b = xp.array([4, 6, 2, 5, 7, 6], dtype=dtype)
         return xp.intersect1d(a, b, return_indices=True)
 
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_empty_intersection(self, xp, dtype):
+        a = xp.array([], dtype=dtype)
+        b = xp.array([0], dtype=dtype)
+        return xp.intersect1d(a, b, return_indices=True)
+
 
 class TestUnion1d:
 


### PR DESCRIPTION
The bug is mainly due to line 175 in truth.py, the `_search._exists_kernel` will return an address to the mask object and the later line 
`return arr1[mask]` will just return the illegal memory access. This only happens when the arr2 is an empty array. Therefore, I could simply add one line to protect the edge case. 
```
if arr1.size == 0 or arr2.size == 0 : 
    return cp.array([])
```
In the case of return_indices value is true, return -1, -1 as the intersect indices. 

In the other hand, if not protected such way, we have to modify the /cupy/cupy/_sorting/search.py line 362-373 `_core.ElementwiseKernel`.  

```
_exists_kernel = _core.ElementwiseKernel(
    'S x, raw T bins, int64 n_bins, bool invert',  # Input parameters
    'bool out',  # Output type
    '''
    const bool assume_increasing = true;
    const bool side_is_right = false;
    long long y;

    if (n_bins == 0) {  // Quick fix: Avoid illegal memory access
        out = false;
        return;
    }
    '''
    + _searchsorted_code + '''  
    out = (y == n_bins ? false : bins[y] == x);
    if (invert) out = !out;
    ''', 
    name='cupy_exists_kernel', 
    preamble=_preamble+_hip_preamble
)
```

This fix also simply add a bin check in c++ format. I am not exactly sure which one you would prefer. Currently I add the python solution for the PR, because I consider function call to _kernel and _core may use more time. 