### PR TITLE
[v13.4.1] API: Revert toDlpack() default to the old unversioned one

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -102,7 +102,7 @@ cdef DLDevice get_dlpack_device(_ndarray_base array):
 # The name of this function is following the framework integration guide of
 # TensorComprehensions.
 cpdef object toDlpack(
-    _ndarray_base array, bint use_versioned=True, bint to_cpu=False,
+    _ndarray_base array, bint use_versioned=False, bint to_cpu=False,
     bint ensure_copy=False, stream=None
 ):
     """Create a dlpack capsule for an array.

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -47,6 +47,8 @@ class TestDLPackConversion:
     def test_conversion(self, dtype):
         orig_array = _gen_array(dtype)
         tensor = orig_array.toDlpack()
+        assert '"dltensor"' in repr(tensor)  # unversioned one
+
         out_array = cupy.fromDlpack(tensor)
         testing.assert_array_equal(orig_array, out_array)
         testing.assert_array_equal(orig_array.data.ptr, out_array.data.ptr)


### PR DESCRIPTION
Backport of #9007 by @seberg