### PR TITLE
Fix intersect1d crash with empty arrays

### DIFF
--- a/cupy/_logic/truth.py
+++ b/cupy/_logic/truth.py
@@ -162,6 +162,7 @@ def intersect1d(arr1, arr2, assume_unique=False, return_indices=False):
     numpy.intersect1d
 
     """
+    common_dtype = cupy.result_type(arr1.dtype, arr2.dtype)
     if not assume_unique:
         if return_indices:
             arr1, ind1 = cupy.unique(arr1, return_index=True)
@@ -175,11 +176,11 @@ def intersect1d(arr1, arr2, assume_unique=False, return_indices=False):
 
     if not return_indices:
         mask = _search._exists_kernel(arr1, arr2, arr2.size, False)
-        return arr1[mask]
+        return arr1[mask].astype(common_dtype)
 
     mask, v1 = _search._exists_and_searchsorted_kernel(
         arr1, arr2, arr2.size, False)
-    int1d = arr1[mask]
+    int1d = arr1[mask].astype(common_dtype)
     arr1_indices = cupy.flatnonzero(mask)
     arr2_indices = v1[mask]
 

--- a/cupy/_sorting/search.py
+++ b/cupy/_sorting/search.py
@@ -365,6 +365,12 @@ _exists_kernel = _core.ElementwiseKernel(
     'S x, raw T bins, int64 n_bins, bool invert',
     'bool out',
     '''
+    // Handle empty bins array to avoid illegal memory access
+    if (n_bins == 0) {
+        out = (invert ? true : false);
+        return;
+    }
+
     const bool assume_increasing = true;
     const bool side_is_right = false;
     long long y;
@@ -379,6 +385,13 @@ _exists_and_searchsorted_kernel = _core.ElementwiseKernel(
     'S x, raw T bins, int64 n_bins, bool invert',
     'bool out, int64 y',
     '''
+    // Handle empty bins array to avoid illegal memory access
+    if (n_bins == 0) {
+        out = (invert ? true : false);
+        y = 0;
+        return;
+    }
+
     const bool assume_increasing = true;
     const bool side_is_right = false;
     '''

--- a/tests/cupy_tests/logic_tests/test_truth.py
+++ b/tests/cupy_tests/logic_tests/test_truth.py
@@ -263,6 +263,36 @@ class TestIntersect1d:
         b = xp.array([4, 6, 2, 5, 7, 6], dtype=dtype)
         return xp.intersect1d(a, b, return_indices=True)
 
+    @testing.numpy_cupy_array_equal()
+    def test_intersect1d_both_empty(self, xp):
+        return xp.intersect1d(xp.array([]), xp.array([]))
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_intersect1d_empty_array(self, xp, dtype):
+        a = xp.array([], dtype=dtype)
+        b = xp.array([0], dtype=dtype)
+        return xp.intersect1d(a, b, return_indices=True)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_intersect1d_second_empty_array(self, xp, dtype):
+        a = xp.array([0], dtype=dtype)
+        b = xp.array([], dtype=dtype)
+        return xp.intersect1d(a, b, return_indices=True)
+
+    @testing.numpy_cupy_array_equal()
+    def test_intersect1d_mixed_dtypes_empty(self, xp):
+        a = xp.array([0], dtype=xp.int64)
+        b = xp.array([], dtype=xp.float64)
+        return xp.intersect1d(a, b)
+
+    @testing.numpy_cupy_array_equal()
+    def test_intersect1d_mixed_dtypes_empty_with_indices(self, xp):
+        a = xp.array([0], dtype=xp.int64)
+        b = xp.array([], dtype=xp.float64)
+        return xp.intersect1d(a, b, return_indices=True)
+
 
 class TestUnion1d:
 


### PR DESCRIPTION
Fix illegal memory access when either input array is empty. The CUDA kernel was accessing non-existent memory, corrupting the CUDA context for subsequent operations.

Add early return with proper dtype handling using result_type() to match NumPy behavior.

Fixes #8937