### PR TITLE
Add `cupy.win.cuda129` CI

### DIFF
--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -280,6 +280,12 @@
     "cupy.win.cuda128": [
         "@push",
         "full",
+        "windows",
+        "cuda128"
+    ],
+    "cupy.win.cuda129": [
+        "@push",
+        "full",
         "mini",
         "windows",
         "cuda128"

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -814,6 +814,12 @@
 - project: "cupy.win.cuda128"
   _extern: true
   target: "cuda128"
+  tags: ["@push", "full", "windows", "cuda128"]
+  system: "windows"
+
+- project: "cupy.win.cuda129"
+  _extern: true
+  target: "cuda129"
   tags: ["@push", "full", "mini", "windows", "cuda128"]
   system: "windows"
 


### PR DESCRIPTION
Follows-up #9200. Without this configuration CUDA 12.9 + Windows matrix will not be triggered.