### PR TITLE
adding permuted function to cupy

### DIFF
--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -97,6 +97,7 @@ from cupy.random._generator import RandomState  # NOQA
 from cupy.random._generator import reset_states  # NOQA
 from cupy.random._generator import seed  # NOQA
 from cupy.random._generator import set_random_state  # NOQA
+from cupy.random._permutations import permuted  # NOQA
 from cupy.random._permutations import permutation  # NOQA
 from cupy.random._permutations import shuffle  # NOQA
 from cupy.random._sample import choice  # NOQA

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -1183,10 +1183,25 @@ class RandomState(object):
         array = cupy.argsort(sample)
         return array
 
+    def permuted(a:cp.ndarray,axis=0,type=cp.int32):
+	"""Returns a pertated array for multi dimensional array"""
+        #added type to tweek the sample datatype if you run out of memory
+        #check axis
+        if axis > a.ndim or axis<0:
+            raise TypeError('Axis not valid')
+        num = a.shape
+
+        sample = cp.empty(num,dtype=type) #empty memory of equal shape to array a
+        curand.generate(self._generator,sample.data.ptr,num[axis]) #give data and number to generator to rearrange in place
+        order = cp.argsort(sample,axis=axis) # reorder the array which basically shuffles it
+        return(a[order])
+
     _gumbel_kernel = _core.ElementwiseKernel(
         'T x, T loc, T scale', 'T y',
         'y = T(loc) - log(-log(x)) * T(scale)',
         'cupy_gumbel_kernel')
+
+
 
     def gumbel(self, loc=0.0, scale=1.0, size=None, dtype=float):
         """Returns an array of samples drawn from a Gumbel distribution.

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -1183,17 +1183,16 @@ class RandomState(object):
         array = cupy.argsort(sample)
         return array
 
-    def permuted(a:cp.ndarray,axis=0,type=cp.int32):
-	"""Returns a pertated array for multi dimensional array"""
+    def permuted(self,a,axis=0,type=numpy.int32):
+        #"""Returns a pertated array for multi dimensional array."""
         #added type to tweek the sample datatype if you run out of memory
         #check axis
-        if axis > a.ndim or axis<0:
+        if (axis > a.ndim) or (axis < 0):
             raise TypeError('Axis not valid')
         num = a.shape
-
-        sample = cp.empty(num,dtype=type) #empty memory of equal shape to array a
+        sample = cupy.empty(num,dtype=type) #empty memory of equal shape to array a
         curand.generate(self._generator,sample.data.ptr,num[axis]) #give data and number to generator to rearrange in place
-        order = cp.argsort(sample,axis=axis) # reorder the array which basically shuffles it
+        order = cupy.argsort(sample,axis=axis) # reorder the array which basically shuffles it
         return(a[order])
 
     _gumbel_kernel = _core.ElementwiseKernel(

--- a/cupy/random/_permutations.py
+++ b/cupy/random/_permutations.py
@@ -1,5 +1,5 @@
 from cupy.random import _generator
-
+import numpy as np
 
 def shuffle(a):
     """Shuffles an array.
@@ -31,7 +31,7 @@ def permutation(a):
     return rs.permutation(a)
 
 
-def permuted(a, axis=0):
+def permuted(a, axis=0,type=np.uint16):
     """Returns a permutation of an array for each row.
 
     Args:
@@ -46,4 +46,4 @@ def permuted(a, axis=0):
     .. seealso:: :meth:`numpy.random.permuted`
     """
     rs = _generator.get_random_state()
-    return rs.permuted(a, axis=axis, type=int)
+    return rs.permuted(a, axis=axis, type=type)

--- a/cupy/random/_permutations.py
+++ b/cupy/random/_permutations.py
@@ -29,3 +29,21 @@ def permutation(a):
     """
     rs = _generator.get_random_state()
     return rs.permutation(a)
+
+
+def permuted(a, axis=0):
+    """Returns a permutation of an array for each row.
+
+    Args:
+        a (int or cupy.ndarray): The range or the array to be shuffled.
+        axis (int >= 0): the axis that will be shuffled
+
+    Returns:
+        cupy.ndarray: If `a` is an integer, it is permutation range between 0
+        and `a` - 1.
+        Otherwise, it is a permutation of `a`.
+
+    .. seealso:: :meth:`numpy.random.permuted`
+    """
+    rs = _generator.get_random_state()
+    return rs.permuted(a, axis=axis, type=int)


### PR DESCRIPTION
Just want to add this function to cupy it is useful for shuffling individual rows of a matrix which is available in [numpy](https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.permuted.html) it is fairly close to the permutation method but sorts by rows not by the whole array.

#4557

I was having problems as it was saying that my new method permuted was not found I could use some guidance on this end. I will attach a python script.
[test.py.txt](https://github.com/user-attachments/files/20598359/test.py.txt)
 that shows its use just scroll to bottom