### PR TITLE
Add hipTensor support for ROCm

### DIFF
--- a/cupy/_core/_accelerator.pyx
+++ b/cupy/_core/_accelerator.pyx
@@ -15,6 +15,8 @@ cdef int _get_accelerator(accelerator) except -1:
         return ACCELERATOR_CUB
     if accelerator == 'cutensor':
         return ACCELERATOR_CUTENSOR
+    if accelerator == 'hiptensor':
+        return ACCELERATOR_CUTENSOR
     if accelerator == 'cutensornet':
         return ACCELERATOR_CUTENSORNET
     raise ValueError('Unknown accelerator: {}'.format(accelerator))

--- a/cupy/_core/include/cupy/hiptensor.h
+++ b/cupy/_core/include/cupy/hiptensor.h
@@ -1,0 +1,16 @@
+#ifndef INCLUDE_GUARD_CUPY_HIPTENSOR_H
+#define INCLUDE_GUARD_CUPY_HIPTENSOR_H
+
+#if __has_include(<hiptensor/hiptensor.h>)
+#include <hiptensor/hiptensor.h>
+#elif __has_include(<hiptensor/hiptensor.hpp>)
+#include <hiptensor/hiptensor.hpp>
+#elif __has_include(<hiptensor.h>)
+#include <hiptensor.h>
+#elif __has_include(<hiptensor.hpp>)
+#include <hiptensor.hpp>
+#else
+#error "hipTensor header not found"
+#endif
+
+#endif  // INCLUDE_GUARD_CUPY_HIPTENSOR_H

--- a/cupy/linalg/_einsum.py
+++ b/cupy/linalg/_einsum.py
@@ -383,15 +383,23 @@ def reduced_binary_einsum(arr0, sub0, arr1, sub1, sub_others):
         if accelerator != _accelerator.ACCELERATOR_CUTENSOR:
             continue
         try:
-            import cupy_backends.cuda.libs.cutensor  # NOQA
+            import cupy_backends.cuda.libs.cutensor as _cutensor_backend
             from cupyx import cutensor
         except ImportError:
             continue
         else:
+            from cupy_backends.cuda.api import runtime as _runtime
+            if _runtime.is_hip:
+                # hipTensor 2.3 contraction is not reliable across the full
+                # einsum mode/shape surface. Keep direct contraction available,
+                # but preserve einsum correctness with CuPy's implementation.
+                continue
+            _einsum_cutensor_dtypes = (
+                cupy.float32, cupy.float64,
+                cupy.complex64, cupy.complex128)
             if (
                 arr0.dtype != arr1.dtype
-                or arr0.dtype not in (cupy.float32, cupy.float64,
-                                      cupy.complex64, cupy.complex128)
+                or arr0.dtype not in _einsum_cutensor_dtypes
             ):
                 continue
             if len(sub_out) == len(sub_others):
@@ -402,12 +410,23 @@ def reduced_binary_einsum(arr0, sub0, arr1, sub1, sub_others):
             arr_out = cupy.empty(out_shape, arr0.dtype)
             arr0 = cupy.ascontiguousarray(arr0)
             arr1 = cupy.ascontiguousarray(arr1)
-            arr_out = cutensor.contraction(
-                1.0,
-                arr0, sub0,
-                arr1, sub1,
-                0.0,
-                arr_out, sub_out)
+            try:
+                arr_out = cutensor.contraction(
+                    1.0,
+                    arr0, sub0,
+                    arr1, sub1,
+                    0.0,
+                    arr_out, sub_out)
+            except _cutensor_backend.CuTensorError as e:
+                # cuTENSOR/hipTensor can be present but not support certain
+                # dtypes/operators on a given architecture. In such cases, fall
+                # back to the default implementation.
+                if e.status in (
+                    _cutensor_backend.STATUS_NOT_SUPPORTED,
+                    _cutensor_backend.STATUS_ARCH_MISMATCH,
+                ):
+                    continue
+                raise
             return arr_out, sub_out
 
     tmp0, shapes0 = _flatten_transpose(arr0, [bs0, ts0, cs0])

--- a/cupy_backends/cupy_cutensor.h
+++ b/cupy_backends/cupy_cutensor.h
@@ -3,9 +3,7 @@
 
 #ifdef CUPY_USE_HIP
 
-// Since ROCm/HIP does not have cuTENSOR, we simply include the stubs here
-// to avoid code dup.
-#include "stub/cupy_cutensor.h"
+#include "hip/cupy_hiptensor.h"
 
 #elif !defined(CUPY_NO_CUDA)
 

--- a/cupy_backends/hip/cupy_hiptensor.h
+++ b/cupy_backends/hip/cupy_hiptensor.h
@@ -1,0 +1,185 @@
+#ifndef INCLUDE_GUARD_HIP_CUPY_HIPTENSOR_H
+#define INCLUDE_GUARD_HIP_CUPY_HIPTENSOR_H
+
+#include "cupy_hip.h"
+
+#include <cupy/hiptensor.h>
+#if __has_include(<hiptensor/hiptensor-version.hpp>)
+#include <hiptensor/hiptensor-version.hpp>
+#endif
+
+extern "C" {
+
+// Core types
+typedef hiptensorHandle_t cutensorHandle_t;
+typedef hiptensorTensorDescriptor_t cutensorTensorDescriptor_t;
+typedef hiptensorOperationDescriptor_t cutensorOperationDescriptor_t;
+typedef hiptensorPlanPreference_t cutensorPlanPreference_t;
+typedef hiptensorPlan_t cutensorPlan_t;
+
+typedef hiptensorStatus_t cutensorStatus_t;
+typedef hiptensorAlgo_t cutensorAlgo_t;
+typedef hiptensorJitMode_t cutensorJitMode_t;
+typedef hiptensorOperator_t cutensorOperator_t;
+typedef hiptensorWorksizePreference_t cutensorWorksizePreference_t;
+typedef hiptensorPlanAttribute_t cutensorPlanAttribute_t;
+typedef hiptensorPlanPreferenceAttribute_t cutensorPlanPreferenceAttribute_t;
+typedef hiptensorCacheMode_t cutensorCacheMode_t;
+typedef hiptensorDataType_t cutensorDataType_t;
+// hipTensor 2.0 does not expose hiptensorComputeType_t; keep ABI compatible.
+typedef int cutensorComputeType_t;
+
+typedef hiptensorComputeDescriptor_t cutensorComputeDescriptor_t;
+
+// Normalize hipTensor's component macros to the version encoding used by its
+// runtime API: major * 1,000,000 + minor * 1,000 + patch.
+#if defined(HIPTENSOR_MAJOR_VERSION)
+#define CUPY_HIPTENSOR_VERSION \
+    (HIPTENSOR_MAJOR_VERSION * 1000000 + \
+     HIPTENSOR_MINOR_VERSION * 1000 + HIPTENSOR_PATCH_VERSION)
+#elif defined(HIPTENSOR_MAJOR)
+#define CUPY_HIPTENSOR_VERSION \
+    (HIPTENSOR_MAJOR * 1000000 + \
+     HIPTENSOR_MINOR * 1000 + HIPTENSOR_PATCH)
+#else
+#define CUPY_HIPTENSOR_VERSION 0
+#endif
+
+#ifndef CUTENSOR_VERSION
+#define CUTENSOR_VERSION CUPY_HIPTENSOR_VERSION
+#endif
+
+// Status mapping (for stubs below)
+//
+// Note: HIPTENSOR_STATUS_* are enum values, not preprocessor macros, so we
+// should not use #ifdef to test for their existence.
+static const cutensorStatus_t CUTENSOR_STATUS_SUCCESS = HIPTENSOR_STATUS_SUCCESS;
+static const cutensorStatus_t CUTENSOR_STATUS_NOT_SUPPORTED = HIPTENSOR_STATUS_NOT_SUPPORTED;
+
+// Function mapping (core APIs)
+#define cutensorGetErrorString hiptensorGetErrorString
+static inline size_t cutensorGetVersion() {
+    return static_cast<size_t>(CUPY_HIPTENSOR_VERSION);
+}
+
+#define cutensorCreate hiptensorCreate
+#define cutensorDestroy hiptensorDestroy
+
+#define cutensorCreateTensorDescriptor hiptensorCreateTensorDescriptor
+#define cutensorDestroyTensorDescriptor hiptensorDestroyTensorDescriptor
+
+#define cutensorCreatePlanPreference hiptensorCreatePlanPreference
+#define cutensorDestroyPlanPreference hiptensorDestroyPlanPreference
+
+#define cutensorEstimateWorkspaceSize hiptensorEstimateWorkspaceSize
+
+#define cutensorCreatePlan hiptensorCreatePlan
+#define cutensorPlanGetAttribute hiptensorPlanGetAttribute
+#define cutensorDestroyPlan hiptensorDestroyPlan
+
+#define cutensorCreateElementwiseTrinary hiptensorCreateElementwiseTrinary
+#define cutensorElementwiseTrinaryExecute hiptensorElementwiseTrinaryExecute
+
+#define cutensorCreateElementwiseBinary hiptensorCreateElementwiseBinary
+#define cutensorElementwiseBinaryExecute hiptensorElementwiseBinaryExecute
+
+#define cutensorCreatePermutation hiptensorCreatePermutation
+#define cutensorPermute hiptensorPermute
+
+#define cutensorCreateContraction hiptensorCreateContraction
+#define cutensorContract hiptensorContract
+
+#define cutensorCreateReduction hiptensorCreateReduction
+#define cutensorReduce hiptensorReduce
+
+#define cutensorDestroyOperationDescriptor hiptensorDestroyOperationDescriptor
+
+#define cutensorGetAlignmentRequirement hiptensorGetAlignmentRequirement
+
+// cuTENSOR compute descriptor constants
+//
+// Note: HIPTENSOR_COMPUTE_DESC_* are enum values, not preprocessor macros, so
+// #ifdef checks will always fail and incorrectly map them to 0.
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_16F = HIPTENSOR_COMPUTE_DESC_16F;
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_16BF = HIPTENSOR_COMPUTE_DESC_16BF;
+// hipTensor does not currently define TF32 variants; map them to FP32.
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_TF32 = HIPTENSOR_COMPUTE_DESC_32F;
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_3XTF32 = HIPTENSOR_COMPUTE_DESC_32F;
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_32F = HIPTENSOR_COMPUTE_DESC_32F;
+static const cutensorComputeDescriptor_t CUTENSOR_COMPUTE_DESC_64F = HIPTENSOR_COMPUTE_DESC_64F;
+
+// hipTensor does not expose a CUDA runtime version query; fall back to HIP.
+static inline size_t cutensorGetCudartVersion() {
+    int version = 0;
+    hipRuntimeGetVersion(&version);
+    return static_cast<size_t>(version);
+}
+
+// cuTENSORMg is not available in hipTensor. Provide stubs.
+typedef void* cutensorMgHandle_t;
+typedef void* cutensorMgTensorDescriptor_t;
+typedef void* cutensorMgCopyDescriptor_t;
+typedef void* cutensorMgCopyPlan_t;
+typedef void* cutensorMgContractionDescriptor_t;
+typedef void* cutensorMgContractionFind_t;
+typedef void* cutensorMgContractionPlan_t;
+typedef int cutensorMgAlgo_t;
+
+static inline cutensorStatus_t cutensorMgCreate(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroy(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateTensorDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyTensorDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateCopyDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyCopyDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCopyGetWorkspace(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateCopyPlan(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyCopyPlan(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCopy(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateContractionDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyContractionDescriptor(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateContractionFind(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyContractionFind(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgContractionGetWorkspace(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgCreateContractionPlan(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgDestroyContractionPlan(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+static inline cutensorStatus_t cutensorMgContraction(...) {
+    return CUTENSOR_STATUS_NOT_SUPPORTED;
+}
+
+}  // extern "C"
+
+#endif  // INCLUDE_GUARD_HIP_CUPY_HIPTENSOR_H

--- a/cupyx/_cutensor.pyx
+++ b/cupyx/_cutensor.pyx
@@ -2,6 +2,7 @@ import numpy as _numpy
 
 import cupy as _cupy
 from cupy import _util
+from cupy_backends.cuda.api import runtime as _runtime
 
 cimport cython
 from libcpp cimport vector
@@ -18,6 +19,7 @@ from cupy._core cimport _reduction
 from cupy.cuda cimport device
 from cupy.cuda.pinned_memory cimport alloc_pinned_memory, is_memory_pinned
 from cupy_backends.cuda.libs cimport cutensor
+from cupy_backends.cuda.libs import cutensor as _cutensor_py
 from cupy.cuda import Device
 
 cdef dict _modes = {}
@@ -73,6 +75,11 @@ cdef class CutensorHandle:
 
 @_util.memoize(for_each_device=True)
 def check_availability(name):
+    if _runtime.is_hip:
+        if name in (
+                'elementwise', 'contraction', 'copyMg', 'contractMg'):
+            return False
+        return True
     if name in _available_compute_capability:
         compute_capability = int(device.get_compute_capability())
         if compute_capability < _available_compute_capability[name]:
@@ -88,12 +95,22 @@ def check_availability(name):
 cdef class TensorDescriptor:
     cdef intptr_t _ptr
     cdef int _cutensor_dtype
+    cdef object _extent
+    cdef object _stride
 
-    def __init__(self, intptr_t handle, uint32_t num_modes, intptr_t extent,
-                 intptr_t stride, int cutensor_dtype,
+    def __init__(self, intptr_t handle, uint32_t num_modes, extent, stride,
+                 int cutensor_dtype,
                  uint32_t alignment_req=256):
+        # hipTensor appears to keep pointers to `extent`/`stride` arrays
+        # instead of copying them internally. Keep them alive for the
+        # descriptor's lifetime to avoid use-after-free and correctness issues.
+        self._extent = extent
+        self._stride = stride
         self._ptr = cutensor.createTensorDescriptor(
-            handle, num_modes, extent, stride, cutensor_dtype, alignment_req)
+            handle, num_modes,
+            extent.ctypes.data,
+            stride.ctypes.data,
+            cutensor_dtype, alignment_req)
         self._cutensor_dtype = cutensor_dtype
 
     def __dealloc__(self):
@@ -265,7 +282,7 @@ cpdef TensorDescriptor create_tensor_descriptor(_ndarray_base a):
         stride = _numpy.array(a.strides, dtype=_numpy.int64) // a.itemsize
         cutensor_dtype = _get_cutensor_dtype(a.dtype)
         handle._tensor_descriptors[key] = TensorDescriptor(
-            handle.ptr, num_modes, extent.ctypes.data, stride.ctypes.data,
+            handle.ptr, num_modes, extent, stride,
             cutensor_dtype, alignment_req=alignment_req)
     return handle._tensor_descriptors[key]
 
@@ -369,6 +386,182 @@ cdef inline Mode _auto_create_mode(_ndarray_base array, mode):
     return mode
 
 
+cdef tuple _get_mode_labels(mode):
+    if isinstance(mode, Mode):
+        return tuple(int(x) for x in (<Mode>mode)._array)
+    return tuple(
+        ord(x) if isinstance(x, str) else int(x)
+        for x in mode)
+
+
+cdef void _validate_mode_labels(x, tuple labels) except *:
+    if len(labels) != x.ndim:
+        raise ValueError(
+            'mode length does not match array ndim: {} != {}'.format(
+                len(labels), x.ndim))
+    if len(set(labels)) != len(labels):
+        raise ValueError('tensor modes must be unique')
+
+
+cdef void _validate_shared_mode_extents(tuple operands) except *:
+    cdef dict extents = {}
+    for x, labels in operands:
+        _validate_mode_labels(x, labels)
+        for axis, label in enumerate(labels):
+            extent = x.shape[axis]
+            if label in extents and extents[label] != extent:
+                raise ValueError(
+                    'extent mismatch for mode {}: {} != {}'.format(
+                        label, extents[label], extent))
+            extents[label] = extent
+
+
+cdef _align_array_to_modes(x, tuple labels, tuple output_labels):
+    _validate_mode_labels(x, labels)
+    if len(set(output_labels)) != len(output_labels):
+        raise ValueError('output tensor modes must be unique')
+    if not set(labels).issubset(set(output_labels)):
+        raise ValueError('input modes must be a subset of output modes')
+
+    axes = {label: axis for axis, label in enumerate(labels)}
+    permutation = tuple(
+        axes[label] for label in output_labels if label in axes)
+    if permutation != tuple(range(x.ndim)):
+        x = x.transpose(permutation)
+    shape = tuple(
+        x.shape[permutation.index(axes[label])] if label in axes else 1
+        for label in output_labels)
+    return x.reshape(shape)
+
+
+cdef _get_fallback_compute_dtype(int compute_desc, default_dtype):
+    default_dtype = _numpy.dtype(default_dtype)
+    if compute_desc == 0:
+        return default_dtype
+    if compute_desc == cutensor.COMPUTE_DESC_16F:
+        return _numpy.dtype(_numpy.float16)
+    if (compute_desc == cutensor.COMPUTE_DESC_TF32
+            or compute_desc == cutensor.COMPUTE_DESC_3xTF32):
+        return _numpy.dtype(_numpy.float32)
+    if compute_desc == cutensor.COMPUTE_DESC_32F:
+        if default_dtype.kind == 'c':
+            return _numpy.dtype(_numpy.complex64)
+        return _numpy.dtype(_numpy.float32)
+    if compute_desc == cutensor.COMPUTE_DESC_64F:
+        if default_dtype.kind == 'c':
+            return _numpy.dtype(_numpy.complex128)
+        return _numpy.dtype(_numpy.float64)
+    raise ValueError(
+        'unsupported fallback compute descriptor: {}'.format(compute_desc))
+
+
+cdef _apply_unary(int op, x):
+    if op == cutensor.OP_IDENTITY:
+        return x
+    if op == cutensor.OP_SQRT:
+        return _cupy.sqrt(x)
+    if op == cutensor.OP_RELU:
+        return _cupy.maximum(x, 0)
+    if op == cutensor.OP_CONJ:
+        return _cupy.conj(x)
+    if op == cutensor.OP_RCP:
+        return _cupy.reciprocal(x)
+    if op == cutensor.OP_SIGMOID:
+        return 1 / (1 + _cupy.exp(-x))
+    if op == cutensor.OP_TANH:
+        return _cupy.tanh(x)
+    if op == cutensor.OP_EXP:
+        return _cupy.exp(x)
+    if op == cutensor.OP_LOG:
+        return _cupy.log(x)
+    if op == cutensor.OP_ABS:
+        return _cupy.abs(x)
+    if op == cutensor.OP_NEG:
+        return -x
+    if op == cutensor.OP_SIN:
+        return _cupy.sin(x)
+    if op == cutensor.OP_COS:
+        return _cupy.cos(x)
+    if op == cutensor.OP_TAN:
+        return _cupy.tan(x)
+    if op == cutensor.OP_SINH:
+        return _cupy.sinh(x)
+    if op == cutensor.OP_COSH:
+        return _cupy.cosh(x)
+    if op == cutensor.OP_ASIN:
+        return _cupy.arcsin(x)
+    if op == cutensor.OP_ACOS:
+        return _cupy.arccos(x)
+    if op == cutensor.OP_ATAN:
+        return _cupy.arctan(x)
+    if op == cutensor.OP_ASINH:
+        return _cupy.arcsinh(x)
+    if op == cutensor.OP_ACOSH:
+        return _cupy.arccosh(x)
+    if op == cutensor.OP_ATANH:
+        return _cupy.arctanh(x)
+    if op == cutensor.OP_CEIL:
+        return _cupy.ceil(x)
+    if op == cutensor.OP_FLOOR:
+        return _cupy.floor(x)
+    raise ValueError('unsupported unary operator: {}'.format(op))
+
+
+cdef void _validate_unary_operator(int op) except *:
+    if op not in (
+            cutensor.OP_IDENTITY,
+            cutensor.OP_SQRT,
+            cutensor.OP_RELU,
+            cutensor.OP_CONJ,
+            cutensor.OP_RCP,
+            cutensor.OP_SIGMOID,
+            cutensor.OP_TANH,
+            cutensor.OP_EXP,
+            cutensor.OP_LOG,
+            cutensor.OP_ABS,
+            cutensor.OP_NEG,
+            cutensor.OP_SIN,
+            cutensor.OP_COS,
+            cutensor.OP_TAN,
+            cutensor.OP_SINH,
+            cutensor.OP_COSH,
+            cutensor.OP_ASIN,
+            cutensor.OP_ACOS,
+            cutensor.OP_ATAN,
+            cutensor.OP_ASINH,
+            cutensor.OP_ACOSH,
+            cutensor.OP_ATANH,
+            cutensor.OP_CEIL,
+            cutensor.OP_FLOOR):
+        raise ValueError('unsupported unary operator: {}'.format(op))
+
+
+cdef _scale_unary(scale, int op, x, compute_dtype):
+    _validate_unary_operator(op)
+    if scale == 0:
+        return compute_dtype.type(0)
+    x = x.astype(compute_dtype, copy=False)
+    return compute_dtype.type(scale) * _apply_unary(op, x)
+
+
+cdef _apply_binary(int op, x, y):
+    if op == cutensor.OP_ADD:
+        return x + y
+    if op == cutensor.OP_MUL:
+        return x * y
+    if op == cutensor.OP_MAX:
+        return _cupy.maximum(x, y)
+    if op == cutensor.OP_MIN:
+        return _cupy.minimum(x, y)
+    raise ValueError('unsupported binary operator: {}'.format(op))
+
+
+cpdef bint _is_unsupported_status(int status):
+    return (
+        status == cutensor.STATUS_NOT_SUPPORTED
+        or status == cutensor.STATUS_ARCH_MISMATCH)
+
+
 cdef class _Scalar:
     cdef:
         object _array
@@ -410,6 +603,19 @@ cdef dict _elementwise_binary_compute_descs = {
 }
 
 
+cdef int _resolve_elementwise_binary_compute_desc(
+        int ct_dtype_A, int ct_dtype_C, int compute_desc) except -1:
+    compute_descs = _elementwise_binary_compute_descs
+    if not (ct_dtype_A in compute_descs
+            and ct_dtype_C in compute_descs[ct_dtype_A]):
+        raise ValueError(
+            'This combination of cutensor dtype is not supported in '
+            'elementwise_binary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
+    if compute_desc == 0:
+        return compute_descs[ct_dtype_A][ct_dtype_C]
+    return compute_desc
+
+
 cpdef OperationDescriptor create_elementwise_binary(
         TensorDescriptor desc_A, Mode mode_A, int op_A,
         TensorDescriptor desc_C, Mode mode_C, int op_C,
@@ -434,27 +640,23 @@ cpdef OperationDescriptor create_elementwise_binary(
     Returns:
         (Descriptor): A instance of class OperationDescriptor.
     """
-    compute_descs = _elementwise_binary_compute_descs
     ct_dtype_A = desc_A.cutensor_dtype
     ct_dtype_C = desc_C.cutensor_dtype
-    if not (ct_dtype_A in compute_descs and
-            ct_dtype_C in compute_descs[ct_dtype_A]):
-        raise ValueError(
-            'This combination of cutensor dtype is not supported in '
-            'elementwise_binary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
-    if compute_desc == 0:
-        compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
+    compute_desc = _resolve_elementwise_binary_compute_desc(
+        ct_dtype_A, ct_dtype_C, compute_desc)
     cdef CutensorHandle handle = _get_handle()
     key = (desc_A.ptr, mode_A.data, op_A,
            desc_C.ptr, mode_C.data, op_C,
            desc_D.ptr, mode_D.data, op_AC, compute_desc)
     if key not in handle._elementwise_binary_operators:
-        handle._elementwise_binary_operators[key] = OperationDescriptor()
-        handle._elementwise_binary_operators[key].create_elementwise_binary(
+        # Avoid caching a partially-initialized descriptor if creation fails.
+        op = OperationDescriptor()
+        op.create_elementwise_binary(
             handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_D.ptr, mode_D.data, op_AC, compute_desc)
+        handle._elementwise_binary_operators[key] = op
     return handle._elementwise_binary_operators[key]
 
 
@@ -489,6 +691,18 @@ def elementwise_binary(
     Examples:
         See examples/cutensor/elementwise_binary.py
     """
+    # hipTensor 2.3 elementwise execution is unreliable. Align tensor modes
+    # explicitly and preserve this direct API with CuPy elementwise kernels.
+    if _runtime.is_hip:
+        labels_A = _get_mode_labels(mode_A)
+        labels_C = _get_mode_labels(mode_C)
+        _validate_shared_mode_extents((
+            (A, labels_A), (C, labels_C)))
+        A = _align_array_to_modes(A, labels_A, labels_C)
+        compute_desc = _resolve_elementwise_binary_compute_desc(
+            _get_cutensor_dtype(A.dtype),
+            _get_cutensor_dtype(C.dtype), compute_desc)
+
     if out is None:
         out = core._ndarray_init(
             _cupy.ndarray, C._shape, dtype=C.dtype, obj=None)
@@ -496,6 +710,15 @@ def elementwise_binary(
         raise ValueError('dtype mismatch: {} != {}'.format(C.dtype, out.dtype))
     elif not internal.vector_equal(C._shape, out._shape):
         raise ValueError('shape mismatch: {} != {}'.format(C.shape, out.shape))
+
+    if _runtime.is_hip:
+        compute_dtype = _get_fallback_compute_dtype(
+            compute_desc, _numpy.result_type(A.dtype, C.dtype))
+        out[...] = _apply_binary(
+            op_AC,
+            _scale_unary(alpha, op_A, A, compute_dtype),
+            _scale_unary(gamma, op_C, C, compute_dtype))
+        return out
 
     desc_A = create_tensor_descriptor(A)
     desc_C = create_tensor_descriptor(C)
@@ -532,6 +755,24 @@ cdef dict _elementwise_trinary_compute_descs = {
 }
 
 
+cdef int _resolve_elementwise_trinary_compute_desc(
+        int ct_dtype_A, int ct_dtype_B, int ct_dtype_C,
+        int compute_desc) except -1:
+    if ct_dtype_A != ct_dtype_B:
+        raise ValueError(
+            'cutensor dtype mismatch: {} != {}'.format(
+                ct_dtype_A, ct_dtype_B))
+    compute_descs = _elementwise_trinary_compute_descs
+    if not (ct_dtype_A in compute_descs
+            and ct_dtype_C in compute_descs[ct_dtype_A]):
+        raise ValueError(
+            'This combination of cutensor dtype is not supported in '
+            'elementwise_trinary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
+    if compute_desc == 0:
+        return compute_descs[ct_dtype_A][ct_dtype_C]
+    return compute_desc
+
+
 cpdef OperationDescriptor create_elementwise_trinary(
         TensorDescriptor desc_A, Mode mode_A, int op_A,
         TensorDescriptor desc_B, Mode mode_B, int op_B,
@@ -561,33 +802,26 @@ cpdef OperationDescriptor create_elementwise_trinary(
     Returns:
         (Descriptor): A instance of class OperationDescriptor.
     """
-    compute_descs = _elementwise_trinary_compute_descs
     ct_dtype_A = desc_A.cutensor_dtype
     ct_dtype_B = desc_B.cutensor_dtype
     ct_dtype_C = desc_C.cutensor_dtype
-    if not (ct_dtype_A == ct_dtype_B):
-        raise ValueError(
-            'cutensor dtype mismatch: {} != {}'.format(ct_dtype_A, ct_dtype_B))
-    if not (ct_dtype_A in compute_descs and
-            ct_dtype_C in compute_descs[ct_dtype_A]):
-        raise ValueError(
-            'This combination of cutensor dtype is not supported in '
-            'elementwise_trinary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
-    if compute_desc == 0:
-        compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
+    compute_desc = _resolve_elementwise_trinary_compute_desc(
+        ct_dtype_A, ct_dtype_B, ct_dtype_C, compute_desc)
     cdef CutensorHandle handle = _get_handle()
     key = (desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
            desc_D.ptr, mode_D.data, op_AB, op_ABC, compute_desc)
     if key not in handle._elementwise_trinary_operators:
-        handle._elementwise_trinary_operators[key] = OperationDescriptor()
-        handle._elementwise_trinary_operators[key].create_elementwise_trinary(
+        # Avoid caching a partially-initialized descriptor if creation fails.
+        op = OperationDescriptor()
+        op.create_elementwise_trinary(
             handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
             desc_D.ptr, mode_D.data, op_AB, op_ABC, compute_desc)
+        handle._elementwise_trinary_operators[key] = op
     return handle._elementwise_trinary_operators[key]
 
 
@@ -629,6 +863,20 @@ def elementwise_trinary(
     Examples:
         See examples/cutensor/elementwise_trinary.py
     """
+    if _runtime.is_hip:
+        # Align tensor modes explicitly for the CuPy elementwise fallback.
+        labels_A = _get_mode_labels(mode_A)
+        labels_B = _get_mode_labels(mode_B)
+        labels_C = _get_mode_labels(mode_C)
+        _validate_shared_mode_extents((
+            (A, labels_A), (B, labels_B), (C, labels_C)))
+        A = _align_array_to_modes(A, labels_A, labels_C)
+        B = _align_array_to_modes(B, labels_B, labels_C)
+        compute_desc = _resolve_elementwise_trinary_compute_desc(
+            _get_cutensor_dtype(A.dtype),
+            _get_cutensor_dtype(B.dtype),
+            _get_cutensor_dtype(C.dtype), compute_desc)
+
     if out is None:
         out = core._ndarray_init(
             _cupy.ndarray, C._shape, dtype=C.dtype, obj=None)
@@ -636,6 +884,18 @@ def elementwise_trinary(
         raise ValueError('dtype mismatch: {} != {}'.format(C.dtype, out.dtype))
     elif not internal.vector_equal(C._shape, out._shape):
         raise ValueError('shape mismatch: {} != {}'.format(C.shape, out.shape))
+
+    if _runtime.is_hip:
+        compute_dtype = _get_fallback_compute_dtype(
+            compute_desc, _numpy.result_type(A.dtype, B.dtype, C.dtype))
+        AB = _apply_binary(
+            op_AB,
+            _scale_unary(alpha, op_A, A, compute_dtype),
+            _scale_unary(beta, op_B, B, compute_dtype))
+        out[...] = _apply_binary(
+            op_ABC, AB, _scale_unary(
+                gamma, op_C, C, compute_dtype))
+        return out
 
     desc_A = create_tensor_descriptor(A)
     desc_B = create_tensor_descriptor(B)
@@ -682,6 +942,22 @@ cdef dict _contraction_compute_descs = {
 }
 
 
+cdef int _resolve_contraction_compute_desc(
+        int ct_dtype_A, int ct_dtype_B, int ct_dtype_C,
+        int compute_desc) except -1:
+    compute_descs = _contraction_compute_descs
+    if not (ct_dtype_A in compute_descs
+            and ct_dtype_B in compute_descs[ct_dtype_A]
+            and ct_dtype_C in compute_descs[ct_dtype_A][ct_dtype_B]):
+        raise ValueError(
+            'This cutensor dtype combination is not supported in contraction'
+            ' ({}, {}, {})'.format(
+                ct_dtype_A, ct_dtype_B, ct_dtype_C))
+    if compute_desc == 0:
+        return compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
+    return compute_desc
+
+
 cpdef OperationDescriptor create_contraction(
         TensorDescriptor desc_A, Mode mode_A, int op_A,
         TensorDescriptor desc_B, Mode mode_B, int op_B,
@@ -707,31 +983,26 @@ cpdef OperationDescriptor create_contraction(
         (Descriptor): A instance of class Descriptor which holds a pointer to
         tensor descriptor and its destructor.
     """
-    compute_descs = _contraction_compute_descs
     ct_dtype_A = desc_A.cutensor_dtype
     ct_dtype_B = desc_B.cutensor_dtype
     ct_dtype_C = desc_C.cutensor_dtype
-    if not (ct_dtype_A in compute_descs and
-            ct_dtype_B in compute_descs[ct_dtype_A] and
-            ct_dtype_C in compute_descs[ct_dtype_A][ct_dtype_B]):
-        raise ValueError(
-            'This cutensor dtype combination is not supported in contraction'
-            ' ({}, {}, {})'.format(ct_dtype_A, ct_dtype_B, ct_dtype_C))
-    if compute_desc == 0:
-        compute_desc = compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
+    compute_desc = _resolve_contraction_compute_desc(
+        ct_dtype_A, ct_dtype_B, ct_dtype_C, compute_desc)
     cdef CutensorHandle handle = _get_handle()
     key = (desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
            compute_desc)
     if key not in handle._contraction_operators:
-        handle._contraction_operators[key] = OperationDescriptor()
-        handle._contraction_operators[key].create_contraction(
+        # Avoid caching a partially-initialized descriptor if creation fails.
+        op = OperationDescriptor()
+        op.create_contraction(
             handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
             desc_C.ptr, mode_C.data, compute_desc)
+        handle._contraction_operators[key] = op
     return handle._contraction_operators[key]
 
 
@@ -781,6 +1052,41 @@ def contraction(
     Examples:
         See examples/cutensor/contraction.py
     """
+    if _runtime.is_hip:
+        compute_desc = _resolve_contraction_compute_desc(
+            _get_cutensor_dtype(A.dtype),
+            _get_cutensor_dtype(B.dtype),
+            _get_cutensor_dtype(C.dtype), compute_desc)
+        labels_A = _get_mode_labels(mode_A)
+        labels_B = _get_mode_labels(mode_B)
+        labels_C = _get_mode_labels(mode_C)
+        _validate_shared_mode_extents((
+            (A, labels_A), (B, labels_B), (C, labels_C)))
+        if not set(labels_C).issubset(set(labels_A) | set(labels_B)):
+            raise ValueError(
+                'output modes must appear in at least one input tensor')
+        _validate_unary_operator(op_A)
+        _validate_unary_operator(op_B)
+        _validate_unary_operator(op_C)
+
+        compute_dtype = _get_fallback_compute_dtype(
+            compute_desc, _get_scalar_dtype(C.dtype))
+        if alpha == 0:
+            AB = compute_dtype.type(0)
+        else:
+            all_labels = dict.fromkeys(
+                labels_A + labels_B + labels_C)
+            remapped = {
+                label: index for index, label in enumerate(all_labels)}
+            A_u = _scale_unary(alpha, op_A, A, compute_dtype)
+            B_u = _scale_unary(1, op_B, B, compute_dtype)
+            AB = _cupy.einsum(
+                A_u, [remapped[label] for label in labels_A],
+                B_u, [remapped[label] for label in labels_B],
+                [remapped[label] for label in labels_C])
+        C_u = _scale_unary(beta, op_C, C, compute_dtype)
+        C[...] = AB + C_u
+        return C
     desc_A = create_tensor_descriptor(A)
     desc_B = create_tensor_descriptor(B)
     desc_C = create_tensor_descriptor(C)
@@ -858,13 +1164,15 @@ cpdef OperationDescriptor create_reduction(
            desc_C.ptr, mode_C.data, op_C,
            op_reduce, compute_desc)
     if key not in handle._reduction_operators:
-        handle._reduction_operators[key] = OperationDescriptor()
-        handle._reduction_operators[key].create_reduction(
+        # Avoid caching a partially-initialized descriptor if creation fails.
+        op = OperationDescriptor()
+        op.create_reduction(
             handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_C.ptr, mode_C.data,
             op_reduce, compute_desc)
+        handle._reduction_operators[key] = op
     return handle._reduction_operators[key]
 
 
@@ -898,6 +1206,17 @@ def reduction(
     Examples:
         See examples/cutensor/reduction.py
     """
+    cdef _ndarray_base C_view = C
+    cdef bint copy_back_C = False
+    if _runtime.is_hip:
+        # hipTensor currently appears unstable on general strided views. As
+        # a safety fallback, materialize unsupported layouts as contiguous.
+        if not (A._c_contiguous or A._f_contiguous):
+            A = _cupy.ascontiguousarray(A)
+        if not (C._c_contiguous or C._f_contiguous):
+            C = _cupy.ascontiguousarray(C)
+            copy_back_C = True
+
     desc_A = create_tensor_descriptor(A)
     desc_C = create_tensor_descriptor(C)
     mode_A = _auto_create_mode(A, mode_A)
@@ -910,13 +1229,20 @@ def reduction(
         _get_handle().ptr, operator.ptr, plan_pref.ptr,
         cutensor.WORKSPACE_RECOMMENDED)
     plan = create_plan(operator, plan_pref, ws_limit=ws_size)
-    ws = core._ndarray_init(
-        _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
+
+    cdef intptr_t ws_ptr = <intptr_t>0
+    if ws_size != 0:
+        ws = core._ndarray_init(
+            _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
+        ws_ptr = ws.data.ptr
     cutensor.reduce(
         _get_handle().ptr, plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(beta, out.dtype).ptr, C.data.ptr, out.data.ptr,
-        ws.data.ptr, ws_size)
+        ws_ptr, ws_size)
+    if copy_back_C:
+        C_view[...] = out
+        return C_view
     return out
 
 
@@ -995,6 +1321,13 @@ def _try_reduction_routine(
             alpha, in_arg, _create_mode_with_cache(in_arg._shape.size()),
             beta, out_arg, _create_mode_with_cache(out_axis),
             op_reduce=reduce_op)
+    except _cutensor_py.CuTensorError as e:
+        # cuTENSOR/hipTensor can report "not supported" for otherwise-valid
+        # inputs (for example depending on dtype/operator support). In such
+        # cases, fall back to CuPy's implementation instead of raising.
+        if _is_unsupported_status(e.status):
+            return None
+        raise
     except ValueError:
         return None
 
@@ -1077,6 +1410,10 @@ def _try_elementwise_binary_routine(
             alpha, a, _create_mode_with_cache(a._shape.size()),
             gamma, c, _create_mode_with_cache(c._shape.size()),
             out=out, op_AC=op)
+    except _cutensor_py.CuTensorError as e:
+        if _is_unsupported_status(e.status):
+            return None
+        raise
     except ValueError:
         return None
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -429,6 +429,18 @@ The following ROCm libraries are required:
 
   $ sudo apt install hipblas hipsparse rocsparse rocrand hiprand rocthrust rocsolver rocfft hipfft hipcub rocprim rccl roctracer-dev
 
+hipTensor 2.3.0 or later is optional. Installing ``hiptensor`` and
+``hiptensor-dev`` enables :mod:`cupyx.cutensor` and the ``hiptensor`` value of
+:envvar:`CUPY_ACCELERATORS`. Supported GPU architectures and data types are
+listed in the `hipTensor support matrix
+<https://rocm.docs.amd.com/projects/hipTensor/en/develop/api-reference/api-reference.html>`_.
+CuPy falls back to its own implementation when a transparent accelerator call
+reports an unsupported operation or architecture.
+
+hipTensor does not provide the cuTENSORMg API. Complex data types are not
+enabled in CuPy's hipTensor integration, and TF32 compute requests use the
+FP32 compute descriptor.
+
 Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -487,7 +499,7 @@ Limitations
 
 The following features are not available due to the limitation of ROCm or because that they are specific to CUDA:
 
-* cuTENSOR
+* cuTENSORMg (hipTensor does not provide the multi-GPU API)
 * Handling extremely large arrays whose size is around 32-bit boundary (HIP is known to fail with sizes `2**32-1024`)
 * Atomic addition in FP16 (``cupy.ndarray.scatter_add`` and ``cupyx.scatter_add``)
 * Multi-GPU FFT and FFT callback

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -93,8 +93,15 @@ Here are the environment variables that CuPy uses at runtime.
 
   Default: ``"cub"`` (In ROCm HIP environment, the default value is ``""``. i.e., no accelerators are used.)
 
-  A comma-separated string of backend names (``cub``, ``cutensor``, or ``cutensornet``) which indicates the acceleration backends used in CuPy operations and its priority (in descending order).
+  A comma-separated string of backend names (``cub``, ``cutensor``, ``hiptensor``, or ``cutensornet``) which indicates the acceleration backends used in CuPy operations and its priority (in descending order).
   By default, all accelerators are disabled on HIP and only CUB is enabled on CUDA.
+  The ``hiptensor`` backend requires hipTensor 2.3.0 or later. Unsupported
+  operations and GPU architectures fall back to CuPy's own implementation.
+  CuPy currently enables transparent hipTensor acceleration for supported
+  reductions. Elementwise operations, Einstein summation, and cuTENSORMg are
+  unavailable as transparent accelerators. The corresponding high-level
+  :mod:`cupyx.cutensor` elementwise and contraction APIs remain compatible on
+  HIP through correctness fallbacks implemented with CuPy operations.
 
 .. envvar:: CUPY_TF32
 
@@ -167,6 +174,11 @@ These environment variables are used during installation (building CuPy from sou
 .. envvar:: CUTENSOR_PATH
 
   Path to the cuTENSOR root directory that contains ``lib`` and ``include`` directories. (experimental)
+
+.. envvar:: HIPTENSOR_PATH
+
+  Path to a hipTensor 2.3.0 or later root directory that contains ``lib`` and
+  ``include`` directories. (experimental)
 
 .. envvar:: CUPY_INSTALL_USE_HIP
 

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -363,6 +363,22 @@ def get_features(ctx: Context) -> dict[str, Feature]:
         'check_method': build.check_nccl_version,
         'version_method': build.get_nccl_version,
     }
+    HIP_cutensor = {
+        'name': 'cutensor',
+        'file': [
+            'cupy_backends.cuda.libs.cutensor',
+            'cupyx._cutensor',
+        ],
+        'include': [
+            'cupy/hiptensor.h',
+        ],
+        'libraries': [
+            'hiptensor',
+            'hipblas',
+        ],
+        'check_method': build.check_hiptensor_version,
+        'version_method': build.get_hiptensor_version,
+    }
     HIP_thrust = {
         'name': 'thrust',
         'required': True,
@@ -409,6 +425,7 @@ def get_features(ctx: Context) -> dict[str, Feature]:
             _from_dict(HIP_cuda_nvtx_cusolver, ctx),
             _from_dict(HIP_cub, ctx),
             _from_dict(HIP_nccl, ctx),
+            _from_dict(HIP_cutensor, ctx),
             _from_dict(HIP_random, ctx),
             _from_dict(HIP_thrust, ctx),
             _from_dict(COMMON_dlpack, ctx),

--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -164,11 +164,17 @@ def get_compiler_setting(ctx: Context, use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include', 'hipfft'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocsolver'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rccl'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'hiptensor'))
+        include_dirs.append(os.path.join(rocm_path, 'hiptensor', 'include'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
+        library_dirs.append(os.path.join(rocm_path, 'hiptensor', 'lib'))
 
     if use_hip:
         # ROCm 5.3 and above requires c++14
         extra_compile_args.append('-std=c++14')
+        # HIP headers require one of the HIP platform macros.
+        define_macros.append(('__HIP_PLATFORM_AMD__', '1'))
+        define_macros.append(('__HIP_PLATFORM_HCC__', '1'))
     else:
         # CCCL 3.x (for CUDA) requires c++17
         if PLATFORM_LINUX:
@@ -298,12 +304,19 @@ _hip_version = None
 _thrust_version = None
 _nccl_version = None
 _cutensor_version = None
+_hiptensor_version = None
 _cub_path = None
 _cub_version = None
 _jitify_path = None
 _jitify_version = None
 _compute_capabilities = None
 _cusparselt_version = None
+
+_minimum_hiptensor_version = 2_003_000
+
+
+def _is_supported_hiptensor_version(version):
+    return version >= _minimum_hiptensor_version
 
 
 def check_hip_version(compiler, settings):
@@ -646,6 +659,61 @@ def get_cutensor_version(formatted=False):
         msg = 'check_cutensor_version() must be called first.'
         raise RuntimeError(msg)
     return _cutensor_version
+
+
+def check_hiptensor_version(compiler, settings):
+    global _hiptensor_version
+    try:
+        out = build_and_run(compiler, '''
+        #include <cupy/hiptensor.h>
+        #if __has_include(<hiptensor/hiptensor-version.hpp>)
+        #include <hiptensor/hiptensor-version.hpp>
+        #endif
+        #include <stdio.h>
+        #if defined(HIPTENSOR_MAJOR_VERSION)
+        #  define CUPY_HIPTENSOR_VERSION \
+             (HIPTENSOR_MAJOR_VERSION * 1000000 + \
+              HIPTENSOR_MINOR_VERSION * 1000 + \
+              HIPTENSOR_PATCH_VERSION)
+        #elif defined(HIPTENSOR_MAJOR)
+        #  define CUPY_HIPTENSOR_VERSION \
+             (HIPTENSOR_MAJOR * 1000000 + \
+              HIPTENSOR_MINOR * 1000 + \
+              HIPTENSOR_PATCH)
+        #else
+        #  define CUPY_HIPTENSOR_VERSION 0
+        #endif
+        int main(int argc, char* argv[]) {
+          printf("%d", CUPY_HIPTENSOR_VERSION);
+          return 0;
+        }
+        ''', include_dirs=settings['include_dirs'],
+                            extra_compile_args=(
+                                settings['extra_compile_args'] +
+                                ['-D__HIP_PLATFORM_AMD__=1']))
+    except Exception as e:
+        utils.print_warning('Cannot check hipTensor version\n{}'.format(e))
+        _hiptensor_version = -1
+        return False
+
+    _hiptensor_version = int(out)
+    if not _is_supported_hiptensor_version(_hiptensor_version):
+        utils.print_warning(
+            'Unsupported hipTensor version: {}'.format(_hiptensor_version)
+        )
+        _hiptensor_version = -1
+        return False
+
+    return True
+
+
+def get_hiptensor_version(formatted=False):
+    """Return hipTensor version cached in check_hiptensor_version()."""
+    global _hiptensor_version
+    if _hiptensor_version is None:
+        msg = 'check_hiptensor_version() must be called first.'
+        raise RuntimeError(msg)
+    return _hiptensor_version
 
 
 def check_cusparselt_version(compiler, settings):

--- a/tests/cupy_tests/linalg_tests/test_einsum.py
+++ b/tests/cupy_tests/linalg_tests/test_einsum.py
@@ -6,10 +6,31 @@ import numpy
 import pytest
 
 import cupy
+from cupy._core import _accelerator
 from cupy import testing
+from cupy.cuda import cutensor as ct
+from cupy_backends.cuda.api import runtime
 
 
 rng = numpy.random.default_rng(seed=0)
+
+
+@pytest.mark.skipif(
+    not runtime.is_hip or not ct.available,
+    reason='hipTensor is unavailable')
+def test_hiptensor_einsum_falls_back():
+    old_accelerators = _accelerator.get_routine_accelerators()
+    try:
+        _accelerator.set_routine_accelerators(['hiptensor'])
+        a = testing.shaped_arange((3, 4, 2), cupy, numpy.float32)
+        b = testing.shaped_arange((4, 3, 2), cupy, numpy.float32)
+        actual = cupy.einsum('ij...,ji...->i...', a, b)
+    finally:
+        _accelerator.set_routine_accelerators(old_accelerators)
+
+    expected = numpy.einsum(
+        'ij...,ji...->i...', cupy.asnumpy(a), cupy.asnumpy(b))
+    testing.assert_array_equal(actual, expected)
 
 
 def _dec_shape(shape, dec):

--- a/tests/cupyx_tests/test_cutensor.py
+++ b/tests/cupyx_tests/test_cutensor.py
@@ -10,11 +10,13 @@ import cupyx
 from cupy._core import _routines_linalg as _linalg
 from cupy import testing
 from cupy.cuda import device
+from cupy_backends.cuda.api import runtime
 
 from cupy.cuda import cutensor as ct
 
 if ct.available:
     from cupyx import cutensor
+    from cupyx import _cutensor as _cutensor_module
 
 
 @testing.parameterize(
@@ -29,6 +31,10 @@ class TestCuTensor:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        # hipTensor currently does not support complex kernels.
+        if (runtime.is_hip
+                and self.dtype in (numpy.complex64, numpy.complex128)):
+            pytest.skip('hipTensor does not support complex dtypes')
         self.a = testing.shaped_random(
             (20, 40, 30), cupy, self.dtype, seed=0)
         self.b = testing.shaped_random(
@@ -114,9 +120,10 @@ class TestCuTensor:
         )
 
     def test_contraction(self):
-        compute_capability = int(device.get_compute_capability())
-        if compute_capability < 70 and self.dtype == numpy.float16:
-            pytest.skip('Not supported.')
+        if not runtime.is_hip:
+            compute_capability = int(device.get_compute_capability())
+            if compute_capability < 70 and self.dtype == numpy.float16:
+                pytest.skip('Not supported.')
 
         c = self.c.copy("K")
         d = cutensor.contraction(
@@ -134,7 +141,7 @@ class TestCuTensor:
         )
 
     def test_reduction(self):
-        if self.dtype == numpy.float16:
+        if not runtime.is_hip and self.dtype == numpy.float16:
             pytest.skip('Not supported.')
 
         c = testing.shaped_random((30,), cupy, self.dtype, seed=2)
@@ -152,6 +159,226 @@ class TestCuTensor:
             d,
             rtol=self.tol, atol=self.tol
         )
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+@pytest.mark.parametrize('mode_objects', [False, True])
+def test_hip_contraction_without_reduction(mode_objects):
+    a = testing.shaped_random((2, 3), cupy, numpy.float32, seed=0)
+    b = testing.shaped_random((3, 2), cupy, numpy.float32, seed=1)
+    c = testing.shaped_random((2, 3), cupy, numpy.float32, seed=2)
+    c_orig = c.copy()
+    mode_a = ('m', 'n')
+    mode_b = ('n', 'm')
+    mode_c = ('m', 'n')
+    if mode_objects:
+        mode_a = cutensor.create_mode(*mode_a)
+        mode_b = cutensor.create_mode(*mode_b)
+        mode_c = cutensor.create_mode(*mode_c)
+
+    out = cutensor.contraction(
+        1.25, a, mode_a, b, mode_b, 0.5, c, mode_c,
+        op_A=ct.OP_NEG, op_C=ct.OP_ABS)
+
+    assert out is c
+    expected = 1.25 * (-a) * b.T + 0.5 * cupy.abs(c_orig)
+    testing.assert_allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_float16_contraction_beta_and_op_c():
+    a = testing.shaped_random((4, 3), cupy, numpy.float16, seed=0)
+    b = testing.shaped_random((3, 5), cupy, numpy.float16, seed=1)
+    c = testing.shaped_random((4, 5), cupy, numpy.float16, seed=2)
+    c_orig = c.copy()
+
+    out = cutensor.contraction(
+        1.0, a, ('m', 'k'), b, ('k', 'n'),
+        0.5, c, ('m', 'n'), op_C=ct.OP_NEG,
+        compute_desc=ct.COMPUTE_DESC_32F)
+
+    assert out is c
+    expected = cupy.matmul(a, b) - 0.5 * c_orig
+    testing.assert_allclose(out, expected, rtol=3e-3, atol=3e-3)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+@pytest.mark.parametrize('mode_objects', [False, True])
+def test_hip_elementwise_mode_broadcast(mode_objects):
+    a = testing.shaped_random((3,), cupy, numpy.float32, seed=0)
+    b = testing.shaped_random((2,), cupy, numpy.float32, seed=1)
+    c = testing.shaped_random((2, 3), cupy, numpy.float32, seed=2)
+    mode_a = ('n',)
+    mode_b = ('m',)
+    mode_c = ('m', 'n')
+    if mode_objects:
+        mode_a = cutensor.create_mode(*mode_a)
+        mode_b = cutensor.create_mode(*mode_b)
+        mode_c = cutensor.create_mode(*mode_c)
+
+    binary_out = cutensor.elementwise_binary(
+        1.25, a, mode_a, 0.5, c, mode_c)
+    testing.assert_allclose(
+        binary_out, 1.25 * a[None, :] + 0.5 * c,
+        rtol=1e-6, atol=1e-6)
+
+    trinary_out = cutensor.elementwise_trinary(
+        1.25, a, mode_a, 0.75, b, mode_b,
+        0.5, c, mode_c)
+    testing.assert_allclose(
+        trinary_out,
+        1.25 * a[None, :] + 0.75 * b[:, None] + 0.5 * c,
+        rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_fallback_compute_descriptor():
+    a = testing.shaped_random((100, 100), cupy, numpy.float16, seed=0)
+    b = testing.shaped_random((100, 100), cupy, numpy.float16, seed=1)
+    c = testing.shaped_random((100, 100), cupy, numpy.float16, seed=2)
+    c_orig = c.copy()
+
+    binary_out = cutensor.elementwise_binary(
+        1.1, a, ('m', 'n'), 0.7, c, ('m', 'n'),
+        compute_desc=ct.COMPUTE_DESC_32F)
+    expected_binary = (
+        numpy.float32(1.1) * a.astype(numpy.float32)
+        + numpy.float32(0.7) * c_orig.astype(numpy.float32)
+    ).astype(numpy.float16)
+    testing.assert_array_equal(binary_out, expected_binary)
+
+    trinary_out = cutensor.elementwise_trinary(
+        1.1, a, ('m', 'n'), 0.9, b, ('m', 'n'),
+        0.7, c, ('m', 'n'), compute_desc=ct.COMPUTE_DESC_32F)
+    expected_trinary = (
+        numpy.float32(1.1) * a.astype(numpy.float32)
+        + numpy.float32(0.9) * b.astype(numpy.float32)
+        + numpy.float32(0.7) * c_orig.astype(numpy.float32)
+    ).astype(numpy.float16)
+    testing.assert_array_equal(trinary_out, expected_trinary)
+
+    contraction_out = cutensor.contraction(
+        1.1, a, ('m', 'n'), b, ('m', 'n'),
+        0.7, c, ('m', 'n'), compute_desc=ct.COMPUTE_DESC_32F)
+    expected_contraction = (
+        numpy.float32(1.1) * a.astype(numpy.float32)
+        * b.astype(numpy.float32)
+        + numpy.float32(0.7) * c_orig.astype(numpy.float32)
+    ).astype(numpy.float16)
+    testing.assert_array_equal(contraction_out, expected_contraction)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_trinary_rejects_mixed_input_dtypes():
+    a = cupy.ones((2, 3), dtype=numpy.float32)
+    b = cupy.ones((2, 3), dtype=numpy.float64)
+    c = cupy.ones((2, 3), dtype=numpy.float32)
+
+    with pytest.raises(ValueError, match='dtype mismatch'):
+        cutensor.elementwise_trinary(
+            1, a, ('m', 'n'), 1, b, ('m', 'n'),
+            1, c, ('m', 'n'))
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_zero_scalar_skips_unary_operator():
+    a = -cupy.ones((2, 3), dtype=numpy.float32)
+    b = -cupy.ones((2, 3), dtype=numpy.float32)
+    c = testing.shaped_random((2, 3), cupy, numpy.float32, seed=0)
+    expected = c.copy()
+
+    binary_out = cutensor.elementwise_binary(
+        0, a, ('m', 'n'), 1, c, ('m', 'n'),
+        op_A=ct.OP_SQRT)
+    testing.assert_array_equal(binary_out, expected)
+
+    trinary_out = cutensor.elementwise_trinary(
+        0, a, ('m', 'n'), 0, b, ('m', 'n'),
+        1, c, ('m', 'n'), op_A=ct.OP_SQRT, op_B=ct.OP_LOG)
+    testing.assert_array_equal(trinary_out, expected)
+
+    contraction_out = cutensor.contraction(
+        0, a, ('m', 'n'), b, ('m', 'n'),
+        1, c, ('m', 'n'), op_A=ct.OP_SQRT, op_B=ct.OP_LOG)
+    testing.assert_array_equal(contraction_out, expected)
+
+    positive = cupy.ones((2, 3), dtype=numpy.float32)
+    negative = -positive
+    binary_out = cutensor.elementwise_binary(
+        1, positive, ('m', 'n'), 0, negative, ('m', 'n'),
+        op_C=ct.OP_SQRT)
+    testing.assert_array_equal(binary_out, positive)
+
+    contraction_out = cutensor.contraction(
+        1, positive, ('m', 'n'), positive, ('m', 'n'),
+        0, negative, ('m', 'n'), op_C=ct.OP_SQRT)
+    testing.assert_array_equal(contraction_out, positive)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_batched_contraction_fallback():
+    a = cupy.arange(24, dtype=numpy.float32).reshape(3, 4, 2)
+    b = cupy.arange(24, dtype=numpy.float32).reshape(4, 3, 2)
+    c = cupy.zeros((3, 2), dtype=numpy.float32)
+
+    out = cutensor.contraction(
+        1, a, ('i', 'j', 'k'), b, ('j', 'i', 'k'),
+        0, c, ('i', 'k'))
+
+    expected = cupy.einsum('ijk,jik->ik', a, b)
+    testing.assert_array_equal(out, expected)
+
+
+@pytest.mark.skipif(
+    not ct.available or not runtime.is_hip,
+    reason='hipTensor is unavailable')
+def test_hip_fallback_input_validation():
+    a = cupy.ones((2, 3), dtype=numpy.float32)
+    c = cupy.ones((2, 3), dtype=numpy.float32)
+
+    with pytest.raises(ValueError, match='mode length'):
+        cutensor.elementwise_binary(
+            1, a, ('m', 'n'), 1, c, ('m',))
+    with pytest.raises(ValueError, match='mode length'):
+        cutensor.elementwise_trinary(
+            1, a, ('m', 'n'), 1, a, ('m', 'n'),
+            1, c, ('m',))
+    with pytest.raises(ValueError, match='unsupported unary operator'):
+        cutensor.contraction(
+            0, a, ('m', 'n'), a, ('m', 'n'),
+            1, c, ('m', 'n'), op_A=999)
+
+    a_i = cupy.ones((1,), dtype=numpy.float32)
+    b_i = cupy.ones((1,), dtype=numpy.float32)
+    c_i = cupy.ones((3,), dtype=numpy.float32)
+    with pytest.raises(ValueError, match='extent mismatch'):
+        cutensor.elementwise_binary(
+            0, a_i, ('i',), 1, c_i, ('i',))
+    with pytest.raises(ValueError, match='extent mismatch'):
+        cutensor.elementwise_trinary(
+            1, a_i, ('i',), 0, b_i, ('i',),
+            1, c_i, ('i',))
+
+    a_ij = cupy.ones((1, 2), dtype=numpy.float32)
+    b_j = cupy.ones((2,), dtype=numpy.float32)
+    with pytest.raises(ValueError, match='extent mismatch'):
+        cutensor.contraction(
+            0, a_ij, ('i', 'j'), b_j, ('j',),
+            1, c_i, ('i',))
 
 
 @pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
@@ -176,6 +403,22 @@ class TestMode:
         m2 = cutensor.create_mode(12, 11, 10)
         assert m1 != m2
         assert m1.data != m2.data
+
+    def test_hip_unavailable_features(self):
+        if not runtime.is_hip:
+            pytest.skip('For ROCm/HIP environment')
+        assert not cutensor.check_availability('elementwise')
+        assert not cutensor.check_availability('contraction')
+        assert not cutensor.check_availability('copyMg')
+        assert not cutensor.check_availability('contractMg')
+
+    def test_unsupported_status_classification(self):
+        assert _cutensor_module._is_unsupported_status(
+            ct.STATUS_NOT_SUPPORTED)
+        assert _cutensor_module._is_unsupported_status(
+            ct.STATUS_ARCH_MISMATCH)
+        assert not _cutensor_module._is_unsupported_status(
+            ct.STATUS_INVALID_VALUE)
 
 
 @pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
@@ -257,6 +500,41 @@ class TestCuTensorDescriptor:
             rtol=1e-6, atol=1e-6
         )
 
+    def test_plan_cache(self):
+        desc = cutensor.create_tensor_descriptor(self.c)
+        mode = cutensor.create_mode(*self.mode_c)
+        operator = cutensor.create_elementwise_binary(
+            desc, mode, ct.OP_IDENTITY,
+            desc, mode, ct.OP_IDENTITY,
+            desc, mode, ct.OP_ADD)
+        preference = cutensor.create_plan_preference()
+        plan = cutensor.create_plan(operator, preference)
+
+        assert cutensor.create_plan(operator, preference) is plan
+
+    def test_repeated_plan_execution(self):
+        a = self.a[:, :, 0]
+        b = self.b[:, :, 0]
+        expected_contraction = cupy.matmul(a, b)
+        contraction_out = cupy.empty_like(expected_contraction)
+        for _ in range(2):
+            cutensor.contraction(
+                1, a, ('m', 'k'), b, ('k', 'n'),
+                0, contraction_out, ('m', 'n'))
+            testing.assert_allclose(
+                contraction_out, expected_contraction,
+                rtol=1e-6, atol=1e-6)
+
+        reduction_out = cupy.empty((30,), dtype=self.a.dtype)
+        expected_reduction = self.a.sum(axis=(0, 1))
+        for _ in range(2):
+            cutensor.reduction(
+                1, self.a, self.mode_a,
+                0, reduction_out, ('x',))
+            testing.assert_allclose(
+                reduction_out, expected_reduction,
+                rtol=1e-6, atol=1e-6)
+
 
 @testing.parameterize(*testing.product({
     'dtype_combo': ['eee', 'fff', 'ddd', 'FFF', 'DDD', 'dDD', 'DdD'],
@@ -285,6 +563,14 @@ class TestCuTensorContraction:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        if runtime.is_hip:
+            # hipTensor currently does not support complex kernels.
+            if any(c in 'FD' for c in self.dtype_combo):
+                pytest.skip('hipTensor does not support complex dtypes')
+            # hipTensor does not expose TF32 compute; CuPy maps TF32 to a
+            # CUDA-specific compute path.
+            if self.compute_type_hint == 'TF32':
+                pytest.skip('hipTensor does not support TF32 compute')
         compute_capability = int(device.get_compute_capability())
         if compute_capability < 70 and 'e' in self.dtype_combo:
             pytest.skip("Not supported")
@@ -357,6 +643,8 @@ class TestCuTensorIncontiguous:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        if runtime.is_hip and self.dtype_char in ('F', 'D'):
+            pytest.skip('hipTensor does not support complex dtypes')
         compute_capability = int(device.get_compute_capability())
         if compute_capability < 70 and self.dtype_char == 'e':
             pytest.skip("Not supported")
@@ -483,6 +771,8 @@ class TestCuTensorMg:
 
     @pytest.fixture(autouse=True)
     def setUp(self):
+        if runtime.is_hip:
+            pytest.skip('cuTENSORMg is not available in hipTensor')
         compute_capability = int(device.get_compute_capability())
         if compute_capability < 70 and self.dtype_char == 'e':
             pytest.skip("Not supported")

--- a/tests/install_tests/test_build.py
+++ b/tests/install_tests/test_build.py
@@ -4,6 +4,7 @@ from distutils import ccompiler
 from distutils import sysconfig
 import os
 import unittest
+from unittest import mock
 
 import pytest
 
@@ -30,3 +31,19 @@ class TestCheckVersion(unittest.TestCase):
             self.compiler, self.settings)
         assert isinstance(build.get_hip_version(), int)
         assert isinstance(build.get_hip_version(True), str)
+
+    def test_hiptensor_minimum_version(self):
+        assert not build._is_supported_hiptensor_version(0)
+        assert not build._is_supported_hiptensor_version(2_002_999)
+        assert build._is_supported_hiptensor_version(2_003_000)
+
+    def test_check_hiptensor_minimum_version(self):
+        for version, expected in (
+                ('0', False),
+                ('2002999', False),
+                ('2003000', True)):
+            with self.subTest(version=version):
+                with mock.patch.object(
+                        build, 'build_and_run', return_value=version):
+                    assert build.check_hiptensor_version(
+                        self.compiler, self.settings) is expected


### PR DESCRIPTION
Closes #9386.

## Summary

- Add a HIP compatibility shim for the cuTENSOR wrapper layer and detect hipTensor 2.3.0 or later at build time.
- Enable native hipTensor acceleration for supported reductions.
- Keep the public `cupyx.cutensor` elementwise and contraction APIs available on HIP through mode-aware CuPy correctness fallbacks.
- Report unsupported transparent accelerator surfaces accurately: elementwise operations, Einstein summation, and cuTENSORMg are not advertised as hipTensor accelerators.
- Document the supported capability envelope and add HIP-specific correctness, fallback, version-detection, caching, and status-handling tests.

## Why the capability envelope is intentionally narrow

ROCm 7.14 includes the upstream hipTensor workspace fixes that originally blocked this integration. On hipTensor 2.3.0, native reductions are stable in CuPy&#39;s test surface. Native elementwise and contraction execution still produces errors or silent incorrect results for valid mode/shape combinations, so those paths are not exposed as transparent accelerators. Direct high-level API calls preserve correctness through CuPy operations instead.

hipTensor does not provide cuTENSORMg. Complex data types are not enabled in the native integration, and TF32 requests map to the FP32 compute descriptor.


## Upstream hipTensor correctness tracking

The CuPy fallbacks are tied to these upstream reports so their native paths can be revisited when the underlying behavior changes:

- [ROCm/rocm-libraries#9543](https://github.com/ROCm/rocm-libraries/issues/9543#issuecomment-5135277447): explicit output strides are ignored by permutation, binary, and trinary elementwise execution; calls can return success while writing a packed layout.
- [ROCm/ROCm#6560](https://github.com/ROCm/ROCm/issues/6560): documented trinary input-mode subsets fail at execution with `HIPTENSOR_STATUS_INTERNAL_ERROR`.
- [ROCm/ROCm#6559](https://github.com/ROCm/ROCm/issues/6559): batched contractions with a mode shared by A, B, and D return success but produce incorrect results.

Accordingly, elementwise and contraction remain correctness fallbacks in this PR, while supported reductions use native hipTensor acceleration.

## Validation

Validated on:

- AMD Instinct MI300X (`gfx942`)
- Ubuntu 24.04
- ROCm 7.14.0
- hipTensor 2.3.0 (`2003000`)
- Python 3.12

Results:

- 20-core in-place ROCm build: passed
- Pre-commit checks on every changed file: passed
- Direct cuTENSOR/cupyx/build tests: 150 passed, 117 skipped, 3 subtests passed
- Focused HIP fallback regressions: 6 passed
- Full `einsum` suite with `CUPY_ACCELERATORS=hiptensor`: 762 passed
- Full sum/reduction accelerator suite: 750 passed
- Runtime linkage verified against the ROCm 7.14 `libhiptensor.so.0`