### PR TITLE
Fix Windows directory path for cuTENSOR 2.3+

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -220,9 +220,10 @@ The current platform ({}) is not supported.'''.format(target_platform))
             shutil.move(
                 os.path.join(outdir, dir_name, 'include'),
                 os.path.join(destination, 'include'))
+            lib_dir = 'lib' if platform.system() == 'Linux' else 'bin'
             shutil.move(
-                os.path.join(outdir, dir_name, 'lib'),
-                os.path.join(destination, 'lib'))
+                os.path.join(outdir, dir_name, lib_dir),
+                os.path.join(destination, lib_dir))
             shutil.move(
                 os.path.join(outdir, dir_name, license), destination)
         elif library == 'nccl':


### PR DESCRIPTION
Follows-up #9439. Part of #9429. `cutensor.dll` is now in `bin` directory instead of `lib` on Windows.

Found in CI failure in https://github.com/cupy/cupy-release-tools/pull/462 (https://ci.preferred.jp/cupy-release-tools.win/202938/)