### PR TITLE
MAINT: Fix cuda-version check and disable bfloat16 on NumPy <2.1.2

### DIFF
--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -70,18 +70,21 @@ cdef _setup_type_dict():
     for t in ('cudaTextureObject_t',):
         _typenames[t] = (t, None)
 
-    try:
-        import ml_dtypes
-    except ImportError:
-        pass
-    else:
-        dt = numpy.dtype(ml_dtypes.bfloat16)
-        _dtype_kind_size_dict[dt] = ("V", 2)
-        _typenames[dt] = (
-            "bfloat16", '#include "cupy/bfloat16.cuh"')
-        _dtype_kind_size_dict[dt.type] = ("V", 2)
-        _typenames[dt.type] = (
-            "bfloat16", '#include "cupy/bfloat16.cuh"')
+    # See also _util.pyx. older NumPy versions will cause crashes if we add
+    # bfloat16 loops, so don't enable it.
+    if numpy.lib.NumpyVersion(numpy.__version__) >= "2.1.2":
+        try:
+            import ml_dtypes
+        except ImportError:
+            pass
+        else:
+            dt = numpy.dtype(ml_dtypes.bfloat16)
+            _dtype_kind_size_dict[dt] = ("V", 2)
+            _typenames[dt] = (
+                "bfloat16", '#include "cupy/bfloat16.cuh"')
+            _dtype_kind_size_dict[dt.type] = ("V", 2)
+            _typenames[dt.type] = (
+                "bfloat16", '#include "cupy/bfloat16.cuh"')
 
 _setup_type_dict()
 

--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -223,6 +223,11 @@ def is_shutting_down(_shutting_down=_shutting_down):
 
 
 try:
+    # We cannot add loops for bfloat16 on because the loops existance alone
+    # means NumPy code-paths are used that will lead to segfaults.
+    # (I.e. these crashes happen even without bfloat16 ever being used.)
+    if numpy.lib.NumpyVersion(numpy.__version__) < "2.1.2":
+        raise ImportError("NumPy had a critical result-type issue")
     import ml_dtypes
 except ImportError:
     def bf16_loop(in_types=1, out_types=1, code=None):

--- a/tests/cupy_tests/core_tests/test_bfloat16.py
+++ b/tests/cupy_tests/core_tests/test_bfloat16.py
@@ -8,10 +8,14 @@ from cupy.cuda import runtime
 from cupy import testing
 
 
-if not runtime.is_hip and runtime.runtimeGetVersion() < 12020:
+if not runtime.is_hip and cupy.cuda.get_local_runtime_version() < 12020:
     # We may be ablel to enable this, but for now skip to pass tests.
     pytest.skip(allow_module_level=True,
                 reason="bfloat16 is missing some features")
+
+if numpy.lib.NumpyVersion(numpy.__version__) < "2.1.2":
+    pytest.skip(allow_module_level=True,
+                reason="bfloat16 not enabled due to NumPy bug.")
 
 
 ml_dtypes = pytest.importorskip('ml_dtypes')


### PR DESCRIPTION
NumPy versions 2.0 to 2.1.1 had a reference counting bug when promoting user old style dtypes (i.e. `bfloat16`).
The obvious trigger for this was code like `1 / cupy_array` where we eventually see if the `bfloat16` loop works and run into the NumPy bug.

This means that just the existance of bfloat16 loops trigger this and the sane thing to me seems to me to just require NumPy >=2.1.2.

This was not found in the PR stage, because the tests did not generate a case where a Python integer was devided.
I.e. it would probably have triggered all over, but only with `CUPY_TEST_FULL_COMBINATION=1`!

EDIT: I checked locally that the failing cuda 12.0 CI run should be working with this. 