### PR TITLE
Rankdata

### DIFF
--- a/cupyx/scipy/stats/__init__.py
+++ b/cupyx/scipy/stats/__init__.py
@@ -9,3 +9,4 @@ from cupyx.scipy.stats._stats import trim_mean  # NOQA
 from cupyx.scipy.stats._morestats import boxcox_llf  # NOQA
 from cupyx.scipy.stats._stats_py import zmap  # NOQA
 from cupyx.scipy.stats._stats_py import zscore  # NOQA
+from cupyx.scipy.stats._stats_py import rankdata  # NOQA

--- a/cupyx/scipy/stats/_stats_py.py
+++ b/cupyx/scipy/stats/_stats_py.py
@@ -2,9 +2,7 @@ import cupy
 
 
 def _first(arr, axis):
-    """Return arr[..., 0:1, ...] where 0:1 is in the `axis` position
-
-    """
+    """Return arr[..., 0:1, ...] where 0:1 is in the `axis` position"""
 
     return cupy.take_along_axis(arr, cupy.array(0, ndmin=arr.ndim), axis)
 
@@ -23,7 +21,7 @@ def _isconst(x):
         return (y[0] == y).all(keepdims=True)
 
 
-def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
+def zscore(a, axis=0, ddof=0, nan_policy="propagate"):
     """Compute the z-score.
 
     Compute the z-score of each value in the sample, relative to
@@ -59,7 +57,7 @@ def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
     return zmap(a, a, axis=axis, ddof=ddof, nan_policy=nan_policy)
 
 
-def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
+def zmap(scores, compare, axis=0, ddof=0, nan_policy="propagate"):
     """Calculate the relative z-scores.
 
     Return an array of z-scores, i.e., scores that are standardized
@@ -95,25 +93,27 @@ def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
 
     """
 
-    policies = ['propagate', 'raise', 'omit']
+    policies = ["propagate", "raise", "omit"]
 
     if nan_policy not in policies:
-        raise ValueError("nan_policy must be one of {%s}" %
-                         ', '.join("'%s'" % s for s in policies))
+        raise ValueError(
+            "nan_policy must be one of {%s}" % ", ".join(
+                "'%s'" % s for s in policies)
+        )
 
     a = compare
 
     if a.size == 0:
-        dtype = a.dtype if a.dtype.kind in 'fc' else cupy.float64
+        dtype = a.dtype if a.dtype.kind in "fc" else cupy.float64
         return cupy.empty(a.shape, dtype)
 
-    if nan_policy == 'raise':
+    if nan_policy == "raise":
         contains_nan = cupy.isnan(cupy.sum(a))
 
         if contains_nan:  # synchronize!
             raise ValueError("The input contains nan values")
 
-    if nan_policy == 'omit':
+    if nan_policy == "omit":
         if axis is None:
             mn = cupy.nanmean(a.ravel())
             std = cupy.nanstd(a.ravel(), ddof=ddof)
@@ -137,3 +137,157 @@ def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
     # Set the outputs associated with a constant input to nan.
     z[cupy.broadcast_to(isconst, z.shape)] = cupy.nan
     return z
+
+
+def rankdata(a, method="average", *, axis=None, nan_policy="propagate"):
+    """Assign ranks to data, dealing with ties appropriately.
+
+    By default (``axis=None``), the data array is first flattened, and a flat
+    array of ranks is returned. Separately reshape the rank array to the
+    shape of the data array if desired (see Examples).
+
+    Ranks begin at 1.  The `method` argument controls how ranks are assigned
+    to equal values.  See [1]_ for further discussion of ranking methods.
+
+    Parameters
+    ----------
+    a : array_like
+        The array of values to be ranked.
+    method : {'average', 'min', 'max', 'dense', 'ordinal'}, optional
+        The method used to assign ranks to tied elements.
+        The following methods are available (default is 'average'):
+
+          * 'average': The average of the ranks that would have been assigned
+             to all the tied values is assigned to each value.
+          * 'min': The minimum of the ranks that would have been assigned to
+             all the tied values is assigned to each value.  (This is also
+            referred to as "competition" ranking.)
+          * 'max': The maximum of the ranks that would have been assigned to
+             all the tied values is assigned to each value.
+          * 'dense': Like 'min', but the rank of the next highest element is
+            assigned the rank immediately after those assigned to the tied
+            elements.
+          * 'ordinal': All values are given a distinct rank, corresponding to
+            the order that the values occur in `a`.
+    axis : {None, int}, optional
+        Axis along which to perform the ranking. If ``None``, the data array
+        is first flattened.
+    nan_policy : {'propagate', 'omit', 'raise'}, optional
+        Defines how to handle when input contains nan.
+        The following options are available (default is 'propagate'):
+
+          * 'propagate': propagates nans through the rank calculation
+          * 'omit': performs the calculations ignoring nan values
+          * 'raise': raises an error
+
+        .. note::
+
+            When `nan_policy` is 'propagate', the output is an array of *all*
+            nans because ranks relative to nans in the input are undefined.
+            When `nan_policy` is 'omit', nans in `a` are ignored when ranking
+            the other values, and the corresponding locations of the output
+            are nan.
+
+        .. versionadded:: 1.10
+
+    Returns
+    -------
+    ranks : ndarray
+         An array of size equal to the size of `a`, containing rank
+         scores.
+
+    References
+    ----------
+    .. [1] "Ranking", https://en.wikipedia.org/wiki/Ranking
+
+
+    """
+
+    methods = ("average", "min", "max", "dense", "ordinal")
+    if method not in methods:
+        raise ValueError(f'unknown method "{method}"')
+
+    x = cupy.asarray(a)
+
+    if axis is None:
+        x = x.ravel()
+        axis = -1
+
+    if x.size == 0:
+        dtype = float if method == "average" else cupy.dtype("long")
+        return cupy.empty(x.shape, dtype=dtype)
+
+    policies = ["propagate", "raise", "omit"]
+    if nan_policy not in policies:
+        raise ValueError(
+            "nan_policy must be one of {%s}" % ", ".join(
+                "'%s'" % s for s in policies)
+        )
+
+    contains_nan = cupy.isnan(cupy.sum(x))
+
+    x = cupy.swapaxes(x, axis, -1)
+    ranks = _rankdata(x, method)
+
+    if contains_nan:
+        i_nan = cupy.isnan(
+            x) if nan_policy == "omit" else cupy.isnan(x).any(axis=-1)
+        ranks = ranks.astype(float, copy=False)
+        ranks[i_nan] = cupy.nan
+
+    ranks = cupy.swapaxes(ranks, axis, -1)
+    return ranks
+
+
+def _order_ranks(ranks, j):
+    # Reorder ascending order `ranks` according to `j`
+    ordered_ranks = cupy.empty(j.shape, dtype=ranks.dtype)
+    cupy.put_along_axis(ordered_ranks, j, ranks, axis=-1)
+    return ordered_ranks
+
+
+def _rankdata(x, method, return_ties=False):
+    # Rank data `x` by desired `method`; `return_ties` if desired
+    shape = x.shape
+
+    # Get sort order
+    j = cupy.argsort(x, axis=-1, kind="stable")
+    ordinal_ranks = cupy.broadcast_to(
+        cupy.arange(1, shape[-1] + 1, dtype=int), shape)
+
+    # Ordinal ranks is very easy because ties don't matter. We're done.
+    if method == "ordinal":
+        return _order_ranks(ordinal_ranks, j)  # never return ties
+
+    # Sort array
+    y = cupy.take_along_axis(x, j, axis=-1)
+    # Logical indices of unique elements
+    i = cupy.concatenate(
+        [cupy.ones(shape[:-1] + (1,), dtype=cupy.bool_),
+         y[..., :-1] != y[..., 1:]],
+        axis=-1,
+    )
+
+    # Integer indices of unique elements
+    indices = cupy.arange(y.size)[i.ravel()]
+    # Counts of unique elements
+    counts = cupy.diff(indices, append=y.size)
+
+    # Compute `'min'`, `'max'`, and `'mid'` ranks of unique elements
+    if method == "min":
+        ranks = ordinal_ranks[i]
+    elif method == "max":
+        ranks = ordinal_ranks[i] + counts - 1
+    elif method == "average":
+        ranks = ordinal_ranks[i] + (counts - 1) / 2
+    elif method == "dense":
+        ranks = cupy.cumsum(i, axis=-1)[i]
+
+    ranks = cupy.repeat(ranks, counts.tolist()).reshape(shape)
+    ranks = _order_ranks(ranks, j)
+
+    if return_ties:
+        t = cupy.zeros(shape, dtype=float)
+        t[i] = counts
+        return ranks, t
+    return ranks

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -5,6 +5,9 @@ import cupy
 from cupy import testing
 import cupyx
 import cupyx.scipy.stats  # NOQA
+from cupyx.scipy.stats import rankdata
+from cupy.testing import assert_array_equal
+
 
 try:
     import scipy.stats
@@ -248,3 +251,219 @@ class TestZscore:
             x = xp.array([1, 2, 3, xp.nan], dtype=dtype)
             with pytest.raises(ValueError):
                 scp.stats.zscore(x, nan_policy='raise')
+
+
+class TestRankData:
+
+    def test_empty(self):
+        """stats.rankdata([]) should return an empty array."""
+        a = cupy.array([], dtype=int)
+        r = rankdata(a)
+        assert_array_equal(r, cupy.array([], dtype=cupy.float64))
+        r = rankdata([])
+        assert_array_equal(r, cupy.array([], dtype=cupy.float64))
+
+    @pytest.mark.parametrize("shape", [(0, 1, 2)])
+    @pytest.mark.parametrize("axis", [None, *range(3)])
+    def test_empty_multidim(self, shape, axis):
+        a = cupy.empty(shape, dtype=int)
+        r = rankdata(a, axis=axis)
+        expected_shape = (0,) if axis is None else shape
+        assert_array_equal(r.shape, expected_shape)
+        assert r.dtype == cupy.float64
+
+    def test_one(self):
+        """Check stats.rankdata with an array of length 1."""
+        data = [100]
+        a = cupy.array(data, dtype=int)
+        r = rankdata(a)
+        assert_array_equal(r, cupy.array([1.0], dtype=cupy.float64))
+        r = rankdata(data)
+        assert_array_equal(r, cupy.array([1.0], dtype=cupy.float64))
+
+    def test_basic(self):
+        """Basic tests of stats.rankdata."""
+        data = [100, 10, 50]
+        expected = cupy.array([3.0, 1.0, 2.0], dtype=cupy.float64)
+        a = cupy.array(data, dtype=int)
+        r = rankdata(a)
+        assert_array_equal(r, expected)
+        r = rankdata(data)
+        assert_array_equal(r, expected)
+
+        data = [40, 10, 30, 10, 50]
+        expected = cupy.array([4.0, 1.5, 3.0, 1.5, 5.0], dtype=cupy.float64)
+        a = cupy.array(data, dtype=int)
+        r = rankdata(a)
+        assert_array_equal(r, expected)
+        r = rankdata(data)
+        assert_array_equal(r, expected)
+
+        data = [20, 20, 20, 10, 10, 10]
+        expected = cupy.array(
+            [5.0, 5.0, 5.0, 2.0, 2.0, 2.0], dtype=cupy.float64)
+        a = cupy.array(data, dtype=int)
+        r = rankdata(a)
+        assert_array_equal(r, expected)
+        r = rankdata(data)
+        assert_array_equal(r, expected)
+        # The docstring states explicitly that the argument is flattened.
+        a2d = a.reshape(2, 3)
+        r = rankdata(a2d)
+        assert_array_equal(r, expected)
+
+    def test_large_int(self):
+        data = cupy.array([2**60, 2**60+1], dtype=cupy.uint64)
+        r = rankdata(data)
+        assert_array_equal(r, [1.0, 2.0])
+
+        data = cupy.array([2**60, 2**60+1], dtype=cupy.int64)
+        r = rankdata(data)
+        assert_array_equal(r, [1.0, 2.0])
+
+        data = cupy.array([2**60, -2**60+1], dtype=cupy.int64)
+        r = rankdata(data)
+        assert_array_equal(r, [2.0, 1.0])
+
+    def test_big_tie(self):
+        for n in [10000, 100000, 1000000]:
+            data = cupy.ones(n, dtype=int)
+            r = rankdata(data)
+            expected_rank = 0.5 * (n + 1)
+            assert_array_equal(r, expected_rank * data,
+                               err_msg=f"test failed with n={n}")
+
+    def test_axis(self):
+        data = [[0, 2, 1],
+                [4, 2, 2]]
+        expected0 = [[1., 1.5, 1.],
+                     [2., 1.5, 2.]]
+        r0 = rankdata(data, axis=0)
+        assert_array_equal(r0, expected0)
+        expected1 = [[1., 3., 2.],
+                     [3., 1.5, 1.5]]
+        r1 = rankdata(data, axis=1)
+        assert_array_equal(r1, expected1)
+
+    methods = ["average", "min", "max", "dense", "ordinal"]
+    dtypes = [cupy.float64] + [cupy.int64]*4
+
+    @pytest.mark.parametrize("axis", [0, 1])
+    @pytest.mark.parametrize("method, dtype", zip(methods, dtypes))
+    def test_size_0_axis(self, axis, method, dtype):
+        shape = (3, 0)
+        data = cupy.zeros(shape)
+        r = rankdata(data, method=method, axis=axis)
+        assert_array_equal(r.shape, shape)
+        assert r.dtype == dtype
+
+    @pytest.mark.parametrize('axis', range(3))
+    @pytest.mark.parametrize('method', methods)
+    def test_nan_policy_omit_3d(self, axis, method):
+        shape = (20, 21, 22)
+        rng = cupy.random.RandomState(23983242)
+
+        a = rng.rand(*shape)
+        i = rng.rand(*shape) < 0.4
+        j = rng.rand(*shape) < 0.1
+        k = rng.rand(*shape) < 0.1
+        a[i] = cupy.nan
+        a[j] = -cupy.inf
+        a[k] - cupy.inf
+
+        def rank_1d_omit(a, method):
+            out = cupy.zeros_like(a)
+            i = cupy.isnan(a)
+            a_compressed = a[~i]
+            res = rankdata(a_compressed, method)
+            out[~i] = res
+            out[i] = cupy.nan
+            return out
+
+        def rank_omit(a, method, axis):
+            return cupy.apply_along_axis(lambda a: rank_1d_omit(a, method),
+                                         axis, a)
+
+        res = rankdata(a, method, axis=axis, nan_policy='omit')
+        res0 = rank_omit(a, method, axis=axis)
+
+        assert_array_equal(res, res0)
+
+    def test_nan_policy_2d_axis_none(self):
+        # 2 2d-array test with axis=None
+        data = [[0, cupy.nan, 3],
+                [4, 2, cupy.nan],
+                [1, 2, 2]]
+        assert_array_equal(rankdata(data, axis=None, nan_policy='omit'),
+                           [1., cupy.nan, 6., 7., 4., cupy.nan, 2., 4., 4.])
+        assert_array_equal(rankdata(data, axis=None, nan_policy='propagate'),
+                           [cupy.nan, cupy.nan, cupy.nan, cupy.nan, cupy.nan,
+                            cupy.nan, cupy.nan, cupy.nan, cupy.nan])
+
+    def test_nan_policy_propagate(self):
+        # 1 1d-array test
+        data = [0, 2, 3, -2, cupy.nan, cupy.nan]
+        assert_array_equal(rankdata(data, nan_policy='propagate'),
+                           [cupy.nan, cupy.nan, cupy.nan, cupy.nan, cupy.nan,
+                            cupy.nan])
+
+        # 2 2d-array test
+        data = [[0, cupy.nan, 3],
+                [4, 2, cupy.nan],
+                [1, 2, 2]]
+        assert_array_equal(rankdata(data, axis=0, nan_policy='propagate'),
+                           [[1, cupy.nan, cupy.nan],
+                            [3, cupy.nan, cupy.nan],
+                            [2, cupy.nan, cupy.nan]])
+        assert_array_equal(rankdata(data, axis=1, nan_policy='propagate'),
+                           [[cupy.nan, cupy.nan, cupy.nan],
+                            [cupy.nan, cupy.nan, cupy.nan],
+                            [1, 2.5, 2.5]])
+
+
+_cases = (
+    # values, method, expected
+    ([], 'average', []),
+    ([], 'min', []),
+    ([], 'max', []),
+    ([], 'dense', []),
+    ([], 'ordinal', []),
+    #
+    ([100], 'average', [1.0]),
+    ([100], 'min', [1.0]),
+    ([100], 'max', [1.0]),
+    ([100], 'dense', [1.0]),
+    ([100], 'ordinal', [1.0]),
+    #
+    ([100, 100, 100], 'average', [2.0, 2.0, 2.0]),
+    ([100, 100, 100], 'min', [1.0, 1.0, 1.0]),
+    ([100, 100, 100], 'max', [3.0, 3.0, 3.0]),
+    ([100, 100, 100], 'dense', [1.0, 1.0, 1.0]),
+    ([100, 100, 100], 'ordinal', [1.0, 2.0, 3.0]),
+    #
+    ([100, 300, 200], 'average', [1.0, 3.0, 2.0]),
+    ([100, 300, 200], 'min', [1.0, 3.0, 2.0]),
+    ([100, 300, 200], 'max', [1.0, 3.0, 2.0]),
+    ([100, 300, 200], 'dense', [1.0, 3.0, 2.0]),
+    ([100, 300, 200], 'ordinal', [1.0, 3.0, 2.0]),
+    #
+    ([100, 200, 300, 200], 'average', [1.0, 2.5, 4.0, 2.5]),
+    ([100, 200, 300, 200], 'min', [1.0, 2.0, 4.0, 2.0]),
+    ([100, 200, 300, 200], 'max', [1.0, 3.0, 4.0, 3.0]),
+    ([100, 200, 300, 200], 'dense', [1.0, 2.0, 3.0, 2.0]),
+    ([100, 200, 300, 200], 'ordinal', [1.0, 2.0, 4.0, 3.0]),
+    #
+    ([100, 200, 300, 200, 100], 'average', [1.5, 3.5, 5.0, 3.5, 1.5]),
+    ([100, 200, 300, 200, 100], 'min', [1.0, 3.0, 5.0, 3.0, 1.0]),
+    ([100, 200, 300, 200, 100], 'max', [2.0, 4.0, 5.0, 4.0, 2.0]),
+    ([100, 200, 300, 200, 100], 'dense', [1.0, 2.0, 3.0, 2.0, 1.0]),
+    ([100, 200, 300, 200, 100], 'ordinal', [1.0, 3.0, 5.0, 4.0, 2.0]),
+    #
+    ([10] * 30, 'ordinal', cupy.arange(1.0, 31.0)),
+)
+
+
+def test_cases():
+    for values, method, expected in _cases:
+        r = rankdata(values, method=method)
+        assert_array_equal(r, expected)


### PR DESCRIPTION

## Add `rankdata` implementation in `cupyx.scipy.stats`

### Description  
This PR adds an implementation of `rankdata` in `cupyx.scipy.stats`, addressing the feature request in [#8587](https://github.com/cupy/cupy/issues/8587).  
- Implemented `rankdata` to compute the ranks of elements in an array. It's almost verbatim translation of same function from scipy.
- Added tests in `test_stats.py` to verify correctness and consistency with `scipy.stats.rankdata`.  
- Updated `__init__.py` to expose the new function in the `cupyx.scipy.stats` module.  

### Related Issues  
Resolves [#8587](https://github.com/cupy/cupy/issues/8587).  

### Checklist  
- [x] Tested the new implementation with `pytest` and ensured all tests pass.  
- [x] Verified consistency with `scipy.stats.rankdata`.  
- [x] Followed the contribution guidelines and coding style of CuPy.  
