### PR TITLE
Fix #9568: Handle negative inputs in sawtooth and square waveforms

### DIFF
--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -73,7 +73,12 @@ _sawtooth_kernel = cupy.ElementwiseKernel(
         out = nan("0xfff8000000000000ULL");
     }
 
-    const T tmod { fmod( t, 2.0 * M_PI ) };
+    // Use Python-compatible modulo: result is always in [0, 2*pi)
+    // C fmod can return negative values for negative inputs
+    T tmod { fmod( t, 2.0 * M_PI ) };
+    if ( tmod < 0 ) {
+        tmod += 2.0 * M_PI;
+    }
     const bool mask2 { ( ( 1 - mask1 ) && ( tmod < ( w * 2.0 * M_PI ) ) ) };
 
     if ( mask2 ) {
@@ -141,7 +146,12 @@ _square_kernel = cupy.ElementwiseKernel(
         y = nan("0xfff8000000000000ULL");
     }
 
-    const T tmod { fmod( t, 2.0 * M_PI ) };
+    // Use Python-compatible modulo: result is always in [0, 2*pi)
+    // C fmod can return negative values for negative inputs
+    T tmod { fmod( t, 2.0 * M_PI ) };
+    if ( tmod < 0 ) {
+        tmod += 2.0 * M_PI;
+    }
     const bool mask2 { ( ( 1 - mask1 ) && ( tmod < ( w * 2.0 * M_PI ) ) ) };
 
     if ( mask2 ) {

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
@@ -179,6 +179,12 @@ class TestSawtooth:
         t = xp.linspace(0, 1, 500)
         return scp.signal.sawtooth(t, width)
 
+    @pytest.mark.parametrize('width', [0.0, 0.5, 1.0])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_sawtooth_negative_input(self, width, xp, scp):
+        t = xp.linspace(-2 * xp.pi, 2 * xp.pi, 500)
+        return scp.signal.sawtooth(t, width)
+
 
 @testing.with_requires('scipy')
 class TestSquare:
@@ -186,6 +192,12 @@ class TestSquare:
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_square(self, duty, xp, scp):
         t = xp.linspace(0, 1, 500)
+        return scp.signal.square(t, duty)
+
+    @pytest.mark.parametrize('duty', [0.0, 0.5, 1.0])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_square_negative_input(self, duty, xp, scp):
+        t = xp.linspace(-2 * xp.pi, 2 * xp.pi, 500)
         return scp.signal.square(t, duty)
 
 


### PR DESCRIPTION
## Summary
- Fix incorrect behavior of `cupyx.scipy.signal.sawtooth` and `cupyx.scipy.signal.square` for negative input values
- The root cause was the difference between C's `fmod()` and Python's `%` operator:
  - C `fmod(-0.5, 2π)` returns `-0.5` (same sign as dividend)
  - Python `-0.5 % (2π)` returns positive value (always non-negative)
- Added normalization to ensure `tmod` is always in `[0, 2π)` range

## Test plan
- [x] Verified fix in Google Colab with GPU
- [x] Added tests for negative input values (`test_sawtooth_negative_input`, `test_square_negative_input`)
- [] CI tests

Closes #9568