### PR TITLE
Allow host function call during CUDA graph capture

### DIFF
--- a/cupy/cuda/graph.pxd
+++ b/cupy/cuda/graph.pxd
@@ -5,11 +5,13 @@ cdef class Graph:
     cdef:
         readonly intptr_t graph  # cudaGraph_t
         readonly intptr_t graphExec  # cudaGraphExec_t
+        readonly object host_funcargs
 
-    cdef void _init(self, intptr_t g, intptr_t ge) except*
+    cdef void _init(
+        self, intptr_t g, intptr_t ge, object host_funcargs) except*
 
     @staticmethod
-    cdef Graph from_stream(intptr_t g)
+    cdef Graph from_stream(intptr_t g, object host_funcargs)
 
     cpdef launch(self, stream=*)
     cpdef upload(self, stream=*)

--- a/cupy/cuda/graph.pyx
+++ b/cupy/cuda/graph.pyx
@@ -13,9 +13,14 @@ cdef class Graph:
 
     """
 
-    cdef void _init(self, intptr_t graph, intptr_t graphExec) except*:
+    cdef void _init(
+        self, intptr_t graph, intptr_t graphExec, object host_funcargs
+    ) except*:
         self.graph = graph
         self.graphExec = graphExec
+        # Reference to the host functions and arguments captured by
+        # cudaLaunchHostFunc.
+        self.host_funcargs = host_funcargs
 
     def __dealloc__(self):
         if self.graph > 0:
@@ -29,11 +34,11 @@ cdef class Graph:
             'be created via stream capture')
 
     @staticmethod
-    cdef Graph from_stream(intptr_t g):
+    cdef Graph from_stream(intptr_t g, object host_funcargs):
         # TODO(leofang): optionally print out the error log?
         cdef intptr_t ge = runtime.graphInstantiate(g)
         cdef Graph graph = Graph.__new__(Graph)
-        graph._init(g, ge)
+        graph._init(g, ge, host_funcargs)
         return graph
 
     cpdef launch(self, stream=None):

--- a/cupy/cuda/stream.pyx
+++ b/cupy/cuda/stream.pyx
@@ -204,6 +204,7 @@ class _BaseStream:
     def __init__(self, ptr, device_id):
         self.ptr = ptr
         self.device_id = device_id
+        self._graph_host_funcargs: list[tuple] | None = None
 
     def __eq__(self, other):
         # This operator needed as the ptr may be shared between multiple Stream
@@ -265,7 +266,8 @@ class _BaseStream:
         .. note::
             Whenever possible, use the :meth:`launch_host_func` method
             instead of this one, as it may be deprecated and removed from
-            CUDA at some point.
+            CUDA at some point. Also note that this function does not support
+            CUDA graph capture.
 
         """
         def f(stream, status, dummy):
@@ -281,21 +283,23 @@ class _BaseStream:
                 argument (user data object), and returns nothing.
             arg (object): Argument to the callback.
 
-        .. note::
-            Whenever possible, this method is recommended over
-            :meth:`add_callback`, which may be deprecated and removed from
-            CUDA at some point.
-
         .. seealso:: `cudaLaunchHostFunc()`_
 
         .. _cudaLaunchHostFunc():
             https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EXECUTION.html#group__CUDART__EXECUTION_1g05841eaa5f90f27124241baafb3e856f
 
         """
-        def f(dummy):
-            callback(arg)
-
-        runtime.launchHostFunc(self.ptr, f, 0)
+        if self.is_capturing():
+            func_arg = (callback, arg)
+            runtime._launchHostFuncUnmanaged(self.ptr, func_arg)
+            # Keep reference to the host callback function and arguments.
+            # The ownership is later transferred to the captured Graph
+            # instance in `end_capture()`.
+            self._graph_host_funcargs.append(func_arg)
+        else:
+            def f(dummy):
+                callback(arg)
+            runtime.launchHostFunc(self.ptr, f, 0)
 
     def record(self, event=None):
         """Records an event on the stream.
@@ -383,6 +387,7 @@ class _BaseStream:
             # the async APIs, such as cudaMallocAsync.)
             mode = runtime.streamCaptureModeRelaxed
         runtime.streamBeginCapture(self.ptr, mode)
+        self._graph_host_funcargs = []
 
     def end_capture(self):
         """End stream capture and retrieve the constructed CUDA graph.
@@ -401,8 +406,10 @@ class _BaseStream:
         """
         if runtime._is_hip_environment:
             raise RuntimeError('This function is not supported on HIP')
+        host_funcargs = self._graph_host_funcargs
+        self._graph_host_funcargs = None
         cdef intptr_t g = runtime.streamEndCapture(self.ptr)
-        return graph.Graph.from_stream(g)
+        return graph.Graph.from_stream(g, host_funcargs)
 
     def is_capturing(self):
         """Check if the stream is capturing.

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -275,6 +275,7 @@ cpdef streamSynchronize(intptr_t stream)
 cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
                         unsigned int flags=*)
 cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg)
+cpdef _launchHostFuncUnmanaged(intptr_t stream, tuple func_arg)
 cpdef streamQuery(intptr_t stream)
 cpdef streamWaitEvent(intptr_t stream, intptr_t event, unsigned int flags=*)
 cpdef streamBeginCapture(intptr_t stream, int mode=*)

--- a/cupy_backends/cuda/api/runtime.pyx
+++ b/cupy_backends/cuda/api/runtime.pyx
@@ -894,6 +894,12 @@ cdef _HostFnFunc(void* func_arg) with gil:
     cpython.Py_DECREF(obj)
 
 
+cdef _HostFnFuncUnmanaged(void* func_arg) with gil:
+    obj = <object>func_arg
+    func, arg = obj
+    func(arg)
+
+
 cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
                         unsigned int flags=0):
     if _is_hip_environment and stream == 0:
@@ -909,6 +915,10 @@ cpdef streamAddCallback(intptr_t stream, callback, intptr_t arg,
 
 
 cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg):
+    # N.B. Currently this function should not be called during CUDA graph
+    # capture, as the reference to the callback/arg will be DECREFed on the
+    # first callback.
+    # Eventually this should be replaced by `_launchHostFuncUnmanaged`.
     if _is_hip_environment:
         raise RuntimeError('This feature is not supported on HIP')
 
@@ -917,6 +927,20 @@ cpdef launchHostFunc(intptr_t stream, callback, intptr_t arg):
     with nogil:
         status = cudaLaunchHostFunc(
             <driver.Stream>stream, <HostFn>_HostFnFunc,
+            <void*>func_arg)
+    check_status(status)
+
+
+cpdef _launchHostFuncUnmanaged(intptr_t stream, tuple func_arg):
+    # Private API for CuPy internal use only.
+    # The caller is responsible for managing the lifetime of `callback_arg`,
+    # which is a `tuple(callback_function, argument)`.
+    if _is_hip_environment:
+        raise RuntimeError('This feature is not supported on HIP')
+
+    with nogil:
+        status = cudaLaunchHostFunc(
+            <driver.Stream>stream, <HostFn>_HostFnFuncUnmanaged,
             <void*>func_arg)
     check_status(status)
 


### PR DESCRIPTION
This allows use of `Stream.launch_host_func()` during CUDA graph capture.
Closes #9274.
