### PR TITLE
Fix message of shims removed in NumPy v2

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1094,12 +1094,6 @@ else:
     _template = '''\
 ''This function has been removed in NumPy v2.
 Use {recommendation} instead.
-
-CuPy has been providing this function as an alias to the NumPy
-implementation, so it cannot be used in environments with NumPy
-v2 installed. If you rely on this function and you cannot modify
-the code to use {recommendation}, please downgrade NumPy to v1.26
-or earlier.
 '''
 
     def find_common_type(*args, **kwds):


### PR DESCRIPTION
NumPy v1 support has been dropped. We don't recommend downgrading to NumPy v1.