### PR TITLE
feat(CI) ROCm 6.4.3

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -92,7 +92,7 @@ jobs:
         token: ${{ steps.generate-token.outputs.token }}
         client-payload: |
           {
-            "targets": ["rocm-6-2"],
+            "targets": ["rocm-6-4"],
             "head_sha": "${{ needs.pre-dispatch.outputs.head_sha }}",
             "merge_commit_sha": "${{ needs.pre-dispatch.outputs.merge_commit_sha }}",
             "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",

--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -54,9 +54,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - System
      - 
+     - linux
      - linux
      - linux
      - linux
@@ -142,13 +144,15 @@ CuPy CI Test Coverage
      - `rocm-5-0 <t35_>`_ `🐳 <d35_>`_ `📜 <s35_>`_
      - `rocm-5-3 <t36_>`_ `🐳 <d36_>`_ `📜 <s36_>`_
      - `rocm-6-2 <t37_>`_ `🐳 <d37_>`_ `📜 <s37_>`_
-     - `cuda-slow <t38_>`_ `🐳 <d38_>`_ `📜 <s38_>`_
-     - `cuda-example <t39_>`_ `🐳 <d39_>`_ `📜 <s39_>`_
-     - `cuda-head <t40_>`_ `🐳 <d40_>`_ `📜 <s40_>`_
-     - `cuda12x-cuda-python <t41_>`_ `🐳 <d41_>`_ `📜 <s41_>`_
-     - `benchmark.head <t42_>`_ `🐳 <d42_>`_ `📜 <s42_>`_
-     - `benchmark <t43_>`_ `🐳 <d43_>`_ `📜 <s43_>`_
+     - `rocm-6-4 <t38_>`_ `🐳 <d38_>`_ `📜 <s38_>`_
+     - `cuda-slow <t39_>`_ `🐳 <d39_>`_ `📜 <s39_>`_
+     - `cuda-example <t40_>`_ `🐳 <d40_>`_ `📜 <s40_>`_
+     - `cuda-head <t41_>`_ `🐳 <d41_>`_ `📜 <s41_>`_
+     - `cuda12x-cuda-python <t42_>`_ `🐳 <d42_>`_ `📜 <s42_>`_
+     - `benchmark.head <t43_>`_ `🐳 <d43_>`_ `📜 <s43_>`_
+     - `benchmark <t44_>`_ `🐳 <d44_>`_ `📜 <s44_>`_
    * - 
+     - 
      - 
      - 
      - 
@@ -197,7 +201,8 @@ CuPy CI Test Coverage
      - 
    * - system
      - linux
-     - 44
+     - 45
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -289,6 +294,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - os
      - ubuntu:20.04
      - 39
@@ -330,6 +336,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - 
+     - 
      - ✅
      - ✅
      - ✅
@@ -338,7 +345,7 @@ CuPy CI Test Coverage
      - ✅
    * - 
      - ubuntu:22.04
-     - 3
+     - 4
      - 
      - 
      - 
@@ -376,6 +383,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - 
      - 
@@ -430,9 +438,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - centos:8
      - 🚨
+     - 
      - 
      - 
      - 
@@ -524,9 +534,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - cuda
      - null
-     - 4
+     - 5
      - 
      - 
      - 
@@ -561,6 +572,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -576,6 +588,7 @@ CuPy CI Test Coverage
      - 2
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -665,6 +678,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 11.4
      - 2
@@ -674,6 +688,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -759,6 +774,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 11.6
      - 2
@@ -772,6 +788,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -853,6 +870,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 11.8
      - 7
@@ -870,6 +888,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -947,6 +966,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 12.1
      - 2
@@ -968,6 +988,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1041,6 +1062,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 12.3
      - 2
@@ -1066,6 +1088,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1135,6 +1158,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 12.5
      - 2
@@ -1164,6 +1188,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1229,6 +1254,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 12.8
      - 2
@@ -1262,6 +1288,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1311,6 +1338,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1370,6 +1398,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - rocm
      - null
      - 40
@@ -1407,6 +1436,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1464,6 +1494,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 5.0
      - 1
@@ -1503,6 +1534,7 @@ CuPy CI Test Coverage
      - 
      - 
      - ✅
+     - 
      - 
      - 
      - 
@@ -1558,6 +1590,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 6.2
      - 1
@@ -1605,9 +1638,58 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+   * - 
+     - 6.4
+     - 1
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - ✅
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
    * - nccl
      - null
-     - 4
+     - 5
      - 
      - 
      - 
@@ -1642,6 +1724,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1669,6 +1752,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1746,6 +1830,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 2.18
      - 2
@@ -1769,6 +1854,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1840,6 +1926,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 2.20
      - 2
@@ -1867,6 +1954,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -1934,6 +2022,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 2.22
      - 2
@@ -1981,9 +2070,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 2.25
      - 🚨
+     - 
      - 
      - 
      - 
@@ -2072,6 +2163,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
@@ -2122,9 +2214,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - cutensor
      - null
-     - 8
+     - 9
      - ✅
      - ✅
      - 
@@ -2157,6 +2250,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2210,6 +2304,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - ✅
      - ✅
@@ -2218,7 +2313,7 @@ CuPy CI Test Coverage
      - ✅
    * - cusparselt
      - null
-     - 38
+     - 39
      - ✅
      - ✅
      - ✅
@@ -2253,6 +2348,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2310,6 +2406,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - python
      - 3.10
      - 9
@@ -2355,11 +2452,12 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - ✅
    * - 
      - 3.11
-     - 13
+     - 14
      - 
      - 
      - 
@@ -2398,6 +2496,7 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
      - 
      - 
      - 
@@ -2445,6 +2544,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - ✅
      - ✅
      - ✅
@@ -2482,6 +2582,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -2545,9 +2646,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - numpy
      - 1.24
-     - 7
+     - 8
      - ✅
      - ✅
      - ✅
@@ -2586,6 +2688,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - 
      - 
      - 
@@ -2639,6 +2742,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 1.26
      - 14
@@ -2680,6 +2784,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - ✅
      - ✅
      - 
@@ -2711,6 +2816,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -2780,6 +2886,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 2.2
      - 6
@@ -2811,6 +2918,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -2871,12 +2979,14 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
    * - 
      - pre
      - 1
+     - 
      - 
      - 
      - 
@@ -2968,6 +3078,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 1.10
      - 3
@@ -3006,6 +3117,7 @@ CuPy CI Test Coverage
      - 
      - 
      - ✅
+     - 
      - 
      - 
      - 
@@ -3062,9 +3174,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 1.12
-     - 7
+     - 8
      - 
      - 
      - 
@@ -3103,6 +3216,7 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
      - 
      - 
      - 
@@ -3132,6 +3246,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -3197,6 +3312,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - 
+     - 
      - ✅
      - ✅
      - 
@@ -3236,6 +3352,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -3294,12 +3411,14 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
    * - 
      - pre
      - 1
+     - 
      - 
      - 
      - 
@@ -3391,9 +3510,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 3
-     - 33
+     - 34
      - ✅
      - ✅
      - ✅
@@ -3432,6 +3552,7 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - 
+     - ✅
      - ✅
      - ✅
      - 
@@ -3482,6 +3603,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
@@ -3528,13 +3650,14 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
      - 
    * - mpi4py
      - null
-     - 28
+     - 29
      - ✅
      - ✅
      - ✅
@@ -3569,6 +3692,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3626,6 +3750,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - 4
      - 3
@@ -3673,9 +3798,10 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - cython
      - 3.0
-     - 36
+     - 37
      - 
      - 
      - ✅
@@ -3710,6 +3836,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3767,6 +3894,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - pre
      - 🚨
@@ -3814,9 +3942,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - fastrlock
      - latest
-     - 44
+     - 45
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3863,7 +3993,8 @@ CuPy CI Test Coverage
      - ✅
    * - cuda-python
      - null
-     - 43
+     - 44
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3952,12 +4083,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
    * - env:CUPY_ACCELERATORS
      - null
-     - 4
+     - 5
      - 
      - 
      - 
@@ -3992,6 +4124,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -4007,6 +4140,7 @@ CuPy CI Test Coverage
      - 3
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -4096,6 +4230,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - cub,cutensor
      - 3
@@ -4103,6 +4238,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
      - 
      - 
      - 
@@ -4184,6 +4320,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
@@ -4192,7 +4329,7 @@ CuPy CI Test Coverage
      - ✅
    * - test
      - unit
-     - 23
+     - 24
      - ✅
      - 
      - ✅
@@ -4227,6 +4364,7 @@ CuPy CI Test Coverage
      - 
      - ✅
      - 
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -4284,9 +4422,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
    * - 
      - unit-slow
      - 1
+     - 
      - 
      - 
      - 
@@ -4373,6 +4513,7 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
      - ✅
      - 
      - 
@@ -4381,6 +4522,7 @@ CuPy CI Test Coverage
    * - 
      - benchmark
      - 2
+     - 
      - 
      - 
      - 
@@ -4540,21 +4682,24 @@ CuPy CI Test Coverage
 .. _t37: https://github.com/cupy/self-hosted-ci/actions/workflows/ci.yml
 .. _d37: linux/tests/rocm-6-2.Dockerfile
 .. _s37: linux/tests/rocm-6-2.sh
-.. _t38: https://ci.preferred.jp/cupy.linux.cuda-slow/
-.. _d38: linux/tests/cuda-slow.Dockerfile
-.. _s38: linux/tests/cuda-slow.sh
-.. _t39: https://ci.preferred.jp/cupy.linux.cuda-example/
-.. _d39: linux/tests/cuda-example.Dockerfile
-.. _s39: linux/tests/cuda-example.sh
-.. _t40: https://ci.preferred.jp/cupy.linux.cuda-head/
-.. _d40: linux/tests/cuda-head.Dockerfile
-.. _s40: linux/tests/cuda-head.sh
-.. _t41: https://ci.preferred.jp/cupy.linux.cuda12x-cuda-python/
-.. _d41: linux/tests/cuda12x-cuda-python.Dockerfile
-.. _s41: linux/tests/cuda12x-cuda-python.sh
-.. _t42: https://ci.preferred.jp/cupy.linux.benchmark.head/
-.. _d42: linux/tests/benchmark.head.Dockerfile
-.. _s42: linux/tests/benchmark.head.sh
-.. _t43: https://ci.preferred.jp/cupy.linux.benchmark.pr/
-.. _d43: linux/tests/benchmark.Dockerfile
-.. _s43: linux/tests/benchmark.sh
+.. _t38: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-6-4,label=mnj-mi50/
+.. _d38: linux/tests/rocm-6-4.Dockerfile
+.. _s38: linux/tests/rocm-6-4.sh
+.. _t39: https://ci.preferred.jp/cupy.linux.cuda-slow/
+.. _d39: linux/tests/cuda-slow.Dockerfile
+.. _s39: linux/tests/cuda-slow.sh
+.. _t40: https://ci.preferred.jp/cupy.linux.cuda-example/
+.. _d40: linux/tests/cuda-example.Dockerfile
+.. _s40: linux/tests/cuda-example.sh
+.. _t41: https://ci.preferred.jp/cupy.linux.cuda-head/
+.. _d41: linux/tests/cuda-head.Dockerfile
+.. _s41: linux/tests/cuda-head.sh
+.. _t42: https://ci.preferred.jp/cupy.linux.cuda12x-cuda-python/
+.. _d42: linux/tests/cuda12x-cuda-python.Dockerfile
+.. _s42: linux/tests/cuda12x-cuda-python.sh
+.. _t43: https://ci.preferred.jp/cupy.linux.benchmark.head/
+.. _d43: linux/tests/benchmark.head.Dockerfile
+.. _s43: linux/tests/benchmark.head.sh
+.. _t44: https://ci.preferred.jp/cupy.linux.benchmark.pr/
+.. _d44: linux/tests/benchmark.Dockerfile
+.. _s44: linux/tests/benchmark.sh

--- a/.pfnci/linux/tests/rocm-6-4.Dockerfile
+++ b/.pfnci/linux/tests/rocm-6-4.Dockerfile
@@ -1,0 +1,41 @@
+# AUTO GENERATED: DO NOT EDIT!
+ARG BASE_IMAGE="rocm/dev-ubuntu-22.04:6.4.3-complete"
+FROM ${BASE_IMAGE}
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    ( apt-get -qqy update || true ) && \
+    apt-get -qqy install ca-certificates && \
+    curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -qqy update && \
+    apt-get -qqy install \
+       make build-essential libssl-dev zlib1g-dev \
+       libbz2-dev libreadline-dev libsqlite3-dev wget \
+       curl llvm libncursesw5-dev xz-utils tk-dev \
+       libxml2-dev libxmlsec1-dev libffi-dev \
+       liblzma-dev \
+\
+       && \
+    apt-get -qqy install ccache git curl && \
+    apt-get -qqy --allow-change-held-packages \
+            --allow-downgrades install 
+
+ENV PATH "/usr/lib/ccache:${PATH}"
+
+ENV ROCM_HOME "/opt/rocm"
+ENV LD_LIBRARY_PATH "${ROCM_HOME}/lib"
+ENV CPATH "${ROCM_HOME}/include"
+ENV LDFLAGS "-L${ROCM_HOME}/lib"
+
+RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
+ENV PYENV_ROOT "/opt/pyenv"
+ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+RUN pyenv install 3.11.10 && \
+    pyenv global 3.11.10 && \
+    pip install -U setuptools pip wheel
+
+RUN pip install -U 'numpy==1.24.*' 'scipy==1.12.*' 'optuna==3.*' 'cython==3.0.*' 'fastrlock>=0.5'
+RUN pip uninstall -y mpi4py cuda-python && \
+    pip check
+
+RUN mkdir /home/cupy-user && chmod 777 /home/cupy-user

--- a/.pfnci/linux/tests/rocm-6-4.sh
+++ b/.pfnci/linux/tests/rocm-6-4.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# AUTO GENERATED: DO NOT EDIT!
+
+set -uex
+
+ACTIONS="$(dirname $0)/actions"
+. "$ACTIONS/_environment.sh"
+
+hipconfig
+
+# TODO(kmaehashi): Tentatively sparsen parameterization to make test run complete.
+export CUPY_TEST_FULL_COMBINATION="0"
+export CUPY_INSTALL_USE_HIP=1
+
+echo "================ Environment Variables ================"
+env
+echo "======================================================="
+
+"$ACTIONS/build.sh"
+"$ACTIONS/unittest.sh" "not slow and not multi_gpu"
+"$ACTIONS/cleanup.sh"

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -619,6 +619,31 @@
   env:CUPY_ACCELERATORS: null
   test: "unit"
 
+  # ROCm 6.4 | Linux
+  # The latest ROCm version matrix is intended to cover the highest supported combination.
+- project: "cupy.linux.rocm-6-4"
+  _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-6-4,label=mnj-mi50/"
+  tags: null  # self-hosted
+  target: "rocm-6-4"
+  system: "linux"
+  os: "ubuntu:22.04"
+  cuda: null
+  rocm: '6.4'
+  nccl: null
+  cutensor: null
+  cusparselt: null
+  cudnn: null
+  python: "3.11"
+  numpy: "1.24"
+  scipy: "1.12"
+  optuna: "3"
+  mpi4py: null
+  cython: "3.0"
+  fastrlock: "latest"
+  cuda-python: null
+  env:CUPY_ACCELERATORS: null
+  test: "unit"
+
 ###############################################################################
 # Slow Tests
 ###############################################################################

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -619,8 +619,8 @@
   env:CUPY_ACCELERATORS: null
   test: "unit"
 
-  # ROCm 6.4 | Linux
-  # The latest ROCm version matrix is intended to cover the highest supported combination.
+# ROCm 6.4 | Linux
+# The latest ROCm version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.rocm-6-4"
   _url: "https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-6-4,label=mnj-mi50/"
   tags: null  # self-hosted

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -111,6 +111,9 @@ rocm:
     packages: ['rocm-dev', 'hipblas', 'hipfft', 'hipsparse', 'hipcub',
                'rocsparse', 'rocrand', 'hiprand', 'rocthrust', 'rocsolver', 'rocfft',
                'rocprim', 'rccl', 'roctracer-dev']
+  "6.4":
+    full_version: "6.4.3-complete"
+    packages: []
 
 ###############################################################################
 # CUDA Optional Libraries


### PR DESCRIPTION
Added support for ROCm 6.4.3 in CI. Using the complete image so that we don't have to download additional dependencies. 

Confirmed that the build compiles on gfx90a. Let me know if there is anything else that I have to do.