### PR TITLE
Support FIPS enabled machines with MD5 hashing

### DIFF
--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -364,7 +364,8 @@ cdef class _CallbackManager:
         # are considered identical regardless of which plan is actually
         # executed at the time of generation
         mod_name = 'cupy_callback_'
-        mod_name += hashlib.md5(keys.encode(), usedforsecurity=False).hexdigest()
+        mod_name += hashlib.md5(
+            keys.encode(), usedforsecurity=False).hexdigest()
         mod_name = mod_name.replace('.', '')
         mod_filename = mod_name + _ext_suffix
 

--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -364,7 +364,7 @@ cdef class _CallbackManager:
         # are considered identical regardless of which plan is actually
         # executed at the time of generation
         mod_name = 'cupy_callback_'
-        mod_name += hashlib.md5(keys.encode()).hexdigest()
+        mod_name += hashlib.md5(keys.encode(), usedforsecurity=False).hexdigest()
         mod_name = mod_name.replace('.', '')
         mod_filename = mod_name + _ext_suffix
 

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -801,7 +801,8 @@ class RandomState(object):
                 seed = (time.time() * 1000000) % _UINT64_MAX
         else:
             if isinstance(seed, numpy.ndarray):
-                seed = int(hashlib.md5(seed, usedforsecurity=False).hexdigest()[:16], 16)
+                seed = int(hashlib.md5(
+                    seed, usedforsecurity=False).hexdigest()[:16], 16)
             else:
                 seed_arr = numpy.asarray(seed)
                 if seed_arr.dtype.kind not in 'biu':

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -801,7 +801,7 @@ class RandomState(object):
                 seed = (time.time() * 1000000) % _UINT64_MAX
         else:
             if isinstance(seed, numpy.ndarray):
-                seed = int(hashlib.md5(seed).hexdigest()[:16], 16)
+                seed = int(hashlib.md5(seed, usedforsecurity=False).hexdigest()[:16], 16)
             else:
                 seed_arr = numpy.asarray(seed)
                 if seed_arr.dtype.kind not in 'biu':


### PR DESCRIPTION
FIPS enabled machines prohibit MD5 hashing for security reasons. Using hashlib.md5 in Python will throw the error ValueError: [digital envelope routines] unsupported. There are typically 2 resolutions to this problem: use the usedforsecrutiy=False flag or use SHA1 hashing. The usedforsecurity flag is easier to implement and was introduced in Python 3.9, which is the minimum Python version for this library, so that is the method I chose.