### PR TITLE
CI: Double the cache size to increase test speed

### DIFF
--- a/.pfnci/windows/test.ps1
+++ b/.pfnci/windows/test.ps1
@@ -29,7 +29,7 @@ function DownloadCache([String]$gcs_dir, [String]$cupy_kernel_cache_file) {
 function UploadCache([String]$gcs_dir, [String]$cupy_kernel_cache_file) {
     # Maximum 3 GiB
     echo "Trimming kernel cache..."
-    RunOrDie python .pfnci\trim_cupy_kernel_cache.py --max-size 3221225472 --rm
+    RunOrDie python .pfnci\trim_cupy_kernel_cache.py --max-size 6442450944 --rm
 
     pushd $Env:USERPROFILE
     # -mx=0 ... no compression


### PR DESCRIPTION
It seems we hit the cache size limit on Windows + CUDA 12.9/13.0 CIs.

win-cuda128 https://ci.preferred.jp/cupy.win.cuda128/202284/

```
02:47:43.836723 STDERR 864]	Total:   3261745703 bytes, 186590 files	
02:47:43.836723 STDERR 864]	Valid:   3221191342 bytes, 184498 files	
02:47:43.836723 STDERR 864]	Expired: 40554361 bytes, 2092 files	
```

win-cuda129: https://ci.preferred.jp/cupy.win.cuda129/202285/

```
05:04:58.444486 STDERR 4180]	Total:   3497108745 bytes, 196697 files	
05:04:58.444486 STDERR 4180]	Valid:   3221145868 bytes, 183789 files	
05:04:58.444486 STDERR 4180]	Expired: 275962877 bytes, 12908 files	
```

win-cuda130: https://ci.preferred.jp/cupy.win.cuda130/202293/

```
04:31:16.206972 STDERR 1544]	Total:   3461339153 bytes, 190334 files	
04:31:16.206972 STDERR 1544]	Valid:   3221223033 bytes, 179659 files	
04:31:16.207130 STDERR 1544]	Expired: 240116120 bytes, 10675 files	
```