### PR TITLE
Make rebuild faster for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ htmlcov/
 .vs/
 .cache/
 .pytest_cache/
+/.cupy_builder.cache
 cupy/.data/
 cupy/cuda/thrust.h
 cupy/_core/numpy_allocator.h

--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -47,6 +47,7 @@ class Context:
     cupy_cache_key: str | None
     win32_cl_exe_path: str | None
     dev_configure_cache: bool
+    dev_configure_cache_key: str
 
     # Deprecated
     wheel_libs: list[str]
@@ -100,27 +101,41 @@ class Context:
         self.dev_configure_cache = (
             _get_env_bool("CUPY_INSTALL_CONFIGURE_CACHE", _env)
             and self.setup_command == "editable_wheel")
+        if self.dev_configure_cache:
+            self.calculate_dev_cache_key()
 
         # Deprecated
         self.wheel_libs = []
         self.wheel_includes = []
 
-    def calculate_cache_key(self) -> None:
-        print('Generating cache key from header files...')
-        include_pattern = os.path.join(
+    def calculate_cupy_cache_key(self) -> None:
+        print('Generating CUPY_CACHE_KEY from header files...')
+        pattern = os.path.join(
             self.source_root, 'cupy', '_core', 'include', '**')
-        include_files = [
-            f for f in sorted(glob.glob(include_pattern, recursive=True))
+        cache_key, count = self._calculate_checksum(pattern)
+        print(f'CUPY_CACHE_KEY ({count} files '
+              f'matching {pattern}): {cache_key}')
+        self.cupy_cache_key = cache_key
+
+    def calculate_dev_cache_key(self) -> None:
+        print('Generating configure cache key...')
+        pattern = os.path.join(
+            self.source_root, 'install', 'cupy_builder', '**')
+        cache_key, count = self._calculate_checksum(pattern)
+        print(f'Configure cache key ({count} files '
+              f'matching {pattern}): {cache_key}')
+        self.dev_configure_cache_key = cache_key
+
+    def _calculate_checksum(self, glob_pattern: str) -> tuple[str, int]:
+        files = [
+            f for f in sorted(glob.glob(glob_pattern, recursive=True))
             if os.path.isfile(f)
         ]
         hasher = hashlib.sha1(usedforsecurity=False)
-        for include_file in include_files:
-            with open(include_file, 'rb') as f:
-                relpath = os.path.relpath(include_file, self.source_root)
+        for path in files:
+            with open(path, 'rb') as f:
+                relpath = os.path.relpath(path, self.source_root)
                 hasher.update(relpath.encode())
                 hasher.update(f.read())
                 hasher.update(b'\x00')
-        cache_key = hasher.hexdigest()
-        print(f'Cache key ({len(include_files)} files '
-              f'matching {include_pattern}): {cache_key}')
-        self.cupy_cache_key = cache_key
+        return hasher.hexdigest(), len(files)

--- a/install/cupy_builder/_context.py
+++ b/install/cupy_builder/_context.py
@@ -46,6 +46,7 @@ class Context:
     features: dict[str, cupy_builder.Feature]
     cupy_cache_key: str
     win32_cl_exe_path: str | None
+    dev_configure_cache: bool
 
     # Deprecated
     wheel_libs: list[str]
@@ -107,6 +108,15 @@ class Context:
 
         # Host compiler path for Windows, see `_command.py`.
         self.win32_cl_exe_path = None
+
+        # EXPERIMENTAL: Persist the build configuration to a cache file to
+        # skip re-configuring modules when rebuilding during development.
+        # Only effective in editable mode (i.e. `pip install -e .`).
+        # This is solely intended for use by CuPy developers.
+        # End users should NEVER use this flag.
+        self.dev_configure_cache = (
+            _get_env_bool("CUPY_INSTALL_CONFIGURE_CACHE", _env)
+            and self.setup_command == "editable_wheel")
 
         # Deprecated
         self.wheel_libs = []

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 
 import copy
+import dataclasses
 from distutils import ccompiler
 from distutils import sysconfig
 import logging
 import os
+import os.path
+import pickle
 import shutil
 import sys
 
@@ -294,6 +297,21 @@ def _find_static_library(name: str) -> str:
 def make_extensions(ctx: Context, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
+    CACHE_FILE = f"{ctx.source_root}/.cupy_builder.cache"
+    if ctx.dev_configure_cache and os.path.exists(CACHE_FILE):
+        with open(CACHE_FILE, "rb") as f:
+            (prev_ctx, ret) = pickle.load(f)
+        if ctx.cupy_cache_key == prev_ctx.cupy_cache_key:
+            print("***************************************************")
+            print("*** NOTICE: Reusing build configuration from previous "
+                  f"run. Remove the configuration cache ({CACHE_FILE}) "
+                  "if you intend to reconfigure.")
+            print("***************************************************")
+            for f in dataclasses.fields(prev_ctx):
+                setattr(ctx, f.name, getattr(prev_ctx, f.name))
+            return ret
+        print("*** NOTICE: Cache key has changed, ignoring config cache.")
+
     MODULES = ctx.features.values()
 
     no_cuda = ctx.use_stub
@@ -471,6 +489,10 @@ def make_extensions(ctx: Context, compiler, use_cython):
             extension = setuptools.Extension(name, sources, **s_file)
             ret.append(extension)
 
+    if ctx.dev_configure_cache:
+        print(f"Persisting build configuration cache: {CACHE_FILE}")
+        with open(CACHE_FILE, "wb") as f:
+            pickle.dump((ctx, ret), f)
     return ret
 
 

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -297,6 +297,7 @@ def _find_static_library(name: str) -> str:
 def make_extensions(ctx: Context, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
+    ctx.calculate_cache_key()
     CACHE_FILE = f"{ctx.source_root}/.cupy_builder.cache"
     if ctx.dev_configure_cache and os.path.exists(CACHE_FILE):
         with open(CACHE_FILE, "rb") as f:

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -297,12 +297,13 @@ def _find_static_library(name: str) -> str:
 def make_extensions(ctx: Context, compiler, use_cython):
     """Produce a list of Extension instances which passed to cythonize()."""
 
-    ctx.calculate_cache_key()
+    ctx.calculate_cupy_cache_key()
     CACHE_FILE = f"{ctx.source_root}/.cupy_builder.cache"
     if ctx.dev_configure_cache and os.path.exists(CACHE_FILE):
         with open(CACHE_FILE, "rb") as f:
             (prev_ctx, ret) = pickle.load(f)
-        if ctx.cupy_cache_key == prev_ctx.cupy_cache_key:
+        if (ctx.dev_configure_cache_key == prev_ctx.dev_configure_cache_key and
+                ctx.cupy_cache_key == prev_ctx.cupy_cache_key):
             print("***************************************************")
             print("*** NOTICE: Reusing build configuration from previous "
                   f"run. Remove the configuration cache ({CACHE_FILE}) "


### PR DESCRIPTION
This PR intends to make try-and-error iteration faster during CuPy development for better DX.

I confirmed the build time (measured by `time pip install --no-build-isolation -e . -v`) decreased from 9.5 sec. to 5.1 sec when rebuilding CuPy without any modification. While the difference might seem small, for CuPy developers who are repeatedly rebuilding Cython code, it accumulates into a significant impact.

Specifically, this PR:

1. Introduces an environment variable `CUPY_INSTALL_CONFIGURE_CACHE=1` which persists/reuses the module configuration results to/from `.cupy_builder.cache`. When rebuilding, configuration step will be skipped (i.e. you won't see `-------- Configuring Module: cuda --------` etc. at all.) This was made possible as `cupy_builder.Context` is now defined using `dataclass` in #9079.
2. Defers calculating cache key (hash of all include headers) to avoid unnecessarily computing the hash twice.