### PR TITLE
ENH,MAINT: Allow cupy-like protocols in setitem and consolidate

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -22,7 +22,7 @@ from cupy._core._dtype cimport get_dtype, _raise_if_invalid_cast
 from cupy._core._memory_range cimport may_share_bounds
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core cimport core
-from cupy._core.core cimport _convert_object_with_cuda_array_interface
+from cupy._core.core cimport _convert_from_cupy_like
 from cupy._core.core cimport _ndarray_init
 from cupy._core.core cimport compile_with_cache
 from cupy._core.core cimport _ndarray_base
@@ -116,17 +116,12 @@ cpdef inline _check_peer_access(_ndarray_base arr, int device_id):
 
 cdef inline _preprocess_arg(int dev_id, arg, bint use_c_scalar):
     weak_t = False
-    if isinstance(arg, _ndarray_base):
-        s = arg
+
+    s = _convert_from_cupy_like(arg, error=False)
+    if s is not None:
         _check_peer_access(<_ndarray_base>s, dev_id)
     elif isinstance(arg, texture.TextureObject):
         s = arg
-    elif hasattr(arg, '__cuda_array_interface__'):
-        s = _convert_object_with_cuda_array_interface(arg)
-        _check_peer_access(<_ndarray_base>s, dev_id)
-    elif hasattr(arg, '__cupy_get_ndarray__'):
-        s = arg.__cupy_get_ndarray__()
-        _check_peer_access(<_ndarray_base>s, dev_id)
     else:  # scalars or invalid args
         weak_t = type(arg) if type(arg) in [int, float, complex] else False
         if use_c_scalar:

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -18,7 +18,7 @@ from cupy._core cimport _optimize_config
 from cupy._core cimport _routines_manipulation as _manipulation
 from cupy._core cimport _scalar
 from cupy._core._scalar import get_typename as _get_typename
-from cupy._core.core cimport _convert_object_with_cuda_array_interface
+from cupy._core.core cimport _convert_from_cupy_like
 from cupy._core.core cimport _create_ndarray_from_shape_strides
 from cupy._core.core cimport compile_with_cache
 from cupy._core.core cimport _ndarray_base
@@ -591,18 +591,9 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             return a.__cupy_override_reduction_kernel__(
                 self, axis, dtype, out, keepdims)
 
-        cdef _ndarray_base arr
+        cdef _ndarray_base arr = _convert_from_cupy_like(
+            a, error="Argument 'a'")
 
-        if isinstance(a, _ndarray_base):
-            arr = a
-        elif hasattr(a, '__cuda_array_interface__'):
-            arr = _convert_object_with_cuda_array_interface(a)
-        elif hasattr(a, '__cupy_get_ndarray__'):
-            arr = a.__cupy_get_ndarray__()
-        else:
-            raise TypeError(
-                'Argument \'a\' has incorrect type (expected %s, got %s)' %
-                (cupy.ndarray, type(a)))
         in_args = [arr]
 
         dev_id = device.get_device_id()

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -16,7 +16,7 @@ from cupy._core._carray cimport strides_t
 from cupy._core cimport core
 from cupy._core cimport _routines_math as _math
 from cupy._core cimport _routines_manipulation as _manipulation
-from cupy._core.core cimport _ndarray_base
+from cupy._core.core cimport _convert_from_cupy_like, _ndarray_base
 from cupy._core cimport internal
 
 
@@ -1010,10 +1010,12 @@ cdef _scatter_op(_ndarray_base a, slices, value, op):
     y = a
 
     if op == 'update':
-        if not isinstance(value, _ndarray_base):
+        x = _convert_from_cupy_like(value, error=False)
+        if x is None:
+            # Refuse assignment from CPU arrays, see gh-2079
             y.fill(value)
             return
-        x = value
+
         if (internal.vector_equal(y._shape, x._shape) and
                 internal.vector_equal(y._strides, x._strides)):
             if y.data.ptr == x.data.ptr:

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -118,3 +118,31 @@ cdef _ndarray_base _ndarray_init(subtype, const shape_t& shape, dtype, obj)
 
 cdef _ndarray_base _create_ndarray_from_shape_strides(
     subtype, const shape_t& shape, const strides_t& strides, dtype, obj)
+
+
+cdef inline _ndarray_base _convert_from_cupy_like(
+        obj, str error):
+    """Inline function to convert cupy array-likes to cupy ndarray.
+
+    Includes a check to allow passing a cupy.ndarray itself and converts the
+    protocols `__cuda_array_interface__` and `__cupy_get_ndarray__`.
+    Used where general GPU arrays should be supported but CPU arrays are not
+    supported or handled differently.
+
+    If `error` is False no error will be raised if conversion if the type
+    is not cupy-like and `None` is returned instead.
+    """
+    if isinstance(obj, _ndarray_base):
+        return <_ndarray_base>obj
+    elif hasattr(obj, "__cuda_array_interface__"):
+        return _convert_object_with_cuda_array_interface(obj)
+    elif hasattr(obj, "__cupy_get_ndarray__"):
+        return obj.__cupy_get_ndarray__()
+
+    if error is not False:
+        raise TypeError(
+            f'{error} has incorrect type '
+            f'(expected {_ndarray_base}, got {type(obj)}).'
+        )
+
+    return None

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2564,16 +2564,9 @@ cpdef _ndarray_base array(obj, dtype=None, copy=True, order='K',
     if order is None:
         order = 'K'
 
-    if isinstance(obj, ndarray):
-        return _array_from_cupy_ndarray(obj, dtype, copy, order, ndmin)
-
-    if hasattr(obj, '__cuda_array_interface__'):
-        return _array_from_cuda_array_interface(
-            obj, dtype, copy, order, subok, ndmin)
-
-    if hasattr(obj, '__cupy_get_ndarray__'):
-        return _array_from_cupy_ndarray(
-            obj.__cupy_get_ndarray__(), dtype, copy, order, ndmin)
+    cdef _ndarray_base arr = _convert_from_cupy_like(obj, error=False)
+    if arr is not None:
+        return _array_from_cupy_ndarray(arr, dtype, copy, order, ndmin)
 
     concat_shape, concat_type, concat_dtype = (
         _array_info_from_nested_sequence(obj))
@@ -3008,6 +3001,7 @@ cpdef _ndarray_base asfortranarray(_ndarray_base a, dtype=None):
 
 
 cpdef _ndarray_base _convert_object_with_cuda_array_interface(a):
+    # NOTE: Most code should use this indirectly via `_convert_from_cupy_like`
 
     cdef Py_ssize_t sh, st
     cdef dict desc = a.__cuda_array_interface__

--- a/cupy/testing/_protocol_helpers.py
+++ b/cupy/testing/_protocol_helpers.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import cupy
+from cupy import cuda
+
+
+max_cuda_array_interface_version = 3
+
+
+class DummyObjectWithCudaArrayInterface:
+    # Private helper used for testing cuda array interface support.
+    def __init__(
+        self, a, ver=3, include_strides=False, mask=None, stream=None
+    ):
+        assert ver in tuple(range(max_cuda_array_interface_version+1))
+        self.a = None
+        if isinstance(a, cupy.ndarray):
+            self.a = a
+        else:
+            self.shape, self.strides, self.typestr, self.descr, self.data = a
+        self.ver = ver
+        self.include_strides = include_strides
+        self.mask = mask
+        self.stream = stream
+
+    @property
+    def __cuda_array_interface__(self):
+        if self.a is not None:
+            desc = {
+                'shape': self.a.shape,
+                'typestr': self.a.dtype.str,
+                'descr': self.a.dtype.descr,
+                'data': (self.a.data.ptr, False),
+                'version': self.ver,
+            }
+            if self.a.flags.c_contiguous:
+                if self.include_strides is True:
+                    desc['strides'] = self.a.strides
+                elif self.include_strides is None:
+                    desc['strides'] = None
+                else:  # self.include_strides is False
+                    pass
+            else:  # F contiguous or neither
+                desc['strides'] = self.a.strides
+        else:
+            desc = {
+                'shape': self.shape,
+                'typestr': self.typestr,
+                'descr': self.descr,
+                'data': (self.data, False),
+                'version': self.ver,
+            }
+            if self.include_strides is True:
+                desc['strides'] = self.strides
+            elif self.include_strides is None:
+                desc['strides'] = None
+            else:  # self.include_strides is False
+                pass
+        if self.mask is not None:
+            desc['mask'] = self.mask
+        # The stream field is kept here for compliance. However, since the
+        # synchronization is done via calling a cpdef function, which cannot
+        # be mock-tested.
+        if self.stream is not None:
+            if self.stream is cuda.Stream.null:
+                desc['stream'] = cuda.runtime.streamLegacy
+            elif (not cuda.runtime.is_hip) and self.stream is cuda.Stream.ptds:
+                desc['stream'] = cuda.runtime.streamPerThread
+            else:
+                desc['stream'] = self.stream.ptr
+        return desc
+
+
+class DummyObjectWithCuPyGetNDArray:
+    # Private helper used for testing `__cupy_get_ndarray__` support.
+    def __init__(self, a):
+        self.a = a
+
+    def __cupy_get_ndarray__(self):
+        return self.a

--- a/tests/cupy_tests/core_tests/test_ndarray_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_indexing.py
@@ -8,6 +8,8 @@ import pytest
 
 import cupy
 from cupy import testing
+from cupy.testing._protocol_helpers import (
+    DummyObjectWithCuPyGetNDArray, DummyObjectWithCudaArrayInterface)
 from cupy.exceptions import ComplexWarning
 
 
@@ -233,3 +235,14 @@ class TestSetItemCompatBroadcast:
         a = xp.zeros((2, 3, 4), dtype)
         a[0, 1, 2] = testing.shaped_arange((), xp, dtype)
         return a
+
+
+@pytest.mark.parametrize('cupy_like', [
+    DummyObjectWithCuPyGetNDArray,
+    DummyObjectWithCudaArrayInterface,
+])
+def test_setitem_with_cupy_like(cupy_like):
+    # Test that normal assignment supports interfaces
+    a = cupy.zeros(10)
+    a[...] = cupy_like(cupy.arange(10))
+    testing.assert_array_equal(a, cupy.arange(10))

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -9,6 +9,8 @@ import pytest
 
 import cupy
 from cupy import cuda, testing
+from cupy.testing._protocol_helpers import (
+    DummyObjectWithCuPyGetNDArray, DummyObjectWithCudaArrayInterface)
 
 
 class TestFromData(unittest.TestCase):
@@ -691,67 +693,6 @@ class TestCudaArrayInterfaceBigArray(unittest.TestCase):
         testing.assert_array_equal(a, b)
 
 
-class DummyObjectWithCudaArrayInterface:
-    def __init__(self, a, ver, include_strides=False, mask=None, stream=None):
-        assert ver in tuple(range(max_cuda_array_interface_version+1))
-        self.a = None
-        if isinstance(a, cupy.ndarray):
-            self.a = a
-        else:
-            self.shape, self.strides, self.typestr, self.descr, self.data = a
-        self.ver = ver
-        self.include_strides = include_strides
-        self.mask = mask
-        self.stream = stream
-
-    @property
-    def __cuda_array_interface__(self):
-        if self.a is not None:
-            desc = {
-                'shape': self.a.shape,
-                'typestr': self.a.dtype.str,
-                'descr': self.a.dtype.descr,
-                'data': (self.a.data.ptr, False),
-                'version': self.ver,
-            }
-            if self.a.flags.c_contiguous:
-                if self.include_strides is True:
-                    desc['strides'] = self.a.strides
-                elif self.include_strides is None:
-                    desc['strides'] = None
-                else:  # self.include_strides is False
-                    pass
-            else:  # F contiguous or neither
-                desc['strides'] = self.a.strides
-        else:
-            desc = {
-                'shape': self.shape,
-                'typestr': self.typestr,
-                'descr': self.descr,
-                'data': (self.data, False),
-                'version': self.ver,
-            }
-            if self.include_strides is True:
-                desc['strides'] = self.strides
-            elif self.include_strides is None:
-                desc['strides'] = None
-            else:  # self.include_strides is False
-                pass
-        if self.mask is not None:
-            desc['mask'] = self.mask
-        # The stream field is kept here for compliance. However, since the
-        # synchronization is done via calling a cpdef function, which cannot
-        # be mock-tested.
-        if self.stream is not None:
-            if self.stream is cuda.Stream.null:
-                desc['stream'] = cuda.runtime.streamLegacy
-            elif (not cuda.runtime.is_hip) and self.stream is cuda.Stream.ptds:
-                desc['stream'] = cuda.runtime.streamPerThread
-            else:
-                desc['stream'] = self.stream.ptr
-        return desc
-
-
 @testing.parameterize(
     *testing.product({
         'ndmin': [0, 1, 2, 3],
@@ -805,3 +746,11 @@ class TestArrayInvalidObject(unittest.TestCase):
         a = numpy.array([1, 2, 3], dtype=object)
         with self.assertRaises(ValueError):
             cupy.array(a)
+
+
+class TestArrayCuPyGetNDArray(unittest.TestCase):
+    def test_cupy_get_ndarray(self):
+        a = cupy.array([1, 2, 3])
+        dummy = DummyObjectWithCuPyGetNDArray(a)
+        res = cupy.asarray(dummy)
+        assert a is res  # OK if it was a view


### PR DESCRIPTION
This allows `cupy_arr[...] = cupy_like` where cupy-like supports the CUDA array interface or `__cupy_get_ndarray__`.

Since there were a few (not many!) places that have a similar logic I, opionatedly, consolidated them into a `cdef inline` function. Similarly moved the test helper classes to not have to repeat them.

The biggest part of the diff is just moving those helpers!

I am very sure that `cdef inline` must be in the `.pyd` file to actually be inlined (which means many are currenlty not).

Closes gh-9089