### PR TITLE
[bug] Include type_traits in filters

### DIFF
--- a/cupyx/scipy/ndimage/_filters_generic.py
+++ b/cupyx/scipy/ndimage/_filters_generic.py
@@ -201,7 +201,7 @@ def _get_generic_filter1d(rk, length, n_lines, filter_size, origin, mode, cval,
 
     name = 'generic1d_{}_{}_{}'.format(length, filter_size, rk.name)
     if runtime.is_hip:
-        include_type_traits = ''
+        include_type_traits = '#include <type_traits>'
     else:
         include_type_traits = '''
 #include <cupy/cuda_workaround.h>  // provide C++ std:: coverage


### PR DESCRIPTION
test_filters.py relies on the type_traits library. When JIT compiling code that uses something `std::enable_if` in these tests, users are met with a compilation error saying that `std::enable_if` can't be found and to try using the namespace `__hip_internal::enable_if` instead. This is likely because `std::enable_if` was previously pulled in via some other headers or defined elsewhere in ROCm versions < 7, but is no longer the case.

When printing the failing generated code, it became clear that the type_traits header was not included, which caused the compilation failure.

This is easily fixed by including `type_traits` in the filters JIT strings.