### PR TITLE
CI: Add ROCm CI trigger allow list

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -18,8 +18,9 @@ jobs:
           ( github.event_name == 'issue_comment' && github.event.issue.pull_request ) ||
           github.event_name == 'pull_request_review_comment'
         ) && (
+          github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER'
+          contains('|gpinkert|', github.event.comment.user.login)
         ) && (
           contains(github.event.comment.body, '/test ')
         )


### PR DESCRIPTION
As per the offline discussion with @asi1024, considering recent active contributions to CuPy, I would like to grant @gpinkert permission to trigger `/test rocm` to accelerate the development.
