### PR TITLE
MAINT: simplify and fix `CUPY_TEST_GPU_LIMIT`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,8 @@ filterwarnings = [
   "ignore::UserWarning",
   "error::DeprecationWarning",
   "error::PendingDeprecationWarning",
-  "error::cupy.exceptions.VisibleDeprecationWarning",
-  "error::cupy.exceptions.ComplexWarning",
+  "error::numpy.exceptions.VisibleDeprecationWarning",
+  "error::numpy.exceptions.ComplexWarning",
   # distutils (Python 3.10)
   "ignore:The distutils(.+) is deprecated:DeprecationWarning",
   "ignore:dep_util is Deprecated:DeprecationWarning",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
 
 # enable NEP 50 weak promotion rules
 import numpy
@@ -38,47 +36,43 @@ def pytest_configure(config):
         print("***** Installed packages *****", flush=True)
         subprocess.check_call([sys.executable, '-m', 'pip', 'freeze', '--all'])
     if config.pluginmanager.hasplugin("xdist"):
-        config.pluginmanager.register(DeferPlugin())
-
-
-# https://docs.pytest.org/en/latest/how-to/writing_hook_functions.html#optionally-using-hooks-from-3rd-party-plugins
-class DeferPlugin:
-    """Simple plugin to defer pytest-xdist hook functions."""
-
-    # Edit the environment variable `CUDA_VISIBLE_DEVICES` for each session.
-    # Cannot use `pytest_configure_node` nor `pytest_testnodeready` hook,
-    # because they are called in the `master` node (process).
-    # See also https://github.com/pytest-dev/pytest-xdist/issues/179.
-    @pytest.fixture(autouse=True, scope='session')
-    def _rotate_cuda_visible_devices(self, worker_id):
-        if worker_id == 'master':
-            # `worker_id` can be `master` if `pytest-xdist` is installed and
-            # run without `-n` option.
-            return
-
         n_gpu = os.environ.get('CUPY_TEST_GPU_LIMIT')
+        worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+
         if n_gpu is None:
-            print('Tip: when using pytest-xdist, you can automatically rotate'
-                  ' CUDA_VISIBLE_DEVICES for each test worker by setting'
-                  ' CUPY_TEST_GPU_LIMIT environment variable.')
-            return
-        n_gpu = int(n_gpu)
+            if worker_id == 'master':
+                print('\nTIP: when using pytest-xdist, you can automatically '
+                      'rotate CUDA_VISIBLE_DEVICES for each test worker by '
+                      'setting CUPY_TEST_GPU_LIMIT environment variable.\n')
+        elif worker_id != 'master':
+            assert worker_id.startswith('gw')
+            w = int(worker_id[2:])
 
-        assert worker_id.startswith('gw')
-        w = int(worker_id[2:])
+            # Edit the environment variable `CUDA_VISIBLE_DEVICES` for each
+            # worker. We have to take care that it happens before any init.
+            n_gpu = int(n_gpu)
 
-        devices = os.environ.get('CUDA_VISIBLE_DEVICES')
-        if devices is None:
-            devices = [str(k) for k in range(n_gpu)]
-        else:
-            devices = devices.split(',')[:n_gpu]
-        devices = collections.deque(devices)
-        devices.rotate(w)
-        devices = ','.join(devices)
-        os.environ['CUDA_VISIBLE_DEVICES'] = devices
-        # With PyTest's default, the print will be shown as
-        # "--- Captured stdout setup ---" on failure.
-        print(f'CUDA_VISIBLE_DEVICES={devices}')
+            devices = os.environ.get('CUDA_VISIBLE_DEVICES')
+            if devices is None:
+                devices = [str(k) for k in range(n_gpu)]
+            else:
+                devices = devices.split(',')[:n_gpu]
+            devices = collections.deque(devices)
+            devices.rotate(w)
+            devices = ','.join(devices)
+            os.environ['CUDA_VISIBLE_DEVICES'] = devices
+            # Print to stderr as xdist captures stdout even with `-s`.
+            print(
+                f'\nSetting up worker {worker_id} with '
+                f'CUDA_VISIBLE_DEVICES={devices}',
+                file=sys.stderr, flush=True
+            )
+
+            if "cupy" in sys.modules:
+                raise RuntimeError(
+                    "CuPy was imported already but this probably breaks "
+                    "CUPY_TEST_GPU_LIMIT which is used. Warning filters "
+                    "in pyproject.toml could cause this.")
 
 
 if int(os.environ.get('CUPY_ENABLE_UMP', 0)) != 0:


### PR DESCRIPTION
Not that `CUPY_TEST_GPU_LIMIT` is a game-changer probably, but it didn't actually work reliably (I assume it used to work). I am not sure why exactly, it may be that the fixture is too late because it is run after test collection (which then may e.g.
create cupy arrays).

This pattern using the environment variables was probably not available when it was introduced initially, but works now.

(N.B. at least for high-memory tests using two runners on the same GPU probably doesn't work, xdist groupings may be a way to solve this.)

---

Funny observation is that it isn't necessarily faster to use many GPUs...
