### PR TITLE
BUG: cupyx.scipy.signal: make gammatone return arrays

### DIFF
--- a/cupyx/scipy/signal/_filter_design.py
+++ b/cupyx/scipy/signal/_filter_design.py
@@ -793,7 +793,7 @@ def gammatone(freq, ftype, order=None, numtaps=None, fs=None):
         scale_factor /= float_factorial(order - 1)
         scale_factor /= fs
         b *= scale_factor
-        a = [1.0]
+        a = cupy.asarray([1.0])
 
     # Calculate IIR gammatone filter
     elif ftype == 'iir':


### PR DESCRIPTION
Currently, one of `gammatone` return values is an array or a list, depending on other inputs. Fix it to always return arrays.

Observed in https://github.com/scipy/scipy/pull/22914, which delegates to `cupyx.scipy.signal.gammatone` from `scipy.signal.gammatone`.