### PR TITLE
Fix piecewise to handle list of boolean conditions

### DIFF
--- a/cupy/_functional/piecewise.py
+++ b/cupy/_functional/piecewise.py
@@ -35,9 +35,13 @@ def piecewise(x, condlist, funclist):
 
         .. seealso:: :func:`numpy.piecewise`
         """
-    if cupy.isscalar(condlist):
+    x = cupy.asanyarray(x)
+
+    if cupy.isscalar(condlist) or (
+            not isinstance(condlist[0], (list, cupy.ndarray)) and x.ndim != 0):
         condlist = [condlist]
 
+    condlist = cupy.asarray(condlist, dtype=bool)
     condlen = len(condlist)
     funclen = len(funclist)
     if condlen == funclen:

--- a/tests/cupy_tests/functional_tests/test_piecewise.py
+++ b/tests/cupy_tests/functional_tests/test_piecewise.py
@@ -119,3 +119,11 @@ class TestPiecewise(unittest.TestCase):
         funclist = [-10, lambda x: -x, 10, lambda x: x]
         with pytest.raises(NotImplementedError):
             cupy.piecewise(x, condlist, funclist)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_piecewise_condition_boolean_list(self, xp, dtype):
+        x = xp.array([0, 0], dtype=dtype)
+        condlist = [True, False]
+        funclist = [1, 2]
+        return xp.piecewise(x, condlist, funclist)


### PR DESCRIPTION
This PR will fix: https://github.com/cupy/cupy/issues/9267
cupy.piecewise returned incorrect results when condlist contained booleans in a list (e.g., [True, False]). Now, such lists are properly handle boolean arrays, matching NumPy behavior. Also added test case for it.

I picked up this issue as a way to get started with contributing to CuPy and to better understand its codebase. Please let me know if there are improvements I can make to this PR or if there are other small issues/features I could contribute to next.

Thank you.