### PR TITLE
feat(tests): fix `mvdr` failure on float32

### DIFF
--- a/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
+++ b/tests/cupyx_tests/signal_tests/radartools_tests/test_radartools.py
@@ -158,4 +158,8 @@ def test_mvdr(dtype):
     sv = cupy.array([1, 2], dtype=dtype)
     out = signal.mvdr(x, sv)
     assert out.dtype == dtype
-    testing.assert_allclose(out, [-2, 1.5])
+
+    expected = cupy.array([-2, 1.5], dtype=dtype)
+    rtol = 1e-6 if dtype == numpy.float32 else 1e-12
+    atol = 1e-6 if dtype == numpy.float32 else 0.0
+    testing.assert_allclose(out, expected, rtol=rtol, atol=atol)


### PR DESCRIPTION
The test was comparing results from `mvdr` against `[-2, 1.5]` with an extremely tight tolerance (`rtol=1e-7, atol=0`). On **float32** this is stricter than the natural rounding error of the type, so values like `[-1.9999995, 1.4999998]` (mathematically equal for single precision) caused a failure.

This change makes the test match the precision of the data type:

* Build the expected array in the **same dtype** as the output.
* Use **dtype-aware tolerances** (looser for float32, tighter for float64).

No algorithmic changes—only the assertion threshold. This keeps the test meaningful while avoiding false negatives due to normal single-precision rounding.

Example before vs after (float32):

* before: expected `[-2, 1.5]` vs actual `[-1.9999995, 1.4999998]`
* after: same values within float32-appropriate tolerance

This should also reduce flakiness across different GPUs/compilers.