### PR TITLE
Decrease Windows build jobs from 16 to 8

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -74,7 +74,7 @@ function Main {
     ActivatePython $python
 
     # Setup build environment variables
-    $Env:CUPY_NUM_BUILD_JOBS = "16"
+    $Env:CUPY_NUM_BUILD_JOBS = "8"
     $Env:CUPY_NVCC_GENERATE_CODE = "current"
     echo "Environment:"
     RunOrDie cmd.exe /C set


### PR DESCRIPTION
Reduce the number of parallel build jobs used in Windows builds. With this change, it now matches what is used on Linux.

https://github.com/cupy/cupy/blob/418a9169bc9994574a22e6bfb07edb39d91899c6/.pfnci/linux/tests/actions/build.sh#L5

We may also consider reducing the number of threads used by `nvcc`.