### PR TITLE
MAINT: Specify texture address precisely

### DIFF
--- a/cupy_backends/cuda/api/_runtime_typedef.pxi
+++ b/cupy_backends/cuda/api/_runtime_typedef.pxi
@@ -93,7 +93,7 @@ cdef extern from *:
         MemoryKind kind
 
     ctypedef struct TextureDesc 'cudaTextureDesc':
-        int addressMode[3]
+        TextureAddressMode addressMode[3]
         int filterMode
         int readMode
         int sRGB


### PR DESCRIPTION
I tried using `profile=True` and I think I also ran into this once before (not sure due to what).
In some cases Cython generates code to expose this to Python and then it fails casting to `int*` when compiling the generated C++ code.

Maybe whether it fails compiling is dependent on more things, since it doesn't happen in CI?