### PR TITLE
Implement lazy load for cuquantum

### DIFF
--- a/cupy/linalg/_einsum_cutn.py
+++ b/cupy/linalg/_einsum_cutn.py
@@ -1,20 +1,6 @@
 import threading
 import warnings
 
-try:
-    import cuquantum
-    if hasattr(cuquantum, 'bindings'):
-        # cuquantum-python >= 25.03
-        from cuquantum.bindings import cutensornet  # binding module
-        from cuquantum import tensornet  # module for pythonic APIs
-    else:
-        # for cuquantum < 25.03, bindings & pythonic APIs
-        # all reside under cuquantum.cutensornet
-        from cuquantum import cutensornet
-        tensornet = cutensornet
-except ImportError:
-    cuquantum = cutensornet = tensornet = None
-
 import cupy
 from cupy import _util
 from cupy._core import _accelerator
@@ -22,6 +8,28 @@ from cupy.cuda.device import Handle
 
 
 _tls = threading.local()
+
+cuquantum = cutensornet = tensornet = None
+
+def _maybe_lazy_load_cutensornet():
+    global cuquantum, cutensornet, tensornet
+
+    if cuquantum is not None:
+        return 
+
+    try:
+        import cuquantum
+        if hasattr(cuquantum, 'bindings'):
+            # cuquantum-python >= 25.03
+            from cuquantum.bindings import cutensornet  # binding module
+            from cuquantum import tensornet  # module for pythonic APIs
+        else:
+            # for cuquantum < 25.03, bindings & pythonic APIs
+            # all reside under cuquantum.cutensornet
+            from cuquantum import cutensornet
+            tensornet = cutensornet
+    except ImportError:
+        pass
 
 
 @_util.memoize()
@@ -72,6 +80,8 @@ def _try_use_cutensornet(*args, **kwargs):
     if (_accelerator.ACCELERATOR_CUTENSORNET not in
             _accelerator.get_routine_accelerators()):
         return None
+
+    _maybe_lazy_load_cutensornet()
 
     if cutensornet is None:
         warnings.warn(

--- a/cupy/linalg/_einsum_cutn.py
+++ b/cupy/linalg/_einsum_cutn.py
@@ -11,11 +11,12 @@ _tls = threading.local()
 
 cuquantum = cutensornet = tensornet = None
 
+
 def _maybe_lazy_load_cutensornet():
     global cuquantum, cutensornet, tensornet
 
     if cuquantum is not None:
-        return 
+        return
 
     try:
         import cuquantum


### PR DESCRIPTION
This PR implements lazy load for `cuquantum` in `cupy.einsum`.

Currently `cuquantum/cutensornet` is an optional accelerator of `cupy.einsum`. However the optional module will be loaded regardless of whether it has been set as `CUPY_ACCELERATOR` if it's installed. Since `cuquantum` has its own dependencies with some overhead during import,  we here switch to lazy import for `cuquantum` such that non-einsum users will not need to load it into their environment.

