### PR TITLE
Add N-D array support to upfirdn

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_upfirdn.py
@@ -226,6 +226,32 @@ class TestUpfirdn:
         return y
 
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
+    @pytest.mark.parametrize('h', (1., 1j))
+    @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
+    @pytest.mark.parametrize('shape, axis', [
+        # 3D
+        ((2, 3, 4), 0),
+        ((2, 3, 4), 1),
+        ((2, 3, 4), 2),
+        ((2, 3, 4), -1),
+        # 4D
+        ((2, 3, 4, 5), 0),
+        ((2, 3, 4, 5), 2),
+        ((2, 3, 4, 5), -1),
+    ])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_vs_naive_delta_nd(self, x_dtype, h, up, down, shape, axis,
+                               xp, scp):
+        rng = np.random.RandomState(17)
+        x = rng.randn(*shape).astype(x_dtype)
+        if x_dtype in (np.complex64, np.complex128):
+            x += 1j * rng.randn(*shape)
+        x = xp.asarray(x)
+        h = xp.asarray(np.atleast_1d(h))
+        y = scp.signal.upfirdn(h, x, up, down, axis=axis)
+        return y
+
+    @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('p_max, q_max',
                              list(product((10, 100), (10, 100))))


### PR DESCRIPTION
Extend cupyx.scipy.signal.upfirdn to support N-dimensional arrays, matching SciPy's behavior. Previously limited to 1D/2D arrays.

Implementation:
- Extract 2D kernel code into _apply_filter_2d helper method
- For N-D arrays: move target axis to end, reshape to 2D, apply existing kernel, reshape back to original dimensions

Ref #8716