### PR TITLE
[v13] Skip some dtype checks with NumPy 2.x

### DIFF
--- a/tests/cupy_tests/random_tests/common_distributions.py
+++ b/tests/cupy_tests/random_tests/common_distributions.py
@@ -14,7 +14,8 @@ def two_sample_Kolmogorov_Smirnov_test(observed1, observed2):
     Unlike `scipy.stats.ks_2samp`, the returned p-value is not accurate
     for large p.
     """
-    assert observed1.dtype == observed2.dtype
+    if numpy.lib.NumpyVersion(numpy.__version__) < '2.0.0':
+        assert observed1.dtype == observed2.dtype
     n1, = observed1.shape
     n2, = observed2.shape
     assert n1 >= 100 and n2 >= 100

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -771,7 +771,9 @@ class TestChoice1(RandomGeneratorTestCase):
             expected_dtype = 'float'
         else:
             expected_dtype = 'int64'
-        assert v.dtype == expected_dtype
+
+        if numpy.lib.NumpyVersion(numpy.__version__) < '2.0.0':
+            assert v.dtype == expected_dtype
         assert v.shape == expected_shape
 
     @_condition.repeat(3, 10)
@@ -806,7 +808,8 @@ class TestChoice2(RandomGeneratorTestCase):
             expected_dtype = 'float'
         else:
             expected_dtype = 'int'
-        assert v.dtype == expected_dtype
+        if numpy.lib.NumpyVersion(numpy.__version__) < '2.0.0':
+            assert v.dtype == expected_dtype
         assert v.shape == expected_shape
 
     @_condition.repeat(3, 10)
@@ -902,7 +905,8 @@ class TestChoiceReplaceFalse(RandomGeneratorTestCase):
             expected_dtype = 'float'
         else:
             expected_dtype = 'int'
-        assert v.dtype == expected_dtype
+        if numpy.lib.NumpyVersion(numpy.__version__) < '2.0.0':
+            assert v.dtype == expected_dtype
         assert v.shape == expected_shape
 
     @_condition.repeat(3, 10)


### PR DESCRIPTION
CuPy v13 does not guarantee the compatibility with NumPy 2.x.