### PR TITLE
Add `numpy.isdtype` support and tests

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -395,6 +395,7 @@ from numpy import finfo  # NOQA
 from numpy import iinfo  # NOQA
 
 from numpy import issubdtype  # NOQA
+from numpy import isdtype  # NOQA
 
 from numpy import mintypecode  # NOQA
 from numpy import typename  # NOQA

--- a/tests/cupy_tests/test_type_routines.py
+++ b/tests/cupy_tests/test_type_routines.py
@@ -91,3 +91,73 @@ class TestResultType(unittest.TestCase):
         ret = xp.result_type(input1, input2)
         assert isinstance(ret, numpy.dtype)
         return ret
+
+
+class TestIsDtype(unittest.TestCase):
+
+    @testing.numpy_cupy_equal()
+    def test_isdtype_bool(self, xp):
+        ret = xp.isdtype(xp.bool_, 'bool')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_dtypes([numpy.int8, numpy.int16, numpy.int32, numpy.int64])
+    @testing.numpy_cupy_equal()
+    def test_isdtype_signed_integer(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'signed integer')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_dtypes([numpy.uint8, numpy.uint16, numpy.uint32,
+                         numpy.uint64])
+    @testing.numpy_cupy_equal()
+    def test_isdtype_unsigned_integer(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'unsigned integer')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_dtypes([numpy.int8, numpy.int32, numpy.uint16, numpy.uint64])
+    @testing.numpy_cupy_equal()
+    def test_isdtype_integral(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'integral')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_dtypes([numpy.float16, numpy.float32, numpy.float64])
+    @testing.numpy_cupy_equal()
+    def test_isdtype_real_floating(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'real floating')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_dtypes([numpy.complex64, numpy.complex128])
+    @testing.numpy_cupy_equal()
+    def test_isdtype_complex_floating(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'complex floating')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_equal()
+    def test_isdtype_numeric(self, xp, dtype):
+        ret = xp.isdtype(dtype, 'numeric')
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.numpy_cupy_equal()
+    def test_isdtype_dtype_match(self, xp):
+        ret = xp.isdtype(xp.float32, xp.float32)
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.numpy_cupy_equal()
+    def test_isdtype_dtype_no_match(self, xp):
+        ret = xp.isdtype(xp.float32, xp.float64)
+        assert isinstance(ret, bool)
+        return ret
+
+    @testing.numpy_cupy_equal()
+    def test_isdtype_tuple_kinds(self, xp):
+        ret = xp.isdtype(xp.complex128, ('real floating', 'complex floating'))
+        assert isinstance(ret, bool)
+        return ret


### PR DESCRIPTION
Add support for numpy.isdtype by importing it from NumPy.

Implements `numpy.isdtype` from #6078

Added tests covering all dtype kinds (bool, integers, floating point, numeric) and edge cases (dtype matching, tuple kinds).