### PR TITLE
CI: Fix `/test force-skip` option

### DIFF
--- a/.github/workflows/scripts/flexci_dispatcher.py
+++ b/.github/workflows/scripts/flexci_dispatcher.py
@@ -86,8 +86,12 @@ def _fill_commit_status(
         _log('No projects to complement commit status')
         return
 
+    # Get the latest commit status for each context.
     _log(f'Checking statuses for commit {sha}')
-    contexts = {s.context: s for s in gh_commit.get_statuses()}
+    contexts = {
+        s.context: s
+        for s in sorted(gh_commit.get_statuses(), key=lambda s: s.updated_at)
+    }
     force_skip_contexts: list[str] = []
     for prj in projects:
         context = f'{context_prefix}/{prj}'


### PR DESCRIPTION
Follows up #9416. When doing `/test force-skip`, the dispatcher script mistakenly use the oldest status information because GitHub API returns contexts sorted in newest-first (although not documented or guaranteed). This PR fixes the script to use the latest commit status instead, by sorting commit statuses by `updated_at` field before constructing a dict from context name to status.

This error was found in https://github.com/cupy/cupy/pull/9420#issuecomment-3406911665.