### PR TITLE
Fix rocThrust build for ROCm 6.3

### DIFF
--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -332,7 +332,8 @@ def make_extensions(ctx: Context, compiler, use_cython):
         # deprecated since ROCm 4.2.0
         settings['define_macros'].append(('__HIP_PLATFORM_HCC__', '1'))
         # Fix for ROCm 6.3.0, See https://github.com/ROCm/rocThrust/issues/502
-        settings['define_macros'].append(('THRUST_DEVICE_SYSTEM', 'THRUST_DEVICE_SYSTEM_HIP'))
+        settings['define_macros'].append(
+            ('THRUST_DEVICE_SYSTEM', 'THRUST_DEVICE_SYSTEM_HIP'))
     settings['define_macros'].append(('CUPY_CACHE_KEY', ctx.cupy_cache_key))
 
     try:

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -331,6 +331,8 @@ def make_extensions(ctx: Context, compiler, use_cython):
         settings['define_macros'].append(('__HIP_PLATFORM_AMD__', '1'))
         # deprecated since ROCm 4.2.0
         settings['define_macros'].append(('__HIP_PLATFORM_HCC__', '1'))
+        # Fix for ROCm 6.3.0, See https://github.com/ROCm/rocThrust/issues/502
+        settings['define_macros'].append(('THRUST_DEVICE_SYSTEM', 'THRUST_DEVICE_SYSTEM_HIP'))
     settings['define_macros'].append(('CUPY_CACHE_KEY', ctx.cupy_cache_key))
 
     try:

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -168,7 +168,8 @@ def get_compiler_setting(ctx: Context, use_hip):
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 
     if use_hip:
-        extra_compile_args.append('-std=c++11')
+        # ROCm 5.3 and above requires c++14
+        extra_compile_args.append('-std=c++14')
 
     if PLATFORM_WIN32:
         nvtx_path = _environment.get_nvtx_path()


### PR DESCRIPTION
This commit fixes `/opt/rocm/include/thrust/version.h:34:10: fatal error: cuda/version: No such file or directory` error when try to build cupy for ROCm 6.3. See https://github.com/ROCm/rocThrust/issues/502. 

It also addresses the C++ version warning by changing compiler argument from c++11 to c++14