### PR TITLE
feat(kernels) fix HIPRTC build error ROCm 6/7

### DIFF
--- a/cupyx/scipy/signal/windows/_windows.py
+++ b/cupyx/scipy/signal/windows/_windows.py
@@ -68,7 +68,6 @@ _general_cosine_kernel = cupy.ElementwiseKernel(
     w = temp;
     """,
     "_general_cosine_kernel",
-    options=("-std=c++11",),
     loop_prep="const double delta { ( M_PI - -M_PI ) / ( _ind.size() - 1 ) }",
 )
 
@@ -232,9 +231,8 @@ _triang_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_triang_kernel",
-    options=("-std=c++11",),
     loop_prep="const int m { static_cast<int>( 0.5 * _ind.size() ) }; \
-               const bool odd { _ind.size() & 1 };",
+               const bool odd { (_ind.size() & 1) != 0 };",
 )
 
 
@@ -330,10 +328,9 @@ _parzen_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_parzen_kernel",
-    options=("-std=c++11",),
     loop_prep="const double start { 0.5 * -( _ind.size () - 1 ) }; \
                const double den { 1.0 / ( 0.5 * _ind.size () ) }; \
-               const bool odd { _ind.size() & 1 }; \
+               const bool odd { (_ind.size() & 1) != 0 }; \
                double s1 { floor(-0.25 * ( _ind.size () - 1 ) ) }; \
                double s2 { floor(0.25 * ( _ind.size () - 1 ) ) };",
 )
@@ -413,7 +410,6 @@ _bohman_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_bohman_kernel",
-    options=("-std=c++11",),
     loop_prep="const double delta { 2.0 / ( _ind.size() - 1 ) }; \
                const double start { -1.0 + delta };",
 )
@@ -749,7 +745,6 @@ _bartlett_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_bartlett_kernel",
-    options=("-std=c++11",),
     loop_prep="const double N { 1.0 / ( _ind.size() - 1 ) }; \
                const double temp { 0.5 * ( _ind.size() - 1 ) };",
 )
@@ -953,7 +948,6 @@ _tukey_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_tukey_kernel",
-    options=("-std=c++11",),
     loop_prep="const double N { 1.0 / ( _ind.size() - 1 ) }; \
                const int width { static_cast<int>( alpha * \
                    ( _ind.size() - 1 ) * 0.5 ) }",
@@ -1047,7 +1041,6 @@ _barthann_kernel = cupy.ElementwiseKernel(
     w = 0.62 - 0.48 * fac + 0.38 * cos(2.0 * M_PI * fac);
     """,
     "_barthann_kernel",
-    options=("-std=c++11",),
     loop_prep="const double N { 1.0 / ( _ind.size() - 1 ) };",
 )
 
@@ -1205,7 +1198,6 @@ _hamming_kernel = cupy.ElementwiseKernel(
     w = 0.54 - 0.46 * cos(2.0 * M_PI * i * N);
     """,
     "_hamming_kernel",
-    options=("-std=c++11",),
     loop_prep="const double N { 1.0 / ( _ind.size() - 1 ) };",
 )
 
@@ -1300,7 +1292,6 @@ _kaiser_kernel = cupy.ElementwiseKernel(
         cyl_bessel_i0( beta );
     """,
     "_kaiser_kernel",
-    options=("-std=c++11",),
     loop_prep="const double alpha { 0.5 * ( _ind.size() - 1 ) };",
 )
 
@@ -1494,7 +1485,6 @@ _gaussian_kernel = cupy.ElementwiseKernel(
     w = exp( - ( n * n ) / sig2 );
     """,
     "_gaussian_kernel",
-    options=("-std=c++11",),
     loop_prep="const double sig2 { 2.0 * std * std };",
 )
 
@@ -1569,7 +1559,6 @@ _general_gaussian_kernel = cupy.ElementwiseKernel(
     w = exp( -0.5 * pow( abs( n / sig ), 2.0 * p ) );
     """,
     "_general_gaussian_kernel",
-    options=("-std=c++11",),
 )
 
 
@@ -1666,9 +1655,8 @@ _chebwin_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_chebwin_kernel",
-    options=("-std=c++11",),
     loop_prep="const double N { M_PI * ( 1.0 / _ind.size() ) }; \
-               const bool odd { _ind.size() & 1 };",
+               const bool odd { (_ind.size() & 1) != 0 };",
 )
 
 
@@ -1804,7 +1792,6 @@ _cosine_kernel = cupy.ElementwiseKernel(
     w = sin( M_PI / _ind.size() * ( i + 0.5 ) );
     """,
     "_cosine_kernel",
-    options=("-std=c++11",),
 )
 
 
@@ -1875,7 +1862,6 @@ _exponential_kernel = cupy.ElementwiseKernel(
     w = exp( -abs( i - center ) / tau );
     """,
     "_exponential_kernel",
-    options=("-std=c++11",),
 )
 
 
@@ -1993,7 +1979,6 @@ _taylor_kernel = cupy.ElementwiseKernel(
     out *= scale;
     """,
     "_taylor_kernel",
-    options=("-std=c++11",),
     loop_prep="const double mod_pi { 2.0 * M_PI / _ind.size() }",
 )
 

--- a/cupyx/signal/_acoustics/_cepstrum.py
+++ b/cupyx/signal/_acoustics/_cepstrum.py
@@ -30,7 +30,6 @@ _real_cepstrum_kernel = cupy.ElementwiseKernel(
     output = log( abs( spectrum ) );
     """,
     "_real_cepstrum_kernel",
-    options=("-std=c++11",),
 )
 
 
@@ -71,7 +70,6 @@ _complex_cepstrum_kernel = cupy.ElementwiseKernel(
     output = log( abs( spectrum ) ) + C( 0, temp );
     """,
     "_complex_cepstrum_kernel",
-    options=("-std=c++11",),
     return_tuple=True,
     loop_prep="const int center { static_cast<int>( 0.5 * \
         ( _ind.size() + 1 ) ) };",
@@ -117,7 +115,6 @@ _inverse_complex_cepstrum_kernel = cupy.ElementwiseKernel(
     spectrum = exp( C( log_spectrum.real(), wrapped ) )
     """,
     "_inverse_complex_cepstrum_kernel",
-    options=("-std=c++11",),
     loop_prep="const double center { 0.5 * ( _ind.size() + 1 ) };",
 )
 
@@ -160,8 +157,7 @@ _minimum_phase_kernel = cupy.ElementwiseKernel(
     }
     """,
     "_minimum_phase_kernel",
-    options=("-std=c++11",),
-    loop_prep="const bool odd { _ind.size() & 1 }; \
+    loop_prep="const bool odd { (_ind.size() & 1) != 0 }; \
                const int bend { static_cast<int>( 0.5 * \
                     ( _ind.size() + odd ) ) };",
 )


### PR DESCRIPTION
`const bool odd{ _ind.size() & 1 };` triggered a hard compile error under clang/HIPRTC:

> non-constant-expression cannot be narrowed from type ‘ptrdiff\_t’ to ‘bool’ in initializer list \[-Wc++11-narrowing]

C++11 **list-initialization** (`{...}`) forbids implicit narrowing conversions. Here `_ind.size()` returns an integral type (e.g., `ptrdiff_t`), and brace- initializing a `bool` from a non-constant integral expression is ill-formed.

Change the expression to produce a real `bool`:

```cpp
const bool odd{ (_ind.size() & 1) != 0 };  // (or: _ind.size() % 2 != 0)
```

This avoids narrowing, keeps brace-init, and restores compatibility with HIPRTC/clang and other strict compilers/flags.

We have also updated kernels to use the default hipRTC compilation standard (14). This enables cepstrum tests on ROCm 7.0

@kmaehashi It would be great to get this backported to v13 since this doesn't break any behavior