### PR TITLE
Fix rocThrust build on ROCm 6.4

### DIFF
--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -334,7 +334,7 @@ def make_extensions(ctx: Context, compiler, use_cython):
         # Fix for ROCm 6.3.0, See https://github.com/ROCm/rocThrust/issues/502
         settings['define_macros'].append(
             ('THRUST_DEVICE_SYSTEM', 'THRUST_DEVICE_SYSTEM_HIP'))
-        # Fix for https://github.com/ROCm/rocThrust/commit/df75ae8520fad81f1dc9a4b3b66358137c34daa6
+        # Fix for ROCm 6.3.2 #9098
         settings['define_macros'].append(('__HIP__', '1'))
     settings['define_macros'].append(('CUPY_CACHE_KEY', ctx.cupy_cache_key))
 

--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -334,6 +334,8 @@ def make_extensions(ctx: Context, compiler, use_cython):
         # Fix for ROCm 6.3.0, See https://github.com/ROCm/rocThrust/issues/502
         settings['define_macros'].append(
             ('THRUST_DEVICE_SYSTEM', 'THRUST_DEVICE_SYSTEM_HIP'))
+        # Fix for https://github.com/ROCm/rocThrust/commit/df75ae8520fad81f1dc9a4b3b66358137c34daa6
+        settings['define_macros'].append(('__HIP__', '1'))
     settings['define_macros'].append(('CUPY_CACHE_KEY', ctx.cupy_cache_key))
 
     try:


### PR DESCRIPTION
I've checked #9099 and it seems we need to define an extra macro to pretend it's HIP to mitigate the issue from https://github.com/ROCm/rocThrust/blob/cce4f169de50228a401df104d97b7c90433a87dd/thrust/detail/config/config.h#L24. By using this method we don't need to define THRUST_VERSION 0, which makes it a bit less hacky.