### PR TITLE
Fix OOM in slow CI

### DIFF
--- a/tests/cupy_tests/sorting_tests/test_search.py
+++ b/tests/cupy_tests/sorting_tests/test_search.py
@@ -87,7 +87,7 @@ class TestSearch:
 
     @testing.slow
     def test_argmax_int32_overflow(self):
-        a = testing.shaped_arange((2 ** 32 + 1,), cupy, numpy.float64)
+        a = cupy.arange(2 ** 32 + 1, dtype=cupy.float64)
         assert a.argmax().item() == 2 ** 32
 
     @testing.for_all_dtypes(no_complex=True)
@@ -166,7 +166,7 @@ class TestSearch:
 
     @testing.slow
     def test_argmin_int32_overflow(self):
-        a = testing.shaped_arange((2 ** 32 + 1,), cupy, numpy.float64)
+        a = cupy.arange(2 ** 32 + 1, dtype=cupy.float64)
         cupy.negative(a, out=a)
         assert a.argmin().item() == 2 ** 32
 


### PR DESCRIPTION
`testing.shaped_arange` utility first creates an array using NumPy. This fixes host OOM triggered in CI due to excessive memory usage.

e.g. https://ci.preferred.jp/cupy.linux.cuda-slow/201785/


xref #8031
