### PR TITLE
Fixed cupy clip behaviour to match numpy clip and added tests

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1143,12 +1143,33 @@ _sqrt = create_ufunc(
     ''')
 
 
+# Define the specialized logic for floats
+_float_routine = '''
+if (isnan(in1) || isnan(in2)) {
+    out0 = (out0_type)nan("");
+} else {
+    out0 = in1 > in2 ? in2 : (in0 < in1 ? in1 : (in0 > in2 ? in2 : in0));
+}
+'''
+
+# Define the default logic for integers
+_default_routine = (
+    'out0 = in1 > in2 ? in2 : '
+    '(in0 < in1 ? in1 : (in0 > in2 ? in2 : in0))'
+)
+
+
 _clip = create_ufunc(
     'cupy_clip',
-    ('???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
-     'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q',
-     'eee->e', 'fff->f', 'ddd->d'),
-    'out0 = in1 > in2 ? in2 : (in0 < in1 ? in1 : (in0 > in2 ? in2 : in0))')
+    (
+        '???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
+        'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q',
+        ('eee->e', _float_routine),
+        ('fff->f', _float_routine),
+        ('ddd->d', _float_routine)
+    ),
+    _default_routine
+)
 
 
 # Variables to expose to Python

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1144,7 +1144,7 @@ _sqrt = create_ufunc(
 
 
 # Define the specialized logic for floats
-_float_routine = '''
+_float_clip = '''
 if (isnan(in1) || isnan(in2)) {
     out0 = (out0_type)nan("");
 } else {
@@ -1164,9 +1164,9 @@ _clip = create_ufunc(
     (
         '???->?', 'bbb->b', 'BBB->B', 'hhh->h', 'HHH->H', 'iii->i', 'III->I',
         'lll->l', 'LLL->L', 'qqq->q', 'QQQ->Q',
-        ('eee->e', _float_routine),
-        ('fff->f', _float_routine),
-        ('ddd->d', _float_routine)
+        ('eee->e', _float_clip),
+        ('fff->f', _float_clip),
+        ('ddd->d', _float_clip)
     ),
     _default_routine
 )

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -149,6 +149,38 @@ class TestMisc:
         a_max = xp.array([[10], [9], [8]], dtype=dtype)
         return a.clip(a_min, a_max)
 
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_clip_nan_in_array(self, xp, dtype):
+        # NaN in array is preserved; finite bounds clip other values
+        nan = float('nan')
+        a = xp.array([1.0, nan, 5.0, -1.0, 3.0], dtype=dtype)
+        return xp.clip(a, 2.0, 4.0)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_clip_nan_min(self, xp, dtype):
+        # When min bound is NaN, output is NaN (NumPy behavior)
+        nan = float('nan')
+        a = xp.array([1.0, 2.0, 3.0], dtype=dtype)
+        return xp.clip(a, nan, 4.0)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_clip_nan_max(self, xp, dtype):
+        # When max bound is NaN, output is NaN (NumPy behavior)
+        nan = float('nan')
+        a = xp.array([1.0, 2.0, 3.0], dtype=dtype)
+        return xp.clip(a, 0.0, nan)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(atol=1e-5)
+    def test_clip_nan_min_max(self, xp, dtype):
+        # When both bounds are NaN, output is NaN
+        nan = float('nan')
+        a = xp.array([1.0, 2.0, 3.0], dtype=dtype)
+        return xp.clip(a, nan, nan)
+
     def test_sqrt(self):
         self.check_unary('sqrt')
 


### PR DESCRIPTION
This code changes fixes: https://github.com/cupy/cupy/issues/9031 making cupy clip to have the same behavior as numpy clip.

In order to fix it I created a different function for the float types that checks if any of the min/max arguments are nan. Only applied to float values since nan is a float type.