### PR TITLE
Support building NVTX on Windows without Nsight Systems

### DIFF
--- a/install/cupy_builder/_environment.py
+++ b/install/cupy_builder/_environment.py
@@ -23,19 +23,32 @@ def _memoize(f: Callable) -> Callable:
 def get_nvtx_path() -> str | None:
     assert sys.platform == 'win32'
 
+    if os.environ.get('CONDA_BUILD', '0') == '1':
+        return os.environ['PREFIX']
+
+    candidates = []
+
+    # $Env:ProgramFiles\NVIDIA Corporation\Nsight Systems 2025.3.2\
+    # target-windows-x64\nvtx\include\nvtx3\nvToolsExt.h
     prog = os.environ.get('ProgramFiles', 'C:\\Program Files')
     pattern = os.path.join(
         prog, 'NVIDIA Corporation', 'Nsight Systems *', 'target-windows-x64',
         'nvtx',
     )
-    print(f'Looking for NVTX: {pattern}')
-    candidates = sorted(glob.glob(pattern))
+    candidates += sorted(p for p in glob.glob(pattern) if os.path.exists(p))
+
+    # $Env:CUDA_PATH\include\nvtx3\nvToolsExt.h
+    cuda_path = os.environ.get('CUDA_PATH', None)
+    if cuda_path is not None:
+        cuda_include_path = os.path.join(cuda_path, 'include')
+        if os.path.exists(cuda_include_path):
+            candidates += [cuda_include_path]
+
+    print(f'Looking for NVTX from: {candidates}')
     if len(candidates) != 0:
-        # Pick the latest one
+        # Pick the one from CUDA_PATH or use the latest one from Nsight
         nvtx = candidates[-1]
         print(f'Using NVTX at: {nvtx}')
         return nvtx
-    if os.environ.get('CONDA_BUILD', '0') == '1':
-        return os.environ['PREFIX']
     print('NVTX could not be found')
     return None


### PR DESCRIPTION
This PR allows building NVTX support in CuPy under environment that does not have Nsight Systems installed.
NVTX3 is placed under `$CUDA_PATH/include` so we can just use it. (I'm not sure why I overlooked this in https://github.com/cupy/cupy/pull/7304#issuecomment-1383431537 ...)

This is a blocker for the next release. Our new Windows CI machine image does not have Nsight installed, thus the wheel build CI is failing (https://ci.preferred.jp/cupy-release-tools.win/198100/).
