### PR TITLE
[docs] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,12 @@ You can pass `ndarray` to existing CUDA C/C++ programs via [RawKernels](https://
 Binary packages (wheels) are available for Linux and Windows on [PyPI](https://pypi.org/org/cupy/).
 Choose the right package for your platform.
 
-| Platform              | Architecture      | Command                                                       |
-| --------------------- | ----------------- | ------------------------------------------------------------- |
-| CUDA 11.x (11.2+)     | x86_64 / aarch64  | `pip install cupy-cuda11x`                                    |
-| CUDA 12.x             | x86_64 / aarch64  | `pip install cupy-cuda12x`                                    |
-| CUDA 13.x             | x86_64 / aarch64  | `pip install cupy-cuda13x`                                    |
-| ROCm 4.3 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-4-3`                                   |
-| ROCm 5.0 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*)          | x86_64            | `pip install cupy-rocm-5-0`                                   |
+| Platform                                                                                                     | Architecture      | Command                     |
+|--------------------------------------------------------------------------------------------------------------| ----------------- |-----------------------------|
+| CUDA 11.x (11.2+)                                                                                            | x86_64 / aarch64  | `pip install cupy-cuda11x`  |
+| CUDA 12.x                                                                                                    | x86_64 / aarch64  | `pip install cupy-cuda12x`  |
+| CUDA 13.x                                                                                                    | x86_64 / aarch64  | `pip install cupy-cuda13x`  |
+| ROCm 7.0 (*[experimental](https://docs.cupy.dev/en/latest/install.html#using-cupy-on-amd-gpu-experimental)*) | x86_64            | `pip install cupy-rocm-7-0` |
 
 > [!NOTE]\
 > To install pre-releases, append `--pre -U -f https://pip.cupy.dev/pre` (e.g., `pip install cupy-cuda12x --pre -U -f https://pip.cupy.dev/pre`).


### PR DESCRIPTION
Cupy now officially support ROCm 7.0 and has dropped support for ROCm < 7. This commit updates the main README to reflect this.