### PR TITLE
Revert "Bump disk size limit for cuda.head CI"

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -489,7 +489,7 @@ configs {
     requirement {
       cpu: 8
       memory: 50
-      disk: 20
+      disk: 10
       gpu: 2
     }
     time_limit: {


### PR DESCRIPTION
Reverts cupy/cupy#9636

Merge after confirming disk full issue fixed by #9644