### PR TITLE
[v13] API: Revert toDlpack() default to the old unversioned one

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -102,7 +102,7 @@ cdef DLDevice get_dlpack_device(_ndarray_base array):
 # The name of this function is following the framework integration guide of
 # TensorComprehensions.
 cpdef object toDlpack(
-    _ndarray_base array, bint use_versioned=True, bint to_cpu=False,
+    _ndarray_base array, bint use_versioned=False, bint to_cpu=False,
     bint ensure_copy=False, stream=None
 ):
     """Create a dlpack capsule for an array.

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -47,6 +47,8 @@ class TestDLPackConversion:
     def test_conversion(self, dtype):
         orig_array = _gen_array(dtype)
         tensor = orig_array.toDlpack()
+        assert '"dltensor"' in repr(tensor)  # unversioned one
+
         out_array = cupy.fromDlpack(tensor)
         testing.assert_array_equal(orig_array, out_array)
         testing.assert_array_equal(orig_array.data.ptr, out_array.data.ptr)


### PR DESCRIPTION
This was an oversight in the original PR, even if this is basically deprecated, we should not have changed the default here.

We noticed this in downstream code, but the impact was not very big (use `__dlpack__()` and not common code) for now.

As this reverts behavior, I think it would probably only be useful if backported to a 13.4.1 in the not-so-far future.
(So if that is unlikely to happen, we can probably just close it. Those running into the issue should use `__dlpack__()`.)

---

CC @leofang.