### PR TITLE
Add polyadd function and tests for polynomial addition

### DIFF
--- a/cupy/polynomial/polynomial.py
+++ b/cupy/polynomial/polynomial.py
@@ -1,6 +1,18 @@
 import cupy
 
 
+def polyadd(c1, c2):
+    """Add one polynomial to another.
+
+    Args:
+        c1, c2 (cupy.ndarray): 1-D arrays of polynomial coefficients ordered
+            from low to high.
+
+    Returns:
+        cupy.ndarray: The coefficient array representing their sum.
+    """
+    return cupy.polynomial.polyutils._add(c1, c2)
+
 def polyvander(x, deg):
     """Computes the Vandermonde matrix of given degree.
 

--- a/cupy/polynomial/polyutils.py
+++ b/cupy/polynomial/polyutils.py
@@ -2,6 +2,28 @@ import cupy
 
 import operator
 
+def _add(c1, c2):
+    """Helper function used to implement the `<type>add` functions.
+
+    Parameters
+    ----------
+    c1, c2 : array_like
+        1-d arrays of polynomial coefficients to add.
+
+    Returns
+    -------
+    out : ndarray
+        The sum of the inputs, with trailing zeros removed.
+    """
+    # c1, c2 are trimmed copies
+    [c1, c2] = as_series([c1, c2])
+    if len(c1) > len(c2):
+        c1[:c2.size] += c2
+        ret = c1
+    else:
+        c2[:c1.size] += c1
+        ret = c2
+    return trimseq(ret)
 
 def _as_int(x, desc):
     """
@@ -23,7 +45,6 @@ def _as_int(x, desc):
         return operator.index(x)
     except TypeError as e:
         raise TypeError(f"{desc} must be an integer, received {x}") from e
-
 
 def trimseq(seq):
     """Removes small polynomial series coefficients.

--- a/tests/cupy_tests/polynomial_tests/test_polynomial.py
+++ b/tests/cupy_tests/polynomial_tests/test_polynomial.py
@@ -8,7 +8,42 @@ from cupy import testing
 
 
 class TestPolynomial(unittest.TestCase):
+# Tests for polyadd
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_polyadd_basic(self, xp, dtype):
+        a = xp.array([1, 2, 3], dtype=dtype)
+        b = xp.array([3, 2, 1], dtype=dtype)
+        return xp.polynomial.polynomial.polyadd(a, b)
 
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_polyadd_different_lengths1(self, xp, dtype):
+        a = xp.array([1, 2, 3, 4], dtype=dtype)
+        b = xp.array([3, 2, 1], dtype=dtype)
+        return xp.polynomial.polynomial.polyadd(a, b)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_polyadd_different_lengths2(self, xp, dtype):
+        a = xp.array([1, 2], dtype=dtype)
+        b = xp.array([3, 2, 1, 0, 5], dtype=dtype)
+        return xp.polynomial.polynomial.polyadd(a, b)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_polyadd_zeros(self, xp, dtype):
+        a = xp.zeros(5, dtype=dtype)
+        b = xp.array([1, 2, 3], dtype=dtype)
+        return xp.polynomial.polynomial.polyadd(a, b)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_polyadd_trailing_zeros(self, xp, dtype):
+        a = xp.array([1, 2, 3, 0, 0], dtype=dtype)
+        b = xp.array([3, 2, 1, 0, 0, 0], dtype=dtype)
+        return xp.polynomial.polynomial.polyadd(a, b)
+    
     @testing.for_all_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-5)
     def test_polyvander1(self, xp, dtype):


### PR DESCRIPTION
### Summary

This PR adds a new `polyadd` function to `cupy.polynomial.polynomial`, along with test coverage to validate its correctness.

### Changes
- `cupy/polynomial/polynomial.py`: New `polyadd()` function.
- `cupy/polynomial/polyutils.py`: Internal logic reused for coefficient addition.
- `tests/cupy_tests/polynomial_tests/test_polynomial.py`: Unit tests covering various polynomial combinations and data types.

Let me know if you'd like changes in naming, style, or structure. Thanks!