### PR TITLE
Fix cuTENSOR import libs missing in Windows by `cupyx.tools.install_library` installation

### DIFF
--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -220,10 +220,13 @@ The current platform ({}) is not supported.'''.format(target_platform))
             shutil.move(
                 os.path.join(outdir, dir_name, 'include'),
                 os.path.join(destination, 'include'))
-            lib_dir = 'lib' if platform.system() == 'Linux' else 'bin'
+            if platform.system() == 'Windows':
+                shutil.move(
+                    os.path.join(outdir, dir_name, 'bin'),
+                    os.path.join(destination, 'bin'))
             shutil.move(
-                os.path.join(outdir, dir_name, lib_dir),
-                os.path.join(destination, lib_dir))
+                os.path.join(outdir, dir_name, 'lib'),
+                os.path.join(destination, 'lib'))
             shutil.move(
                 os.path.join(outdir, dir_name, license), destination)
         elif library == 'nccl':


### PR DESCRIPTION
Follows-up #9519. In #9519 I overlooked that the tool is also used at build time and thus we can't omit installing import libs (`lib/cutensor.lib` etc) which is required for Windows build.
