### PR TITLE
CI: NVTX1 removed from Windows machine image

### DIFF
--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -84,14 +84,6 @@ function ActivateCuDNN($cudnn_version, $cuda_version) {
     $Env:PATH = "$base\bin;" + $Env:PATH
 }
 
-function ActivateNVTX1() {
-    $base = "C:\Development\NvToolsExt"
-    $Env:NVTOOLSEXT_PATH = "C:\Development\NvToolsExt"
-    $Env:CL = "-I$base\include " + $Env:CL
-    $Env:LINK = "/LIBPATH:$base\lib\x64 " + $Env:LINK
-    $Env:PATH = "$base\bin\x64;" + $Env:PATH
-}
-
 function InstallZLIB() {
     Copy-Item -Path "C:\Development\ZLIB\zlibwapi.dll" -Destination "C:\Windows\System32"
 }

--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -68,7 +68,6 @@ function Main {
     } elseif ($cuda.startswith("12.")) {
         ActivateCuDNN "8.8" $cuda
     }
-    ActivateNVTX1
     ActivatePython $python
 
     # Setup build environment variables


### PR DESCRIPTION
Our new Windows CI machine image does not have NVTX1.
