### PR TITLE
Fix cuTENSOR workspace size query

### DIFF
--- a/cupy_backends/cuda/libs/cutensor.pxd
+++ b/cupy_backends/cuda/libs/cutensor.pxd
@@ -184,7 +184,7 @@ cpdef intptr_t createPlan(
     intptr_t pref,
     uint64_t workspaceSizeLimit) except? 0
 
-cpdef getPlanAttribute(
+cpdef planGetAttribute(
     intptr_t handle,
     intptr_t plan,
     int attr,

--- a/cupy_backends/cuda/libs/cutensor.pxd
+++ b/cupy_backends/cuda/libs/cutensor.pxd
@@ -48,7 +48,7 @@ cpdef enum:
     WORKSPACE_MAX = 3          # NOQA, All algorithms will be available
 
     # cutensorPlanAttribute_t
-    PLAN_REQUIRED_WORKSPACE = 0 # NOQA, The required workspace size for the plan
+    PLAN_REQUIRED_WORKSPACE = 0  # NOQA, The required workspace size for the plan
 
     # cutensorOperator_t (Unary)
     OP_IDENTITY = 1  # NOQA, Identity operator (i.e., elements are not changed)
@@ -185,10 +185,10 @@ cpdef intptr_t createPlan(
     uint64_t workspaceSizeLimit) except? 0
 
 cpdef getPlanAttribute(
-    intptr_t handle, 
-    intptr_t plan, 
-    int attr, 
-    intptr_t buf, 
+    intptr_t handle,
+    intptr_t plan,
+    int attr,
+    intptr_t buf,
     size_t sizeInBytes)
 
 cpdef destroyPlan(intptr_t plan)

--- a/cupy_backends/cuda/libs/cutensor.pxd
+++ b/cupy_backends/cuda/libs/cutensor.pxd
@@ -47,6 +47,9 @@ cpdef enum:
     WORKSPACE_RECOMMENDED = 2  # NOQA, The most suitable algorithm will be available
     WORKSPACE_MAX = 3          # NOQA, All algorithms will be available
 
+    # cutensorPlanAttribute_t
+    PLAN_REQUIRED_WORKSPACE = 0 # NOQA, The required workspace size for the plan
+
     # cutensorOperator_t (Unary)
     OP_IDENTITY = 1  # NOQA, Identity operator (i.e., elements are not changed)
     OP_SQRT = 2      # NOQA, Square root
@@ -180,6 +183,14 @@ cpdef intptr_t createPlan(
     intptr_t desc,
     intptr_t pref,
     uint64_t workspaceSizeLimit) except? 0
+
+cpdef getPlanAttribute(
+    intptr_t handle, 
+    intptr_t plan, 
+    int attr, 
+    intptr_t buf, 
+    size_t sizeInBytes)
+
 cpdef destroyPlan(intptr_t plan)
 
 # cutensorElementwiseTrinary

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -78,10 +78,10 @@ cdef extern from '../../cupy_cutensor.h' nogil:
         PlanPreference_t pref,
         uint64_t workspaceSizeLimit)
     Status_t cutensorPlanGetAttribute(
-        Handle_t handle, 
-        Plan_t plan, 
-        PlanAttribute_t attr, 
-        void* buf, 
+        Handle_t handle,
+        Plan_t plan,
+        PlanAttribute_t attr,
+        void* buf,
         size_t sizeInBytes)
     Status_t cutensorDestroyPlan(Plan_t plan)
 
@@ -394,11 +394,16 @@ cpdef intptr_t createPlan(
     check_status(status)
     return <intptr_t>plan
 
-cpdef getPlanAttribute(intptr_t handle, intptr_t plan, int attr, intptr_t buf, size_t sizeInBytes):
+cpdef getPlanAttribute(
+        intptr_t handle,
+        intptr_t plan,
+        int attr,
+        intptr_t buf,
+        size_t sizeInBytes):
     """Retrieves information about an already-created plan."""
     with nogil:
         status = cutensorPlanGetAttribute(
-            <Handle_t>handle, <Plan_t>plan, 
+            <Handle_t>handle, <Plan_t>plan,
             <PlanAttribute_t>attr, <void*>buf, <size_t>sizeInBytes)
     check_status(status)
 

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -20,6 +20,7 @@ cdef extern from '../../cupy_cutensor.h' nogil:
     ctypedef int JitMode_t 'cutensorJitMode_t'
     ctypedef int Operator_t 'cutensorOperator_t'
     ctypedef int WorksizePreference_t 'cutensorWorksizePreference_t'
+    ctypedef int PlanAttribute_t 'cutensorPlanAttribute_t'
     ctypedef int DataType_t 'cutensorDataType_t'
     ctypedef int ComputeType_t 'cutensorComputeType_t'
 
@@ -76,6 +77,12 @@ cdef extern from '../../cupy_cutensor.h' nogil:
         OperationDescriptor_t desc,
         PlanPreference_t pref,
         uint64_t workspaceSizeLimit)
+    Status_t cutensorPlanGetAttribute(
+        Handle_t handle, 
+        Plan_t plan, 
+        PlanAttribute_t attr, 
+        void* buf, 
+        size_t sizeInBytes)
     Status_t cutensorDestroyPlan(Plan_t plan)
 
     # cutensorElementwiseTrinary
@@ -386,6 +393,14 @@ cpdef intptr_t createPlan(
             <PlanPreference_t>pref, workspaceSizeLimit)
     check_status(status)
     return <intptr_t>plan
+
+cpdef getPlanAttribute(intptr_t handle, intptr_t plan, int attr, intptr_t buf, size_t sizeInBytes):
+    """Retrieves information about an already-created plan."""
+    with nogil:
+        status = cutensorPlanGetAttribute(
+            <Handle_t>handle, <Plan_t>plan, 
+            <PlanAttribute_t>attr, <void*>buf, <size_t>sizeInBytes)
+    check_status(status)
 
 cpdef destroyPlan(intptr_t plan):
     with nogil:

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -394,7 +394,7 @@ cpdef intptr_t createPlan(
     check_status(status)
     return <intptr_t>plan
 
-cpdef getPlanAttribute(
+cpdef planGetAttribute(
         intptr_t handle,
         intptr_t plan,
         int attr,

--- a/cupy_backends/stub/cupy_cutensor.h
+++ b/cupy_backends/stub/cupy_cutensor.h
@@ -21,6 +21,7 @@ extern "C" {
     typedef enum {} cutensorPlan_t;
     typedef enum {} cutensorPlanPreference_t;
     typedef enum {} cutensorPlanPreferenceAttribute_t;
+    typedef enum {} cutensorPlanAttribute_t;
     typedef enum {} cutensorJitMode_t;
     typedef enum {} cutensorCacheMode_t;
     typedef enum {} cutensorWorksizePreference_t;
@@ -102,6 +103,10 @@ extern "C" {
     }
 
     cutensorStatus_t cutensorCreatePlan(...) {
+	return CUTENSOR_STATUS_SUCCESS;
+    }
+
+    cutensorStatus_t cutensorPlanGetAttribute(...) {
 	return CUTENSOR_STATUS_SUCCESS;
     }
 

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -803,7 +803,7 @@ def contraction(
         _get_handle().ptr, operator.ptr, plan_pref.ptr, ws_pref)
     plan = create_plan(operator, plan_pref, ws_limit=estimated_ws_size)
     actual_ws_size = _numpy.empty(1, dtype=_numpy.uint64)
-    cutensor.getPlanAttribute(
+    cutensor.planGetAttribute(
         _get_handle().ptr, plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
         actual_ws_size.ctypes.data, actual_ws_size.itemsize)
     ws_size = actual_ws_size.item()

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -798,9 +798,16 @@ def contraction(
         desc_A, mode_A, op_A, desc_B, mode_B, op_B, desc_C, mode_C, op_C,
         compute_desc)
     plan_pref = create_plan_preference(algo=algo, jit_mode=jit_mode)
-    ws_size = cutensor.estimateWorkspaceSize(
+    # Query the estimated workspace size
+    estimated_ws_size = cutensor.estimateWorkspaceSize(
         _get_handle().ptr, operator.ptr, plan_pref.ptr, ws_pref)
-    plan = create_plan(operator, plan_pref, ws_limit=ws_size)
+    plan = create_plan(operator, plan_pref, ws_limit=estimated_ws_size)
+    actual_ws_size = _numpy.empty(1, dtype=_numpy.uint64)
+    cutensor.getPlanAttribute(
+        _get_handle().ptr, plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
+        actual_ws_size.ctypes.data, actual_ws_size.itemsize)
+    ws_size = actual_ws_size.item()
+    assert ws_size <= estimated_ws_size, "Workspace size is larger than the estimated workspace size" # NOQA
     ws = core._ndarray_init(
         _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     scalar_dtype = _get_scalar_dtype(C.dtype)

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -807,7 +807,7 @@ def contraction(
         _get_handle().ptr, plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
         actual_ws_size.ctypes.data, actual_ws_size.itemsize)
     ws_size = actual_ws_size.item()
-    assert ws_size <= estimated_ws_size, "Workspace size is larger than the estimated workspace size" # NOQA
+    assert ws_size <= estimated_ws_size, "Workspace size is larger than the estimated workspace size"  # NOQA
     ws = core._ndarray_init(
         _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     scalar_dtype = _get_scalar_dtype(C.dtype)


### PR DESCRIPTION
closes #9350

This MR updates cutensor contraction backend with improvement on the workspace size inquiry. 

An additional call to `cutensorPlanGetAttribute` is made to reduce the workspace size actually needed to execute the contraction. A few extra bindings were added to support this improvement. Example usage from [here](https://github.com/NVIDIA/CUDALibrarySamples/blob/a2433ef214c238e0abdb5e4307ba4b1862f81d1a/cuTENSOR/contraction.cu#L286)