### PR TITLE
[backport] Bump supported NumPy version to v2.3

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,7 @@ Python Dependencies
 
 NumPy/SciPy-compatible API in CuPy v13 is based on NumPy 1.26 and SciPy 1.11, and has been tested against the following versions:
 
-* `NumPy <https://numpy.org/>`_: v1.22 / v1.23 / v1.24 / v1.25 / v1.26 / v2.0 / 2.1
+* `NumPy <https://numpy.org/>`_: v1.22 / v1.23 / v1.24 / v1.25 / v1.26 / v2.0 / 2.1 / v2.2 / v2.3
 
 * `SciPy <https://scipy.org/>`_ (*optional*): v1.7 / v1.8 / v1.9 / v1.10 / v1.11 / v1.12 / v1.13 / v1.14
 


### PR DESCRIPTION
Backport of #9198 by @kmaehashi