### PR TITLE
raise ValueErrors for zerodim arrays that define an axis in nanmedian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ htmlcov/
 cupy/.data/
 cupy/cuda/thrust.h
 cupy/_core/numpy_allocator.h
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.enabled": true
+}

--- a/cupy/_statistics/meanvar.py
+++ b/cupy/_statistics/meanvar.py
@@ -62,6 +62,16 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     .. seealso:: :func:`numpy.nanmedian`
 
     """
+    a = cupy.asarray(a)
+    if a.ndim == 0 and axis is not None:
+        if isinstance(axis, (tuple, list)):
+            if len(axis) != 0:
+                raise ValueError(
+                    f"axis {axis} is out of bounds for array of dimension 0")
+        else:
+            raise ValueError(
+                f"axis {axis} is out of bounds for array of dimension 0")
+
     if a.dtype.char in 'efdFD':
         return _statistics._nanmedian(a, axis, out, overwrite_input, keepdims)
     else:

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -135,6 +135,36 @@ class TestNanMedian:
         return xp.ascontiguousarray(out)
 
 
+class TestNanMedianZeroDim:
+    def test_nanmedian_0d_no_axis(self):
+        array_cp = cupy.array(5.0)
+        array_np = numpy.array(5.0)
+        cupy.testing.assert_array_equal(cupy.nanmedian(
+            array_cp), cupy.array(numpy.nanmedian(array_np)))
+
+    def test_nanmedian_0d_empty_tuple(self):
+        array_cp = cupy.array(5.0)
+        array_np = numpy.array(5.0)
+        cupy.testing.assert_array_equal(cupy.nanmedian(
+            array_cp, axis=()), cupy.array(numpy.nanmedian(array_np, axis=())))
+
+    def test_nanmedian_0d_axis_defined(self):
+        array_cp = cupy.array(5.0)
+        array_np = numpy.array(5.0)
+        with pytest.raises(ValueError):
+            cupy.nanmedian(array_cp, axis=0)
+        with pytest.raises(ValueError):
+            numpy.nanmedian(array_np, axis=0)
+
+    def test_nanmedian_0d_incomplete_axis(self):
+        array_cp = cupy.array(5.0)
+        array_np = numpy.array(5.0)
+        with pytest.raises(ValueError):
+            cupy.nanmedian(array_cp, axis=(0,))
+        with pytest.raises(ValueError):
+            numpy.nanmedian(array_np, axis=(0,))
+
+
 class TestAverage:
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
made cupy.nanmedian raise a ValueError when called on a zerodim array with a defined axis to match what NumPy does. also matched NumPy by not raising an error if an empty tuple or list is passed into axis (ex: axis = ())

Fixes #9332 