### PR TITLE
[Bugfix] Fix ComplexWarning error

### DIFF
--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -4,6 +4,7 @@ import numpy
 import warnings
 
 from cupy_backends.cuda.api cimport runtime
+from cupy.exceptions import ComplexWarning
 
 
 cdef str all_type_chars = '?bhilqBHILQefdFD'


### PR DESCRIPTION
cupy is built to work with numpy major versions one and two. This is why classes like cupy.exceptions exist - a user can access numpy exceptions via cupy without having to worry about which version of numpy cupy was built with. 

However, one of the .pyx files directly accesses numpy.ComplexWarning. This is ok if the file was built numpy < 2, but will break in numpy>2 builds. 

This commit fixes this by using the version agnostic cupy.exceptions.