### PR TITLE
Lazy load the testing module

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import sys
+import importlib.util
 
 import functools as _functools
 import sys as _sys
@@ -45,8 +47,6 @@ from cupy import polynomial  # NOQA
 from cupy import random  # NOQA
 # `cupy.sparse` is deprecated in v8
 from cupy import sparse  # NOQA
-from cupy import testing  # NOQA  # NOQA
-
 
 # import class and function
 from cupy._core import ndarray  # NOQA
@@ -1146,8 +1146,21 @@ def _embed_signatures(dirs):
 
 
 _embed_signatures(globals())
-_embed_signatures(fft.__dict__)
-_embed_signatures(linalg.__dict__)
-_embed_signatures(random.__dict__)
-_embed_signatures(sparse.__dict__)
-_embed_signatures(testing.__dict__)
+
+# Lazy import testing. Set up after _embed_signatures so that we don't access
+# any cupy.testing attributes. cupy.testing does not contain any ufuncs so it
+# is not necessary to call _embed_signatures on it.
+# https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
+
+
+def lazy_import(name):
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
+
+
+testing = lazy_import("cupy.testing")

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-import sys
-import importlib.util
 
 import functools as _functools
 import sys as _sys
@@ -1153,14 +1151,15 @@ _embed_signatures(globals())
 # https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
 
 
-def lazy_import(name):
+def _lazy_import(name):
+    import importlib.util
     spec = importlib.util.find_spec(name)
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader
     module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
+    _sys.modules[name] = module
     loader.exec_module(module)
     return module
 
 
-testing = lazy_import("cupy.testing")
+testing = _lazy_import("cupy.testing")


### PR DESCRIPTION
As part of the import time investigations I have been doing regarding #9324 and #9325 I also noticed that cupy.testing adds significant testing overhead in environments where pytest is installed. I considered making the pytest import lazy or trying to hide its cost in other ways, but ultimately I decided that since most users of cupy do not need the testing module directly the best option would be to make the testing module import in cupy's `__init__.py` lazy and hide all of the overhead. The module load is fast enough that for users actually accessing the testing module the first attribute access (which triggers the load, and is therefore made slower by making this module load lazy) is still less than 0.1 s so it doesn't degrade that experience much (in exchange for making the majority use case of importing cupy without using testing faster).