### PR TITLE
Implement remaining quantile methods: inverted_cdf, averaged_inverted…

### DIFF
--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -13,9 +13,9 @@ from cupy import testing
 
 _all_methods = (
     # 'inverted_cdf',               # TODO(takagi) Not implemented
-    # 'averaged_inverted_cdf',      # TODO(takagi) Not implemented
-    # 'closest_observation',        # TODO(takagi) Not implemented
-    # 'interpolated_inverted_cdf',  # TODO(takagi) Not implemented
+    'averaged_inverted_cdf',
+    'closest_observation',
+    'interpolated_inverted_cdf',
     'hazen',
     'weibull',
     'linear',


### PR DESCRIPTION
…_cdf, closest_observation, interpolated_inverted_cdf

Add support for the final four quantile estimation methods from NumPy 1.22:
- inverted_cdf (H&F type 1): Discontinuous, takes j if g > 0, else i
- averaged_inverted_cdf (H&F type 2): Discontinuous, takes j if g > 0, else average(i, j)
- closest_observation (H&F type 3): Discontinuous, rounds to nearest observation
- interpolated_inverted_cdf (H&F type 4): Continuous with alpha=0, beta=1

Closes #6229