### PR TITLE
Removing duplicate check in `cupyx.scipy.interpolate.interpn`

### DIFF
--- a/cupyx/scipy/interpolate/_rgi.py
+++ b/cupyx/scipy/interpolate/_rgi.py
@@ -635,7 +635,7 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
                                  "in dimension %d" % i)
 
     # perform interpolation
-    interp = RegularGridInterpolator(
-        points, values, method=method, bounds_error=bounds_error, fill_value=fill_value
-    )
+    interp = RegularGridInterpolator(points, values, method=method,
+                                     bounds_error=bounds_error,
+                                     fill_value=fill_value)
     return interp(xi)


### PR DESCRIPTION
The first check, which raises `ValueError` is performed here: https://github.com/cupy/cupy/blob/38f21af5ff342f821b8adb1bc677cde6b8f063ba/cupyx/scipy/interpolate/_rgi.py#L605

There is an additional check at the end, prior to calling `RegularGridInterpolator` here: https://github.com/cupy/cupy/blob/38f21af5ff342f821b8adb1bc677cde6b8f063ba/cupyx/scipy/interpolate/_rgi.py#L638

This second check does not seem necessary, but more importantly Pylance interprets this logic as `interpn -> Any | None` when in reality it should _never_ return `None` due to the `ValueError` raised at the beginning.