### PR TITLE
[WIP] Implements Lapack potrs

### DIFF
--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -37,6 +37,7 @@ from cupy.linalg._solve import lstsq  # NOQA
 from cupy.linalg._solve import inv  # NOQA
 from cupy.linalg._solve import pinv  # NOQA
 from cupy.linalg._solve import tensorinv  # NOQA
+from cupy.linalg._solve import cho_solve
 
 # -----------------------------------------------------------------------------
 # Exceptions
@@ -46,4 +47,4 @@ from numpy.linalg import LinAlgError  # NOQA
 
 __all__ = ["matrix_power", "cholesky", "qr", "svd", "eigh", "eigvalsh", "norm",
            "det", "matrix_rank", "slogdet", "solve", "tensorsolve", "inv",
-           "pinv", "tensorinv", "LinAlgError"]
+           "pinv", "tensorinv", "LinAlgError", "cho_solve"]

--- a/cupy/linalg/_solve.py
+++ b/cupy/linalg/_solve.py
@@ -7,6 +7,7 @@ from cupy.cuda import device
 from cupy.linalg import _decomposition
 from cupy.linalg import _util
 import cupyx
+import cupyx.lapack
 
 
 def solve(a, b):
@@ -398,3 +399,68 @@ def tensorinv(a, ind=2):
     a = a.reshape(prod, -1)
     a_inv = inv(a)
     return a_inv.reshape(*invshape)
+
+
+def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
+    """
+    Solves the linear system Ax = b using the Cholesky factorization of A.
+    Batched input arrays are also supported.
+
+    Args:
+        c (tuple of cupy.ndarray and bool): The first tuple item is the
+            Cholesky factor of the matrix `A`, typically obtained from
+            `cupy.linalg.cholesky`. The second item is a bool that indicates
+            whether the Cholesky factor is stored in the lower-triangular
+            part (when True) or in the upper-triangular part (when False).
+        b (cupy.ndarray): Right-hand side array.
+        overwrite_b (bool, optional): If True, the contents of `b` may be
+            overwritten for efficiency. Default is False.
+        check_finite (bool, optional): If True, checks whether the input arrays
+            contain only finite numbers. Disabling this may improve performance
+            but can lead to crashes or non-termination if NaNs or infs are
+            present. Default is True.
+
+    Returns:
+        cupy.ndarray: Solution to the linear system Ax = b.
+
+    See Also:
+        cupy.linalg.cho_factor: Computes the Cholesky factorization.
+
+    Examples:
+        >>> import cupy as cp
+        >>> from cupy.linalg import cholesky, cho_solve
+        >>> A = cp.array([[9, 3, 1, 5],
+        ...               [3, 7, 5, 1],
+        ...               [1, 5, 9, 2],
+        ...               [5, 1, 2, 6]])
+        >>> c= cholesky(A)
+        >>> x = cho_solve((c, True), cp.ones(4))
+        >>> cp.allclose(A @ x, cp.ones(4))
+        True
+    """
+
+    (c, lower) = c_and_lower
+
+    # Check finiteness of input arrays
+    if check_finite:
+        indexes = (numpy.tril_indices(c.shape[-1], -1) if lower else
+                   numpy.triu_indices(c.shape[-1], 1))
+        if not cupy.isfinite(c[..., *indexes]).all():
+            raise ValueError("Input array contains NaN or infinity.")
+        del indexes
+        if not cupy.isfinite(b).all():
+            raise ValueError("Input array contains NaN or infinity.")
+
+    # cupyx.lapack.potrs may overwrite b, so we need to ensure it will not
+    # happen
+    if not overwrite_b:
+        if c.ndim == 2:
+            # Handled by potrs (non-batched case)
+            if b.flags.f_contiguous:
+                b = cupy.asarray(b, order='F', copy=True)
+        else:
+            # Handled by potrs (batched case)
+            if b.flags.c_contiguous:
+                b = cupy.asarray(b, order='C', copy=True)
+
+    return cupyx.lapack.potrs(c, b, lower=lower)

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -346,3 +346,189 @@ def posv(a, b):
         potrs, dev_info)
 
     return _cupy.ascontiguousarray(b.reshape(b_shape))
+
+
+def potrs(L, b, lower):
+    """ Implements lapack XPOTRS through cusolver.potrs. Solves linear system
+    A x = b given the cholesky decomposition of A, namely L. Supports also
+    batches of linear systems and more than one right-hand side (NRHS > 1).
+
+    Args
+    ----------
+    L (cupy.ndarray): Array of Cholesky decomposition of real symmetric or
+        complex hermitian matrices with dimension (..., N, N).
+
+    b (cupy.ndarray): right-hand side (..., N) or (..., N, NRHS). Note that
+        this array may be modified in place, as usually done in LAPACK
+
+    lower (bool): If True, L is lower triangular. If False, L is upper
+        triangular.
+
+    Returns
+    -------
+        cupy.ndarray: The solution to the linear system. Note this may point to
+            the same memory as b, since b may be modified in place.
+
+    .. warning::
+        This function calls one or more cuSOLVER routine(s) which may yield
+        invalid results if input conditions are not met.
+        To detect these invalid results, you can set the `linalg`
+        configuration to a value that is not `ignore` in
+        :func:`cupyx.errstate` or :func:`cupyx.seterr`.
+
+    """
+
+    from cupy_backends.cuda.libs import cusolver as _cusolver
+
+    # Check if batched should be used
+    if len(L.shape) > 2:
+        return _batched_potrs(L, b, lower)
+
+    # Check input arguments
+    assert L.ndim == 2, "L is not a matrix"
+    assert L.shape[0] == L.shape[1], "L is not a square matrix"
+    n = L.shape[-1]
+    b_shape = b.shape
+    if b.ndim == 1:
+        b = b[:, None]
+    assert b.ndim == 2, "b is not a vector or a matrix"
+    assert b.shape[0] == n, "length of arrays in b does not match size of L"
+
+    # Check memory order and type
+    dtype = _numpy.promote_types(L.dtype, b.dtype)
+    dtype = _numpy.promote_types(dtype, 'f')
+    L, b = L.astype(dtype, copy=False), b.astype(dtype, copy=False)
+    if (not L.flags.f_contiguous) and (not L.flags.c_contiguous):
+        L = _cupy.asfortranarray(L)
+    if L.flags.c_contiguous:
+        lower = not lower  # Cusolver assumes F-order
+        # For complex types, we need to conjugate the matrix
+        if b.size < L.size:  # Conjugate the one with lower memory footprint
+            b = b.conj()
+        else:
+            L = L.conj()
+    if (b.dtype != dtype) or (not b.flags.f_contiguous):
+        b = _cupy.asfortranarray(b)
+
+    # Take correct dtype
+    if dtype == 'f':
+        potrs = _cusolver.spotrs
+    elif dtype == 'd':
+        potrs = _cusolver.dpotrs
+    elif dtype == 'F':
+        potrs = _cusolver.cpotrs
+    elif dtype == 'D':
+        potrs = _cusolver.zpotrs
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(L.dtype))
+        raise ValueError(msg)
+
+    handle = _device.get_cusolver_handle()
+    dev_info = _cupy.empty(1, dtype=_cupy.int32)
+
+    potrs(
+        handle,
+        _cublas.CUBLAS_FILL_MODE_LOWER if lower else
+        _cublas.CUBLAS_FILL_MODE_UPPER,
+        L.shape[0],  # n, matrix size
+        b.shape[1],  # nrhs
+        L.data.ptr,
+        L.shape[0],  # ldL
+        b.data.ptr,
+        b.shape[0],  # ldB
+        dev_info.data.ptr)
+    _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrs, dev_info)
+
+    # Conjugate back if necessary
+    if L.flags.c_contiguous and b.size < L.size:
+        b = b.conj()
+    return _cupy.asarray(b, order='C').reshape(b_shape)
+
+
+def _batched_potrs(L, b, lower: bool):
+    from cupy_backends.cuda.libs import cusolver as _cusolver
+    import cupyx.cusolver
+
+    if not cupyx.cusolver.check_availability('potrsBatched'):
+        raise RuntimeError('potrsBatched is not available')
+
+    # CHeck input arrays
+    assert L.shape[-1] == L.shape[-2], "L is not a batch of square matrices"
+    assert b.ndim >= L.ndim-1, "Batch dimension of b is different than that \
+        of L"
+    b_shape = b.shape
+    if b.ndim < L.ndim:
+        b = b[..., None]
+    assert b.shape[:-2] == L.shape[:-2], \
+        "Batch dimension of L and b do not match"
+
+    # Check dtype and memory alignment
+    dtype = _numpy.promote_types(L.dtype, b.dtype)
+    dtype = _numpy.promote_types(dtype, 'f')
+    L = L.astype(dtype, order='C', copy=False)
+    b = b.astype(dtype, order='C', copy=False)
+    assert L.flags.c_contiguous and b.flags.c_contiguous, \
+        "Unexpected non C-contiguous arrays"
+    lower = not lower  # Cusolver assumes F-order
+
+    # Pick function handle
+    if dtype == 'f':
+        potrsBatched = _cusolver.spotrsBatched
+    elif dtype == 'd':
+        potrsBatched = _cusolver.dpotrsBatched
+    elif dtype == 'F':
+        potrsBatched = _cusolver.cpotrsBatched
+    elif dtype == 'D':
+        potrsBatched = _cusolver.zpotrsBatched
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(L.dtype))
+        raise ValueError(msg)
+
+    # Variables for potrs batched
+    handle = _device.get_cusolver_handle()
+    dev_info = _cupy.empty(1, dtype=_numpy.int32)
+    batch_size = _numpy.prod(L.shape[:-2])
+    n = L.shape[-1]
+    b = b.conj()
+    L_p = _cupy._core._mat_ptrs(L)
+    nrhs = b.shape[-1]
+
+    # Allocate temporary working array in case nrhs > 1
+    if nrhs == 1:
+        b_tmp = b[..., 0]
+    else:
+        b_tmp = _cupy.empty(b.shape[:-1], dtype=b.dtype, order='C')
+    b_tmp_p = _cupy._core._mat_ptrs(b_tmp[..., None])
+
+    # potrs_batched supports only nrhs=1, so we have to loop over the nrhs
+    for i in range(b.shape[-1]):
+
+        if nrhs > 1:  # Copy results back to the original array
+            b_tmp[...] = b[..., i]
+
+        potrsBatched(
+            handle,
+            _cublas.CUBLAS_FILL_MODE_LOWER if lower else
+            _cublas.CUBLAS_FILL_MODE_UPPER,
+            n,  # n
+            1,  # nrhs
+            L_p.data.ptr,  # A
+            L.shape[-2],  # lda
+            b_tmp_p.data.ptr,  # Barray
+            b_tmp.shape[-1],  # ldb
+            dev_info.data.ptr,  # info
+            batch_size  # batchSize
+        )
+        _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+            potrsBatched, dev_info)
+
+        if nrhs > 1:  # Copy results back to the original array
+            b[..., i] = b_tmp.conj()
+        else:
+            b = b_tmp.conj()
+
+    # Return b in the original shape
+    return _cupy.asarray(b, order='C').reshape(b_shape)

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -175,3 +175,55 @@ class TestXFailBatchedPosv(unittest.TestCase):
         a = a @ a.swapaxes(-2, -1).conjugate()
         a = a + n * xp.eye(n)
         return a
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 4, 2, 2), (5, 3, 3), (7, 7)],
+    'nrhs': [None, 1, 8],
+    'lower': [True, False],
+    'order': ['F', 'C'],
+}))
+class TestPotrs(unittest.TestCase):
+
+    @staticmethod
+    def _solve(a, b):
+        if (
+            numpy.lib.NumpyVersion(numpy.__version__) < "2.0.0"
+            or a.shape[:-1] != b.shape
+        ):
+            return numpy.linalg.solve(a, b)
+        b = b[..., numpy.newaxis]
+        return numpy.linalg.solve(a, b)[..., 0]
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_potrs(self, xp, dtype):
+
+        if (len(self.shape) > 2 and
+                not cusolver.check_availability('potrsBatched')):
+            pytest.skip('potrsBatched is not available')
+
+        a = self._create_posdef_matrix(xp, self.shape, dtype)
+        b_shape = list(self.shape[:-1])
+        if self.nrhs is not None:
+            b_shape.append(self.nrhs)
+        b = testing.shaped_random(b_shape, xp, dtype=dtype)
+
+        if xp == cupy:
+            L = xp.linalg.cholesky(a)
+            if self.lower:
+                L[..., *numpy.triu_indices(L.shape[-1], 1)] = numpy.nan
+            else:
+                L = xp.moveaxis(L, -1, -2).conj()
+                L[..., *numpy.tril_indices(L.shape[-1], -1)] = numpy.nan
+            L = cupy.asarray(L, order=self.order)
+            return lapack.potrs(L, b, self.lower)
+        else:
+            return self._solve(a, b)
+
+    def _create_posdef_matrix(self, xp, shape, dtype):
+        n = shape[-1]
+        a = testing.shaped_random(shape, xp, dtype, scale=1)
+        a = a @ a.swapaxes(-2, -1).conjugate()
+        a = a + n * xp.eye(n)
+        return a


### PR DESCRIPTION
Addresses #9087 and, partially, #6324. Implements Lapack `potrs` and also exposes the `scipy.linalg.cho_solve` interface.

As explained in #9087, `potrs` is useful when multiple linear systems have to be solved for the same symmetric matrix A. Multiple calls to `posv` are suboptimal because the same Cholesky decomposition is recalculated multiple times. This happens, for example, in Gaussian Processes.

`potrs` is here implemented inside `cupyx.lapack`, offering a Lapack-like interface. It supports batched systems and also more than one RHS (cusolver does not support NRHS > 1 for the batched version, here a workaround is implemented). Next to that, a scipy-like function in added in `cupy.linalg.cho_solve` which keeps the same interface as the corresponding `scipy` equivalent.

I intentionally did not modify the existing `cupyx.lapack.posv` function to make use of the new `potrs` implementation so as not to add too much boilerplate code to it, as requested by @leofang [here](https://github.com/cupy/cupy/issues/9087#issuecomment-2814600368).

This PR is marked as WIP for this reason: I noted that if non C-contiguous arrays are returned, unittests failed. Thus I modified the return statements to ensure C-contiguity. I would like to avoid this because it may introduce unnecessary memory copies (the end-users may simply use an F-contiguous array), but I don't know if it's allowed by cupy common practices as unittests were failing.