### PR TITLE
Run `cupy.show_config()` at the head of cuda-example CI

### DIFF
--- a/.pfnci/linux/tests/actions/example.sh
+++ b/.pfnci/linux/tests/actions/example.sh
@@ -13,6 +13,8 @@ export MPLBACKEND=Agg
 
 pushd examples
 
+timeout --signal INT --kill-after 10 60 python3 -c 'import cupy; cupy.show_config(_full=True)'
+
 # K-means
 python3 kmeans/kmeans.py -m 1
 python3 kmeans/kmeans.py -m 1 --use-custom-kernel


### PR DESCRIPTION
`unittest.sh` calls `cupy.show_config()`, but `example.sh` does not. To verify that cuTENSOR 2.3 is properly installed for the failing CI in #9413, I’d like to call `show_config()` in example.sh as well.