### PR TITLE
Do `gc.collect()` in MemoryHook test code to avoid `free` hook to happen

### DIFF
--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py
@@ -1,3 +1,4 @@
+import gc
 import io
 import json
 import unittest
@@ -10,6 +11,7 @@ from cupy.cuda import memory_hooks
 class TestDebugPrintHook(unittest.TestCase):
 
     def setUp(self):
+        gc.collect()
         self.io = io.StringIO()
         self.hook = memory_hooks.DebugPrintHook(file=self.io)
         self.pool = memory.MemoryPool()

--- a/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
+++ b/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_line_profile.py
@@ -1,3 +1,4 @@
+import gc
 import io
 import unittest
 import re
@@ -9,6 +10,7 @@ from cupy.cuda import memory_hooks
 class TestLineProfileHook(unittest.TestCase):
 
     def setUp(self):
+        gc.collect()
         self.pool = memory.MemoryPool()
 
     def test_print_report(self):

--- a/tests/cupy_tests/cuda_tests/test_memory_hook.py
+++ b/tests/cupy_tests/cuda_tests/test_memory_hook.py
@@ -1,3 +1,4 @@
+import gc
 import unittest
 
 import cupy.cuda
@@ -38,6 +39,7 @@ class SimpleMemoryHook(memory_hook.MemoryHook):
 class TestMemoryHook(unittest.TestCase):
 
     def setUp(self):
+        gc.collect()
         self.pool = memory.MemoryPool()
         self.unit = 512
 


### PR DESCRIPTION
Closes #9077

I repeatedly ran the test locally but could not reproduce the origianl issue. My guess is that Python GC has triggered somewhere between `with self.hook:` and `alloc_postprocess`, which caused `free_postprocess` (for a memory block acquired in the previous test cases) to be triggered.
https://github.com/cupy/cupy/blob/1e8ade16f7f0af01e748e706e8c8302ffd2fc873/tests/cupy_tests/cuda_tests/memory_hooks_tests/test_debug_print.py#L22-L23

Adding `gc.collect()` to `setUp` to avoid `free_*` to be triggered.
