### PR TITLE
Fix `UnboundLocalError` when `blocking=True`

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2760,8 +2760,8 @@ cdef _ndarray_base _array_default(
     # Fast path: zero-copy a NumPy array if possible
     if not blocking:
         a = _try_skip_h2d_copy(obj, dtype, copy, order, ndmin)
-    if a is not None:
-        return a
+        if a is not None:
+            return a
 
     if order is not None and len(order) >= 1 and order[0] in 'KAka':
         if isinstance(obj, numpy.ndarray) and obj.flags.fnc:

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2718,11 +2718,11 @@ cdef inline _ndarray_base _try_skip_h2d_copy(
     if not (obj_dtype == get_dtype(dtype) if dtype is not None else True):
         return None
 
-    # CuPy onlt supports numerical dtypes
+    # CuPy only supports numerical dtypes
     if obj_dtype.char not in _dtype.all_type_chars:
         return None
 
-    # CUDA onlt supports little endianness
+    # CUDA only supports little endianness
     if obj_dtype.byteorder not in ('|', '=', '<'):
         return None
 

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -38,6 +38,10 @@ class TestFromData(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), numpy, dtype)
         return xp.array(a, order=order)
 
+    def test_array_from_numpy_blocking(self):
+        a = testing.shaped_arange((2, 3, 4), numpy, numpy.float32)
+        testing.assert_array_equal(cupy.array(a, blocking=True), a)
+
     @testing.for_orders('CFAK')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -383,6 +387,10 @@ class TestFromData(unittest.TestCase):
         a = testing.shaped_arange((2, 3, 4), xp, dtype)
         return xp.asarray(a)
 
+    def test_asarray_blocking(self):
+        a = testing.shaped_arange((2, 3, 4), numpy, numpy.float32)
+        testing.assert_array_equal(cupy.asarray(a, blocking=True), a)
+
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_asarray_is_not_copied(self, xp, dtype):
@@ -434,6 +442,10 @@ class TestFromData(unittest.TestCase):
         # Make a computation here as just moving big-endian data back and forth
         # happens to work before the change in #5828
         return b + b
+
+    def test_asanyarray_blocking(self):
+        a = testing.shaped_arange((2, 3, 4), numpy, numpy.float32)
+        testing.assert_array_equal(cupy.asanyarray(a, blocking=True), a)
 
     @testing.for_CF_orders()
     @testing.for_all_dtypes()


### PR DESCRIPTION
This PR fixes `UnboundLocalError` when creating CuPy ndarray with `blocking` e.g. `cp.array(..., blocking=True)`. Closes #9271.

xref #8442, #7939
cc/ @rongou @leofang
