### PR TITLE
Fix return dtype of csr_matrix minmax with scalar

### DIFF
--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -297,22 +297,13 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
 
     def _maximum_minimum(self, other, cupy_op, op_name, dense_check):
         if _util.isscalarlike(other):
+            dtype = cupy.result_type(self.dtype, other)
             other = cupy.asarray(other)
             if dense_check(other):
-                dtype = self.dtype
-                # Note: This is a work-around to make the output dtype the same
-                # as SciPy. It might be SciPy version dependent.
-                if dtype == numpy.float32:
-                    dtype = numpy.float64
-                elif dtype == numpy.complex64:
-                    dtype = numpy.complex128
-                dtype = cupy.result_type(dtype, other)
                 other = other.astype(dtype, copy=False)
-                # Note: The computation steps below are different from SciPy.
                 new_array = cupy_op(self.todense(), other)
                 return csr_matrix(new_array)
             else:
-                dtype = cupy.result_type(self.dtype, other)
                 self.sum_duplicates()
                 new_data = cupy_op(self.data, other)
                 return csr_matrix((new_data, self.indices, self.indptr),

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1925,16 +1925,19 @@ class TestCsrMatrixMaximumMinimum:
         b = self._make_sp_matrix_col(self.b_dtype, xp, sp).toarray()
         return getattr(a, self.opt)(b)
 
+    @testing.with_requires('scipy>=1.16')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_plus(self, xp, sp):
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         return getattr(a, self.opt)(0.5)
 
+    @testing.with_requires('scipy>=1.16')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_minus(self, xp, sp):
         a = self._make_sp_matrix(self.a_dtype, xp, sp)
         return getattr(a, self.opt)(-0.5)
 
+    @testing.with_requires('scipy>=1.16')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_scalar_zero(self, xp, sp):
         a = self._make_sp_matrix(self.a_dtype, xp, sp)


### PR DESCRIPTION
Related to https://github.com/cupy/cupy/pull/8844.