### PR TITLE
feat(JIT) Remove CCCL includes dir

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2354,10 +2354,11 @@ cpdef tuple assemble_cupy_compiler_options(tuple options):
     else:
         warn_on_unsupported_std(options)
 
-    # make sure bundled CCCL is searched first
-    options = (_get_cccl_include_options()
-               + options
-               + ('-I%s' % _get_header_dir_path(),))
+    if not _is_hip:
+        # make sure bundled CCCL is searched first
+        options += (_get_cccl_include_options(),)
+
+    options += ('-I%s' % _get_header_dir_path(),)
 
     global _cuda_path
     if _cuda_path == '':

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2356,7 +2356,7 @@ cpdef tuple assemble_cupy_compiler_options(tuple options):
 
     if not _is_hip:
         # make sure bundled CCCL is searched first
-        options += (_get_cccl_include_options(),)
+        options = (_get_cccl_include_options() + options)
 
     options += ('-I%s' % _get_header_dir_path(),)
 


### PR DESCRIPTION
Cupy bundles cccl include directories inside of it's wheel. When building compilation commands, cupy will also place CCCL directories first in the include path. This means that if any kernel includes a CCCL header (thrust, cub, etc), hipcc or hiprtc will read the actual CUDA header rather than the system thrust/cub/etc. This will result in failures on hip systems.

This commit now only adds CCCL headers if on CUDA.

@kmaehashi It would be great to get this into v13 since it is just a bug fix. 