### PR TITLE
CI: Add `/test force-skip` option

### DIFF
--- a/.github/workflows/flexci.yml
+++ b/.github/workflows/flexci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
   statuses: write
 
 jobs:


### PR DESCRIPTION
This PR introduces the special CI trigger phrase: `/test force-skip`. In occasional cases where test failures are caused by transient/unrelated issues (such as network timeouts) or by known flaky tests, we may want to merge the PR while ignoring those failures. Previously, this was accomplished by using risky "bypass rules" feature that ignores all repository [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets). This new CI command will allow committers show the intent to ignore failures explicitly, and enables a safer workflow that does not rely on "bypass rules".