### PR TITLE
MAINT: Remove `-fno-gnu-unique` again

### DIFF
--- a/install/cupy_builder/_compiler.py
+++ b/install/cupy_builder/_compiler.py
@@ -236,8 +236,7 @@ class DeviceCompilerUnix(DeviceCompilerBase):
         # Note: we only support CUDA 11.2+ since CuPy v13.0.0.
         # Bumping C++ standard from C++14 to C++17 for "if constexpr"
         postargs += ['--std=c++17',
-                     f'-t{num_threads}',
-                     '-Xcompiler=-fno-gnu-unique']
+                     f'-t{num_threads}']
         print('NVCC options:', postargs)
         self.spawn(compiler_so + base_opts + cc_args + [src, '-o', obj] +
                    postargs)


### PR DESCRIPTION
I was using sanitizers and tried compiling with clang, which did not like `-fno-gnu-unique`.

Based on the history, this seems to have been to avoid symbol clashes via cub/thrust. Based on feedback from the CCCL team, CCCL now makes sure to use a namespace that is system and version dependent, so I think this option should be unnecessary now.

This was introduced in https://github.com/cupy/cupy/pull/6106 which refers to https://github.com/NVIDIA/thrust/issues/1401#issuecomment-806403746 where `THRUST_CUB_WRAPPED_NAMESPACE` was added as a fix.
From my understanding that would have been a solution here as well, but with the new CCCL code, `THRUST_CUB_WRAPPED_NAMESPACE` is unnecessary as well.

---

I also had a problem with a `constexpr` in `cuda_cub.cu`, but a separate thing.