### PR TITLE
Implement the scipy.stats.gmean function for cupy using cupy routines.

### DIFF
--- a/cupyx/scipy/stats/__init__.py
+++ b/cupyx/scipy/stats/__init__.py
@@ -9,3 +9,4 @@ from cupyx.scipy.stats._stats import trim_mean  # NOQA
 from cupyx.scipy.stats._morestats import boxcox_llf  # NOQA
 from cupyx.scipy.stats._stats_py import zmap  # NOQA
 from cupyx.scipy.stats._stats_py import zscore  # NOQA
+from cupyx.scipy.stats._stats_py import gmean  # NOQA

--- a/cupyx/scipy/stats/_stats_py.py
+++ b/cupyx/scipy/stats/_stats_py.py
@@ -1,5 +1,65 @@
 import cupy
 
+def gmean(a, axis=0, dtype=None, weights=None):
+    # This is just the gmean function from scipy, but adapted to use cp functions instead of numpy/scipy ones.
+    r"""Compute the weighted geometric mean along the specified axis.
+
+    The weighted geometric mean of the array :math:`a_i` associated to weights
+    :math:`w_i` is:
+
+    .. math::
+
+        \exp \left( \frac{ \sum_{i=1}^n w_i \ln a_i }{ \sum_{i=1}^n w_i }
+                   \right) \, ,
+
+    and, with equal weights, it gives:
+
+    .. math::
+
+        \sqrt[n]{ \prod_{i=1}^n a_i } \, .
+
+    Parameters
+    ----------
+    a : cupy.ndarray
+        Input array or object that can be converted to an array.
+    axis : int or None, optional
+        Axis along which the geometric mean is computed. Default is 0.
+        If None, compute over the whole array `a`.
+    dtype : dtype, optional
+        Type to which the input arrays are cast before the calculation is
+        performed.
+    weights : cupy.ndarray, optional
+        The `weights` array must be broadcastable to the same shape as `a`.
+        Default is None, which gives each value a weight of 1.0.
+
+    Returns
+    -------
+    gmean : ndarray
+        See `dtype` parameter above.
+
+    Notes
+    -----
+    The sample geometric mean is the exponential of the mean of the natural
+    logarithms of the observations.
+    Negative observations will produce NaNs in the output because the *natural*
+    logarithm (as opposed to the *complex* logarithm) is defined only for
+    non-negative reals.
+
+    References
+    ----------
+    .. [1] "Weighted Geometric Mean", *Wikipedia*,
+           https://en.wikipedia.org/wiki/Weighted_geometric_mean.
+    .. [2] Grossman, J., Grossman, M., Katz, R., "Averages: A New Approach",
+           Archimedes Foundation, 1983
+
+    """
+    
+    with cupy.errstate(divide='ignore'):
+        log_a = cupy.log(a)
+
+    return cupy.exp(cupy.mean(log_a, axis=axis, dtype=dtype, weights=weights))
+
+
 
 def _first(arr, axis):
     """Return arr[..., 0:1, ...] where 0:1 is in the `axis` position

--- a/cupyx/scipy/stats/_stats_py.py
+++ b/cupyx/scipy/stats/_stats_py.py
@@ -1,7 +1,9 @@
 import cupy
 
+
 def gmean(a, axis=0, dtype=None, weights=None):
-    # This is just the gmean function from scipy, but adapted to use cp functions instead of numpy/scipy ones.
+    # This is just the gmean function from scipy,
+    # but adapted to use cp functions instead of numpy/scipy ones.
     r"""Compute the weighted geometric mean along the specified axis.
 
     The weighted geometric mean of the array :math:`a_i` associated to weights
@@ -53,12 +55,18 @@ def gmean(a, axis=0, dtype=None, weights=None):
            Archimedes Foundation, 1983
 
     """
-    
-    with cupy.errstate(divide='ignore'):
-        log_a = cupy.log(a)
 
-    return cupy.exp(cupy.mean(log_a, axis=axis, dtype=dtype, weights=weights))
+    if dtype == cupy.float16:
+        # Avoid large numerical errors in float16
+        dtype = cupy.float32
 
+    a = cupy.asarray(a, dtype=dtype)
+    if weights is not None:
+        weights = cupy.asarray(weights, dtype=dtype)
+
+    log_a = cupy.log(a)
+
+    return cupy.exp(cupy.average(log_a, axis=axis, weights=weights))
 
 
 def _first(arr, axis):

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -67,6 +67,40 @@ class TestTrim:
 
 
 @testing.with_requires('scipy')
+class TestGmean:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name='scp', rtol=1e-6, contiguous_check=False)
+    @pytest.mark.parametrize('shape', [(24,), (6, 4), (6, 4, 3), (4, 6)])
+    def test_base(self, xp, scp, dtype, shape):
+        a = testing.shaped_random(
+            shape, xp=xp, dtype=dtype, scale=100)
+        return scp.stats.gmean(a)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(
+        scipy_name='scp', rtol=1e-5, contiguous_check=False)
+    @pytest.mark.parametrize('axis', [0, 1, 2, 3, -1, None])
+    def test_axis(self, xp, scp, dtype, axis):
+        a = testing.shaped_random(
+            (5, 6, 4, 7), xp=xp, dtype=dtype, scale=100)
+        return scp.stats.gmean(a, axis=axis)
+
+    def test_weights(self):
+        a_cp = cupy.asarray([1, 2, 3, 4, 5])
+        a_np = numpy.asarray([1, 2, 3, 4, 5])
+
+        weights_cp = cupy.asarray([0.1, 0.2, 0.3, 0.4, 0.5])
+        weights_np = numpy.asarray([0.1, 0.2, 0.3, 0.4, 0.5])
+
+        result_cp = cupyx.scipy.stats.gmean(a_cp, weights=weights_cp)
+        result_np = scipy.stats.gmean(a_np, weights=weights_np)
+
+        cupy.testing.assert_allclose(result_cp, result_np, rtol=1e-5)
+
+
+@testing.with_requires('scipy')
 class TestZmap:
 
     @testing.for_all_dtypes(no_bool=True)


### PR DESCRIPTION
In the comparison table (https://docs.cupy.dev/en/latest/reference/comparison.html#statistical-functions), the function scipy.stats.gmean did not have a cupy counterpart, so I adapted the scipy implementation to work with cupy functions. Includes some testcases.

