### PR TITLE
Do not pass `filter=data` for ZIP (cuTENSOR on Windows)

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -140,7 +140,9 @@ library_records['nccl'] = _nccl_records
 
 
 def _unpack_archive(filename, extract_dir):
-    kwargs = {} if sys.version_info < (3, 12) else {"filter": "data"}
+    kwargs = {"filter": "data"}
+    if sys.version_info < (3, 12) or filename.endswith(".zip"):
+        kwargs = {}
     try:
         shutil.unpack_archive(filename, extract_dir, **kwargs)
     except shutil.ReadError:


### PR DESCRIPTION
Follows up #9439. `shutil.unpack_archive` accepts various file formats (tar/zip/...), however `filter` kwarg shouldn't be passed when processing zip files.

https://docs.python.org/ja/3/library/shutil.html:
> For zip files, filter is not accepted

Detected in the following release-tools CI failure:
https://ci.preferred.jp/cupy-release-tools.win/202226/#L295

```
00:01:26.359394 STDERR 6576]	TypeError: _unpack_zipfile() got an unexpected keyword argument 'filter'	
```