### PR TITLE
Increase CPU memory limit of `linux.cuda{128,129}` CIs

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -510,7 +510,7 @@ configs {
   value {
     requirement {
       cpu: 8
-      memory: 50
+      memory: 60
       disk: 10
       gpu: 1
     }
@@ -527,7 +527,7 @@ configs {
   value {
     requirement {
       cpu: 8
-      memory: 50
+      memory: 60
       disk: 10
       gpu: 2
     }
@@ -545,7 +545,7 @@ configs {
   value {
     requirement {
       cpu: 8
-      memory: 50
+      memory: 60
       disk: 10
       gpu: 1
     }
@@ -562,7 +562,7 @@ configs {
   value {
     requirement {
       cpu: 8
-      memory: 50
+      memory: 60
       disk: 10
       gpu: 2
     }


### PR DESCRIPTION
Sometimes CIs are failing with `[ABORTED] excessive memory usage is detected`.

- cuda129: https://ci.preferred.jp/cupy.linux.cuda129/196030/
- cuda128: https://ci.preferred.jp/cupy.linux.cuda128/195922/
