### PR TITLE
[v13] BUG: Hot fix for numpy 2 support in some fusion paths

### DIFF
--- a/cupy/_core/fusion.pyx
+++ b/cupy/_core/fusion.pyx
@@ -551,7 +551,11 @@ class _FusionHistory(object):
                         # decidable statically, because it depends on the value
                         # of the scalar variable.
                         scalar_value = arg.dtype.type(0)
-                    if not numpy.can_cast(scalar_value, in_dtypes[i]):
+                    # Can-cast usage works OK mostly, but doesn't for Python
+                    # scalars on NumPy 2.  Phrase it as a promotion instead.
+                    # (This may be a band-aid, v14 logic is refactored.)
+                    promoted = numpy.result_type(scalar_value, in_dtypes[i])
+                    if promoted != in_dtypes[i]:
                         return False
                 else:
                     assert False

--- a/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
@@ -314,3 +314,12 @@ class TestFusionScalar(unittest.TestCase):
             return scalar
 
         return func
+
+    @testing.for_all_dtypes_combination(names=('dtype1', 'dtype2'))
+    @fusion_utils.check_fusion(generate_inputs_name='numpy_scalar_param_r')
+    def test_scalar_and_constant_mix(self, xp, dtype1, dtype2):
+        # Example from gh-8536
+        def func(array, scalar):
+            return 1.0 - (array * array) / (scalar * scalar)
+
+        return func


### PR DESCRIPTION
Scalars are a problem, and I am not convinced that this is a complete fix (for example w.r.t. integers).  OTOH v14 should already be working here, I believe.

But I think this is safe and could be back-portable.

---

Closes gh-8536

~Need to still check if v14 is indeed fine, we may want to forward port the test to make sure.~  v14 is fine as expected.