### PR TITLE
[v13] Wrong test skip condition of test_zscore_empty

### DIFF
--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -212,7 +212,7 @@ class TestZscore:
         x = testing.shaped_random((2, 3, 8), xp, dtype=xp.float16)
         return scp.stats.zscore(x, axis=2, ddof=2)
 
-    @testing.with_requires('scipy>=1.15')
+    @testing.with_requires('scipy<1.15')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_zscore_empty(self, xp, scp, dtype):


### PR DESCRIPTION
Wrong `testing.with_requires` condition is added in #9024.