### PR TITLE
Allow discovering cuTENSOR using major version

### DIFF
--- a/cupyx/tools/_generate_wheel_metadata.py
+++ b/cupyx/tools/_generate_wheel_metadata.py
@@ -37,8 +37,11 @@ def _generate_wheel_metadata(cuda_version, target_system, libraries):
     for library in libraries:
         for record in _get_records(library, cuda_version):
             if record['cuda'] == cuda_version:
+                version = record[library]
+                min_pypi_version = record.get('min_pypi_version', version)
                 metadata = {
-                    'version': record[library],
+                    'version': version,
+                    'min_pypi_version': min_pypi_version,
                     'filenames': record['assets'][target_system]['filenames'],
                 }
                 break

--- a/cupyx/tools/_generate_wheel_metadata.py
+++ b/cupyx/tools/_generate_wheel_metadata.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+"""
+Generates a wheel metadata.
+
+This tool is NOT intended for end-user use.
+"""
+
+# This script will also be used as a standalone script when building wheels.
+# Keep the script runnable without CuPy dependency.
+
+import argparse
+import json
+import os.path
+import platform
+import subprocess
+import sys
+
+
+def _get_records(library: str, cuda: str):
+    command = [
+        sys.executable,
+        'install_library.py',
+        '--library', library,
+        '--cuda', cuda,
+        '--action', 'dump',
+    ]
+    return json.loads(
+        subprocess.check_output(command, cwd=os.path.dirname(__file__)))
+
+
+def _generate_wheel_metadata(cuda_version, target_system, libraries):
+    wheel_metadata = {
+        'cuda': cuda_version,
+        'packaging': 'pip',
+    }
+    for library in libraries:
+        for record in _get_records(library, cuda_version):
+            if record['cuda'] == cuda_version:
+                metadata = {
+                    'version': record[library],
+                    'filenames': record['assets'][target_system]['filenames'],
+                }
+                break
+        else:
+            raise RuntimeError(
+                'Specified library/CUDA combination not supported')
+        wheel_metadata[library] = metadata
+
+    return wheel_metadata
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--cuda', type=str, required=True,
+                        help='CUDA version')
+    parser.add_argument('--target', type=str,
+                        help='Target system (default: platform.system())')
+    parser.add_argument('--library',
+                        choices=['cudnn', 'cutensor', 'nccl'],
+                        action='append',
+                        required=True)
+    params = parser.parse_args(args)
+
+    print(json.dumps(
+        _generate_wheel_metadata(
+            params.cuda,
+            params.target or platform.system(),
+            params.library,
+        ), indent=4
+    ))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -82,10 +82,12 @@ def _make_cutensor_url(platform, filename):
 
 
 def __make_cutensor_record(
-        cuda_version, public_version, filename_linux, filename_windows):
+        cuda_version, public_version, min_pypi_version,
+        filename_linux, filename_windows):
     return {
         'cuda': cuda_version,
         'cutensor': public_version,
+        'min_pypi_version': min_pypi_version,
         'assets': {
             'Linux': {
                 'url': _make_cutensor_url('linux', filename_linux),
@@ -103,8 +105,12 @@ def __make_cutensor_record(
 
 
 def _make_cutensor_record(cuda_version):
+    # cuTENSOR guarantees ABI compatibility within the major version (#9017).
+    # `min_pypi_version` must be bumped only when:
+    # (1) Bumping the major version, or
+    # (2) CuPy started to use APIs introduced in minor versions
     return __make_cutensor_record(
-        cuda_version, '2.1.0',
+        cuda_version, '2.1.0', '2.0.0',
         'libcutensor-linux-x86_64-2.1.0.9-archive.tar.xz',
         'libcutensor-windows-x86_64-2.1.0.9-archive.zip')
 


### PR DESCRIPTION
Allow loading cuTENSOR 2.x wheels regardless of the version used at build time (currently 2.1). Fixes #9017.

This PR also moves the generation logic of wheel metadata file (`cupy/.data/_wheel.json`) from [cupy-release-tools](https://github.com/cupy/cupy-release-tools/blob/3e75f4c5b20f62f6898770ed5f190ba1e2fb221e/dist.py#L75-L96) to cupy, so that CuPy developers can generate the wheel metadata by

```
$ python cupyx/tools/_generate_wheel_metadata.py --cuda 12.x --library cutensor --library cudnn --library nccl > cupy/.data/_wheel.json
```

and easily test the preload mechanism like:

```
$ export CUPY_DEBUG_LIBRARY_LOAD=1
$ python -c 'import cupy'
```
