### PR TITLE
Add new `sm_*` from CUDA 12.9

### DIFF
--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -96,6 +96,9 @@ def _nvcc_gencode_options(cuda_version: int) -> List[str]:
                 arch_list += [('compute_100', 'sm_100'),
                               ('compute_120', 'sm_120'),
                               'compute_100']
+            elif cuda_version >= 12090:
+                arch_list += [('compute_103', 'sm_103'),
+                              ('compute_121', 'sm_121'),]
             else:
                 arch_list.append('compute_90')
 


### PR DESCRIPTION
Include the new `sm_*` added in CUDA 12.9 per [this release note]( https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#general-cuda )