### PR TITLE
Bump doc build requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
-sphinx==5.3.0
-# TODO(kmaehashi): Bump pydata-sphinx-theme when https://github.com/pydata/pydata-sphinx-theme/issues/1161 closed
-pydata_sphinx_theme==0.11.0
-sphinx-copybutton==0.5.1
+sphinx==8.2.3
+pydata_sphinx_theme==0.16.1
+sphinx-copybutton==0.5.2
 
 # These requirements must match with the Baseline API version documented in the Installation Guide.
 numpy==2.1.*

--- a/docs/source/reference/ext.rst
+++ b/docs/source/reference/ext.rst
@@ -65,4 +65,4 @@ Automatic Kernel Parameters Optimizations (:mod:`cupyx.optimizing`)
 .. autosummary::
    :toctree: generated/
 
-   cupyx.optimizing.optimize
+   optimize

--- a/docs/source/reference/polynomials.rst
+++ b/docs/source/reference/polynomials.rst
@@ -52,7 +52,7 @@ Basics
    :toctree: generated/
 
    poly1d
-   cupy.poly
+   poly
    polyval
    roots
 


### PR DESCRIPTION
Now that RTD offers version switchers as [Flyout menu add-on](https://docs.readthedocs.com/platform/stable/flyout-menu.html), I guess it's safe to bump up pydata-sphinx-theme to the latest one.