### PR TITLE
[WIP] Add cumulative_sum

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -602,6 +602,7 @@ from cupy._math.sumprod import product  # NOQA
 from cupy._math.sumprod import sum  # NOQA
 from cupy._math.sumprod import cumprod  # NOQA
 from cupy._math.sumprod import cumproduct  # NOQA
+from cupy._math.sumprod import cumulative_sum  # NOQA
 from cupy._math.sumprod import cumsum  # NOQA
 from cupy._math.sumprod import ediff1d  # NOQA
 from cupy._math.sumprod import nancumprod  # NOQA


### PR DESCRIPTION
Hello,

This is a **work-in-progress** PR for implementing the `cupy.cumulative_sum` function.

### Current Progress

- The function has been ported from NumPy, following a similar implementation pattern.
- One key difference from NumPy’s implementation is how the identity value is handled:
  - In NumPy, `add.identity` is used when `include_initial=True`.
  - In CuPy, using `func.identity` raises an `AttributeError` since CuPy’s ufuncs do not have an `identity` attribute.
  - To resolve this, the identity value is passed explicitly to the `_cumulative_func` function. This also allows the same helper to be reused for `cupy.cumulative_prod`.
- Doc string written

### Pending Work

1. **Tests**  
   I need some clarification on whether the test cases for `cupy.cumulative_sum` should:
   - Be integrated into the existing test suite for `cupy.cumsum`, similar to how it's done in NumPy ([reference](https://github.com/numpy/numpy/blob/1fefc5c6b767e86c2642641e7ba7a22ab0cf554b/numpy/lib/tests/test_function_base.py#L734)), 
   OR
   - Be implemented as a separate test class.

2. **Documentation**  