### PR TITLE
Upgrade `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:
-      - id: ruff
+      - id: ruff-check
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.16.6


### PR DESCRIPTION
### Changes

- Run `pre-commit autoupdate`
- Rename `ruff` (deprecated) -> `ruff-check`