### PR TITLE
Change default c++ RTC standard from 11 to 14

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2326,14 +2326,33 @@ cdef inline str _translate_cucomplex_to_thrust(str source):
     return ''.join(lines)
 
 
+cpdef bint use_default_std(tuple options):
+    cdef str opt
+    for opt in options:
+        if ('-std=' in opt) or ('--std=' in opt):
+            return False
+    return True
+
+cpdef void warn_on_unsupported_std(tuple options):
+    cdef str opt
+    for opt in options:
+        if _is_hip:
+            major, minor = nvrtc.getVersion()
+            if '-std=c++11' in opt and minor == 0 and major == 7:
+                warnings.warn(
+                    'hipRTC on some ROCm 7.0 builds have a known bug '
+                    'that causes RTC to break when the standard is set '
+                    'to c++11. Please use c++14, or use ROCm >= 7.0'
+                )
+        elif '-std=c++03' in opt:
+            warnings.warn('CCCL requires c++11 or above')
+
+
 cpdef tuple assemble_cupy_compiler_options(tuple options):
-    for op in options:
-        if '-std=c++' in op:
-            if op.endswith('03'):
-                warnings.warn('CCCL requires c++11 or above')
-            break
+    if use_default_std(options):
+        options += ('--std=c++14',)
     else:
-        options += ('--std=c++11',)
+        warn_on_unsupported_std(options)
 
     # make sure bundled CCCL is searched first
     options = (_get_cccl_include_options()

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2342,7 +2342,7 @@ cpdef void warn_on_unsupported_std(tuple options):
                 warnings.warn(
                     'hipRTC on some ROCm 7.0 builds have a known bug '
                     'that causes RTC to break when the standard is set '
-                    'to c++11. Please use c++14, or use ROCm >= 7.0'
+                    'to c++11. Please use c++14, or use ROCm > 7.0'
                 )
         elif '-std=c++03' in opt:
             warnings.warn('CCCL requires c++11 or above')


### PR DESCRIPTION
To help modernize development, AMD would like to bump the default RTC c++ standard from 11 to 14. 

This would give projects using cupy and AMD hardware zero day support for ROCm 7.0.0 and encourage
development using newer standards. Some new features in c++ 14:

* Generic lambdas (`[] (auto x, auto y) { … }`)
* Lambda init-capture (`[p = std::move(p)] { … }`)
* Return type deduction for normal functions (`auto f(){ … }`)
* Relaxed `constexpr` (loops/branches allowed in `constexpr` functions)
* Variable templates (`template<class T> constexpr T k = …;`)
* `std::integer_sequence` / `std::index_sequence`
* `_t` type aliases (e.g., `std::enable_if_t`, `std::decay_t`, `std::remove_reference_t`)
* `std::exchange`
* Binary literals & digit separators (`0b1010`, `1'000'000`)
* `[[deprecated]]` attribute
* More literal/`constexpr`-friendly aggregates and `std::array`

Given that there are no deprecations, tests should not need updating. Once extra CUDA test failures have been identified in the PN CI, I can triage them and create a report on how difficult it would be to upgrade and fix those tests such that we can still upgrade the default.

I have also created two more functions to help improve readability. I understand that this is a personal preference, so I can revert back to placing all c++ standard logic into the assemble_cupy_compiler_options function.

