### PR TITLE
NCCL ID Fix for ARM systems

### DIFF
--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -104,13 +104,15 @@ class NCCLBackend(_Backend):
             # get_unique_id return negative values due to cython issues
             # with bytes && c strings. We shift them by 128 to
             # make them positive and send them as bytes to the proxy store
-            shifted_nccl_id = bytes([b + 128 for b in nccl_id])
+            #shifted_nccl_id = bytes([b + 128 for b in nccl_id])
+            shifted_nccl_id = bytes([b for b in nccl_id])
             self._store_proxy['nccl_id'] = shifted_nccl_id
             self._store_proxy.barrier()
         else:
             self._store_proxy.barrier()
             nccl_id = self._store_proxy['nccl_id']
-            nccl_id = tuple([int(b) - 128 for b in nccl_id])
+            #nccl_id = tuple([int(b) - 128 for b in nccl_id])
+            nccl_id = tuple([int(b) for b in nccl_id])
         self._comm = nccl.NcclCommunicator(n_devices, nccl_id, rank)
 
     def _check_contiguous(self, array):


### PR DESCRIPTION
This is a fix for this issue here:

https://github.com/cupy/cupy/issues/9430


But also, if our only goal is to make sure its within 8 bits, a better fix may be:

```python
shifted_nccl_id = bytes([b & 0xFF for b in nccl_id])
nccl_id = tuple([int(b) for b in shifted_nccl_id])
```

I can update it if that is more correct (and will work for all systems regardless of how they encode chars)