### PR TITLE
`np.unique_values` may return unsorted data from NumPy 2.3

### DIFF
--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -308,7 +308,8 @@ class TestUnique:
     @testing.numpy_cupy_array_equal()
     def test_unique_values(self, xp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
-        return xp.unique_values(a)
+        out = xp.unique_values(a)  # may not be sorted from NumPy 2.3.
+        return xp.sort(out)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Part of https://github.com/cupy/cupy/issues/9157.

https://numpy.org/devdocs/release/2.3.0-notes.html#unique-values-may-return-unsorted-data