### PR TITLE
Fix coplanarity check in Delaunay triangulation

### DIFF
--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -2482,6 +2482,7 @@ RealType* det
 
     if(detFull >= errBound || -detFull >= errBound ) {
         *det = detFull;
+        return;
     }
 
     *det = 0;


### PR DESCRIPTION
This PR fixes the issue described in #9120.
I am having problems testing it on my machine due to pip installation issues so it is not tested yet.
Since this is a very small change, I would appreciate it if someone with a working local pip installation can help my by running the unit tests after this update.