### PR TITLE
TYP: Fix small typing issues found in new pre-commit env

### DIFF
--- a/cupy/_creation/basic.py
+++ b/cupy/_creation/basic.py
@@ -68,7 +68,7 @@ def _new_like_order_and_strides(
 
 def empty_like(
         prototype: NDArray[Any],
-        dtype: DTypeLike = None,
+        dtype: DTypeLike | None = None,
         order: _OrderKACF = 'K',
         subok: None = None,
         shape: _ShapeLike | None = None,
@@ -189,7 +189,7 @@ def ones(
 
 def ones_like(
         a: NDArray[Any],
-        dtype: DTypeLike = None,
+        dtype: DTypeLike | None = None,
         order: _OrderKACF = 'K',
         subok: None = None,
         shape: _ShapeLike | None = None,
@@ -256,7 +256,7 @@ def zeros(
 
 def zeros_like(
         a: NDArray[Any],
-        dtype: DTypeLike = None,
+        dtype: DTypeLike | None = None,
         order: _OrderKACF = 'K',
         subok: None = None,
         shape: _ShapeLike | None = None,
@@ -300,7 +300,7 @@ def zeros_like(
 def full(
         shape: _ShapeLike,
         fill_value: Any,
-        dtype: DTypeLike = None,
+        dtype: DTypeLike | None = None,
         order: _OrderCF = 'C',
 ) -> NDArray[Any]:
     """Returns a new array of given shape and dtype, filled with a given value.
@@ -333,7 +333,7 @@ def full(
 def full_like(
         a: NDArray[Any],
         fill_value: Any,
-        dtype: DTypeLike = None,
+        dtype: DTypeLike | None = None,
         order: _OrderKACF = 'K',
         subok: None = None,
         shape: _ShapeLike | None = None,

--- a/cupyx/jit/_compile.py
+++ b/cupyx/jit/_compile.py
@@ -34,7 +34,7 @@ _typeclasses = (bool, numpy.bool_, numbers.Number)
 
 if (3, 8) <= sys.version_info:
     from typing import Literal
-    _CastingType = Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] | None
+    _CastingType = Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe']
 else:
     _CastingType = str
 


### PR DESCRIPTION
Some versions changes seems to have flushed these out locally. The `like`/`full` functions explicitly support `None` of course while the `astype` helper function does indeed not support it.