### PR TITLE
CI: Pin setuptools version on Windows

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -82,7 +82,7 @@ function Main {
     # Build
     echo "Setting up test environment"
     RunOrDie python -V
-    RunOrDie python -m pip install -U pip setuptools wheel
+    RunOrDie python -m pip install -U pip "setuptools<76.0.0" wheel
     RunOrDie python -m pip freeze
 
     echo "Building..."


### PR DESCRIPTION
Tentatively workaround Windows build error with setuptools v76.0.0.

The fix is ongoing at https://github.com/pypa/distutils/pull/342

