### PR TITLE
Remove cupyx.scipy.linalg.kron

### DIFF
--- a/cupyx/scipy/linalg/__init__.py
+++ b/cupyx/scipy/linalg/__init__.py
@@ -1,7 +1,7 @@
 # flake8: NOQA
 from cupyx.scipy.linalg._special_matrices import (
     toeplitz, circulant, hankel,
-    hadamard, leslie, kron, block_diag, companion,
+    hadamard, leslie, block_diag, companion,
     helmert, hilbert, dft,
     fiedler, fiedler_companion, convolution_matrix
 )

--- a/cupyx/scipy/linalg/_special_matrices.py
+++ b/cupyx/scipy/linalg/_special_matrices.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import warnings
 
 import cupy
 from cupy import _core
@@ -160,36 +159,6 @@ def leslie(f, s):
     a[0] = f
     cupy.fill_diagonal(a[1:], s)
     return a
-
-
-@_uarray.implements('kron')
-def kron(a, b):
-    """Kronecker product.
-
-    The result is the block matrix::
-        a[0,0]*b    a[0,1]*b  ... a[0,-1]*b
-        a[1,0]*b    a[1,1]*b  ... a[1,-1]*b
-        ...
-        a[-1,0]*b   a[-1,1]*b ... a[-1,-1]*b
-
-    Args:
-        a (cupy.ndarray): Input array
-        b (cupy.ndarray): Input array
-
-    Returns:
-        cupy.ndarray: Kronecker product of ``a`` and ``b``.
-
-    .. seealso:: :func:`scipy.linalg.kron`
-    """
-    warnings.warn(
-        '`cupyx.scipy.linalg.kron` has been deprecated in CuPy v14 and will '
-        'be removed in the near future. Please use `cupy.kron` instead.',
-        DeprecationWarning,
-    )
-
-    o = cupy.outer(a, b)
-    o = o.reshape(a.shape + b.shape)
-    return cupy.concatenate(cupy.concatenate(o, axis=1), axis=1)
 
 
 @_uarray.implements('block_diag')

--- a/docs/source/reference/scipy_linalg.rst
+++ b/docs/source/reference/scipy_linalg.rst
@@ -12,7 +12,6 @@ Basics
    :toctree: generated/
 
    solve_triangular
-   kron
    khatri_rao
 
 

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import unittest
-import warnings
 
 from cupy import testing
 import cupyx.scipy.linalg  # NOQA
@@ -50,10 +49,6 @@ class TestSpecialMatricesBase(unittest.TestCase):
         'function': ['dft'],
         'args': [(4, 'sqrtn'), (5, 'n')],
     }) + testing.product({
-        # 2 arguments: both 2D arrays
-        'function': ['kron'],
-        'args': [((5, 5), (4, 5),), ((5, 4), (4, 4),), ((1, 2), (4, 5))],
-    }) + testing.product({
         # 0 or more arguments: all 1 or 2D arrays
         'function': ['block_diag'],
         'args': [(), ((5,),), ((4, 5),), ((5,), (4, 4),), ((1, 2), (4, 5)),
@@ -66,13 +61,7 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
                                  accept_error=ValueError)
     def test_special_matrix(self, xp, scp):
         function = getattr(scp.linalg, self.function)
-
-        if self.function == "kron":
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=DeprecationWarning)
-                return function(*[self._get_arg(xp, arg) for arg in self.args])
-        else:
-            return function(*[self._get_arg(xp, arg) for arg in self.args])
+        return function(*[self._get_arg(xp, arg) for arg in self.args])
 
 
 @testing.parameterize(*(


### PR DESCRIPTION
Part of #9690.
https://docs.scipy.org/doc/scipy/release/1.17.0-notes.html#expired-deprecations