### PR TITLE
ENH: cupyx/signal: add freqz_sos, a preferred alias for sosfreqz

### DIFF
--- a/cupyx/scipy/signal/__init__.py
+++ b/cupyx/scipy/signal/__init__.py
@@ -114,6 +114,7 @@ from cupyx.scipy.signal._filter_design import freqs_zpk  # NOQA
 
 from cupyx.scipy.signal._filter_design import freqz  # NOQA
 from cupyx.scipy.signal._filter_design import freqz_zpk  # NOQA
+from cupyx.scipy.signal._filter_design import freqz_sos  # NOQA
 from cupyx.scipy.signal._filter_design import sosfreqz  # NOQA
 
 from cupyx.scipy.signal._waveforms import chirp  # NOQA

--- a/cupyx/scipy/signal/_filter_design.py
+++ b/cupyx/scipy/signal/_filter_design.py
@@ -566,7 +566,7 @@ def _validate_sos(sos):
     return sos, n_sections
 
 
-def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
+def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
     r"""
     Compute the frequency response of a digital filter in SOS format.
 
@@ -626,6 +626,11 @@ def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
         w, rowh = freqz(row[:3], row[3:], worN=worN, whole=whole, fs=fs)
         h *= rowh
     return w, h
+
+
+def sosfreqz(sos, worN=512, whole=False, fs=2*pi):
+    """A legacy alias for freqz_sos."""
+    return freqz_sos(sos, worN, whole, fs)
 
 
 def _hz_to_erb(hz):

--- a/docs/source/reference/scipy_signal.rst
+++ b/docs/source/reference/scipy_signal.rst
@@ -81,6 +81,7 @@ Filter design
    freqs_zpk
    freqz
    freqz_zpk
+   freqz_sos
    sosfreqz
    firwin
    firwin2


### PR DESCRIPTION
In SciPy 1.15, `scipy.signal.sosfreqz` was renamed to `freqz_sos`, and the original name is kept as a "legacy" alias for backwards compatibility.

Thus, follow the rename/aliasing in `cupyx.scipy.signal`.