### PR TITLE
ENH: (almost) full structured dtype support

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -810,6 +810,8 @@ from cupy._core import RawKernel  # NOQA
 from cupy._core import RawModule  # NOQA
 from cupy._core._reduction import ReductionKernel  # NOQA
 
+from cupy._core._dtype import make_gpu_aligned_dtype  # NOQA
+
 # -----------------------------------------------------------------------------
 # DLPack
 # -----------------------------------------------------------------------------

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -810,7 +810,7 @@ from cupy._core import RawKernel  # NOQA
 from cupy._core import RawModule  # NOQA
 from cupy._core._reduction import ReductionKernel  # NOQA
 
-from cupy._core._dtype import make_gpu_aligned_dtype  # NOQA
+from cupy._core._dtype import make_aligned_dtype  # NOQA
 
 # -----------------------------------------------------------------------------
 # DLPack

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -206,7 +206,7 @@ cdef void populate_format(Py_buffer* buf, str dtype) except*:
     buf.format = dtype_format[dtype]
 
 
-def _make_gpu_aligned_dtype(
+def _make_aligned_dtype(
         dtype, *, int alignment=-1, bint recurse=True):
     # Internal version that also return the final alignment for recursion.
     cdef Py_ssize_t final_alignment = 1
@@ -232,7 +232,7 @@ def _make_gpu_aligned_dtype(
             # (A title is an alternative field name...)
             if offset < min_offset:
                 raise ValueError(
-                    "make_gpu_aligned_dtype() only supports well behaved "
+                    "make_aligned_dtype() only supports well behaved "
                     "in order fields as it ignores field offsets).")
 
             # Keep track of field offset to reject non-ordered inputs.
@@ -251,7 +251,7 @@ def _make_gpu_aligned_dtype(
                 # Must assume the alignment of the subdtype makes sense.
                 subalignment = subdtype.alignment
             else:
-                subdtype, subalignment = _make_gpu_aligned_dtype(
+                subdtype, subalignment = _make_aligned_dtype(
                     subdtype, recurse=recurse)
 
             if curr_offset % subalignment != 0:
@@ -274,7 +274,7 @@ def _make_gpu_aligned_dtype(
             metadata = {"metadata": {"__cuda_alignment__": alignment}}
         else:
             raise ValueError(
-                f"make_gpu_aligned_dtype(): given alignment={alignment} "
+                f"make_aligned_dtype(): given alignment={alignment} "
                 f"smaller than minimum alignment {final_alignment}"
             )
 
@@ -296,7 +296,7 @@ def _make_gpu_aligned_dtype(
     return cnp.dtype(dtype_info, align=True, **metadata), final_alignment
 
 
-def make_gpu_aligned_dtype(
+def make_aligned_dtype(
         dtype, *, int alignment=-1, bint recurse=True):
     """Create a new structured dtype from a NumPy dtype or dtype-like with
     sufficient algnment for GPU use.
@@ -326,10 +326,10 @@ def make_gpu_aligned_dtype(
     Notes:
         By default this function recurses into nested structures as if
         `alignment=-1` is passed for these.  You can nest a dtype with
-        larger alignment by creating it with ``make_gpu_aligned_dtype()``.
+        larger alignment by creating it with ``make_aligned_dtype()``.
 
         NumPy promotion (e.g. in concatenate) may "canonicalize" the dtype
         and drop the struct layout and CuPy alignment metadata.
     """
-    return _make_gpu_aligned_dtype(
+    return _make_aligned_dtype(
         dtype, alignment=alignment, recurse=recurse)[0]

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -276,7 +276,7 @@ def make_gpu_aligned_dtype(
                 subalignment = dtype.alignment
                 if dtype.metadata:
                     subalignment = subdtype.metadata.get(
-                        "__cupy_alignment__", subalignment)
+                        "__cuda_alignment__", subalignment)
 
             if curr_offset % subalignment != 0:
                 curr_offset += subalignment - (curr_offset % subalignment)
@@ -295,7 +295,7 @@ def make_gpu_aligned_dtype(
     if alignment != -1:
         if alignment >= final_alignment:
             final_alignment = alignment
-            metadata = {"metadata": {"__cupy_alignment__": alignment}}
+            metadata = {"metadata": {"__cuda_alignment__": alignment}}
         else:
             raise ValueError(
                 f"make_gpu_aligned_dtype(): given alignment={alignment} "

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -222,6 +222,7 @@ def _make_aligned_dtype(
         # Allow this when `alignment=` is passed, we try to add the metadata
         dtype_info = descr  # unchanged for now
         final_alignment = _scalar.get_cuda_alignment(descr)
+        curr_offset = descr.itemsize  # asserts itemsize multiple of alignment
     else:
         names = []
         offsets = []
@@ -331,5 +332,10 @@ def make_aligned_dtype(
         NumPy promotion (e.g. in concatenate) may "canonicalize" the dtype
         and drop the struct layout and CuPy alignment metadata.
     """
+    cdef cnp.dtype descr = cnp.dtype(dtype, align=True)
+    if descr.type_num != cnp.NPY_VOID or (<object>descr).fields is None:
+        raise ValueError(
+            "make_aligned_dtype() only supports structured dtypes.")
+
     return _make_aligned_dtype(
         dtype, alignment=alignment, recurse=recurse)[0]

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -229,12 +229,12 @@ def _make_aligned_dtype(
         subdtypes = []
 
         for name, (subdtype, offset, *_) in (<object>descr).fields.items():
-            # The fields tupe can contain a 4th title, we ignore it.
+            # The fields tuple can contain a 4th title, we ignore it.
             # (A title is an alternative field name...)
             if offset < min_offset:
                 raise ValueError(
                     "make_aligned_dtype() only supports well behaved "
-                    "in-order fields as it ignores field offsets).")
+                    "in-order fields as it ignores field offsets.")
 
             # Keep track of field offset to reject non-ordered inputs.
             min_offset = offset + subdtype.itemsize

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -233,7 +233,7 @@ def _make_aligned_dtype(
             if offset < min_offset:
                 raise ValueError(
                     "make_aligned_dtype() only supports well behaved "
-                    "in order fields as it ignores field offsets).")
+                    "in-order fields as it ignores field offsets).")
 
             # Keep track of field offset to reject non-ordered inputs.
             min_offset = offset + subdtype.itemsize
@@ -299,7 +299,7 @@ def _make_aligned_dtype(
 def make_aligned_dtype(
         dtype, *, int alignment=-1, bint recurse=True):
     """Create a new structured dtype from a NumPy dtype or dtype-like with
-    sufficient algnment for GPU use.
+    sufficient alignment for GPU use.
 
     Args:
         dtype: Data type specifier compatible with NumPy.
@@ -317,10 +317,10 @@ def make_aligned_dtype(
 
         recurse: Whether to recurse into nested structures, defaults to True.
             When ``False``, the nested struct is assumed to be already
-            sufficientlyaligned.
+            sufficiently aligned.
 
     Returns:
-        cupy.ndarray: A view of the array with reduced dimensions.
+        numpy.dtype: A dtype object with the desired alignment.
 
 
     Notes:

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -51,7 +51,8 @@ cdef bint check_supported_dtype(cnp.dtype dtype, bint error) except -1:
         # We don't really need to know anything about the dtype, but cannot
         # do references (copying back to CPU would be wrong).
         # Of course... the user may not be able to _do_ anything with it!
-        if dtype.flags & (0x01 | 0x04):
+        if dtype.flags & (
+                _scalar.NPY_ITEM_REFCOUNT | _scalar.NPY_ITEM_IS_POINTER):
             # Note, NumPy may (currently) flag this if a dtype has "holes"
             # such as `np.ones(10, dtype="i,O,i")[["f0", "f1"]]`.
             raise ValueError(

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -219,9 +219,9 @@ def _make_aligned_dtype(
         raise ValueError("Reasonable alignments must be >0 and a power of 2.")
 
     if descr.type_num != cnp.NPY_VOID or (<object>descr).fields is None:
-        # Allow this when `alignment=` is passed, we try to add the meatadat
+        # Allow this when `alignment=` is passed, we try to add the metadata
         dtype_info = descr  # unchanged for now
-        final_alignment = descr.alignment
+        final_alignment = _scalar.get_cuda_alignment(descr)
     else:
         names = []
         offsets = []

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -104,6 +104,7 @@ def _guess_routine(func, args, dtype):
 
     # Feeds dummy arguments with appropriate dtypes passed to `guess_routine`.
     dummy_args = []
+    dtypes = []
 
     for x in args:
         if isinstance(x, _TraceScalar):
@@ -115,10 +116,13 @@ def _guess_routine(func, args, dtype):
             assert isinstance(x, _TraceArray)
             obj = core.ndarray((0,), x.dtype)
         dummy_args.append(obj)
+        dtypes.append(x.dtype)
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
-    return op.get_in_dtypes(), op.get_out_dtypes(), op.routine
+
+    in_out_dtypes = op.resolve_dtypes(dtypes[:func.nin], dtypes[func.nin:])
+    return in_out_dtypes[0], in_out_dtypes[1], op.routine
 
 
 def _base(array):

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -104,7 +104,6 @@ def _guess_routine(func, args, dtype):
 
     # Feeds dummy arguments with appropriate dtypes passed to `guess_routine`.
     dummy_args = []
-    dtypes = []
 
     for x in args:
         if isinstance(x, _TraceScalar):
@@ -116,13 +115,12 @@ def _guess_routine(func, args, dtype):
             assert isinstance(x, _TraceArray)
             obj = core.ndarray((0,), x.dtype)
         dummy_args.append(obj)
-        dtypes.append(x.dtype)
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
 
     in_dtypes, out_dtypes = op.resolve_dtypes(
-        dtypes[:func.nin], dtypes[func.nin:])
+        dummy_args[:func.nin], dummy_args[func.nin:])
     return in_dtypes, out_dtypes, op.routine
 
 

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -121,8 +121,9 @@ def _guess_routine(func, args, dtype):
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
 
-    in_out_dtypes = op.resolve_dtypes(dtypes[:func.nin], dtypes[func.nin:])
-    return in_out_dtypes[0], in_out_dtypes[1], op.routine
+    in_dtypes, out_dtypes = op.resolve_dtypes(
+        dtypes[:func.nin], dtypes[func.nin:])
+    return in_dtypes, out_dtypes, op.routine
 
 
 def _base(array):

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -102,18 +102,19 @@ concrete dtype mapping.
         # disallowed, error_func must be set instead of routine.
         # It's called by check_valid() method.
         readonly object error_func
+        readonly object _resolution_func
+        readonly tuple _in_dtypes
+        readonly tuple _out_dtypes
 
     @staticmethod
     cdef _Op _from_type_and_routine_or_error_func(
-        typ, object routine, object error_func)
+        typ, object routine, object error_func, object resolution_func)
 
     # Creates an op instance parsing a dtype mapping.
     @staticmethod
-    cdef _Op from_type_and_routine(typ, routine)
+    cdef _Op from_type_and_routine(typ, routine, object resolution_func)
 
-    cpdef tuple get_in_dtypes(self)
-
-    cpdef tuple get_out_dtypes(self)
+    cpdef tuple resolve_dtypes(self, list in_dtypes, list out_dtypes)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -70,9 +70,9 @@ cdef class _ArgInfo:
 
     cdef bint is_scalar(self) noexcept
 
-    cdef str get_c_type(self, type_headers=*)
+    cdef str get_c_type(self, type_decls=*)
 
-    cdef str get_param_c_type(self, ParameterInfo p, type_headers=*)
+    cdef str get_param_c_type(self, ParameterInfo p, type_decls=*)
 
     cdef str get_c_var_name(self, ParameterInfo p)
 
@@ -84,7 +84,7 @@ cdef class _TypeMap:
     cdef public:
         tuple _pairs
 
-    cdef str get_typedef_code(self, type_headers=*)
+    cdef str get_typedef_code(self, type_decls=*)
 
 
 cdef class _Op:
@@ -155,7 +155,7 @@ cpdef str _full_mask_hex()
 
 cdef tuple _get_arginfos(list args)
 
-cdef str _get_kernel_params(tuple params, tuple arginfos, type_headers=*)
+cdef str _get_kernel_params(tuple params, tuple arginfos, type_decls=*)
 
 cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape)
 

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -114,7 +114,7 @@ concrete dtype mapping.
     @staticmethod
     cdef _Op from_type_and_routine(typ, routine, object resolution_func)
 
-    cpdef tuple resolve_dtypes(self, list in_dtypes, list out_dtypes)
+    cpdef tuple resolve_dtypes(self, list in_args, list out_args)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1387,7 +1387,7 @@ cdef class ufunc:
         if _contains_zero(shape):
             return ret
 
-        for i, t in enumerate(op.in_types):
+        for i, t in enumerate(core_in_dtypes):
             # If necessary, cast scalars here (deals with Python ints also)
             if type(inout_args[i]) is _scalar.CScalar:
                 (<_scalar.CScalar>inout_args[i]).apply_dtype(t)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1100,7 +1100,6 @@ cdef function.Function _get_ufunc_kernel(
         loop_prep=loop_prep, after_loop='', options=("--std=c++17",))
 
 
-
 cdef inline int _get_kind_score(kind) except -1:
     if kind not in (int, float, complex):
         kind = kind.type  # TODO: Make pretty.

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1101,8 +1101,6 @@ cdef function.Function _get_ufunc_kernel(
 
 
 cdef inline int _get_kind_score(kind) except -1:
-    if kind not in (int, float, complex):
-        kind = kind.type  # TODO: Make pretty.
     if issubclass(kind, numpy.bool_):
         return 0
     if issubclass(kind, (numpy.integer, int)):
@@ -1138,7 +1136,7 @@ cdef inline bint _check_should_use_weak_scalar(
             kind = _get_kind_score(w_t)
             max_scalar_kind = max(max_scalar_kind, kind)
         else:
-            kind = _get_kind_score(in_t)
+            kind = _get_kind_score(in_t.type)  # kind score uses scalar type
             max_array_kind = max(max_array_kind, kind)
 
     all_scalars_or_arrays = max_scalar_kind == -1 or max_array_kind == -1

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -78,17 +78,13 @@ cpdef str _full_mask_hex():
 cdef str _get_simple_elementwise_kernel_code(
         tuple params_, tuple arginfos, str operation, str name,
         _TypeMap type_map, str preamble, str loop_prep='', str after_loop=''):
-    type_headers = set()
-    params = _get_kernel_params(params_, arginfos, type_headers)
-    typedef_preamble = type_map.get_typedef_code(type_headers)
-    if not type_headers:
-        type_headers = ""
-    else:
-        type_headers = "\n".join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    params = _get_kernel_params(params_, arginfos, type_decls)
+    typedef_preamble = type_map.get_typedef_code(type_decls)
 
     # No loop unrolling due to avoid 64-bit division
     module_code = string.Template('''
-    ${type_headers}${typedef_preamble}
+    ${type_decls}${typedef_preamble}
     ${preamble}
     extern "C" __global__ void ${name}(${params}) {
       ${loop_prep};
@@ -102,7 +98,7 @@ cdef str _get_simple_elementwise_kernel_code(
     ''').substitute(
         typedef_preamble=typedef_preamble,
         params=params,
-        type_headers=type_headers,
+        type_decls=_scalar.format_type_decls(type_decls),
         operation=operation,
         name=name,
         preamble=preamble,
@@ -312,26 +308,26 @@ cdef class _ArgInfo:
     cdef bint is_scalar(self) noexcept:
         return self.arg_kind == ARG_KIND_SCALAR
 
-    cdef str get_c_type(self, type_headers=None):
+    cdef str get_c_type(self, type_decls=None):
         # Returns the C type representation.
         if self.arg_kind == ARG_KIND_NDARRAY:
-            name = _get_typename(self.dtype, type_headers)
+            name = _get_typename(self.dtype, type_decls)
             name = 'CArray<%s, %d, %d, %d>' % (
                 name, self.ndim,
                 self.c_contiguous, self.index_32_bits)
             return name
         if self.arg_kind == ARG_KIND_SCALAR:
-            return _get_typename(self.dtype, type_headers)
+            return _get_typename(self.dtype, type_decls)
         if self.arg_kind == ARG_KIND_INDEXER:
             return 'CIndexer<%d, %d>' % (self.ndim, self.index_32_bits)
         if self.arg_kind == ARG_KIND_TEXTURE:
             return 'cudaTextureObject_t'
         assert False
 
-    cdef str get_param_c_type(self, ParameterInfo p, type_headers=None):
+    cdef str get_param_c_type(self, ParameterInfo p, type_decls=None):
         # Returns the C type representation in the global function's
         # parameter list.
-        cdef str ctyp = self.get_c_type(type_headers)
+        cdef str ctyp = self.get_c_type(type_decls)
         if p.is_const:
             return 'const ' + ctyp
         return ctyp
@@ -346,7 +342,7 @@ cdef tuple _get_arginfos(list args):
     return tuple([_ArgInfo.from_arg(a) for a in args])
 
 
-cdef str _get_kernel_params(tuple params, tuple arginfos, type_headers=None):
+cdef str _get_kernel_params(tuple params, tuple arginfos, type_decls=None):
     cdef ParameterInfo p
     cdef _ArgInfo arginfo
     cdef lst = []
@@ -355,7 +351,7 @@ cdef str _get_kernel_params(tuple params, tuple arginfos, type_headers=None):
     for i in range(len(params)):
         p = params[i]
         arginfo = arginfos[i]
-        arg = arginfo.get_param_c_type(p, type_headers)
+        arg = arginfo.get_param_c_type(p, type_decls)
         lst.append('{} {}'.format(arg, arginfo.get_c_var_name(p)))
 
     return ', '.join(lst)
@@ -551,10 +547,10 @@ cdef class _TypeMap:
     def __str__(self):
         return '<_TypeMap {}>'.format(self._pairs)
 
-    cdef str get_typedef_code(self, type_headers=None):
+    cdef str get_typedef_code(self, type_decls=None):
         # Returns a code fragment of typedef statements used as preamble.
         return ''.join([
-            'typedef %s %s;\n' % (_get_typename(ctype2, type_headers), ctype1)
+            'typedef %s %s;\n' % (_get_typename(ctype2, type_decls), ctype1)
             for ctype1, ctype2 in self._pairs])
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -234,7 +234,7 @@ cdef class _ArgInfo:
         ret._init(
             ARG_KIND_NDARRAY,
             type(arg),
-            arg.dtype.type,
+            arg.dtype,
             arg._shape.size(),
             arg._c_contiguous,
             arg._index_32_bits)
@@ -243,7 +243,7 @@ cdef class _ArgInfo:
     @staticmethod
     cdef _ArgInfo from_scalar(_scalar.CScalar arg):
         cdef _ArgInfo ret = _ArgInfo.__new__(_ArgInfo)
-        dtype = arg.get_numpy_type()
+        dtype = arg.descr
         ret._init(ARG_KIND_SCALAR, _scalar.CScalar, dtype, 0, True, True)
         return ret
 
@@ -484,9 +484,7 @@ cdef class ParameterInfo:
             self.ctype = t
         else:
             dtype = get_dtype(t)
-            self.dtype = dtype.type
-            if dtype.name != t:
-                raise ValueError('Wrong type %s' % t)
+            self.dtype = dtype
             self.ctype = _get_typename(self.dtype)
 
         for i in s[:-2]:
@@ -894,14 +892,14 @@ cdef class ElementwiseKernel:
         in_ndarray_types = []
         for a in in_args:
             if isinstance(a, _ndarray_base):
-                t = a.dtype.type
+                t = a.dtype
             elif isinstance(a, texture.TextureObject):
                 t = 'cudaTextureObject_t'
             else:
                 t = None
             in_ndarray_types.append(t)
         in_ndarray_types = tuple(in_ndarray_types)
-        out_ndarray_types = tuple([a.dtype.type for a in out_args])
+        out_ndarray_types = tuple([a.dtype for a in out_args])
 
         in_types, out_types, type_map = self._decide_params_type(
             in_ndarray_types, out_ndarray_types)
@@ -970,7 +968,7 @@ cdef class ElementwiseKernel:
         in_types = []
         for x in arginfos:
             if x.type is cupy.ndarray:
-                in_types.append(cupy.dtype(x.dtype).char)
+                in_types.append(cupy.dtype(x.dtype))
         in_types = tuple(in_types)
         if in_types not in self._cached_codes:
             code = _get_elementwise_kernel_code(
@@ -1106,13 +1104,10 @@ cdef function.Function _get_ufunc_kernel(
         loop_prep=loop_prep, after_loop='', options=("--std=c++17",))
 
 
-cdef dict _mst_unsigned_to_signed = {
-    i: (numpy.iinfo(j).max, (i, j))
-    for i, j in [(numpy.dtype(i).type, numpy.dtype(i.lower()).type)
-                 for i in "BHILQ"]}
 
-
-cdef inline int _get_kind_score(type kind) except -1:
+cdef inline int _get_kind_score(kind) except -1:
+    if kind not in (int, float, complex):
+        kind = kind.type  # TODO: Make pretty.
     if issubclass(kind, numpy.bool_):
         return 0
     if issubclass(kind, (numpy.integer, int)):
@@ -1284,7 +1279,7 @@ cdef class ufunc:
         # Note default behavior of casting is 'same_kind' on numpy>=1.10
         casting = kwargs.pop('casting', self._default_casting)
         if dtype is not None:
-            dtype = get_dtype(dtype).type
+            dtype = get_dtype(dtype)
         if kwargs:
             raise TypeError('Wrong arguments %s' % kwargs)
 
@@ -1381,8 +1376,10 @@ cdef class ufunc:
                 template = in_arg
                 break
 
+        core_in_dtypes, core_out_dtypes = op.resolve_dtypes(in_args, out_args)
+
         out_args = _get_out_args_from_optionals(
-            subtype, out_args, op.out_types, shape, casting, template)
+            subtype, out_args, core_out_dtypes, shape, casting, template)
         # inout_args may have included given outputs for broadcasting, replace:
         inout_args[len(in_args) + has_where:] = out_args
 
@@ -1404,7 +1401,8 @@ cdef class ufunc:
         inout_args.append(indexer)
         arginfos = _get_arginfos(inout_args)
 
-        kern = self._get_ufunc_kernel(dev_id, op, arginfos, has_where)
+        kern = self._get_ufunc_kernel(
+            core_in_dtypes, core_out_dtypes, dev_id, op, arginfos, has_where)
 
         kern.linear_launch(indexer.size, inout_args)
         return ret
@@ -1416,7 +1414,7 @@ cdef class ufunc:
         cdef _ArgInfo arginfo
         inout_type_words = []
         for arginfo in arginfos:
-            dtype = str(numpy.dtype(arginfo.dtype))
+            dtype = numpy.dtype(arginfo.dtype).name  # TODO: better scheme!
             if arginfo.is_ndarray():
                 inout_type_words.append(dtype)
             elif arginfo.is_scalar():
@@ -1424,7 +1422,8 @@ cdef class ufunc:
         return '{}__{}'.format(name, '_'.join(inout_type_words))
 
     cdef function.Function _get_ufunc_kernel(
-            self, int dev_id, _Op op, tuple arginfos, bint has_where):
+            self, tuple in_dtypes, tuple out_dtypes,
+            int dev_id, _Op op, tuple arginfos, bint has_where):
         cdef function.Function kern
         key = (dev_id, op, arginfos, has_where)
         kern = self._kernel_memo.get(key, None)
@@ -1432,7 +1431,7 @@ cdef class ufunc:
             name = self._get_name_with_type(arginfos, has_where)
             params = self._params_with_where if has_where else self._params
             kern = _get_ufunc_kernel(
-                op.in_types, op.out_types, op.routine, arginfos, has_where,
+                in_dtypes, out_dtypes, op.routine, arginfos, has_where,
                 params, name, self._preamble, self._loop_prep)
             kern = self._kernel_memo.setdefault(key, kern)
         return kern
@@ -1541,7 +1540,7 @@ cdef class _Op:
 
     def __init__(
             self, tuple in_types, tuple out_types, object routine,
-            object error_func):
+            object error_func, object resolution_func):
         if error_func is None:
             assert routine is not None
         else:
@@ -1553,9 +1552,21 @@ cdef class _Op:
         self.routine = routine
         self.error_func = error_func
 
+        # Resolution func is typically None (non parametric dtypes) but can
+        # implement more complex logic.
+        # NOTE(seberg): Unlike NumPy, we currently have a more "raw"
+        # resolution function which is passed the original dtypes rather than
+        # preprocessed ones.
+        # NumPy normally already casts input dtypes to the loop types and we
+        # skip this. Because (a) it is a bit tricky and (b) it is actually in
+        # the way for structured. Maybe NumPy will allow this in the future...
+        self._resolution_func = resolution_func
+        self._in_dtypes = tuple([get_dtype(t) for t in in_types])
+        self._out_dtypes = tuple([get_dtype(t) for t in out_types])
+
     @staticmethod
     cdef _Op _from_type_and_routine_or_error_func(
-            typ, object routine, object error_func):
+            typ, object routine, object error_func, object resolution_func):
         # TODO(niboshi): Write type mapping specification.
         if isinstance(typ, str):
             types = typ.split('->')
@@ -1569,27 +1580,35 @@ cdef class _Op:
         else:
             raise TypeError("Expected string or list for typ identifier.")
 
-        in_types = tuple([get_dtype(t).type for t in in_types])
-        out_types = tuple([get_dtype(t).type for t in out_types])
-        return _Op(in_types, out_types, routine, error_func)
+        in_types = tuple([get_dtype(t) for t in in_types])
+        out_types = tuple([get_dtype(t) for t in out_types])
+        return _Op(in_types, out_types, routine, error_func, resolution_func)
 
     @staticmethod
-    cdef _Op from_type_and_routine(typ, routine):
-        return _Op._from_type_and_routine_or_error_func(typ, routine, None)
+    cdef _Op from_type_and_routine(typ, routine, resolution_func):
+        return _Op._from_type_and_routine_or_error_func(
+            typ, routine, None, resolution_func)
 
     @staticmethod
     cdef _Op from_type_and_error_func(typ, error_func):
-        return _Op._from_type_and_routine_or_error_func(typ, None, error_func)
+        return _Op._from_type_and_routine_or_error_func(
+            typ, None, error_func, None)
 
     cdef check_valid(self):
         if self.error_func is not None:
             self.error_func()
 
-    cpdef tuple get_in_dtypes(self):
-        return tuple([get_dtype(t) for t in self.in_types])
+    cpdef tuple resolve_dtypes(self, list in_args, list out_args):
+        # In most cases, this just returns the typical dtypes matching the
+        # the dtype kind (or DType class, as of now represented by the scalar).
+        # For parametric DTypes, more complex handling may be necessary and
+        # can be implemented by providing the resolver function.
+        if self._resolution_func is None:
+            return self._in_dtypes, self._out_dtypes
 
-    cpdef tuple get_out_dtypes(self):
-        return tuple([get_dtype(t) for t in self.out_types])
+        in_dtypes = [None if arg is None else arg.dtype for arg in in_args]
+        out_dtypes = [None if arg is None else arg.dtype for arg in out_args]
+        return self._resolution_func(self, tuple(in_dtypes), tuple(out_dtypes))
 
     def __repr__(self):
         # Just for debugging purposes.
@@ -1613,8 +1632,12 @@ cdef class _Ops:
     cdef _Ops from_tuples(object ops, routine):
         ops_ = []
         for t in ops:
+            resolution_func = None
             if isinstance(t, tuple):
-                typ, rt = t
+                typ, rt, *res_func = t
+                if res_func:
+                    resolution_func, = res_func
+
                 if rt is None:
                     rt = routine
                 elif isinstance(rt, tuple):
@@ -1624,6 +1647,7 @@ cdef class _Ops:
                         raise ValueError(
                             f"invalid op {t}, expected callable {rt}")
                     assert callable(rt)
+                    assert resolution_func is None  # can't error and resolve
                     ops_.append(_Op.from_type_and_error_func(typ, rt))
                     continue
             else:
@@ -1631,7 +1655,7 @@ cdef class _Ops:
                     raise ValueError(
                         f"invalid op {t}, expected string or list")
                 typ, rt = t, routine
-            ops_.append(_Op.from_type_and_routine(typ, rt))
+            ops_.append(_Op.from_type_and_routine(typ, rt, resolution_func))
         return _Ops(tuple(ops_))
 
     cpdef _Op guess_routine(
@@ -1646,13 +1670,12 @@ cdef class _Ops:
             in_types_l = []
             for a in in_args:
                 if type(a) is _scalar.CScalar:
-                    # .typeobj is the C-level type (as a PyTypeObject *)
-                    t = <object>((<_scalar.CScalar>a).descr.typeobj)
+                    t = (<_scalar.CScalar>a).descr
                     weak_t = (<_scalar.CScalar>a).weak_t
                     if weak_t is not False:
                         any_weak = True
                 elif isinstance(a, _ndarray_base):
-                    t = (<_ndarray_base>a).dtype.type
+                    t = (<_ndarray_base>a).dtype
                     weak_t = False
                 else:
                     raise RuntimeError(f"Need array or CScalar got {type(a)}")

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -46,14 +46,9 @@ cpdef str _create_reduction_function_code(
         pre_map_expr, reduce_expr, post_map_expr,
         _kernel._TypeMap type_map, input_expr, output_expr, preamble, options):
 
-    type_headers = set()
-    params = _kernel._get_kernel_params(params, arginfos, type_headers)
-    type_preamble = type_map.get_typedef_code(type_headers)
-
-    if not type_headers:
-        type_headers = ''
-    else:
-        type_headers = '\n'.join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    params = _kernel._get_kernel_params(params, arginfos, type_decls)
+    type_preamble = type_map.get_typedef_code(type_decls)
 
     # A (incomplete) list of internal variables:
     # _J            : the index of an element in the array
@@ -62,7 +57,7 @@ cpdef str _create_reduction_function_code(
     #                 be power of 2 and <= _block_size
 
     module_code = string.Template('''
-${type_headers}${type_preamble}
+${type_decls}${type_preamble}
 ${preamble}
 #define REDUCE(a, b) (${reduce_expr})
 #define POST_MAP(a) (${post_map_expr})
@@ -119,7 +114,7 @@ extern "C" __global__ void ${name}(${params}) {
         block_size=block_size,
         reduce_type=reduce_type,
         params=params,
-        type_headers=type_headers,
+        type_decls=_scalar.format_type_decls(type_decls),
         identity=identity,
         reduce_expr=reduce_expr,
         pre_map_expr=pre_map_expr,

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -29,8 +29,16 @@ cdef _ndarray_base _ndarray_getitem(_ndarray_base self, slices):
     cdef list slice_list
     cdef _ndarray_base a
 
-    if isinstance(slices, str) and self.dtype.fields is not None:
-        return _getitem_fields(self, slices)
+    # TODO: Use NumPy C-API to fast-path this.
+    if self.dtype.fields is not None:
+        # The array has fields, check whether this may be field access
+        if (
+            isinstance(slices, str) or (
+                isinstance(slices, list) and
+                all(isinstance(s, str) for s in slices)
+            )
+        ):
+            return _getitem_fields(self, slices)
 
     slice_list = _prepare_slice_list(slices)
     a, adv = _view_getitem(self, slice_list)
@@ -52,11 +60,17 @@ cdef _ndarray_setitem(_ndarray_base self, slices, value):
     if isinstance(value, _ndarray_base):
         value = _squeeze_leading_unit_dims(value)
 
-    if isinstance(slices, str) and self.dtype.fields is not None:
-        # TODO: This is kinda right, but not quite due to finalization
-        # for subclasses.
-        self = _getitem_fields(self, slices)
-        slices = ...  # Need to assign the full thing as if an Ellipsis
+    # TODO: Use NumPy C-API to fast-path this.
+    if self.dtype.fields is not None:
+        # The array has fields, check whether this may be field access
+        if (
+            isinstance(slices, str) or (
+                isinstance(slices, list) and
+                all(isinstance(s, str) for s in slices)
+            )
+        ):
+            self = _getitem_fields(self, slices)
+            slices = ...  # Need to assign the full thing as if an Ellipsis
 
     _scatter_op(self, slices, value, 'update')
 
@@ -1205,8 +1219,15 @@ cdef _ndarray_base _getitem_multiple(
     return _take(a, reduced_idx, start, stop)
 
 
-cdef _ndarray_base _getitem_fields(_ndarray_base a, str name):
+cdef _ndarray_base _getitem_fields(_ndarray_base a, slices):
+    cdef str name
     cdef _ndarray_base v
+    if isinstance(slices, list):
+        new_dtype = a.dtype[slices]
+        return a.view(new_dtype)
+
+    # Otherwise, we got a single field name.
+    name = slices
     try:
         new_dtype, offset, *_ = a.dtype.fields[name]
     except KeyError:

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -70,7 +70,7 @@ def struct_compare_resolution(op, in_dtypes, out_dtypes):
             "dtype.  I.e. `np.result_type(arr1, arr2)` must be defined.")
 
     # Ensure the comparison dtype actually has sufficient alignment.
-    cmp_dtype = cupy.make_gpu_aligned_dtype(cmp_dtype)
+    cmp_dtype = cupy.make_aligned_dtype(cmp_dtype)
 
     out_dtypes = (numpy.dtype(bool),)
     return (cmp_dtype, cmp_dtype), out_dtypes

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -1,3 +1,6 @@
+import numpy
+
+import cupy
 from cupy._core._kernel import create_ufunc
 from cupy._core._reduction import create_reduction_func
 from cupy._util import bf16_loop
@@ -53,7 +56,28 @@ cdef _any = create_reduction_func(
     'false', '')
 
 
-cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
+def struct_compare_resolution(op, in_dtypes, out_dtypes):
+    # NumPy ignores field names, so we'll do that as well.
+    dt1, dt2 = in_dtypes
+    if dt1.fields is None or dt2.fields is None:
+        raise TypeError("Cannot compare structured and non-structured dtypes")
+
+    try:
+        cmp_dtype = numpy.promote_types(dt1, dt2)
+    except TypeError:
+        raise TypeError(
+            "Cannot compare structured arrays unless they have a common "
+            "dtype.  I.e. `np.result_type(arr1, arr2)` must be defined.")
+
+    # Ensure the comparison dtype actually has sufficient alignment.
+    cmp_dtype = cupy.make_gpu_aligned_dtype(cmp_dtype)
+
+    out_dtypes = (numpy.dtype(bool),)
+    return (cmp_dtype, cmp_dtype), out_dtypes
+
+
+cpdef create_comparison(
+        name, op, doc='', no_complex_dtype=True, allow_structured=False):
 
     if no_complex_dtype:
         ops = ('??->?', 'qq->?', 'qQ->?', 'Qq->?', 'QQ->?',
@@ -62,6 +86,9 @@ cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
         ops = ('??->?', 'qq->?', 'qQ->?', 'Qq->?', 'QQ->?',
                'ee->?', *bf16_loop(2, '?'), 'ff->?', 'dd->?',
                'FF->?', 'DD->?')
+
+    if allow_structured:
+        ops += (("VV->?", None, struct_compare_resolution),)
 
     return create_ufunc(
         'cupy_' + name,
@@ -117,7 +144,7 @@ cdef _equal = create_comparison(
     .. seealso:: :data:`numpy.equal`
 
     ''',
-    no_complex_dtype=False)
+    no_complex_dtype=False, allow_structured=True)
 
 
 cdef _not_equal = create_comparison(
@@ -127,7 +154,7 @@ cdef _not_equal = create_comparison(
     .. seealso:: :data:`numpy.equal`
 
     ''',
-    no_complex_dtype=False)
+    no_complex_dtype=False, allow_structured=True)
 
 
 # Variables to expose to Python

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -59,6 +59,13 @@ cdef _any = create_reduction_func(
 def struct_compare_resolution(op, in_dtypes, out_dtypes):
     # NumPy ignores field names, so we'll do that as well.
     dt1, dt2 = in_dtypes
+    if dt1.fields is None and dt2.fields is None:
+        if dt1.itemsize == dt2.itemsize and dt1.itemsize > 0:
+            out_dtypes = (numpy.dtype(bool),)
+            return (dt1, dt1), out_dtypes
+        raise TypeError(
+            f"cannot compare unstructured voids of different size "
+            f"({dt1.itemsize} vs {dt2.itemsize})")
     if dt1.fields is None or dt2.fields is None:
         raise TypeError("Cannot compare structured and non-structured dtypes")
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -528,15 +528,11 @@ def _inclusive_batch_scan_kernel(
     op_char = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     identity = {scan_op.SCAN_SUM: 0, scan_op.SCAN_PROD: 1}
     name = 'cupy_inclusive_batch_scan_kernel'
-    type_headers = set()
-    dtype = get_typename(dtype, type_headers)
-    if not type_headers:
-        type_headers = ''
-    else:
-        type_headers = '\n'.join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    dtype = get_typename(dtype, type_decls)
 
     source = string.Template("""
-    ${type_headers}
+    ${type_decls}
     extern "C" __global__ void ${name}(
         const CArray<${dtype}, 2, ${src_c_cont}> src,
         CArray<${dtype}, 2, ${out_c_cont}> dst, int batch_size){
@@ -613,7 +609,7 @@ def _inclusive_batch_scan_kernel(
     """).substitute(name=name, dtype=dtype, block_size=block_size,
                     op=op_char[op], identity=identity[op],
                     src_c_cont=src_c_cont, out_c_cont=out_c_cont,
-                    type_headers=type_headers)
+                    type_decls=_scalar.format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
 
@@ -621,16 +617,12 @@ def _inclusive_batch_scan_kernel(
 @_util.memoize(for_each_device=True)
 def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     name = 'cupy_add_scan_blocked_sum_kernel'
-    type_headers = set()
-    dtype = get_typename(dtype, type_headers)
-    if not type_headers:
-        type_headers = ''
-    else:
-        type_headers = '\n'.join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    dtype = get_typename(dtype, type_decls)
 
     ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     source = string.Template("""
-    ${type_headers}
+    ${type_decls}
     extern "C" __global__ void ${name}(CArray<${dtype}, 2, ${c_cont}> src_dst,
         int batch_size){
         long long n = src_dst.size();
@@ -656,7 +648,8 @@ def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
         }
     }
     """).substitute(name=name, dtype=dtype, op=ops[op], block_size=block_size,
-                    c_cont=c_cont, type_headers=type_headers)
+                    c_cont=c_cont,
+                    type_decls=_scalar.format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -7,7 +7,7 @@ import cupy
 from cupy._core._reduction import create_reduction_func
 from cupy._core._kernel import create_ufunc, _get_warpsize
 from cupy._core._kernel cimport _full_mask_hex
-from cupy._core._scalar import get_typename
+from cupy._core._scalar import get_typename, format_type_decls
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core
 from cupy._core cimport internal
@@ -609,7 +609,7 @@ def _inclusive_batch_scan_kernel(
     """).substitute(name=name, dtype=dtype, block_size=block_size,
                     op=op_char[op], identity=identity[op],
                     src_c_cont=src_c_cont, out_c_cont=out_c_cont,
-                    type_decls=_scalar.format_type_decls(type_decls))
+                    type_decls=format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
 
@@ -649,7 +649,7 @@ def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     }
     """).substitute(name=name, dtype=dtype, op=ops[op], block_size=block_size,
                     c_cont=c_cont,
-                    type_decls=_scalar.format_type_decls(type_decls))
+                    type_decls=format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
 

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -4,7 +4,7 @@ import numpy
 
 import cupy
 from cupy.exceptions import AxisError
-from cupy._core._scalar import get_typename as _get_typename
+from cupy._core import _scalar
 from cupy._core._ufuncs import elementwise_copy
 from cupy._core._kernel cimport _full_mask_hex
 import cupy._core.core as core
@@ -309,15 +309,11 @@ cdef _ndarray_base _ndarray_argpartition(self, kth, axis):
 def _partition_kernel(dtype):
     name = 'partition_kernel'
     merge_kernel = 'partition_merge_kernel'
-    type_headers = set()
-    dtype = _get_typename(dtype, type_headers)
-    if not type_headers:
-        type_headers = ''
-    else:
-        type_headers = '\n'.join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    dtype = _scalar.get_typename(dtype, type_decls)
 
     source = string.Template('''
-    ${type_headers}
+    ${type_decls}
     template<typename T>
     __device__ void bitonic_sort_step(CArray<T, 1, true> a,
             ptrdiff_t x, ptrdiff_t y, int i, ptrdiff_t s, ptrdiff_t w) {
@@ -423,7 +419,7 @@ def _partition_kernel(dtype):
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype,
-                    type_headers=type_headers,
+                    type_decls=_scalar.format_type_decls(type_decls),
                     full_mask=_full_mask_hex())
     module = compile_with_cache(source)
     return module.get_function(name), module.get_function(merge_kernel)
@@ -433,15 +429,11 @@ def _partition_kernel(dtype):
 def _argpartition_kernel(dtype):
     name = 'argpartition_kernel'
     merge_kernel = 'argpartition_merge_kernel'
-    type_headers = set()
-    dtype = _get_typename(dtype, type_headers)
-    if not type_headers:
-        type_headers = ''
-    else:
-        type_headers = '\n'.join(sorted(type_headers)) + "\n\n"
+    type_decls = set()
+    dtype = _scalar.get_typename(dtype, type_decls)
 
     source = string.Template('''
-    ${type_headers}
+    ${type_decls}
     template<typename T>
     __device__ void bitonic_sort_step(
             CArray<T, 1, true> a, CArray<long long, 1, true> b,
@@ -551,7 +543,7 @@ def _argpartition_kernel(dtype):
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype,
-                    type_headers=type_headers,
+                    type_decls=_scalar.format_type_decls(type_decls),
                     full_mask=_full_mask_hex())
     module = compile_with_cache(source)
     return module.get_function(name), module.get_function(merge_kernel)

--- a/cupy/_core/_scalar.pxd
+++ b/cupy/_core/_scalar.pxd
@@ -20,6 +20,7 @@ cdef class CScalar(CPointer):
     @staticmethod
     cdef CScalar from_int32(int32_t value)
 
+    cdef inline void _free_ptr(self) noexcept
     cdef _store_c_value(self)
     cpdef apply_dtype(self, dtype)
     cpdef get_numpy_type(self)
@@ -28,7 +29,7 @@ cdef class CScalar(CPointer):
 cpdef str format_type_decls(set type_decls)
 
 cpdef str get_typename(dtype, type_decls=*)
-cdef Py_ssize_t get_cuda_alignment(dtype) except -1
+cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1
 
 cdef set scalar_type_set
 cpdef str _get_cuda_scalar_repr(obj, dtype)

--- a/cupy/_core/_scalar.pxd
+++ b/cupy/_core/_scalar.pxd
@@ -25,7 +25,9 @@ cdef class CScalar(CPointer):
     cpdef get_numpy_type(self)
 
 
-cpdef str get_typename(dtype, type_headers=*)
+cpdef str format_type_decls(set type_decls)
+
+cpdef str get_typename(dtype, type_decls=*)
 cdef Py_ssize_t get_cuda_alignment(dtype) except -1
 
 cdef set scalar_type_set

--- a/cupy/_core/_scalar.pxd
+++ b/cupy/_core/_scalar.pxd
@@ -26,6 +26,7 @@ cdef class CScalar(CPointer):
 
 
 cpdef str get_typename(dtype, type_headers=*)
+cdef Py_ssize_t get_cuda_alignment(dtype) except -1
 
 cdef set scalar_type_set
 cpdef str _get_cuda_scalar_repr(obj, dtype)

--- a/cupy/_core/_scalar.pxd
+++ b/cupy/_core/_scalar.pxd
@@ -8,6 +8,15 @@ from libc.stdint cimport int32_t
 from cupy.cuda.function cimport CPointer
 
 
+cdef extern from 'numpy/ndarraytypes.h':
+    cdef int PyArray_Pack(cnp.dtype dtype, void *ptr, object value) except -1
+
+    cdef enum:
+        NPY_ITEM_REFCOUNT
+        NPY_ITEM_IS_POINTER
+        NPY_NEEDS_INIT
+
+
 @cython.final
 cdef class CScalar(CPointer):
 

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -172,7 +172,7 @@ def _build_struct_typename(dtype, type_decls):
     (we consider the maximum alignment of any of the fields here).
     """
     # The alignment must be too small pretty much, but use it anyway.
-    # If `make_gpu_aligned_dtype` was used may use __cuda_alignment__.
+    # If `make_aligned_dtype` was used may use __cuda_alignment__.
     alignment = dtype.alignment
     if dtype.metadata:
         # If manually overridden, use that alignment:
@@ -214,7 +214,7 @@ def _build_struct_typename(dtype, type_decls):
                              f"aligned to {alignment} in dtype {dtype}. "
                              f"This is not supported by CuPy please ensure "
                              "the structure is aligned. You can do so with "
-                             "the `make_gpu_aligned_dtype()` helper.")
+                             "the `make_aligned_dtype()` helper.")
 
         if not (0 <= (offset - curr_start) < subalignment):
             # Addign `alignas({subalignment})` would not align with the
@@ -242,7 +242,7 @@ def _build_struct_typename(dtype, type_decls):
             f"Itemsize {dtype.itemsize} is not a multiple of alignment "
             f"{alignment} for dtype {dtype} and kernel launches are not "
             "supported. You can ensure compatibility with the "
-            "`make_gpu_aligned_dtype()` helper (or try `align=True`).")
+            "`make_aligned_dtype()` helper (or try `align=True`).")
 
     struct_fields = "\n".join(struct_fields)
     hash_ = hashlib.sha1(

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -153,12 +153,14 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
         # It is unclear that this would be useful. Effectively, we would find
         # out the right alignment already as part of `get_typename` before we
         # launch the kernel.
-        if (cnp.PyDataType_HASFIELDS(dtype)
-                or cnp.PyDataType_HASSUBARRAY(dtype)):
+        if cnp.PyDataType_HASFIELDS(dtype):
             # Subarray would be obvious, but we don't suppor them yet.
             raise NotImplementedError(
                 f"get_cuda_alignment() only supports unstructured dtypes, "
                 f"got {dtype}")
+        if cnp.PyDataType_HASSUBARRAY(dtype):
+            # Alignment is inherited from the field dtype
+            return get_cuda_alignment(dtype.base)
 
     if _alignment_kernel is None:
         _alignment_kernel = cupy.ElementwiseKernel(

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -11,10 +11,6 @@ import cupy
 from cupy._core cimport _dtype
 
 
-cdef extern from 'numpy/ndarraytypes.h':
-    cdef int PyArray_Pack(cnp.dtype dtype, void *ptr, object value) except -1
-
-
 cdef dict _typenames_base = {
     numpy.dtype('float64'): ('double', None),
     numpy.dtype('float32'): ('float', None),
@@ -366,7 +362,7 @@ cdef class CScalar(CPointer):
 
     cdef _store_c_value(self):
         # No current support for dtypes that may require initialization
-        assert not self.descr.flags & 0x08
+        assert not self.descr.flags & NPY_NEEDS_INIT
         assert self.ptr == 0
 
         if self.descr.itemsize < sizeof(self._data):
@@ -385,7 +381,7 @@ cdef class CScalar(CPointer):
 
     cpdef apply_dtype(self, dtype):
         cdef cnp.dtype descr = cnp.dtype(dtype)
-        if descr.flags & (0x01 | 0x04):
+        if descr.flags & (NPY_ITEM_REFCOUNT | NPY_ITEM_IS_POINTER):
             # Can't support this, so make sure we raise appropriate error.
             _dtype.check_supported_dtype(descr, True)
             raise RuntimeError(f"Unsupported dtype {dtype} (but not raised?)")

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -172,6 +172,11 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
                 f"get_cuda_alignment() only supports unstructured dtypes, "
                 f"got {dtype}")
         if cnp.PyDataType_HASSUBARRAY(dtype):
+            if dtype.base.fields is not None:
+                # To support nested subarrays on some branches we should
+                # make sure to recurse into the base correctly.
+                # This just gives a nicer error (to avoid hitting the above).
+                raise ValueError("CuPy does not yet support subarray dtypes.")
             # Alignment is inherited from the field dtype
             return get_cuda_alignment(dtype.base)
 

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -121,7 +121,7 @@ cpdef str get_typename(dtype, type_decls=None):
         if descr.type_num == cnp.NPY_VOID:
             if cnp.PyDataType_HASFIELDS(descr):
                 # NOTE: Caching this may not be trivial if we use metadata.
-                name, *_ = _build_struct_typename(dtype, type_decls)
+                name, _ = _build_struct_typename(dtype, type_decls)
                 return name
             elif not cnp.PyDataType_HASSUBARRAY(descr) and descr.itemsize > 0:
                 # Unstructured void is just a blob bytes.
@@ -197,7 +197,7 @@ def _build_struct_typename(dtype, type_decls):
         # TODO(seberg): We should be able to query the JIT for the actual
         # alignment constraints (making this a trivial recursion)
         if subdtype.num == cnp.NPY_VOID and subdtype.fields is not None:
-            subname, _, subalignment = _build_struct_typename(
+            subname, subalignment = _build_struct_typename(
                 subdtype, subtype_decls)
         else:
             subalignment = get_cuda_alignment(subdtype)
@@ -237,7 +237,7 @@ def _build_struct_typename(dtype, type_decls):
     name = (
         f"cupy::StructView<cupy::raw_structview_storage<{dtype.itemsize}, "
         f"{alignment}>, {fields}>")
-    return name, None, alignment
+    return name, alignment
 
 
 cdef dict _typenames = {}

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -215,8 +215,8 @@ def _build_struct_typename(dtype, type_decls):
             subname, subalignment = _build_struct_typename(
                 subdtype, subtype_decls)
         else:
-            subalignment = get_cuda_alignment(subdtype)
             subname = get_typename(subdtype, subtype_decls)
+            subalignment = get_cuda_alignment(subdtype)
             if subdtype.metadata:
                 # If manually overridden, use that alignment:
                 subalignment = subdtype.metadata.get(

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -128,7 +128,7 @@ cpdef str get_typename(dtype, type_decls=None):
             elif not cnp.PyDataType_HASSUBARRAY(descr) and descr.itemsize > 0:
                 # Unstructured void is just a blob bytes.
                 if type_decls is not None:
-                    type_decls.add('#include "cupy/unstructued_void.cuh"')
+                    type_decls.add('#include "cupy/unstructured_void.cuh"')
                 return f"cupy::UnstructuredVoid<{descr.itemsize}>"
 
     raise ValueError(f"Unsupported dtype {dtype}")
@@ -168,6 +168,7 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
             "using in_t = decltype(in); out = alignof(in_t);",
         )
 
+    # synchronize!
     alignment = int(_alignment_kernel(cupy.empty((), dtype=dtype))[()])
     _cuda_alignments[dtype] = alignment
     return alignment
@@ -211,7 +212,7 @@ def _build_struct_typename(dtype, type_decls):
                 subalignment = subdtype.metadata.get(
                     "__cuda_alignment__", subalignment)
 
-        assert (subalignment - 1) & subalignment == 0
+        assert ((subalignment - 1) & subalignment) == 0
         alignment = max(alignment, subalignment)
 
         if offset % subalignment != 0:

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -4,8 +4,6 @@ cimport cpython
 cimport numpy as cnp
 
 import graphlib
-import hashlib
-import textwrap
 
 import numpy
 
@@ -77,12 +75,12 @@ cpdef str format_type_decls(set type_decls):
     if not type_decls:
         return ""
 
-    # Formatting the is unfortunately not as simple as `sorted()` as it can
+    # Formatting this is unfortunately not as simple as `sorted()` as it can
     # be nested, etc.
     cdef dict declarations = {}
     # Recursively flatten the type declarations into a dict
     _flatten_type_decls(type_decls, declarations)
-    # Sort the dictionary by it's keys (to achieve a stable order)
+    # Sort the dictionary by its keys (to achieve a stable order)
     declarations = dict(sorted(declarations.items()))
 
     ts = graphlib.TopologicalSorter(declarations)
@@ -96,7 +94,7 @@ cpdef str get_typename(dtype, type_decls=None):
     If not None, `type_decls` must be a set and the dtype preamble
     (i.e. this should be required headers) will be inserted.
     A preamble is either a string or a tuple of (string, frozenset)
-    where the frozenset is also a set of `type_decls` (the the first
+    where the frozenset is also a set of `type_decls` (that the first
     depends on).
 
     If you just have a header, order should normally not matter so you
@@ -154,7 +152,7 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
         # out the right alignment already as part of `get_typename` before we
         # launch the kernel.
         if cnp.PyDataType_HASFIELDS(dtype):
-            # Subarray would be obvious, but we don't suppor them yet.
+            # Subarray would be obvious, but we don't support them yet.
             raise NotImplementedError(
                 f"get_cuda_alignment() only supports unstructured dtypes, "
                 f"got {dtype}")
@@ -166,6 +164,7 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
         _alignment_kernel = cupy.ElementwiseKernel(
             "T in", "int64 out",
             "using in_t = decltype(in); out = alignof(in_t);",
+            "_cupy_get_cuda_alignment",
         )
 
     # synchronize!
@@ -184,29 +183,25 @@ def _build_struct_typename(dtype, type_decls):
     if dtype.metadata:
         # If manually overridden, use that alignment:
         alignment = dtype.metadata.get("__cuda_alignment__", alignment)
-    curr_start = 0
-    offsets = []
-    struct_fields = []
     fields = []
-    struct_compatible = True
 
-    # subdtype_decls are dependencies for this type, we iclude the header
+    # subdtype_decls are dependencies for this type, we include the header
     # itself here as well:
     cdef set subtype_decls = set()
     subtype_decls.add('#include "cupy/structview.cuh"')
 
     for name, (subdtype, offset, *_) in dtype.fields.items():
-        # The fields tupe can contain a 4th title, we ignore it.
+        # The fields tuple can contain a 4th title, we ignore it.
         # (A title is an alternative field name...)
 
         # TODO(seberg): We should be able to query the JIT for the actual
         # alignment constraints (making this a trivial recursion)
         if subdtype.num == cnp.NPY_VOID and subdtype.fields is not None:
-            subname, struct_name, subalignment = _build_struct_typename(
+            subname, _, subalignment = _build_struct_typename(
                 subdtype, subtype_decls)
         else:
             subalignment = get_cuda_alignment(subdtype)
-            subname = struct_name = get_typename(subdtype, subtype_decls)
+            subname = get_typename(subdtype, subtype_decls)
             if subdtype.metadata:
                 # If manually overridden, use that alignment:
                 subalignment = subdtype.metadata.get(
@@ -218,31 +213,15 @@ def _build_struct_typename(dtype, type_decls):
         if offset % subalignment != 0:
             # NOTE: We don't error earlier (for field access yet).
             raise ValueError(f"Field {name} with offset {offset} is not "
-                             f"aligned to {alignment} in dtype {dtype}. "
+                             f"aligned to {subalignment} in dtype {dtype}. "
                              f"This is not supported by CuPy please ensure "
                              "the structure is aligned. You can do so with "
                              "the `make_aligned_dtype()` helper.")
 
-        if not (0 <= (offset - curr_start) < subalignment):
-            # Addign `alignas({subalignment})` would not align with the
-            # actual offset. So we cannot describe it by a struct.
-            # (If the offset is larger, we could achieve this via padding)
-            struct_compatible = False
-        else:
-            curr_start = offset
-
-        curr_start += subdtype.itemsize
-
-        offsets.append(offset)
-        # fields are only used if all fields are indeed compatible
-        struct_fields.append(
-            f"  alignas({subalignment}) {struct_name} {name};")
+        # We currently keep the backing storage opaque and rely only on
+        # StructView field descriptors for access. If desired, we could later
+        # expose a generated fielded struct for explicit `.data` access.
         fields.append(f"cupy::Field<{subname}, {offset}>")
-
-    if not struct_compatible:
-        # If the struct doesn't work out, just use a single _data field.
-        struct_fields = [
-            f"  char _data[{dtype.itemsize}];"]
 
     if dtype.itemsize % alignment != 0:
         raise ValueError(
@@ -251,27 +230,14 @@ def _build_struct_typename(dtype, type_decls):
             "supported. You can ensure compatibility with the "
             "`make_aligned_dtype()` helper (or try `align=True`).")
 
-    struct_fields = "\n".join(struct_fields)
-    hash_ = hashlib.sha1(
-        struct_fields.encode("utf8"), usedforsecurity=False).hexdigest()
-    struct_name = "struct_" + hash_
-
-    # NOTE: We add this to the "headers", but the headers are always sorted
-    # before use and actual includes start with `#` and go first. We must not
-    # start with a space or newline, though!
-    # We have to do this here, because it is a template parameter.
-    # TODO(seberg): Maybe type-map should be passed through actually?!
-    definition = textwrap.dedent(f"""
-        struct alignas({alignment}) {struct_name} {{
-        {struct_fields}
-        }};
-    """).lstrip("\n")  # for sorting, don't start with \n
     if type_decls is not None:
-        type_decls.add((definition, frozenset(subtype_decls)))
+        type_decls.update(subtype_decls)
 
     fields = ', '.join(fields)
-    name = f"cupy::StructView<{struct_name}, {dtype.itemsize}, {fields}>"
-    return name, struct_name, alignment
+    name = (
+        f"cupy::StructView<cupy::raw_structview_storage<{dtype.itemsize}, "
+        f"{alignment}>, {fields}>")
+    return name, None, alignment
 
 
 cdef dict _typenames = {}

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -125,13 +125,13 @@ cpdef str get_typename(dtype, type_decls=None):
                 # NOTE: Caching this may not be trivial if we use metadata.
                 name, *_ = _build_struct_typename(dtype, type_decls)
                 return name
-            elif not cnp.PyDataType_HASSUBARRAY(descr):
+            elif not cnp.PyDataType_HASSUBARRAY(descr) and descr.itemsize > 0:
                 # Unstructured void is just a blob bytes.
                 if type_decls is not None:
                     type_decls.add('#include "cupy/unstructued_void.cuh"')
                 return f"cupy::UnstructuredVoid<{descr.itemsize}>"
 
-    raise TypeError(f"Unable to find C++ type for dtype {dtype}")
+    raise ValueError(f"Unsupported dtype {dtype}")
 
 
 cdef dict _cuda_alignments = {}

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -132,7 +132,22 @@ cpdef str get_typename(dtype, type_decls=None):
     raise ValueError(f"Unsupported dtype {dtype}")
 
 
-cdef dict _cuda_alignments = {}
+cdef dict _cuda_alignments = {
+    numpy.dtype('bool'): 1,
+    numpy.dtype('int8'): 1,
+    numpy.dtype('uint8'): 1,
+    numpy.dtype('int16'): 2,
+    numpy.dtype('uint16'): 2,
+    numpy.dtype('int32'): 4,
+    numpy.dtype('uint32'): 4,
+    numpy.dtype('int64'): 8,
+    numpy.dtype('uint64'): 8,
+    numpy.dtype('float16'): 2,
+    numpy.dtype('float32'): 4,
+    numpy.dtype('float64'): 8,
+    numpy.dtype('complex64'): 8,
+    numpy.dtype('complex128'): 16,
+}
 cdef object _alignment_kernel = None
 
 

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -7,6 +7,7 @@ from cupy._util import bf16_loop
 elementwise_copy = create_ufunc(
     'cupy_copy',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', *bf16_loop(), 'f->f', 'd->d', 'F->F', 'D->D'),
+     'q->q', 'Q->Q', 'e->e', *bf16_loop(), 'f->f', 'd->d', 'F->F', 'D->D',
+     ('V->V', None, lambda op, x, y: (y, y))),  # copy casts input to output.
     'out0 = in0',
     default_casting='unsafe')

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -993,7 +993,7 @@ cdef class _ndarray_base:
         """
         cupy_arr = _convert_from_cupy_like(value, error=False)
         if cupy_arr is not None:
-            if value.shape != ():
+            if cupy_arr.shape != ():
                 raise ValueError(
                     'non-scalar cupy.ndarray cannot be used for fill')
             value = cupy_arr.astype(self.dtype, copy=False)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -30,6 +30,8 @@ from libc.stdint cimport int64_t, intptr_t, INT32_MAX
 from libc cimport stdlib
 from cpython cimport Py_buffer
 
+cimport numpy as cnp
+
 from cupy._core cimport _carray
 from cupy._core cimport _dtype
 from cupy._core._dtype cimport get_dtype
@@ -1001,9 +1003,12 @@ cdef class _ndarray_base:
             if value.shape != ():
                 raise ValueError(
                     'non-scalar numpy.ndarray cannot be used for fill')
-            value = value.astype(self.dtype, copy=False).item()
+            value = value.astype(self.dtype, copy=False)[()]
 
-        if value == 0 and self._c_contiguous:
+        if ((<cnp.dtype>(self.dtype)).type_num != cnp.NPY_VOID
+                and value == 0 and self._c_contiguous):
+            # For most types, we can just memset if the value is zero.
+            # (Void also works mostly, but the `value == 0` could fail.)
             self.data.memset_async(0, self.nbytes)
         else:
             fill_kernel(value, self)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -3059,7 +3059,7 @@ cdef tuple _compute_concat_info_impl(obj):
 
     if (cai := getattr(obj, '__cuda_array_interface__', None)) is not None:
         # Assume __cuda_array_interface__ is cheap enough to call twice
-        return cai['shape'], ndarray, numpy.dtype(cai['typestr'])
+        return cai['shape'], ndarray, get_cai_dtype(cai)
 
     if isinstance(obj, (list, tuple)):
         dim = len(obj)
@@ -3195,6 +3195,36 @@ cpdef _ndarray_base asfortranarray(_ndarray_base a, dtype=None):
     return newarray
 
 
+cdef inline get_cai_dtype(dict desc):
+    dtype = numpy.dtype(desc['typestr'])
+    if <cnp.dtype>(dtype).num != cnp.NPY_VOID:
+        return dtype
+
+    # extract dtype from descr, this is slightly "smarter" than some
+    # NumPy versions (at least 2.4), but much like `np.load` logic.
+    # (For CuPy it is much more likely to use aligned and thus padded dtypes.)
+    descr = desc['descr']
+    if isinstance(descr, list):
+        offset = 0
+        names = []
+        offsets = []
+        formats = []
+        # Note, we just don't support "titles" here...
+        for name, fmt in descr:
+            field_dtype = numpy.dtype(fmt)
+            if name:  # ignore fields with empty names (assume padding)
+                names.append(name)
+                formats.append(field_dtype)
+                offsets.append(offset)
+            offset += field_dtype.itemsize
+
+        dtype = numpy.dtype(
+            {"names": names, "offsets": offsets, "formats": formats})
+    else:
+        pass  # should be unstructured (and already correct).
+    return dtype
+
+
 cpdef _ndarray_base _convert_object_with_cuda_array_interface(a):
     # NOTE: Most code should use this indirectly via `_convert_from_cupy_like`
 
@@ -3205,7 +3235,7 @@ cpdef _ndarray_base _convert_object_with_cuda_array_interface(a):
     cdef size_t nbytes
 
     ptr = desc['data'][0]
-    dtype = numpy.dtype(desc['typestr'])
+    dtype = get_cai_dtype(desc)
     if dtype.byteorder == '>':
         raise ValueError('CuPy does not support the big-endian byte-order')
     mask = desc.get('mask')

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -3202,7 +3202,9 @@ cdef inline get_cai_dtype(dict desc):
     # extract dtype from descr, this is slightly "smarter" than some
     # NumPy versions (at least 2.4), but much like `np.load` logic.
     # (For CuPy it is much more likely to use aligned and thus padded dtypes.)
-    descr = desc['descr']
+    descr = desc.get('descr')  # allow missing 'descr'
+    if descr is None:
+        return dtype
     if isinstance(descr, list):
         offset = 0
         names = []

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -991,19 +991,18 @@ cdef class _ndarray_base:
         .. seealso:: :meth:`numpy.ndarray.fill`
 
         """
-        if isinstance(value, cupy.ndarray):
+        cupy_arr = _convert_from_cupy_like(value, error=False)
+        if cupy_arr is not None:
             if value.shape != ():
                 raise ValueError(
                     'non-scalar cupy.ndarray cannot be used for fill')
-            value = value.astype(self.dtype, copy=False)
-            fill_kernel(value, self)
-            return
-
-        if isinstance(value, numpy.ndarray):
+            value = cupy_arr.astype(self.dtype, copy=False)
+        else:
+            value = numpy.asarray(value, dtype=self.dtype)
             if value.shape != ():
                 raise ValueError(
                     'non-scalar numpy.ndarray cannot be used for fill')
-            value = value.astype(self.dtype, copy=False)[()]
+            value = value[()]  # use scalar rather than NumPy array
 
         if ((<cnp.dtype>(self.dtype)).type_num != cnp.NPY_VOID
                 and value == 0 and self._c_contiguous):

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -1,0 +1,192 @@
+#ifndef STRUCT_VIEW_H_
+#define STRUCT_VIEW_H_
+
+#include "cupy/carray.cuh"
+
+//#include <cstddef>
+//#include <type_traits>
+//#include <utility>
+
+namespace sv {
+
+// Hack to replace std::false_type and std::true_type
+template<bool Value>
+struct my_integral_constant {
+    static constexpr bool value = Value;
+    using type = my_integral_constant;
+    constexpr operator bool() const noexcept { return value; }
+};
+
+// Forward declaration for SFINAE
+template<typename, size_t, typename...>
+class StructView;
+
+// Trait to detect StructView
+template<typename T>
+struct is_struct_view : my_integral_constant<false> {};
+
+template<typename StructType, size_t Size, typename... Fields>
+struct is_struct_view<StructView<StructType, Size, Fields...>> : my_integral_constant<true> {};
+
+template<typename T>
+inline constexpr bool is_struct_view_v = is_struct_view<T>::value;
+
+// Field descriptor: type and offset only
+template<typename T, size_t Offset>
+struct Field {
+  using type = T;
+  static constexpr size_t offset = Offset;
+};
+
+// Metaprogramming helper: get field type by index
+template<size_t Index, typename... Fields>
+struct FieldAtImpl;
+template<typename First, typename... Rest>
+struct FieldAtImpl<0, First, Rest...> { using type = First; };
+template<size_t Index, typename First, typename... Rest>
+struct FieldAtImpl<Index, First, Rest...> { using type = typename FieldAtImpl<Index - 1, Rest...>::type; };
+
+// ============================================================================
+// StructView - inherits from any struct (real or dummy)
+// ============================================================================
+// Provides:
+// 1. Direct field access: view.x (via struct inheritance)
+// 2. Index-based access: view.at<0>()
+// 3. Cross-type comparisons and assignments (by field order)
+// ============================================================================
+template<typename StructType, size_t Size, typename... Fields>
+class StructView {
+  template<size_t Index>
+  using FieldAt = typename FieldAtImpl<Index, Fields...>::type;
+
+  // Compile-time verification
+  static_assert(sizeof(StructType) == Size, "StructType size must match Size parameter");
+
+public:
+  using struct_type = StructType;
+  static constexpr size_t size = Size;
+  static constexpr size_t field_count = sizeof...(Fields);
+
+  StructType data;
+
+  StructView() {
+    init<0>();
+  };
+
+  StructView(const StructView<StructType, Size, Fields...>& other) {
+    assign<0>(other);  // non-trivial to try and honor "holes"
+  }
+
+  // Construct from other struct
+  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  explicit StructView(const StructView<OtherStruct, OtherSize, OtherFields...>& other) : data{} {
+    static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
+    assign<0>(other);
+  }
+
+  // Construct from "scalar" by broadcasting.
+  template<typename T>
+  explicit StructView(const T& value) : StructType{} {
+    assign_broadcast<0>(value);
+  }
+
+  StructView(const StructType& s) : StructType(s) {}
+  StructView(StructType&& s) : StructType(std::move(s)) {}
+
+  // Access underlying struct
+  StructType& as_struct() { return *this; }
+  const StructType& as_struct() const { return *this; }
+
+  // Index-based field access
+  template<size_t Index>
+  auto& at() {
+    using FT = FieldAt<Index>;
+    using T = typename FT::type;
+    return *reinterpret_cast<T*>(reinterpret_cast<char*>(&data) + FT::offset);
+  }
+
+  template<size_t Index>
+  const auto& at() const {
+    using FT = FieldAt<Index>;
+    using T = typename FT::type;
+    return *reinterpret_cast<const T*>(reinterpret_cast<const char*>(&data) + FT::offset);
+  }
+
+  // Cross-type equality (only requires operator== on field types)
+  // Note: Like NumPy structured dtypes, only == and != are supported
+  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  bool operator==(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+    static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
+    return compare_eq<0>(other);
+  }
+
+  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  bool operator!=(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+    return !(*this == other);
+  }
+
+  // Same as constructor (but more interesting as we actually need to omit holes).
+  StructView& operator=(const StructView<StructType, Size, Fields...>& other) {
+    assign<0>(other);
+    return *this;
+  }
+
+  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  StructView& operator=(const StructView<OtherStruct, OtherSize, OtherFields...>& other) {
+    static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
+    assign<0>(other);
+    return *this;
+  }
+
+  // Broadcast assignment - assign single value to all fields.
+  // NOTE(seberg): Can ommitting enable_if lead to ambiguity?
+  template<typename T>
+  StructView& operator=(const T& value) {
+    assign_broadcast<0>(value);
+    return *this;
+  }
+
+private:
+  // Equality comparison helper (only requires operator==)
+  template<size_t Index, typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  bool compare_eq(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+    if constexpr (Index < sizeof...(Fields)) {
+      if (!(at<Index>() == other.template at<Index>())) return false;
+      return compare_eq<Index + 1>(other);
+    }
+    return true;
+  }
+
+  // Assignment helper (field-by-field from another StructView)
+  template<size_t Index, typename OtherStruct, size_t OtherSize, typename... OtherFields>
+  void assign(const StructView<OtherStruct, OtherSize, OtherFields...>& other) {
+    if constexpr (Index < sizeof...(Fields)) {
+      at<Index>() = other.template at<Index>();
+      assign<Index + 1>(other);
+    }
+  }
+
+  // Initialization helper (field-by-field init)
+  template<size_t Index>
+  void init() {
+    if constexpr (Index < sizeof...(Fields)) {
+      using FT = FieldAt<Index>;
+      using T = typename FT::type;
+      at<Index>() = T{};
+      init<Index + 1>();
+    }
+  }
+
+  // Broadcast assignment helper (assign same value to all fields)
+  template<size_t Index, typename T>
+  void assign_broadcast(const T& value) {
+    if constexpr (Index < sizeof...(Fields)) {
+      at<Index>() = value;
+      assign_broadcast<Index + 1>(value);
+    }
+  }
+};
+
+} // namespace sv
+
+#endif // STRUCT_VIEW_H_

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -7,7 +7,7 @@
 //#include <type_traits>
 //#include <utility>
 
-namespace sv {
+namespace cupy {
 
 // Hack to replace std::false_type and std::true_type
 template<bool Value>
@@ -187,6 +187,6 @@ private:
   }
 };
 
-} // namespace sv
+} // namespace cupy
 
 #endif // STRUCT_VIEW_H_

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -79,13 +79,6 @@ public:
     assign_broadcast<0>(value);
   }
 
-  StructView(const StructType& s) : StructType(s) {}
-  StructView(StructType&& s) : StructType(std::move(s)) {}
-
-  // Access underlying struct
-  StructType& as_struct() { return *this; }
-  const StructType& as_struct() const { return *this; }
-
   // Index-based field access
   template<size_t Index>
   auto& at() {

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -2,6 +2,10 @@
 #define STRUCT_VIEW_H_
 
 #include "cupy/carray.cuh"
+#include "cupy/cuda_workaround.h"
+#ifndef __CUDACC_RTC__
+#include <utility>
+#endif
 
 
 namespace cupy {
@@ -34,13 +38,24 @@ struct Field {
   static constexpr size_t offset = Offset;
 };
 
-// Metaprogramming helper: get field type by index
+// Metaprogramming helper: get field type by index in O(1) depth.
+template<size_t I, typename T>
+struct Indexed { using type = T; };
+
+template<typename Indices, typename... Ts>
+struct IndexedTuple;
+
+template<size_t... Is, typename... Ts>
+struct IndexedTuple<std::index_sequence<Is...>, Ts...> : Indexed<Is, Ts>... {};
+
+template<size_t I, typename T>
+static Indexed<I, T> type_at_index(Indexed<I, T>);
+
 template<size_t Index, typename... Fields>
-struct FieldAtImpl;
-template<typename First, typename... Rest>
-struct FieldAtImpl<0, First, Rest...> { using type = First; };
-template<size_t Index, typename First, typename... Rest>
-struct FieldAtImpl<Index, First, Rest...> { using type = typename FieldAtImpl<Index - 1, Rest...>::type; };
+struct FieldAtImpl {
+  using type = typename decltype(type_at_index<Index>(
+      IndexedTuple<std::make_index_sequence<sizeof...(Fields)>, Fields...>{}))::type;
+};
 
 // StructView represents a NumPy structured dtype as a C struct.
 // Generally, NumPy structured dtypes operate by field index `.at<0>()`
@@ -57,12 +72,12 @@ public:
   static constexpr size_t field_count = sizeof...(Fields);
 
   __device__ StructView() : data_{} {
-    init<0>();
+    init();
   }
 
   __device__ StructView(
       const StructView<storage_type, Fields...>& other) : data_{} {
-    assign<0>(other);  // non-trivial to try and honor "holes"
+    assign(other);  // non-trivial to try and honor "holes"
   }
 
   // Construct from other struct
@@ -71,13 +86,13 @@ public:
       const StructView<OtherStorageType, OtherFields...>& other)
       : data_{} {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
-    assign<0>(other);
+    assign(other);
   }
 
   // Construct from "scalar" by broadcasting.
   template<typename T>
   explicit __device__ StructView(const T& value) : data_{} {
-    assign_broadcast<0>(value);
+    assign_broadcast(value);
   }
 
   // Index-based field access
@@ -102,7 +117,7 @@ public:
   __device__ bool operator==(
       const StructView<OtherStorageType, OtherFields...>& other) const {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
-    return compare_eq<0>(other);
+    return compare_eq(other);
   }
 
   template<typename OtherStorageType, typename... OtherFields>
@@ -114,7 +129,7 @@ public:
   // Same as constructor (but more interesting as we actually need to omit holes).
   __device__ StructView& operator=(
       const StructView<storage_type, Fields...>& other) {
-    assign<0>(other);
+    assign(other);
     return *this;
   }
 
@@ -122,7 +137,7 @@ public:
   __device__ StructView& operator=(
       const StructView<OtherStorageType, OtherFields...>& other) {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
-    assign<0>(other);
+    assign(other);
     return *this;
   }
 
@@ -130,52 +145,51 @@ public:
   // NOTE(seberg): Can omitting enable_if lead to ambiguity?
   template<typename T>
   __device__ StructView& operator=(const T& value) {
-    assign_broadcast<0>(value);
+    assign_broadcast(value);
     return *this;
   }
 
 private:
   storage_type data_;
 
-  // Equality comparison helper (only requires operator==)
-  template<size_t Index, typename OtherStorageType, typename... OtherFields>
-  __device__ bool compare_eq(
-      const StructView<OtherStorageType, OtherFields...>& other) const {
-    if constexpr (Index < sizeof...(Fields)) {
-      if (!(at<Index>() == other.template at<Index>())) return false;
-      return compare_eq<Index + 1>(other);
-    }
-    return true;
+  template<typename O, typename... OF, size_t... Is>
+  __device__ bool compare_eq_impl(
+      const StructView<O, OF...>& other, std::index_sequence<Is...>) const {
+    bool eq = true;
+    ((eq = eq && (at<Is>() == other.template at<Is>())), ...);
+    return eq;
+  }
+  template<typename O, typename... OF>
+  __device__ bool compare_eq(const StructView<O, OF...>& other) const {
+    return compare_eq_impl(other, std::make_index_sequence<sizeof...(Fields)>{});
   }
 
-  // Assignment helper (field-by-field from another StructView)
-  template<size_t Index, typename OtherStorageType, typename... OtherFields>
-  __device__ void assign(
-      const StructView<OtherStorageType, OtherFields...>& other) {
-    if constexpr (Index < sizeof...(Fields)) {
-      at<Index>() = other.template at<Index>();
-      assign<Index + 1>(other);
-    }
+  template<typename O, typename... OF, size_t... Is>
+  __device__ void assign_impl(
+      const StructView<O, OF...>& other, std::index_sequence<Is...>) {
+    ((at<Is>() = other.template at<Is>()), ...);
+  }
+  template<typename O, typename... OF>
+  __device__ void assign(const StructView<O, OF...>& other) {
+    assign_impl(other, std::make_index_sequence<sizeof...(Fields)>{});
   }
 
-  // Initialization helper (field-by-field init)
-  template<size_t Index>
+  template<size_t... Is>
+  __device__ void init_impl(std::index_sequence<Is...>) {
+    ((at<Is>() = typename FieldAt<Is>::type{}), ...);
+  }
   __device__ void init() {
-    if constexpr (Index < sizeof...(Fields)) {
-      using FT = FieldAt<Index>;
-      using T = typename FT::type;
-      at<Index>() = T{};
-      init<Index + 1>();
-    }
+    init_impl(std::make_index_sequence<sizeof...(Fields)>{});
   }
 
-  // Broadcast assignment helper (assign same value to all fields)
-  template<size_t Index, typename T>
+  template<typename T, size_t... Is>
+  __device__ void assign_broadcast_impl(
+      const T& value, std::index_sequence<Is...>) {
+    ((at<Is>() = value), ...);
+  }
+  template<typename T>
   __device__ void assign_broadcast(const T& value) {
-    if constexpr (Index < sizeof...(Fields)) {
-      at<Index>() = value;
-      assign_broadcast<Index + 1>(value);
-    }
+    assign_broadcast_impl(value, std::make_index_sequence<sizeof...(Fields)>{});
   }
 };
 

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -71,9 +71,9 @@ public:
   static constexpr size_t alignment = alignof(storage_type);
   static constexpr size_t field_count = sizeof...(Fields);
 
-  __device__ StructView() : data_{} {
-    init();
-  }
+  // initialize by initializing the storage, we could initialize
+  // individual fields, but assume this would also zero them.
+  __device__ StructView() = default;
 
   __device__ StructView(
       const StructView<storage_type, Fields...>& other) : data_{} {
@@ -150,7 +150,7 @@ public:
   }
 
 private:
-  storage_type data_;
+  storage_type data_{};
 
   template<typename O, typename... OF, size_t... Is>
   __device__ bool compare_eq_impl(
@@ -172,14 +172,6 @@ private:
   template<typename O, typename... OF>
   __device__ void assign(const StructView<O, OF...>& other) {
     assign_impl(other, std::make_index_sequence<sizeof...(Fields)>{});
-  }
-
-  template<size_t... Is>
-  __device__ void init_impl(std::index_sequence<Is...>) {
-    ((at<Is>() = typename FieldAt<Is>::type{}), ...);
-  }
-  __device__ void init() {
-    init_impl(std::make_index_sequence<sizeof...(Fields)>{});
   }
 
   template<typename T, size_t... Is>

--- a/cupy/_core/include/cupy/structview.cuh
+++ b/cupy/_core/include/cupy/structview.cuh
@@ -2,24 +2,30 @@
 #define STRUCT_VIEW_H_
 
 #include "cupy/carray.cuh"
-#include "cupy/cuda_workaround.h"
 
 
 namespace cupy {
 
 // Forward declaration for SFINAE
-template<typename, size_t, typename...>
+template<typename, typename...>
 class StructView;
 
 // Trait to detect StructView
 template<typename T>
-struct is_struct_view : std::false_type {};
+struct is_struct_view {
+  static constexpr bool value = false;
+};
 
-template<typename StructType, size_t Size, typename... Fields>
-struct is_struct_view<StructView<StructType, Size, Fields...>> : std::true_type {};
+template<typename StorageType, typename... Fields>
+struct is_struct_view<StructView<StorageType, Fields...>> {
+  static constexpr bool value = true;
+};
 
-template<typename T>
-inline constexpr bool is_struct_view_v = is_struct_view<T>::value;
+template<size_t Size, size_t Align>
+struct alignas(Align) raw_structview_storage {
+  static_assert(Align != 0);
+  char _data[Size];
+};
 
 // Field descriptor: type and offset only
 template<typename T, size_t Offset>
@@ -37,101 +43,104 @@ template<size_t Index, typename First, typename... Rest>
 struct FieldAtImpl<Index, First, Rest...> { using type = typename FieldAtImpl<Index - 1, Rest...>::type; };
 
 // StructView represents a NumPy structured dtype as a C struct.
-// For convenience in RawKernels the structview may be backed by an actual C
-// struct (but this is generated in Python!)
 // Generally, NumPy structured dtypes operate by field index `.at<0>()`
 // will fetch the first index and casts/assignment only use fields.
-// The C type (if not backed by the struct) currently does not know the field
-// names at all.
-template<typename StructType, size_t Size, typename... Fields>
+template<typename StorageType, typename... Fields>
 class StructView {
   template<size_t Index>
   using FieldAt = typename FieldAtImpl<Index, Fields...>::type;
 
-  // Compile-time verification
-  static_assert(sizeof(StructType) == Size, "StructType size must match Size parameter");
-
 public:
-  using struct_type = StructType;
-  static constexpr size_t size = Size;
+  using storage_type = StorageType;
+  static constexpr size_t size = sizeof(storage_type);
+  static constexpr size_t alignment = alignof(storage_type);
   static constexpr size_t field_count = sizeof...(Fields);
 
-  StructType data;
-
-  StructView() {
+  __device__ StructView() : data_{} {
     init<0>();
-  };
+  }
 
-  StructView(const StructView<StructType, Size, Fields...>& other) {
+  __device__ StructView(
+      const StructView<storage_type, Fields...>& other) : data_{} {
     assign<0>(other);  // non-trivial to try and honor "holes"
   }
 
   // Construct from other struct
-  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  explicit StructView(const StructView<OtherStruct, OtherSize, OtherFields...>& other) : data{} {
+  template<typename OtherStorageType, typename... OtherFields>
+  explicit __device__ StructView(
+      const StructView<OtherStorageType, OtherFields...>& other)
+      : data_{} {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
     assign<0>(other);
   }
 
   // Construct from "scalar" by broadcasting.
   template<typename T>
-  explicit StructView(const T& value) : StructType{} {
+  explicit __device__ StructView(const T& value) : data_{} {
     assign_broadcast<0>(value);
   }
 
   // Index-based field access
   template<size_t Index>
-  auto& at() {
+  __device__ auto& at() {
     using FT = FieldAt<Index>;
     using T = typename FT::type;
-    return *reinterpret_cast<T*>(reinterpret_cast<char*>(&data) + FT::offset);
+    return *reinterpret_cast<T*>(reinterpret_cast<char*>(&data_) + FT::offset);
   }
 
   template<size_t Index>
-  const auto& at() const {
+  __device__ const auto& at() const {
     using FT = FieldAt<Index>;
     using T = typename FT::type;
-    return *reinterpret_cast<const T*>(reinterpret_cast<const char*>(&data) + FT::offset);
+    return *reinterpret_cast<const T*>(
+        reinterpret_cast<const char*>(&data_) + FT::offset);
   }
 
   // Cross-type equality (only requires operator== on field types)
   // Note: Like NumPy structured dtypes, only == and != are supported
-  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  bool operator==(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+  template<typename OtherStorageType, typename... OtherFields>
+  __device__ bool operator==(
+      const StructView<OtherStorageType, OtherFields...>& other) const {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
     return compare_eq<0>(other);
   }
 
-  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  bool operator!=(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+  template<typename OtherStorageType, typename... OtherFields>
+  __device__ bool operator!=(
+      const StructView<OtherStorageType, OtherFields...>& other) const {
     return !(*this == other);
   }
 
   // Same as constructor (but more interesting as we actually need to omit holes).
-  StructView& operator=(const StructView<StructType, Size, Fields...>& other) {
+  __device__ StructView& operator=(
+      const StructView<storage_type, Fields...>& other) {
     assign<0>(other);
     return *this;
   }
 
-  template<typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  StructView& operator=(const StructView<OtherStruct, OtherSize, OtherFields...>& other) {
+  template<typename OtherStorageType, typename... OtherFields>
+  __device__ StructView& operator=(
+      const StructView<OtherStorageType, OtherFields...>& other) {
     static_assert(sizeof...(Fields) == sizeof...(OtherFields), "Field count must match");
     assign<0>(other);
     return *this;
   }
 
   // Broadcast assignment - assign single value to all fields.
-  // NOTE(seberg): Can ommitting enable_if lead to ambiguity?
+  // NOTE(seberg): Can omitting enable_if lead to ambiguity?
   template<typename T>
-  StructView& operator=(const T& value) {
+  __device__ StructView& operator=(const T& value) {
     assign_broadcast<0>(value);
     return *this;
   }
 
 private:
+  storage_type data_;
+
   // Equality comparison helper (only requires operator==)
-  template<size_t Index, typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  bool compare_eq(const StructView<OtherStruct, OtherSize, OtherFields...>& other) const {
+  template<size_t Index, typename OtherStorageType, typename... OtherFields>
+  __device__ bool compare_eq(
+      const StructView<OtherStorageType, OtherFields...>& other) const {
     if constexpr (Index < sizeof...(Fields)) {
       if (!(at<Index>() == other.template at<Index>())) return false;
       return compare_eq<Index + 1>(other);
@@ -140,8 +149,9 @@ private:
   }
 
   // Assignment helper (field-by-field from another StructView)
-  template<size_t Index, typename OtherStruct, size_t OtherSize, typename... OtherFields>
-  void assign(const StructView<OtherStruct, OtherSize, OtherFields...>& other) {
+  template<size_t Index, typename OtherStorageType, typename... OtherFields>
+  __device__ void assign(
+      const StructView<OtherStorageType, OtherFields...>& other) {
     if constexpr (Index < sizeof...(Fields)) {
       at<Index>() = other.template at<Index>();
       assign<Index + 1>(other);
@@ -150,7 +160,7 @@ private:
 
   // Initialization helper (field-by-field init)
   template<size_t Index>
-  void init() {
+  __device__ void init() {
     if constexpr (Index < sizeof...(Fields)) {
       using FT = FieldAt<Index>;
       using T = typename FT::type;
@@ -161,7 +171,7 @@ private:
 
   // Broadcast assignment helper (assign same value to all fields)
   template<size_t Index, typename T>
-  void assign_broadcast(const T& value) {
+  __device__ void assign_broadcast(const T& value) {
     if constexpr (Index < sizeof...(Fields)) {
       at<Index>() = value;
       assign_broadcast<Index + 1>(value);

--- a/cupy/_core/include/cupy/unstructued_void.cuh
+++ b/cupy/_core/include/cupy/unstructued_void.cuh
@@ -1,0 +1,46 @@
+#ifndef UNSTRUCTURED_VOID_H_
+#define UNSTRUCTURED_VOID_H_
+
+
+namespace cupy {
+
+template<size_t Size>
+class UnstructuredVoid {
+public:
+  char data[Size];
+
+  UnstructuredVoid() = default;
+
+  template<typename OtherType>
+  explicit UnstructuredVoid(const OtherType& other) {
+    *this = other;
+  }
+
+  bool operator==(const UnstructuredVoid<Size>& other) const {
+    for (size_t i = 0; i < Size; ++i) {
+        if (data[i] != other.data[i]) return false;
+    }
+    return true;
+  }
+
+  bool operator!=(const UnstructuredVoid<Size>& other) const {
+    return !(*this == other);
+  }
+
+  template<typename OtherType>
+  UnstructuredVoid& operator=(const OtherType& other) {
+    // NumPy allows anything to avoid really, just by copying the bytes
+    // (and filling up with zeros).
+    size_t min_length = Size < sizeof(OtherType) ? Size : sizeof(OtherType);
+    const char* other_bytes = reinterpret_cast<const char*>(&other);
+    memcpy(data, other_bytes, min_length);
+    if (Size > min_length) {
+      memset(data + min_length, '\0', Size - min_length);
+    }
+    return *this;
+  }
+};
+
+} // namespace scupy
+
+#endif // UNSTRUCTURED_VOID_H_

--- a/cupy/_core/include/cupy/unstructured_void.cuh
+++ b/cupy/_core/include/cupy/unstructured_void.cuh
@@ -41,6 +41,6 @@ public:
   }
 };
 
-} // namespace scupy
+} // namespace cupy
 
 #endif // UNSTRUCTURED_VOID_H_

--- a/cupy/_core/include/cupy/unstructured_void.cuh
+++ b/cupy/_core/include/cupy/unstructured_void.cuh
@@ -1,6 +1,8 @@
 #ifndef UNSTRUCTURED_VOID_H_
 #define UNSTRUCTURED_VOID_H_
 
+#include "cupy/carray.cuh"
+
 
 namespace cupy {
 
@@ -9,28 +11,28 @@ class UnstructuredVoid {
 public:
   char data[Size];
 
-  UnstructuredVoid() = default;
+  __device__ UnstructuredVoid() = default;
 
   template<typename OtherType>
-  explicit UnstructuredVoid(const OtherType& other) {
+  explicit __device__ UnstructuredVoid(const OtherType& other) {
     *this = other;
   }
 
-  bool operator==(const UnstructuredVoid<Size>& other) const {
+  __device__ bool operator==(const UnstructuredVoid<Size>& other) const {
     for (size_t i = 0; i < Size; ++i) {
-        if (data[i] != other.data[i]) return false;
+      if (data[i] != other.data[i]) return false;
     }
     return true;
   }
 
-  bool operator!=(const UnstructuredVoid<Size>& other) const {
+  __device__ bool operator!=(const UnstructuredVoid<Size>& other) const {
     return !(*this == other);
   }
 
   template<typename OtherType>
-  UnstructuredVoid& operator=(const OtherType& other) {
-    // NumPy allows anything to avoid really, just by copying the bytes
-    // (and filling up with zeros).
+  __device__ UnstructuredVoid& operator=(const OtherType& other) {
+    // NumPy allows almost anything by copying bytes and
+    // filling up the remainder with zeros.
     size_t min_length = Size < sizeof(OtherType) ? Size : sizeof(OtherType);
     const char* other_bytes = reinterpret_cast<const char*>(&other);
     memcpy(data, other_bytes, min_length);

--- a/cupy/_core/include/cupy/unstructured_void.cuh
+++ b/cupy/_core/include/cupy/unstructured_void.cuh
@@ -11,7 +11,7 @@ class UnstructuredVoid {
 public:
   char data[Size];
 
-  __device__ UnstructuredVoid() = default;
+  UnstructuredVoid() = default;
 
   template<typename OtherType>
   explicit __device__ UnstructuredVoid(const OtherType& other) {

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -50,7 +50,7 @@ def copyto(dst, src, casting='same_kind', where=None):
                 'non-scalar numpy.ndarray cannot be used for copyto')
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src, dst.dtype, casting)
-        src = src[()]  # work with the scalar value
+        src = src.squeeze()[()]  # work with the scalar value
         src_is_scalar = True
     elif numpy.isscalar(src):
         can_cast = numpy.can_cast(src, dst.dtype, casting)

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -44,13 +44,16 @@ def copyto(dst, src, casting='same_kind', where=None):
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src_dtype, dst.dtype, casting)
         src_is_scalar = True
-    elif isinstance(src, numpy.ndarray) or numpy.isscalar(src):
+    elif isinstance(src, numpy.ndarray):
         if src.size != 1:
             raise ValueError(
                 'non-scalar numpy.ndarray cannot be used for copyto')
         src_dtype = src.dtype
         can_cast = numpy.can_cast(src, dst.dtype, casting)
-        src = src.item()
+        src = src[()]  # work with the scalar value
+        src_is_scalar = True
+    elif numpy.isscalar(src):
+        can_cast = numpy.can_cast(src, dst.dtype, casting)
         src_is_scalar = True
     else:
         src_dtype = src.dtype

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -53,6 +53,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         src = src.squeeze()[()]  # work with the scalar value
         src_is_scalar = True
     elif numpy.isscalar(src):
+        src_dtype = src  # just report as the scalar value itself.
         can_cast = numpy.can_cast(src, dst.dtype, casting)
         src_is_scalar = True
     else:

--- a/cupyx/scipy/interpolate/_bspline.py
+++ b/cupyx/scipy/interpolate/_bspline.py
@@ -16,7 +16,7 @@ INT_TYPES = ['int', 'long long']
 
 INTERVAL_KERNEL = r'''
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 extern "C" {
 __global__ void find_interval(
@@ -77,7 +77,7 @@ INTERVAL_MODULE = cupy.RawModule(code=INTERVAL_KERNEL,)
 D_BOOR_KERNEL = r'''
 #include <cupy/complex.cuh>
 #include <cupy/math_constants.h>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 #define COMPUTE_LINEAR 0x1
 
 template<typename T>
@@ -180,7 +180,7 @@ D_BOOR_MODULE = cupy.RawModule(code=D_BOOR_KERNEL,
 
 DESIGN_MAT_KERNEL = r'''
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename U>
 __global__ void compute_design_matrix(

--- a/cupyx/scipy/interpolate/_interpnd.py
+++ b/cupyx/scipy/interpolate/_interpnd.py
@@ -192,7 +192,7 @@ class NDInterpolatorBase:
 LINEAR_INTERP_ND_DEF = r"""
 #include <cupy/complex.cuh>
 #include <cupy/math_constants.h>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __global__ void evaluate_linear_nd_interp(

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -191,13 +191,13 @@ if runtime.is_hip:
     includes = r'''
 // workaround for HIP: line begins with #include
 #include <cupy/math_constants.h>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 #include <type_traits>
 '''
 else:
     includes = r'''
 #include <cupy/cuda_workaround.h>  // provide C++ std:: coverage
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 #include <cupy/math_constants.h>
 
 template<> struct std::is_floating_point<float16> : std::true_type {};

--- a/cupyx/scipy/ndimage/_spline_prefilter_core.py
+++ b/cupyx/scipy/ndimage/_spline_prefilter_core.py
@@ -193,7 +193,7 @@ def _get_spline1d_code(mode, poles, n_boundary):
 _FILTER_GENERAL = '''
 #include "cupy/carray.cuh"
 #include "cupy/complex.cuh"
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 typedef {data_type} T;
 typedef {pole_type} P;

--- a/cupyx/scipy/signal/_iir_utils.py
+++ b/cupyx/scipy/signal/_iir_utils.py
@@ -39,7 +39,7 @@ IIR_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename U, typename T>
 __global__ void compute_correction_factors(
@@ -195,7 +195,7 @@ IIR_SOS_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __global__ void pick_carries(

--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -70,7 +70,7 @@ PEAKS_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __global__ void local_maxima_1d(
@@ -317,7 +317,7 @@ ARGREL_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __device__ __forceinline__ bool less( const T &a, const T &b ) {

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -14,7 +14,7 @@ from cupyx.scipy.signal._iir_utils import collapse_2d, apply_iir_sos
 SYMIIR2_KERNEL = r"""
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __device__ T _compute_symiirorder2_fwd_hc(

--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -666,7 +666,7 @@ UNIT_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 template<typename T>
 __global__ void unit_impulse(const int n, const int iidx, T* out) {

--- a/cupyx/scipy/spatial/_kdtree_utils.py
+++ b/cupyx/scipy/spatial/_kdtree_utils.py
@@ -33,7 +33,7 @@ KD_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 __device__ long long sb(
         const long long s_level, const int n,
@@ -197,7 +197,7 @@ KNN_KERNEL = r'''
 #include <cupy/math_constants.h>
 #include <cupy/carray.cuh>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 
 __device__ unsigned long long abs(unsigned long long x) {
     return x;

--- a/cupyx/signal/_filtering/_filtering.py
+++ b/cupyx/signal/_filtering/_filtering.py
@@ -293,7 +293,7 @@ _CHANNELIZER_KERNEL_PREAMBLE = r"""
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
 #include <cupy/complex.cuh>
-#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_headers?
+#include <cupy/float16.cuh>  // TODO(seberg): Add this via type_decls?
 #include <cupy/cuda_workaround.h>
 
 namespace std {

--- a/docs/source/reference/dtype.rst
+++ b/docs/source/reference/dtype.rst
@@ -10,6 +10,7 @@ Data type routines
 
    can_cast
    min_scalar_type
+   make_aligned_dtype
    result_type
    common_type
 
@@ -25,6 +26,7 @@ Creating data types
    :align: left
 
    ``dtype`` (alias of :class:`numpy.dtype`)
+   ``make_aligned_dtype`` CuPy utility to create structured dtypes with sufficient alignment for GPU use.
    ``format_parser`` (alias of :class:`numpy.rec.format_parser`)
 
 Data type information

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -7,6 +7,8 @@ import cupy
 from cupy.exceptions import ComplexWarning
 from cupy import testing
 from cupy import _util
+from cupy.testing._protocol_helpers import (
+    DummyObjectWithCuPyGetNDArray, DummyObjectWithCudaArrayInterface)
 
 
 def astype_without_warning(x, dtype, *args, **kwargs):
@@ -281,6 +283,26 @@ class TestArrayFill:
         for xp in (numpy, cupy):
             with pytest.raises(ValueError):
                 a.fill(xp.ones((1,), dtype=dtype))
+
+    @pytest.mark.parametrize('value', [
+        (42, 3.14),
+        numpy.asarray((42, 3.14), dtype='i4,f4'),
+    ])
+    @testing.numpy_cupy_array_equal()
+    def test_fill_structured_scalar_like(self, xp, value):
+        a = xp.zeros(3, dtype='i4,f4')
+        a.fill(value)
+        return a
+
+    @pytest.mark.parametrize('cupy_like', [
+        DummyObjectWithCuPyGetNDArray,
+        DummyObjectWithCudaArrayInterface,
+    ])
+    def test_fill_with_cupy_like_scalar_ndarray(self, cupy_like):
+        a = cupy.zeros(3)
+        b = cupy.ones(())
+        a.fill(cupy_like(b))
+        testing.assert_array_equal(a, cupy.ones(3))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -133,7 +133,7 @@ class TestComparison:
         assert cmp_dtype.itemsize == 24
         # However, this isn't aligned for the GPU which wants itemsize
         # alignment for complex.
-        assert cupy.make_gpu_aligned_dtype(cmp_dtype).itemsize == 32
+        assert cupy.make_aligned_dtype(cmp_dtype).itemsize == 32
         res = op(a, b)
         assert numpy.array_equal(res.get(), op(a.get(), b.get()))
 

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -128,7 +128,8 @@ class TestComparison:
     def test_promotion_aligned(self, op):
         a = cupy.array([(1, 2)], dtype="f8,c8")
         b = cupy.array([(1, 2), (1, 3), (2, 3)], dtype="f8,f8")
-        # For comparison, promotion would go to f8,c16
+        # For comparison, promotion would go to f8,c16. But the NumPy
+        # promoted dtype would not be sufficiently aligned for this.
         cmp_dtype = numpy.result_type(a.dtype, b.dtype)
         assert cmp_dtype.itemsize == 24
         # However, this isn't aligned for the GPU which wants itemsize

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import operator
+
 import numpy
 import pytest
 
@@ -51,6 +53,75 @@ class TestCreation:
                 func(ByteSwapped(base))
         else:
             assert func(ByteSwapped(base)).dtype == f"V{base.dtype.itemsize}"
+
+
+class TestFieldCasting:
+    @testing.numpy_cupy_array_equal()
+    def test_casting_simple(self, xp):
+        a = xp.array([(1, 2.), (3, 4.)], dtype="i8,f8")
+        return a.astype("f8,i8")
+
+    @testing.numpy_cupy_array_equal()
+    def test_casting_swapped_fields(self, xp):
+        a = xp.array([(1, 2.), (3, 4.)], dtype="i8,f8")
+        return a[["f0", "f1"]].astype("f8,i8")
+
+    @testing.numpy_cupy_array_equal()
+    def test_casting_nested(self, xp):
+        dt_nested = xp.dtype("i8,f8")
+        dtype = xp.dtype([("a", "f8"), ("b", dt_nested)])
+        a = xp.array([(1, 2.), (3, 4.)], dtype=dtype)
+
+        new_nested = xp.dtype("f4,i4")
+        new_dtype = xp.dtype([("a", "f4"), ("b", new_nested)])
+        return a.astype(new_dtype)
+
+
+@pytest.mark.parametrize("op", [operator.eq, operator.ne])
+class TestComparison:
+    @testing.numpy_cupy_array_equal()
+    def test_simple(self, xp, op):
+        a = xp.array([(1, 2)], dtype="i8,f8")
+        b = xp.array([(1, 2.), (1, 3), (3, 2)], dtype="i8,f8")
+        return op(a, b)
+
+    @testing.numpy_cupy_array_equal()
+    def test_with_cast_simple(self, xp, op):
+        a = xp.array([(1, 2)], dtype="i8,f8")
+        b = xp.array([(1, 2.), (1, 3), (3, 2)], dtype="f8,i8")
+        return op(a, b)
+
+    @testing.numpy_cupy_array_equal(accept_error=TypeError)
+    def test_field_order(self, xp, op):
+        # Swapped fields with name mis-match are unclear how they
+        # should be compared, so NumPy raises.
+        a = xp.array([(1, 2)], dtype="i8,f8")[["f1", "f0"]]
+        b = xp.array([(1, 2.), (1, 3), (3, 2)], dtype="f8,i8")
+        return op(a, b)
+
+    @testing.numpy_cupy_array_equal()
+    def test_nested(self, xp, op):
+        adt_nested = xp.dtype("i8,f8")
+        adtype = xp.dtype([("a", "f8"), ("b", adt_nested)])
+        bdt_nested = xp.dtype("f4,i4")
+        bdtype = xp.dtype([("a", "f4"), ("b", bdt_nested)])
+
+        a = xp.array([(1, (2, 3))], dtype=adtype)
+        b = xp.array([(1, (2, 3)), (1, (2, 4)), (1, (3, 3))], dtype=bdtype)
+
+        return op(a, b)
+
+    def test_promotion_aligned(self, op):
+        a = cupy.array([(1, 2)], dtype="f8,c8")
+        b = cupy.array([(1, 2), (1, 3), (2, 3)], dtype="f8,f8")
+        # For comparison, promotion would go to f8,c16
+        cmp_dtype = numpy.result_type(a.dtype, b.dtype)
+        assert cmp_dtype.itemsize == 24
+        # However, this isn't aligned for the GPU which wants itemsize
+        # alignment for complex.
+        assert cupy.make_gpu_aligned_dtype(cmp_dtype).itemsize == 32
+        res = op(a, b)
+        assert numpy.array_equal(res.get(), op(a.get(), b.get()))
 
 
 class TestFieldAccess:
@@ -106,6 +177,26 @@ class TestFieldAccess:
         msg = "CuPy does not yet support accessing nested subarrays"
         with pytest.raises(ValueError, match=msg):
             a["f1"]
+
+    @testing.numpy_cupy_array_equal()
+    def test_multiple_fields(self, xp):
+        a = xp.ones(10, "i,f,i")
+        a["f1"] = xp.arange(10)
+        a["f2"] = -xp.arange(10)
+        return a[["f2", "f1"]]
+
+    @testing.numpy_cupy_array_equal()
+    def test_multifield_assignment(self, xp):
+        a = xp.ones(10, "i,f,i,f,i,f")
+        for i in range(6):
+            a[f'f{i}'] = xp.arange(i, 10+i)
+
+        # in-place modify `a` with mixed fields that have holes.
+        # This also requires casting the fields.
+        # NOTE(seberg): Behavior is not identical if source and destination
+        # point to the same memory. Don't do that... (i.e. the copy is needed)
+        a[["f1", "f0", "f4"]] = a[["f2", "f1", "f5"]].copy()
+        return a
 
 
 class TestIndexing:

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -249,6 +249,12 @@ class TestFieldAccess:
 
 
 class TestIndexing:
+    def test_assign(self):
+        src = cupy.array([(1, 1.5), (2, 2.5), (3, 3.5)], dtype="i4,f4")
+        dst = cupy.zeros(src.shape, dtype="i4,f4")
+        dst[:] = src
+        testing.assert_array_equal(dst, src)
+
     @testing.numpy_cupy_array_equal()
     @pytest.mark.parametrize("sl", [slice(1, None), slice(None, None, 2)])
     def test_slicing(self, xp, sl):

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -152,6 +152,13 @@ class TestComparison:
         with pytest.raises(ValueError, match="Unsupported dtype"):
             op(a, a)
 
+    def test_many_fields(self, op):
+        fields = [(f"f{i}", "i1") for i in range(256)]
+        dtype = numpy.dtype(fields)
+        a = cupy.zeros(3, dtype=dtype)
+        b = cupy.zeros(3, dtype=dtype)
+        testing.assert_array_equal(op(a, b), op(a.get(), b.get()))
+
 
 class TestMakeAlignedDtype:
     # Note also tested partially in promotion for comparison

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -144,6 +144,14 @@ class TestComparison:
         res = op(a, b)
         assert numpy.array_equal(res.get(), op(a.get(), b.get()))
 
+    def test_subarray_of_struct_error(self, op):
+        # subarrays are usupported right now (but ideally give a nice error)
+        inner = numpy.dtype([("x", "i4"), ("y", "f4")])
+        dtype = numpy.dtype([("a", inner, (3,))])
+        a = cupy.zeros(2, dtype=dtype)
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            op(a, a)
+
 
 class TestMakeAlignedDtype:
     # Note also tested partially in promotion for comparison

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -139,6 +139,25 @@ class TestComparison:
         assert numpy.array_equal(res.get(), op(a.get(), b.get()))
 
 
+class TestMakeAlignedDtype:
+    # Note also tested partially in promotion for comparison
+    @pytest.mark.parametrize("dt,itemsize", [
+        # Complex is 8 byte aligned, padded to 16 (CPU would align 4)
+        ("?,c8", 16),
+        ("c8,?", 16),
+        # Subarray is also aligned (via base dtype)
+        ("?,(3,)c8", 32),
+        ("(3,)c8,?", 32),
+        # Nested structure works (first one is padded so full needs 24)
+        (numpy.dtype([("a", "c8,?"), ("b", "?")]), 24),
+        (numpy.dtype([("a", "?"), ("b", "c8,?")]), 24),
+        # Nested void works and doesn't do much:
+        ("?,(4,)V3", 13),  # All char aligned
+    ])
+    def test_make_aligned_dtype(self, dt, itemsize):
+        assert cupy.make_aligned_dtype(dt).itemsize == itemsize
+
+
 class TestFieldAccess:
     @testing.numpy_cupy_array_equal()
     @pytest.mark.parametrize("index", ["f0", "f1"])

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -145,11 +145,12 @@ class TestComparison:
         assert numpy.array_equal(res.get(), op(a.get(), b.get()))
 
     def test_subarray_of_struct_error(self, op):
-        # subarrays are usupported right now (but ideally give a nice error)
+        # subarrays are unsupported right now (but ideally give a nice error).
+        # This error is currently given pretty explicitly.
         inner = numpy.dtype([("x", "i4"), ("y", "f4")])
         dtype = numpy.dtype([("a", inner, (3,))])
         a = cupy.zeros(2, dtype=dtype)
-        with pytest.raises(ValueError, match="Unsupported dtype"):
+        with pytest.raises(ValueError, match=".*subarray dtypes"):
             op(a, a)
 
     def test_many_fields(self, op):

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -22,8 +22,9 @@ class TestCreation:
 
     @pytest.mark.parametrize("func", [
         cupy.array,
-        cupy.asarray,
         lambda x: cupy.asarray([x, x]),
+        # Uses __cuda_array_interface__ only which doesn't check as strictly:
+        pytest.param(cupy.asarray, marks=pytest.mark.xfail(strict=True)),
     ])
     def test_reject_references(self, func):
         arr = numpy.array([1, 2, 3], dtype="q,O")
@@ -34,7 +35,7 @@ class TestCreation:
         # Check coming from a bad cupy array-like
         base = cupy.zeros(3, dtype="q,q")
 
-        class ByteSwapped(DummyObjectWithCudaArrayInterface):
+        class WithReferences(DummyObjectWithCudaArrayInterface):
             @property
             def __cuda_array_interface__(self):
                 # Fake the dtype to something bad
@@ -43,12 +44,17 @@ class TestCreation:
                 iface["descr"] = arr.dtype.descr
                 return iface
 
-        # Right now, structured dtypes round-trip as V<itemsize> and lose
-        # their structure in the __cuda_array_interface__. As long as that
-        # is the case, this always passes.
-        # with pytest.raises(ValueError):
-        #     func(ByteSwapped(base))
-        assert func(ByteSwapped(base)).dtype == f"V{base.dtype.itemsize}"
+        with pytest.raises(ValueError):
+            func(WithReferences(base))
+
+    def test_cuda_array_interface_dtype(self):
+        # This dtype requires padding, let's make it so it round-trips fine
+        # in __cuda_array_interface__...
+        a = cupy.zeros(3, dtype=cupy.make_aligned_dtype("?,q"))
+        res = cupy.asarray(DummyObjectWithCudaArrayInterface(a))
+
+        assert a.dtype == res.dtype
+        assert cupy.may_share_memory(a, res)
 
 
 class TestFieldCasting:

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -163,6 +163,15 @@ class TestMakeAlignedDtype:
     def test_make_aligned_dtype(self, dt, itemsize):
         assert cupy.make_aligned_dtype(dt).itemsize == itemsize
 
+    @pytest.mark.parametrize("dt", ["c16", "V3"])
+    def test_make_aligned_dtype_non_structured_error(self, dt):
+        # Currently, we really only support structured dtypes. This could
+        # be removed in which case the code should correctly do nothing
+        # except possibly attach the `__cuda_alignment__` metadata.
+        with pytest.raises(
+                ValueError, match="only supports structured dtypes"):
+            cupy.make_aligned_dtype(dt)
+
 
 class TestFieldAccess:
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -251,17 +251,22 @@ class TestIndexing:
         return (a[sl]["f0"], a[sl]["f1"])
 
 
-class TestKernelStructAccess:
+class TestKernelFieldAccess:
     def test_elementwise_kernel(self):
-        # When the data can be defined as a normal struct, then
-        # we allow access via `.data`.
-        # TODO/NOTE(seberg): Is this even desired?!
+        # Structured values are intentionally not exposed as named structs.
+        # Field access is supported by field index only.
+        # NOTE(seberg): We could expose `.data` as a custom struct or field
+        # access by name (which seems to require very modern C++).
         kernel = cupy.ElementwiseKernel(
-            'T in', 'T out', 'out.data.f1 = -in.data.f0;',
+            'T in', 'T out',
+            '''
+            static_assert(T::field_count == 2, "expected 2 fields");
+            out.at<1>() = -in.at<0>();
+            ''',
             'test_struct_access')
         x = cupy.array([1, 2, 3], dtype="i,i")
         y = cupy.array([4, 5, 6], dtype="i,i")
-        # kernel mutates field 1.
+        # kernel mutates field 1 via field-index access.
         kernel(x, y)
         expected = cupy.array([(4, -1), (5, -2), (6, -3)], dtype="i,i")
         testing.assert_array_equal(y, expected)

--- a/tests/cupy_tests/core_tests/test_structured.py
+++ b/tests/cupy_tests/core_tests/test_structured.py
@@ -314,6 +314,13 @@ class TestUnstructuredVoid:
         xp.copyto(a, xp.array(from_values), casting="unsafe")
         return a
 
+    @pytest.mark.parametrize("op", [operator.eq, operator.ne])
+    @testing.numpy_cupy_array_equal()
+    def test_comparison_equal_same_size(self, xp, op):
+        a = xp.array([b"87654321", b"12345678"], dtype="V8")
+        b = xp.array([b"87654321", b"1234567_"], dtype="V8")
+        return op(a, b)
+
 
 @pytest.mark.parametrize("scalar", [
     1.0,

--- a/tests/cupy_tests/creation_tests/test_from_data.py
+++ b/tests/cupy_tests/creation_tests/test_from_data.py
@@ -709,7 +709,7 @@ class TestCudaArrayInterfaceNonBuiltinDtype:
         b = DummyObjectWithCudaArrayInterface(a, ver, strides)
         c = cupy.asarray(b)
         # CAI typestr for structured dtypes is |V<n>; field info is lost
-        assert c.dtype == numpy.dtype(dtype.str)
+        assert c.dtype == dtype
         assert c.shape == (3,)
 
     @pytest.mark.parametrize('ver', range(max_cuda_array_interface_version+1))


### PR DESCRIPTION
**~This is quite far along, but needs cleaning up (and is based on the other PR). So it is a WIP only, just for visibility.~**

Based on gh-9494, this adds the missing support for structured dtypes, that is, allowing casts and multi-field access/assignments.

Major open points:
* We need to thread through the `dtype` much more. This is OK, but we need to refactor things to make use of the NumPy C-API to reduce overheads again.
  * It may make sense to do a bit larger refactors around this.  *EDIT:* Actually, I don't think these changes cause any measurable speed regression, some things may be nice but not much needed here.
* NumPy doesn't help us align types properly, so we'll need a helper to do so.
  * I am curious if we couldn't query the `alignof()` through the JIT to implement this? (plus memoization).
  * This will currently lead to some incorrect paths even for correct inputs in theory (i.e. the comparison compares via a promoted type and that promoted type may be unaligned)
* ~It needs tests of course!~

Smaller points:
* I would like this to be interoperable with a plain struct, if such a plain struct can work. That logic exists, but likely doesn't quite work yet.
* This PR does *not* implement subarray support.

To implement this I added a `resolve_dtypes()` function. This is a concept that NumPy also has, although I made it a bit more raw here. (The divergence has two reasons. First casts as a ufunc don't work well without it, although a cast could maybe be a simple `ElementwiseKernel`. But also the functionality used in NumPy to actual implement it nicely isn't public, oops.)

Addresses gh-2031 (but one could argue that subarray support is missing)