### PR TITLE
Cast points when computing Delaunay triangulation on dtype != float64

### DIFF
--- a/cupyx/scipy/spatial/delaunay_2d/_tri.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_tri.py
@@ -36,8 +36,9 @@ class GDel2D:
         self.tri_num = 0
 
         # self.points = cupy.array(points, copy=True)
-        self.points = points
-        self.point_vec = cupy.empty((self.n_points, 2), dtype=points.dtype)
+        self.points = points.astype(cupy.float64)
+        self.point_vec = cupy.empty((self.n_points, 2),
+                                    dtype=self.points.dtype)
         self.point_vec[:-1] = points
 
         self.triangles = cupy.empty((4, 3), dtype=cupy.int32)

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
@@ -58,8 +58,10 @@ def compute_random_points(tri_points, xp):
 
 class TestDelaunay:
     @testing.numpy_cupy_allclose(scipy_name='scp')
-    def test_2d_triangulation(self, xp, scp):
-        points = testing.shaped_random((100, 2), xp, xp.float64)
+    @pytest.mark.parametrize(
+        'dtype', [cupy.float64, cupy.float32, cupy.float16])
+    def test_2d_triangulation(self, xp, scp, dtype):
+        points = testing.shaped_random((100, 2), xp, dtype)
         tri = scp.spatial.Delaunay(points)
         return xp.sort(xp.sort(tri.simplices, axis=-1), axis=0)
 


### PR DESCRIPTION
Fixes #8765 

This PR makes sure that inputs to Delaunay triangulation are cast as `double`