### PR TITLE
CI: Extend Windows cache size

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -27,9 +27,9 @@ function DownloadCache([String]$gcs_dir, [String]$cupy_kernel_cache_file) {
 }
 
 function UploadCache([String]$gcs_dir, [String]$cupy_kernel_cache_file) {
-    # Maximum 1 GB
+    # Maximum 3 GiB
     echo "Trimming kernel cache..."
-    RunOrDie python .pfnci\trim_cupy_kernel_cache.py --max-size 1000000000 --rm
+    RunOrDie python .pfnci\trim_cupy_kernel_cache.py --max-size 3221225472 --rm
 
     pushd $Env:USERPROFILE
     # -mx=0 ... no compression


### PR DESCRIPTION
Adjust the Windows cache size. CI is taking longer than expected (and some variants time out) as the cache no longer fits within 1 GB.

https://ci.preferred.jp/cupy.win.cuda118/198389/
```
05:12:37.640040 STDERR 5808]	Total:   1327341061 bytes, 93202 files	
05:12:37.640040 STDERR 5808]	Valid:   999999309 bytes, 77738 files	
05:12:37.640040 STDERR 5808]	Expired: 327341752 bytes, 15464 files	
```

This PR bumps the size limit to 3 GiB, aligning with Linux CI:
https://github.com/cupy/cupy/blob/541b9c6af4045172cd97a3c045e375189c811519/.pfnci/linux/tests/actions/cleanup.sh#L5

