### PR TITLE
Support loading NCCL from Pip packages

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -418,7 +418,7 @@ def _find_compatible_wheel(
     is_compatible = (
         actual[0] == expected[0] and
         (
-            actual[1] >= expected[1] or
+            actual[1] > expected[1] or
             (actual[1] == expected[1] and actual[2] >= expected[2])
         )
     )

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -33,8 +33,6 @@ Wheel packages are built against specific versions of CUDA libraries
 To avoid loading wrong version, these shared libraries are manually
 preloaded.
 
-# TODO(kmaehashi): Support NCCL
-
 Example of `_preload_config` is as follows:
 
 {
@@ -352,6 +350,11 @@ def _preload_library(lib):
             libpath_cands = (
                 _get_cutensor_from_wheel(min_pypi_version, config['cuda']) +
                 libpath_cands)
+        elif lib == 'nccl':
+            min_pypi_version = config[lib]['min_pypi_version']
+            libpath_cands = (
+                _get_nccl_from_wheel(min_pypi_version, config['cuda']) +
+                libpath_cands)
 
         for libpath in libpath_cands:
             if not os.path.exists(libpath):
@@ -394,47 +397,79 @@ def _parse_version(version: str) -> tuple[int, int, int]:
     return major, minor, patch
 
 
+def _find_compatible_wheel(
+        package_prefix: str, version: str, cuda: str
+) -> importlib.metadata.Distribution | None:
+    """
+    Returns the distribution of the given package name and version
+    installed via pip (e.g., cutensor-cuXX).
+    If the package is not found or incompatible, returns None.
+    """
+    cuda_major_ver, _ = cuda.split('.')
+    pkg = f'{package_prefix}-cu{cuda_major_ver}'
+    try:
+        dist = importlib.metadata.distribution(pkg)
+    except importlib.metadata.PackageNotFoundError:
+        _log(f'{package_prefix} wheel package ({pkg}) not installed')
+        return None
+
+    actual = _parse_version(dist.version)
+    expected = _parse_version(version)
+    is_compatible = (
+        actual[0] == expected[0] and
+        (
+            actual[1] >= expected[1] or
+            (actual[1] == expected[1] and actual[2] >= expected[2])
+        )
+    )
+    if not is_compatible:
+        _log(f'{package_prefix} wheel package ({pkg}) incompatible: '
+             f'expected {version}, found {dist.version}')
+        return None
+    _log(f'{package_prefix} wheel package ({pkg}) found: {dist.version}')
+    return dist
+
+
 def _get_cutensor_from_wheel(version: str, cuda: str) -> list[str]:
     """
     Returns the list of shared library path candidates for cuTENSOR
     installed via Pip (cutensor-cuXX package).
     """
-    cuda_major_ver, _ = cuda.split('.')
-    cutensor_pkg = f'cutensor-cu{cuda_major_ver}'
-    try:
-        cutensor_dist = importlib.metadata.distribution(cutensor_pkg)
-    except importlib.metadata.PackageNotFoundError:
-        _log(f'cuTENSOR wheel package not installed: {cutensor_pkg}')
+    dist = _find_compatible_wheel('cutensor', version, cuda)
+    if dist is None:
         return []
-
-    actual = _parse_version(cutensor_dist.version)
-    expected = _parse_version(version)
-    is_compatible = (
-        actual[0] == expected[0] and
-        actual[1] >= expected[1] and
-        actual[2] >= expected[2]
-    )
-    if is_compatible:
-        _log(f'cuTENSOR wheel found: {cutensor_dist.version}')
-    else:
-        _log('cuTENSOR wheel incompatible: '
-             f'expected {version}, found {cutensor_dist.version}')
-        return []
-
     if sys.platform == 'linux':
         shared_libs = [
-            cutensor_dist.locate_file(
+            dist.locate_file(
                 f'cutensor/lib/libcutensor.so.{version.split(".")[0]}'
             ),
-            cutensor_dist.locate_file(
+            dist.locate_file(
                 f'cutensor/lib/libcutensorMg.so.{version.split(".")[0]}'
             ),
         ]
     else:
         shared_libs = [
-            cutensor_dist.locate_file('cutensor\\bin\\cutensor.dll'),
-            cutensor_dist.locate_file('cutensor\\bin\\cutensorMg.dll'),
+            dist.locate_file('cutensor\\bin\\cutensor.dll'),
+            dist.locate_file('cutensor\\bin\\cutensorMg.dll'),
         ]
+    return [str(lib) for lib in shared_libs]
+
+
+def _get_nccl_from_wheel(version: str, cuda: str) -> list[str]:
+    """
+    Returns the list of shared library path candidates for NCCL
+    installed via Pip (nvidia-nccl-cuXX package).
+    """
+    if sys.platform != 'linux':
+        return []
+    dist = _find_compatible_wheel('nvidia-nccl', version, cuda)
+    if dist is None:
+        return []
+    shared_libs = [
+        dist.locate_file(
+            f'nvidia/nccl/lib/libnccl.so.{version.split(".")[0]}'
+        ),
+    ]
     return [str(lib) for lib in shared_libs]
 
 
@@ -445,11 +480,15 @@ def _preload_warning(lib, exc):
 
     if config['packaging'] == 'pip':
         cuda = config['cuda']
+        cuda_major = cuda.split('.')[0]
         if lib == 'cutensor':
-            cuda_major = cuda.split('.')[0]
             version = config['cutensor']['min_pypi_version']
             major = _parse_version(version)[0]
             cmd = f'pip install "cutensor-cu{cuda_major}>={version},<{major+1}"'  # NOQA
+        elif lib == 'nccl':
+            version = config['nccl']['min_pypi_version']
+            major = _parse_version(version)[0]
+            cmd = f'pip install "nvidia-nccl-cu{cuda_major}>={version},<{major+1}"'  # NOQA
         else:
             cmd = f'python -m cupyx.tools.install_library --library {lib} --cuda {cuda}'  # NOQA
     elif config['packaging'] == 'conda':

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -130,11 +130,12 @@ def _make_nccl_url(public_version, filename):
 
 
 def _make_nccl_record(
-        cuda_version, full_version, public_version,
+        cuda_version, full_version, public_version, min_pypi_version,
         filename_linux_x86_64, filename_linux_aarch64):
     return {
         'cuda': cuda_version,
         'nccl': full_version,
+        'min_pypi_version': min_pypi_version,
         'assets': {
             'Linux:x86_64': {
                 'url': _make_nccl_url(
@@ -152,11 +153,11 @@ def _make_nccl_record(
 
 # https://docs.nvidia.com/deeplearning/nccl/release-notes/overview.html
 _nccl_records.append(_make_nccl_record(
-    '12.x', '2.25.1', '2.25.1',
+    '12.x', '2.25.1', '2.25.1', '2.16.5',
     'nccl_2.25.1-1+cuda12.8_x86_64.txz',
     'nccl_2.25.1-1+cuda12.8_aarch64.txz'))
 _nccl_records.append(_make_nccl_record(
-    '11.x', '2.16.5', '2.16.5',  # CUDA 11.2+
+    '11.x', '2.16.5', '2.16.5', '2.16.5',  # CUDA 11.2+
     'nccl_2.16.5-1+cuda11.8_x86_64.txz',
     'nccl_2.16.5-1+cuda11.8_aarch64.txz'))
 library_records['nccl'] = _nccl_records


### PR DESCRIPTION
Allow loading NCCL from pip/wheel pacakges. This will give users flexibility of using arbitrary NCCL versions installed in the user's environment with CuPy.

We already supports this for cuTENSOR (#6999/#7025).