### PR TITLE
CUDA 11.1 or earlier is no longer supported

### DIFF
--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -46,9 +46,7 @@ __device__ long long atomicAdd(long long *address, long long val) {
 }
 #endif // __CUDA_ARCH__
 
-#if (defined(_MSC_VER) && (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 2))
-  #define __builtin_unreachable() __assume(false)
-#endif
+#define __builtin_unreachable() __assume(false)
 
 #else // CUPY_NO_CUDA
 

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -46,8 +46,6 @@ __device__ long long atomicAdd(long long *address, long long val) {
 }
 #endif // __CUDA_ARCH__
 
-#define __builtin_unreachable() __assume(false)
-
 #else // CUPY_NO_CUDA
 
 typedef struct CUstream_st *cudaStream_t;

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -46,6 +46,10 @@ __device__ long long atomicAdd(long long *address, long long val) {
 }
 #endif // __CUDA_ARCH__
 
+#if (defined(_MSC_VER) && (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 2))
+  #define __builtin_unreachable() __assume(false)
+#endif
+
 #else // CUPY_NO_CUDA
 
 typedef struct CUstream_st *cudaStream_t;

--- a/cupyx/scipy/signal/_upfirdn.py
+++ b/cupyx/scipy/signal/_upfirdn.py
@@ -61,12 +61,10 @@ __device__ void _cupy_upfirdn1D( const T *__restrict__ inp,
 
     for ( size_t tid = t; tid < outW; tid += stride ) {
 
-#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
         __builtin_assume( padded_len > 0 );
         __builtin_assume( up > 0 );
         __builtin_assume( down > 0 );
         __builtin_assume( tid > 0 );
-#endif
 
         const int x_idx { static_cast<int>( ( tid * down ) / up ) % padded_len };
         int       h_idx { static_cast<int>( ( tid * down ) % up * h_per_phase ) };
@@ -174,22 +172,16 @@ __device__ void _cupy_upfirdn2D( const T *__restrict__ inp,
             int x_idx {};
             int h_idx {};
 
-#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
             __builtin_assume( padded_len > 0 );
             __builtin_assume( up > 0 );
             __builtin_assume( down > 0 );
-#endif
 
             if ( axis == 1 ) {
-#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
                 __builtin_assume( x > 0 );
-#endif
                 x_idx = ( static_cast<int>( x * down ) / up ) % padded_len;
                 h_idx = ( x * down ) % up * h_per_phase;
             } else {
-#if ( __CUDACC_VER_MAJOR__ >= 11 ) && ( __CUDACC_VER_MINOR__ >= 2 )
                 __builtin_assume( y > 0 );
-#endif
                 x_idx = ( static_cast<int>( y * down ) / up ) % padded_len;
                 h_idx = ( y * down ) % up * h_per_phase;
             }


### PR DESCRIPTION
This is the fix for Issue [#9074](https://github.com/cupy/cupy/issues/9074).

Since cupy no longer supports CUDA 11.1 or earlier, the #if checks from [cupy/cupyx/scipy/signal/_upfirdn.py](https://github.com/cupy/cupy/blob/53127099fe5c441fec97567f57974504342f304d/cupyx/scipy/signal/_upfirdn.py#L62) and [cupy/cupyx/scipy/signal/_upfirdn.py](https://github.com/cupy/cupy/blob/53127099fe5c441fec97567f57974504342f304d/cupyx/scipy/signal/_upfirdn.py#L175) have been removed.