### PR TITLE
BUG: fix `cupyx.scipy.linalg.expm`

### DIFF
--- a/cupyx/scipy/linalg/_matfuncs.py
+++ b/cupyx/scipy/linalg/_matfuncs.py
@@ -118,7 +118,7 @@ def expm(a):
     E = cupy.eye(A.shape[0], dtype=a_dtype)
     bb = cupy.asarray(b, dtype=a_dtype)
 
-    u1, u2, v1, v2 = _expm_inner(E, A, A2, A4, A6, bb)
+    u1, u2, v1, v2 = _expm_inner(E, A2, A4, A6, bb)
     u = A @ (A6 @ u1 + u2)
     v = A6 @ v1 + v2
 
@@ -138,10 +138,10 @@ def expm(a):
 
 
 @cupy.fuse
-def _expm_inner(E, A, A2, A4, A6, b):
+def _expm_inner(E, A2, A4, A6, b):
     u1 = b[13]*A6 + b[11]*A4 + b[9]*A2
     u2 = b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*E
 
-    v1 = b[12]*A6 + b[10]*A4 + b[8]*A
+    v1 = b[12]*A6 + b[10]*A4 + b[8]*A2
     v2 = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*E
     return u1, u2, v1, v2

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_matfuncs.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_matfuncs.py
@@ -110,3 +110,23 @@ class TestExpM:
     def test_dtypes(self, xp, scp, dtype):
         a = xp.eye(2, dtype=dtype)
         return scp.linalg.expm(a)
+
+    @testing.numpy_cupy_allclose(scipy_name='scp', contiguous_check=False)
+    def test_gh_9138(self, xp, scp):
+        rng = np.random.default_rng(123)
+        a = rng.standard_normal(size=(3, 3))
+        a = a + 1j*rng.standard_normal(size=(3, 3))
+        A = a.conj().T - a
+        A = xp.asarray(A)
+        return scp.linalg.expm(A)
+
+    def test_gh_9138_2(self):
+        # make sure expm(antisym matrix) is unitary (to a good accuracy)
+        rng = np.random.default_rng(123)
+        a = rng.standard_normal(size=(3, 3))
+        a = a + 1j*rng.standard_normal(size=(3, 3))
+        A = a.conj().T - a
+        A = cupy.asarray(A)
+
+        U = cx_linalg.expm(A)
+        testing.assert_allclose(U.conj().T @ U, cupy.eye(3), atol=1e-14)


### PR DESCRIPTION
closes gh-9138

Fix a math error in `expm` implementation, where a formula from the paper was incorrectly translated from math to python.