### PR TITLE
Remove cupyx.scipy.special.sph_harm

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -84,7 +84,6 @@ from cupyx.scipy.special._erf import erfcinv  # NOQA
 
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA
-from cupyx.scipy.special._sph_harm import sph_harm  # NOQA
 from cupyx.scipy.special._sph_harm import sph_harm_y  # NOQA
 
 # Other special functions

--- a/cupyx/scipy/special/_sph_harm.py
+++ b/cupyx/scipy/special/_sph_harm.py
@@ -7,8 +7,6 @@ https://github.com/scipy/scipy/blob/master/scipy/special/sph_harm.pxd
 from __future__ import annotations
 
 
-import warnings
-
 from cupy import _core
 
 from cupyx.scipy.special._poch import poch_definition
@@ -86,20 +84,6 @@ _sph_harm = _core.create_ufunc(
 
     """,
 )
-
-
-def sph_harm(m, n, theta, phi, out=None):
-    """Spherical Harmonic.
-
-    .. seealso:: :meth:`scipy.special.sph_harm`
-
-    """
-
-    warnings.warn(DeprecationWarning(
-        "`cupyx.scipy.special.sph_harm` is deprecated in CuPy v14 "
-        "and are planned to be removed in the future."))
-
-    return _sph_harm(m, n, theta, phi, out=out)
 
 
 def sph_harm_y(n, m, theta, phi, *, diff_n=0):

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -147,7 +147,7 @@ Legendre functions
    :toctree: generated/
 
    lpmv
-   sph_harm
+   sph_harm_y
 
 
 Lambert W and related functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -20,16 +20,6 @@ def _get_harmonic_list(degree_max):
 @testing.with_requires("scipy")
 class TestBasic:
 
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
-    @testing.for_dtypes(["e", "f", "d"])
-    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-7, atol=1e-10)
-    def test_sph_harm(self, xp, scp, dtype, m, n):
-        theta = xp.linspace(0, 2 * cp.pi)
-        phi = xp.linspace(0, cp.pi)
-        theta, phi = xp.meshgrid(theta, phi)
-        return scp.special.sph_harm(m, n, theta, phi)
-
     @testing.with_requires("scipy>=1.15.0")
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])


### PR DESCRIPTION
Part of #9690.
https://docs.scipy.org/doc/scipy/release/1.17.0-notes.html#expired-deprecations