### PR TITLE
Clean up mempool-related issues

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -18,6 +18,7 @@ from cupy.cuda import pinned_memory  # NOQA
 from cupy.cuda import profiler  # NOQA
 from cupy.cuda import stream  # NOQA
 from cupy.cuda import texture  # NOQA
+from cupy.cuda.memory_adaptor import cuda_core_device_memory_resource_adaptor  # NOQA
 from cupy_backends.cuda.api import driver  # NOQA
 from cupy_backends.cuda.api import runtime  # NOQA
 from cupy_backends.cuda.libs import nvrtc  # NOQA

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -1755,9 +1755,16 @@ cdef class MemoryAsyncPool:
             be set independently.
 
     .. note::
-        :class:`MemoryAsyncPool` currently cannot work with memory hooks.
+        To customize a new mempool, use `cuda.core`_ and
+        :func:`~cupy.cuda.cuda_core_device_memory_resource_adaptor`.
+
+    .. note::
+        :class:`MemoryAsyncPool` does not work with memory hooks.
 
     .. seealso:: `Stream Ordered Memory Allocator`_
+
+    .. _cuda.core:
+        https://nvidia.github.io/cuda-python/cuda-core/latest/index.html
 
     .. _Stream Ordered Memory Allocator:
         https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-ordered-memory-allocator
@@ -1819,11 +1826,8 @@ cdef class MemoryAsyncPool:
         elif handle == 'current':
             # Use the device's current pool
             pool = runtime.deviceGetMemPool(dev_id)
-        elif handle == 'create':
-            # TODO(leofang): Support cudaMemPoolCreate
-            raise NotImplementedError('cudaMemPoolCreate is not yet supported')
         elif isinstance(handle, int):
-            # Use an existing pool (likely from other applications?)
+            # Use an existing pool (from other applications)
             pool = <intptr_t>(handle)
         else:
             raise ValueError("handle must be "

--- a/cupy/cuda/memory_adaptor.py
+++ b/cupy/cuda/memory_adaptor.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from cupy import cuda
+
+
+# TODO(leofang): allow explicitly wrapping a list of custom memory resources?
+def cuda_core_device_memory_resource_adaptor():
+    """A CuPy allocator that wraps DeviceMemoryResource from cuda.core.
+
+    Currently, this adaptor wraps cuda.core's default memory resources. To use
+    custom memory resources, attach them to the respective devices first
+    (``Device.memory_resource``).
+    """
+    try:
+        from cuda.core.experimental import system
+    except ImportError:
+        try:
+            from cuda.core import system
+        except ImportError:
+            raise ModuleNotFoundError("No module named 'cuda.core'")
+    devices = system.devices
+
+    class MemoryAsyncPoolAdaptor(cuda.MemoryAsyncPool):
+
+        __slots__ = ('mrs',)
+
+        def __init__(self):
+            MRs = [dev.memory_resource for dev in devices]
+            self.mrs = MRs
+            super().__init__(pool_handles=[int(mr.handle) for mr in MRs])
+
+    return MemoryAsyncPoolAdaptor

--- a/docs/source/reference/cuda.rst
+++ b/docs/source/reference/cuda.rst
@@ -41,6 +41,7 @@ Memory management
    cupy.cuda.PinnedMemoryPool
    cupy.cuda.PythonFunctionAllocator
    cupy.cuda.CFunctionAllocator
+   cupy.cuda.cuda_core_device_memory_resource_adaptor
 
 
 Memory hook


### PR DESCRIPTION
Close #5349.

- Clean up outdated test skip conditions with the upcoming (v14) CUDA & ROCm support matrices in mind
- Add an adaptor for hooking a `cuda.core.{experimental.}DeviceMemoryResource` with `MemoryAsyncPool`
   - We have been working with the CUDA memory team and exposing more and more knobs for customizing a mempool to Python via `cuda.core`. I suggest CuPy to avoid repeating this work (which is nontrivial) and simply provide an adaptor to interoperate with `cuda.core`. The placeholder `handle == "create"` path is now fully removed.