### PR TITLE
feat(import) Raise import error

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os as _os
 
 import functools as _functools
 import sys as _sys
@@ -51,6 +52,11 @@ from cupy import testing  # NOQA  # NOQA
 # import class and function
 from cupy._core import ndarray  # NOQA
 from cupy._core import ufunc  # NOQA
+
+if getattr(cuda.runtime, "is_hip", False) and "ROCM_HOME" not in _os.environ:
+    raise ImportError("ROCM_HOME is not set but a HIP/ROCm backend was "
+                      "detected. Please set with `export ROCM_HOME=/opt/rocm`"
+                      " or similar.")
 
 
 # =============================================================================


### PR DESCRIPTION
There are many issues with RTC and hipcc compilation if ROCM_HOME is not set. This commit makes it impossible to import cupy unless ROCM_HOME has been set. Missing ROCM_HOME error messages can take a long time to triage,. and the error messages from hipcc/hiprtc are usually not helpful for users to debug. 

Hopefully, this will result in less back and forth among development teams.