### PR TITLE
Do not include files listed in `MANIFEST.in` to wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ dynamic = ["version"]
 "Bug Tracker" = "https://github.com/cupy/cupy/issues"
 "Source Code" = "https://github.com/cupy/cupy"
 
+[tool.setuptools]
+# Do not include files listed in MANIFEST.in to wheels.
+include-package-data = false
+
 [tool.setuptools.packages.find]
 include = ["cupy*", "cupyx*", "cupy_backends*"]
 


### PR DESCRIPTION
Follows up #9079. Closes #9226. For `pyproject.toml`, it seems all files listed in `MANIFEST.in` are added to wheel by default without this settings.

https://setuptools.pypa.io/en/latest/userguide/datafiles.html

> To further include them into the wheels, you can use the include_package_data keyword:
> ...
> The default value for `tool.setuptools.include-package-data` is `true` when projects are configured via `pyproject.toml`. This behaviour differs from `setup.cfg` and `setup.py` (where `include_package_data` is False by default)
