### PR TITLE
Fix `cp.empty(None)` to raise `TypeError`

### DIFF
--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -58,12 +58,7 @@ cpdef inline void _check_not_bool(object x) except *:
 @cython.profile(False)
 cpdef inline tuple get_size(object size):
     if size is None:
-        warnings.warn(
-            'Passing None into shape arguments as an alias for () is '
-            'deprecated.',
-            DeprecationWarning,
-        )
-        return ()
+        raise TypeError("Use () not None as shape arguments")
     if cpython.PySequence_Check(size):
         # A numpy.ndarray unconditionally succeeds in PySequence_Check as
         # it implements __getitem__, but zero-dim one is an unsized object

--- a/tests/cupy_tests/core_tests/test_internal.py
+++ b/tests/cupy_tests/core_tests/test_internal.py
@@ -34,10 +34,6 @@ class TestProdSequence(unittest.TestCase):
 
 class TestGetSize:
 
-    def test_none(self):
-        with testing.assert_warns(DeprecationWarning):
-            assert internal.get_size(None) == ()
-
     def check_collection(self, a):
         assert internal.get_size(a) == tuple(a)
 

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -26,9 +26,8 @@ def wrap_take(array, *args, **kwargs):
 class TestNdarrayInit(unittest.TestCase):
 
     def test_shape_none(self):
-        with testing.assert_warns(DeprecationWarning):
-            a = cupy.ndarray(None)
-        assert a.shape == ()
+        with pytest.raises(TypeError):
+            cupy.ndarray(None)
 
     def test_shape_int(self):
         a = cupy.ndarray(3)

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -42,15 +42,13 @@ class TestBasic:
         a.fill(0)
         return a
 
-    @testing.with_requires('numpy>=1.20')
+    @testing.with_requires('numpy>=2.3')
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_empty_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
-            a = xp.empty(None, dtype=dtype, order=order)
-        a.fill(0)
-        return a
+    def test_empty_scalar_none(self, dtype, order):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError, match=r"Use ()"):
+                xp.empty(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
@@ -196,13 +194,13 @@ class TestBasic:
     def test_zeros_scalar(self, xp, dtype, order):
         return xp.zeros((), dtype=dtype, order=order)
 
-    @testing.with_requires('numpy>=1.20')
+    @testing.with_requires('numpy>=2.3')
     @testing.for_CF_orders()
     @testing.for_all_dtypes()
-    @testing.numpy_cupy_array_equal()
-    def test_zeros_scalar_none(self, xp, dtype, order):
-        with testing.assert_warns(DeprecationWarning):
-            return xp.zeros(None, dtype=dtype, order=order)
+    def test_zeros_scalar_none(self, dtype, order):
+        for xp in (numpy, cupy):
+            with pytest.raises(TypeError, match=r"Use ()"):
+                xp.zeros(None, dtype=dtype, order=order)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/9157.

https://numpy.org/devdocs/release/2.3.0-notes.html#expired-deprecations