### PR TITLE
PERF: Lower thread-local lookup handling into Cython

### DIFF
--- a/cupy/_core/_threadlocal.pxd
+++ b/cupy/_core/_threadlocal.pxd
@@ -1,0 +1,38 @@
+cimport cython
+from cpython.pythread cimport (
+    PyThread_tss_create, PyThread_tss_get, PyThread_tss_set)
+
+import threading
+import weakref
+
+
+@cython.no_gc
+cdef class _ThreadLocalBase:
+    """Helper to organize thread-local storage that we need quite often
+    in CuPy.
+    In some cases it may be that contextvars are a better solution
+    (one problem is that it is hard to support context managers that can be
+    entered multiple times with them).
+
+    The usage pattern is the following::
+
+        cdef Py_tss_t _thread_local_key
+        if PyThread_tss_create(&_thread_local_key) != 0:
+            raise MemoryError()
+
+        @cython.no_gc
+        class _ThreadLocal(_ThreadLocalBase):
+            # define any local objects and use an __init__ if needed.
+
+            @staticmethod
+            cpdef _ThreadLocal get():
+                return <_ThreadLocal>_ThreadLocal.get(
+                    _ThreadLocal, _thread_local_key)
+
+    It is necessary to define the ``_thread_local_key`` module level.
+    So unfortunately, this convoluted ``_get()`` helper call is necessary.
+    """
+    cdef object _wref
+
+    @staticmethod
+    cdef _get(cls, Py_tss_t& _thread_local_key)

--- a/cupy/_core/_threadlocal.pyx
+++ b/cupy/_core/_threadlocal.pyx
@@ -1,0 +1,39 @@
+cimport cython
+from cpython.pythread cimport PyThread_tss_get, PyThread_tss_set
+
+import gc
+import threading
+import weakref
+
+
+@cython.no_gc  # Must have no GC or the `_wref` trick needs strengthening
+cdef class _ThreadLocalBase:
+    """Helper for thread-local storage, see .pxd file for details.
+    """
+    def _cleanup(self, ref):
+        # Use a Python method for cleanup, this way we store a bound
+        # method, which keeps alive the ``_ThreadLocal`` instance ``self``.
+        # We clean up the weakref (just in case it doesn't clean up it's
+        # __callback__ function -- i.e. this method)
+        self._wref = None
+
+    @staticmethod
+    cdef _get(cls, Py_tss_t& _thread_local_key):
+        cdef _ThreadLocalBase new
+        cdef void *tls = PyThread_tss_get(&_thread_local_key)
+        if tls != NULL:
+            return <object>tls
+
+        new = cls()
+        if gc.is_tracked(new):
+            raise RuntimeError(
+                "internal error: _ThreadLocal classes are assumed to be "
+                "marked `@cython.no_gc` (may be needed for _wref trick).")
+        tls = <void *>new
+        if PyThread_tss_set(&_thread_local_key, tls) != 0:
+            raise MemoryError()
+
+        # Tie the lifetime of `new` to the thread (hope it is cleaned up).
+        # This is how threading.local() works as well (2025-11).
+        new._wref = weakref.ref(threading.current_thread(), new._cleanup)
+        return new

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
-import threading
+cimport cython
+from cupy._core._threadlocal cimport _ThreadLocalBase, PyThread_tss_create
 
 from cupy._core import syncdetect
 from cupy_backends.cuda.api cimport runtime
@@ -8,26 +9,36 @@ from cupy_backends.cuda.api import runtime as runtime_module
 from cupy import _util
 
 
-cdef object _thread_local = threading.local()
-
 cdef dict _devices = {}
 cdef dict _compute_capabilities = {}
 
 
-cdef class _ThreadLocalStack:
+cdef Py_tss_t _tlocal_key
+if PyThread_tss_create(&_tlocal_key) != 0:
+    raise MemoryError()
+
+
+@cython.no_gc
+cdef class _ThreadLocal(_ThreadLocalBase):
     cdef list _devices
+    cdef list cublas_handles
+    cdef list cusolver_handles
+    cdef list cusolver_sp_handles
+    cdef list cusparse_handles
+    cdef list cutensor_handles
 
     def __init__(self):
+        cdef int num_devices = runtime.getDeviceCount()
         self._devices = []
+        self.cublas_handles = [None] * num_devices
+        self.cusolver_handles = [None] * num_devices
+        self.cusolver_sp_handles = [None] * num_devices
+        self.cusparse_handles = [None] * num_devices
+        self.cutensor_handles = [None] * num_devices
 
     @staticmethod
-    cdef _ThreadLocalStack get():
-        try:
-            stack = _thread_local._device_stack
-        except AttributeError:
-            stack = _ThreadLocalStack()
-            _thread_local._device_stack = stack
-        return <_ThreadLocalStack>stack
+    cdef _ThreadLocal get():
+        return <_ThreadLocal>_ThreadLocal._get(_ThreadLocal, _tlocal_key)
 
     cdef void push(self, int device_id) except *:
         self._devices.append(device_id)
@@ -176,13 +187,13 @@ cdef class Device:
 
     def __enter__(self):
         cdef int id = runtime.getDevice()
-        _ThreadLocalStack.get().push(id)
+        _ThreadLocal.get().push(id)
         if self.id != id:
             runtime.setDevice(self.id)
         return self
 
     def __exit__(self, *args):
-        runtime.setDevice(_ThreadLocalStack.get().pop())
+        runtime.setDevice(_ThreadLocal.get().pop())
 
     def __repr__(self):
         return '<CUDA Device %d>' % self.id
@@ -230,22 +241,13 @@ cdef class Device:
         finally:
             runtime.setDevice(prev_device)
 
-    def _get_handle(self, name, create_func, destroy_func):
-        handles = getattr(_thread_local, name, None)
-        if handles is None:
-            handles = {}
-            setattr(_thread_local, name, handles)
-        entry = handles.get(self.id, None)
-        if entry is not None:
-            return entry if destroy_func is None else entry.handle
+    def _make_handle(self, create_func, destroy_func):
         prev_device = runtime.getDevice()
         try:
             runtime.setDevice(self.id)
             handle = create_func()
-            if destroy_func is None:
-                handles[self.id] = handle
-            else:
-                handles[self.id] = Handle(handle, destroy_func)
+            if destroy_func is not None:
+                return Handle(handle, destroy_func)
             return handle
         finally:
             runtime.setDevice(prev_device)
@@ -258,9 +260,14 @@ cdef class Device:
         itself is different.
 
         """
+        handle = _ThreadLocal.get().cublas_handles[self.id]
+        if handle is not None:
+            return handle.handle
+
         from cupy_backends.cuda.libs import cublas
-        return self._get_handle(
-            'cublas_handles', cublas.create, cublas.destroy)
+        handle = self._make_handle(cublas.create, cublas.destroy)
+        _ThreadLocal.get().cublas_handles[self.id] = handle
+        return handle.handle
 
     @property
     def cusolver_handle(self):
@@ -270,9 +277,14 @@ cdef class Device:
         itself is different.
 
         """
+        handle = _ThreadLocal.get().cusolver_handles[self.id]
+        if handle is not None:
+            return handle.handle
+
         from cupy_backends.cuda.libs import cusolver
-        return self._get_handle(
-            'cusolver_handles', cusolver.create, cusolver.destroy)
+        handle = self._make_handle(cusolver.create, cusolver.destroy)
+        _ThreadLocal.get().cusolver_handles[self.id] = handle
+        return handle.handle
 
     @property
     def cusolver_sp_handle(self):
@@ -282,9 +294,14 @@ cdef class Device:
         itself is different.
 
         """
+        handle = _ThreadLocal.get().cusolver_sp_handles[self.id]
+        if handle is not None:
+            return handle.handle
+
         from cupy_backends.cuda.libs import cusolver
-        return self._get_handle(
-            'cusolver_sp_handles', cusolver.spCreate, cusolver.spDestroy)
+        handle = self._make_handle(cusolver.spCreate, cusolver.spDestroy)
+        _ThreadLocal.get().cusolver_sp_handles[self.id] = handle
+        return handle.handle
 
     @property
     def cusparse_handle(self):
@@ -294,9 +311,14 @@ cdef class Device:
         itself is different.
 
         """
+        handle = _ThreadLocal.get().cusparse_handles[self.id]
+        if handle is not None:
+            return handle.handle
+
         from cupy_backends.cuda.libs import cusparse
-        return self._get_handle(
-            'cusparse_sp_handles', cusparse.create, cusparse.destroy)
+        handle = self._make_handle(cusparse.create, cusparse.destroy)
+        _ThreadLocal.get().cusparse_handles[self.id] = handle
+        return handle.handle
 
     @property
     def cutensor_handle(self):
@@ -306,8 +328,14 @@ cdef class Device:
         itself is different. Returns a CutensorHandle object that owns the
         raw library handle and all associated per-device caches.
         """
+        handle = _ThreadLocal.get().cutensor_handles[self.id]
+        if handle is not None:
+            return handle
+
         from cupyx.cutensor import CutensorHandle
-        return self._get_handle('cutensor_handles', CutensorHandle, None)
+        handle = self._make_handle(CutensorHandle, None)
+        _ThreadLocal.get().cutensor_handles[self.id] = handle
+        return handle
 
     @property
     def mem_info(self):

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -7,7 +7,6 @@ from cython.operator cimport dereference as deref, postincrement
 import atexit
 import gc
 import os
-import threading
 import warnings
 import weakref
 
@@ -20,6 +19,7 @@ from libcpp.set cimport set as std_set
 from libcpp.pair cimport pair as std_pair
 from libcpp.mutex cimport mutex as cpp_mutex
 
+from cupy._core._threadlocal cimport _ThreadLocalBase, PyThread_tss_create
 from cupy.cuda cimport device
 from cupy.cuda cimport memory_hook
 from cupy.cuda cimport stream as stream_module
@@ -127,17 +127,8 @@ cdef class Memory(BaseMemory):
 cdef inline void check_async_alloc_supported(int device_id) except*:
     if runtime._is_hip_environment:
         raise RuntimeError('HIP does not support memory_async')
-    cdef int dev_id
-    cdef list support
-    try:
-        is_supported = _thread_local.device_support_async_alloc[device_id]
-    except AttributeError:
-        support = [runtime.deviceGetAttribute(
-            runtime.cudaDevAttrMemoryPoolsSupported, dev_id)
-            for dev_id in range(runtime.getDeviceCount())]
-        _thread_local.device_support_async_alloc = support
-        is_supported = support[device_id]
-    if not is_supported:
+
+    if not _ThreadLocal.get().device_support_async_alloc(device_id):
         raise RuntimeError('Device {} does not support '
                            'malloc_async'.format(device_id))
 
@@ -859,19 +850,40 @@ cpdef MemoryPointer malloc_system(size_t size):
 
 
 cdef object _current_allocator = _malloc
-cdef object _thread_local = threading.local()
+cdef Py_tss_t _tlocal_key
+if PyThread_tss_create(&_tlocal_key) != 0:
+    raise MemoryError()
+
+
+@cython.no_gc
+cdef class _ThreadLocal(_ThreadLocalBase):
+    cdef object allocator
+    cdef object _device_support_async_alloc
+
+    def __init__(self):
+        self.allocator = None
+        self._device_support_async_alloc = None
+
+    cdef bint device_support_async_alloc(self, int device_id):
+        if self._device_support_async_alloc is None:
+            self._device_support_async_alloc = [runtime.deviceGetAttribute(
+                runtime.cudaDevAttrMemoryPoolsSupported, dev_id)
+                for dev_id in range(runtime.getDeviceCount())]
+
+        return self._device_support_async_alloc[device_id]
+
+    @staticmethod
+    cdef _ThreadLocal get():
+        return <_ThreadLocal>_ThreadLocal._get(_ThreadLocal, _tlocal_key)
 
 
 def _get_thread_local_allocator():
-    try:
-        allocator = _thread_local.allocator
-    except AttributeError:
-        allocator = _thread_local.allocator = None
-    return allocator
+    return _ThreadLocal.get().allocator
 
 
 def _set_thread_local_allocator(allocator):
-    _thread_local.allocator = allocator
+    thread_local = _ThreadLocal.get()
+    thread_local.allocator = allocator
 
 
 cdef inline intptr_t _get_stream_identifier(intptr_t stream_ptr) except? -1:
@@ -880,12 +892,7 @@ cdef inline intptr_t _get_stream_identifier(intptr_t stream_ptr) except? -1:
     if stream_ptr != runtime.streamPerThread:
         return stream_ptr
 
-    cdef intptr_t tid
-    try:
-        tid = _thread_local._tid
-    except AttributeError:
-        _thread_local._tid_obj = tid_obj = object()
-        _thread_local._tid = tid = id(tid_obj)
+    cdef intptr_t tid = id(_ThreadLocal.get())
     return -tid
 
 
@@ -918,7 +925,7 @@ cpdef set_allocator(allocator=None):
     global _current_allocator
     if allocator is None:
         allocator = _malloc
-    if getattr(_thread_local, 'allocator', None) is not None:
+    if _ThreadLocal.get().allocator is not None:
         raise ValueError('Can\'t change the global allocator inside '
                          '`using_allocator` context manager')
     _current_allocator = allocator
@@ -930,10 +937,7 @@ cpdef get_allocator():
     Returns:
         function: CuPy memory allocator.
     """
-    try:
-        allocator = _thread_local.allocator
-    except AttributeError:
-        _thread_local.allocator = allocator = None
+    allocator = _ThreadLocal.get().allocator
     if allocator is None:
         return _current_allocator
     else:

--- a/cupy/cuda/memory_hook.pyx
+++ b/cupy/cuda/memory_hook.pyx
@@ -1,11 +1,16 @@
+cimport cython
+from cupy._core._threadlocal cimport _ThreadLocalBase, PyThread_tss_create
+
 import collections
-import threading
-
-cdef object _thread_local = threading.local()
 
 
-cdef class _ThreadLocal:
+cdef Py_tss_t _tlocal_key
+if PyThread_tss_create(&_tlocal_key) != 0:
+    raise MemoryError()
 
+
+@cython.no_gc
+cdef class _ThreadLocal(_ThreadLocalBase):
     cdef object memory_hooks
 
     def __init__(self):
@@ -13,11 +18,7 @@ cdef class _ThreadLocal:
 
     @staticmethod
     cdef _ThreadLocal get():
-        try:
-            tls = _thread_local.tls
-        except AttributeError:
-            tls = _thread_local.tls = _ThreadLocal()
-        return <_ThreadLocal>tls
+        return <_ThreadLocal>_ThreadLocal._get(_ThreadLocal, _tlocal_key)
 
 
 cpdef bint _has_memory_hooks() except -1:

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -125,6 +125,7 @@ _cuda_files = [
     'cupy._core._routines_sorting',
     'cupy._core._routines_statistics',
     'cupy._core._scalar',
+    'cupy._core._threadlocal',
     'cupy._core.core',
     'cupy._core.flags',
     'cupy._core.internal',


### PR DESCRIPTION
**Not rather important, but if @leofang loosk at it out of curiosity should also be good to go in, if the pattern looks OK.**

---

Thread local lookups are not very slow but do add up to a noticable amount. This lowers them into C.

The tricky part here is garbage collection when the Python thread is destructured. This works roughly as it does for thread-local also: https://github.com/python/cpython/blob/9f2a34af747e2fc95f3de8a3bb5e1d7ac10d6d04/Lib/_threading_local.py#L62

I.e. we create a weakref on the thread object with a destructor that cleans up our thread-state.
The second trick here is that this is done via a bound method and this only works on account of a reference cycle, so that the `@cython.no_gc` decorator is actually required to make it work correctly. (Otherwise, we would have to store it elsewhere.)

In many places this doesn't matter, but I wanted to align things. I re-structured the "handles" also because the in-line import is not great.

---

I had written this and thought it wasn't bad, but the actual speed-up is not super relevant, so punted a bit.
I do think this may be helpful speed-wise but to really make an impact we probably have to do a lot of small optimizations.

But, I was talking with @leofang and he was curious about the approach/pattern.

Note that for "config" style thread-local variables (e.g. to be used for a `with config():` manager), I would use `contextvars` they also come with `PyContextVar_Get()` from C and should be similarly fast.
In future Python versions (and free-threading) those are inherited by spawned threads.

But CuPy has reasons why this might be a sensible start:
* Some cuda context (such as handles) are _actually_ thread-local, the inheriting pattern of (future) `contextvars` would be incorrect.
* There is no nice pattern to write a `with config(...):` that can be entered an arbitrary number of times (i.e. you would still want a normal thread-local to store the stack of previous values.