### PR TITLE
Limit Cython version to 3.0 or 3.1

### DIFF
--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -293,7 +293,7 @@ In order to run unit tests at the repository root, you first have to build Cytho
 
   In addition, you need to manually install the build-time dependencies listed in the ``build-system.requires`` section of ``pyproject.toml`` before running the above command::
 
-    $ pip install "setuptools>=77" wheel "Cython>=3" "fastrlock>=0.5"
+    $ pip install "setuptools>=77" wheel "Cython>=3,<3.2" "fastrlock>=0.5"
 
 Once Cython modules are built, you can run unit tests by running the following command at the repository root::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Need to be installed manually when using `--no-build-isolation`.
-# Keep in sync with `docs/source/contribution.rst`
-requires = ["setuptools>=77", "wheel", "Cython>=3", "fastrlock>=0.5"]
+# Keep in sync with `docs/source/contribution.rst`.
+requires = ["setuptools>=77", "wheel", "Cython>=3,<3.2", "fastrlock>=0.5"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
To prevent build breakage like #9131 from happening in the future, limiting supported Cython version used for the build time.


xref #9128