### PR TITLE
Fix #7828: Remove `self` from ndarray docstring signature

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -127,7 +127,7 @@ cdef inline bint is_ump_supported(int device_id) except*:
 
 class ndarray(_ndarray_base):
     """
-    __init__(self, shape, dtype=float, memptr=None, strides=None, order='C')
+    __init__(shape, dtype=float, memptr=None, strides=None, order='C')
 
     Multi-dimensional array on a CUDA device.
 


### PR DESCRIPTION
## Summary
Remove `self` from the `__init__` signature in `cupy.ndarray` docstring.

## Problem
The docstring contained `__init__(self, shape, ...)`, which Sphinx rendered as:
`class cupy.ndarray(self, shape, dtype=float, ...)`

The correct rendering (as in v10.6.0) should be:
`class cupy.ndarray(shape, dtype=float, ...)`

Fixes #7828