### PR TITLE
Update Docker images for v14.0.0a1 release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,8 +28,9 @@ jobs:
         include:
           - context: "docker/python3"
             base: "cupy/cupy"
-          - context: "docker/rocm"
-            base: "cupy/cupy-rocm"
+          # TODO(kmaehashi): See `docker/rocm/Dockerfile`.
+          #- context: "docker/rocm"
+          #  base: "cupy/cupy-rocm"
     env:
       DOCKER_TAG_NAME: |
         ${{

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install --no-cache-dir -U setuptools pip
-RUN pip3 install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-cuda12x[all]==13.0.0rc1"
+RUN pip3 install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-cuda12x[all]==14.0.0a1"

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -12,7 +12,10 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2 
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
 RUN python3 -m pip install --no-cache-dir -U setuptools pip
-RUN python3 -m pip install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-rocm-5-0[all]==13.0.0rc1"
+# TODO(kmaehashi): ROCm binary packages are currently unavailable.
+# See https://github.com/cupy/cupy/issues/8607#issuecomment-2658763950
+# `.github/workflows/docker.yml` needs to be fixed to restart uploading the image.
+RUN python3 -m pip install --no-cache-dir -f https://pip.cupy.dev/pre/ "cupy-rocm-5-0[all]==14.0.0a1"
 
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 RUN python3 -c "import cupy; cupy.show_config()"


### PR DESCRIPTION
This includes a forward-port of #8999 (which disables ROCm docker images).
