### PR TITLE
[feat] Fix failing pytest import and add test_raw tests

### DIFF
--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1160,15 +1160,14 @@ void test_grid_sync(const float* x1, const float* x2, float* y, int n) {
     'block': [64, 256],
 }))
 @unittest.skipIf(
-    find_nvcc_ver() >= 12020,
-    "fp16 header compatibility issue, see cupy#8412")
+    cupy.cuda.runtime.is_hip or find_nvcc_ver() >= 12020,
+    "fp16 header compatibility issue, see cupy#8412 (Skip on HIP)")
 @unittest.skipUnless(
     9000 <= cupy.cuda.runtime.runtimeGetVersion(),
     'Requires CUDA 9.x or later')
 @unittest.skipUnless(
     60 <= int(cupy.cuda.device.get_compute_capability()),
     'Requires compute capability 6.0 or later')
-@unittest.skipIf(cupy.cuda.runtime.is_hip, 'Skip on HIP')
 class TestRawGridSync(unittest.TestCase):
 
     def test_grid_sync_rawkernel(self):


### PR DESCRIPTION
Previously, the @unittest.skipIf decorator in test_raw.py was causing an import‑time assertion in find_compiler_ver(), which made pytest abort collection with errors instead of skipping tests.

This commit fixes this by moving the is_hip check up first. Since the pytest skipIfs are evaluated short circuit, there is no call to find_nvcc_ver() which is what caused the import error. 