### PR TITLE
CUDA 13 Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Choose the right package for your platform.
 | --------------------- | ----------------- | ------------------------------------------------------------- |
 | CUDA 11.x (11.2+)     | x86_64 / aarch64  | `pip install cupy-cuda11x`                                    |
 | CUDA 12.x             | x86_64 / aarch64  | `pip install cupy-cuda12x`                                    |
+| CUDA 13.x             | x86_64 / aarch64  | `pip install cupy-cuda13x`                                    |
 | ROCm 4.3 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-4-3`                                   |
 | ROCm 5.0 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-5-0`                                   |
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,7 @@ Requirements
 
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
 
-* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v11.2 / v11.3 / v11.4 / v11.5 / v11.6 / v11.7 / v11.8 / v12.0 / v12.1 / v12.2 / v12.3 / v12.4 / v12.5 / v12.6 / v12.8 / v12.9
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v11.2 / v11.3 / v11.4 / v11.5 / v11.6 / v11.7 / v11.8 / v12.0 / v12.1 / v12.2 / v12.3 / v12.4 / v12.5 / v12.6 / v12.8 / v12.9 / v13.0
 
     * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.
@@ -85,6 +85,8 @@ Package names are different depending on your CUDA Toolkit version.
      - ``pip install cupy-cuda11x``
    * - **v12.x** (x86_64 / aarch64)
      - ``pip install cupy-cuda12x``
+   * - **v13.x** (x86_64 / aarch64)
+     - ``pip install cupy-cuda13x``
 
 .. note::
 


### PR DESCRIPTION
Readme and install guide updated

Not sure if we should update the examples in the install guide to refer to 13x instead of 12x. I feel that keeping those in 12x for a while is better since it is more "tested"

xref https://github.com/cupy/cupy/issues/9286