### PR TITLE
feat: make `cupy.nan_to_num` broadcast `nan`, `posinf`, and `neginf` kwargs

### DIFF
--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -416,10 +416,6 @@ def _check_nan_inf(x, dtype, neg=None):
         x = 0
     elif x is None and neg is not None:
         x = cupy.finfo(dtype).min if neg else cupy.finfo(dtype).max
-    elif cupy.isnan(x):
-        x = cupy.nan
-    elif cupy.isinf(x):
-        x = cupy.inf * (-1)**(x < 0)
     return cupy.asanyarray(x, dtype)
 
 

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -268,9 +268,16 @@ class TestMisc:
 
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
     @testing.numpy_cupy_array_equal()
-    def test_nan_to_num_broadcast_different_shapes(self, xp, kwarg):
+    def test_nan_to_num_broadcast_different_columns(self, xp, kwarg):
         x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
         y = xp.zeros((2, 1), dtype=xp.float64)
+        return xp.nan_to_num(x, **{kwarg: y})
+
+    @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_broadcast_different_rows(self, xp, kwarg):
+        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        y = xp.zeros((1, 4), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -260,7 +260,21 @@ class TestMisc:
         return y
 
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
-    def test_nan_to_num_broadcast(self, kwarg):
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_broadcast_same_shapes(self, xp, kwarg):
+        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        y = xp.zeros((2, 4), dtype=xp.float64)
+        return xp.nan_to_num(x, **{kwarg: y})
+
+    @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
+    @testing.numpy_cupy_array_equal()
+    def test_nan_to_num_broadcast_different_shapes(self, xp, kwarg):
+        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        y = xp.zeros((2, 1), dtype=xp.float64)
+        return xp.nan_to_num(x, **{kwarg: y})
+
+    @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
+    def test_nan_to_num_broadcast_invalid_shapes(self, kwarg):
         for xp in (numpy, cupy):
             x = xp.asarray([0, 1, xp.nan, 4], dtype=xp.float64)
             y = xp.zeros((2, 4), dtype=xp.float64)

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -262,21 +262,24 @@ class TestMisc:
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_same_shapes(self, xp, kwarg):
-        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        x = xp.asarray(
+            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
         y = xp.zeros((2, 4), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_different_columns(self, xp, kwarg):
-        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        x = xp.asarray(
+            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
         y = xp.zeros((2, 1), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 
     @pytest.mark.parametrize('kwarg', ['nan', 'posinf', 'neginf'])
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_different_rows(self, xp, kwarg):
-        x = xp.asarray([[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+        x = xp.asarray(
+            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
         y = xp.zeros((1, 4), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -263,7 +263,7 @@ class TestMisc:
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_same_shapes(self, xp, kwarg):
         x = xp.asarray(
-            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+            [[0, 1, xp.nan, 4], [11, xp.inf, 12, 13]], dtype=xp.float64)
         y = xp.zeros((2, 4), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 
@@ -271,7 +271,7 @@ class TestMisc:
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_different_columns(self, xp, kwarg):
         x = xp.asarray(
-            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+            [[0, 1, xp.nan, 4], [11, xp.inf, 12, 13]], dtype=xp.float64)
         y = xp.zeros((2, 1), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 
@@ -279,7 +279,7 @@ class TestMisc:
     @testing.numpy_cupy_array_equal()
     def test_nan_to_num_broadcast_different_rows(self, xp, kwarg):
         x = xp.asarray(
-            [[0, 1, xp.nan, 4], [11, xp.nan, 12, 13]], dtype=xp.float64)
+            [[0, 1, xp.nan, 4], [11, -xp.inf, 12, 13]], dtype=xp.float64)
         y = xp.zeros((1, 4), dtype=xp.float64)
         return xp.nan_to_num(x, **{kwarg: y})
 


### PR DESCRIPTION
Fixes https://github.com/cupy/cupy/issues/9143

Following numpy here: https://github.com/numpy/numpy/blob/3ccbc6c29bb56795d32ee685bccdc1e9ca8ae47f/numpy/lib/_type_check_impl.py#L469-L492,
I don't think that cupy should check for `cupy.isnan(x)` and `cupy.isinf(x)` for the user defined arguments `nan`, `posinf`, and `neginf`. Numpy doesn't care about them, and does the `copyto` anyway. I believe that `cupy.asanyarray(x, dtype)` is enough here.

cc @leofang since we went over this at the SciPy sprints.

