### PR TITLE
Allow specifing no libraries when generating wheel metadata

### DIFF
--- a/cupyx/tools/_generate_wheel_metadata.py
+++ b/cupyx/tools/_generate_wheel_metadata.py
@@ -63,7 +63,7 @@ def main(args):
     parser.add_argument('--library',
                         choices=['cudnn', 'cutensor', 'nccl'],
                         action='append',
-                        required=True)
+                        default=[])
     params = parser.parse_args(args)
 
     print(json.dumps(


### PR DESCRIPTION
Follows-up #9030.

AArch64 wheels are currently not built with support for optional libraries such as cuDNN/cuTENSOR. `_generate_wheel_metadata.py` must be able to generate a wheel metadata containing no preload libraries for that case.
