### PR TITLE
Fix CI failure in CUDA 12.4

### DIFF
--- a/.pfnci/linux/tests/cuda124.Dockerfile
+++ b/.pfnci/linux/tests/cuda124.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.4.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.4.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/linux/tests/cuda124.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda124.multi.Dockerfile
@@ -1,5 +1,5 @@
 # AUTO GENERATED: DO NOT EDIT!
-ARG BASE_IMAGE="nvidia/cuda:12.4.0-devel-ubuntu20.04"
+ARG BASE_IMAGE="nvidia/cuda:12.4.1-devel-ubuntu20.04"
 FROM ${BASE_IMAGE}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -70,7 +70,7 @@ cuda:
     full_version: "12.3.0"
     repository: "nvidia/cuda"
   "12.4":
-    full_version: "12.4.0"
+    full_version: "12.4.1"
     repository: "nvidia/cuda"
   "12.5":
     full_version: "12.5.0"


### PR DESCRIPTION
Fixes regression in #9295. It seems `cuda_fp16.h` bundled with CUDA 12.4.0 has a problem and causing the following error:

https://ci.preferred.jp/cupy.linux.cuda124/198208/

```
ptxas fatal   : Unresolved extern function '_ZN6__halfC1Ef'
```

I locally confirmed this is fixed in CUDA 12.4.1.
