### PR TITLE
Include `pxd` files in `cupyx`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # Contents of sdist. See also `setup.py`.
 recursive-include cupy *.h *.hpp
 recursive-include cupy *.pyx *.pxd *.pxi
+recursive-include cupyx *.pyx *.pxd *.pxi
 recursive-include cupy_backends *.h *.hpp
 recursive-include cupy_backends *.pyx *.pxd *.pxi
 


### PR DESCRIPTION
Follows-up #8916. `pxd` files must be explicitly added via `MANIFEST.in`, otherwise source build from sdist does not work.
