### PR TITLE
DEP: Deprecate jitify=True support (and jitify=False)

### DIFF
--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -52,9 +52,6 @@ cdef function.Function _create_cub_reduction_function(
         options += ('-I' + _rocm_path + '/include', '-O2')
         backend = 'nvcc'  # this is confusing...
 
-    # We rely on the type traits in cccl to avoid using jitify
-    jitify = False
-
     # TODO(leofang): try splitting the for-loop into full tiles and partial
     # tiles to utilize LoadDirectBlockedVectorized? See, for example,
     # https://github.com/NVlabs/cub/blob/c3cceac115c072fb63df1836ff46d8c60d9eb304/cub/agent/agent_reduce.cuh#L311-L346
@@ -238,7 +235,7 @@ __global__ void ${name}(${params}) {
         module_code, options, arch=None, cachd_dir=None,
         prepend_cupy_headers=True, backend=backend, translate_cucomplex=False,
         enable_cooperative_groups=False, name_expressions=None,
-        log_stream=None, jitify=jitify)
+        log_stream=None, jitify=False)
     return module.get_function(name)
 
 

--- a/cupy/_core/raw.pyx
+++ b/cupy/_core/raw.pyx
@@ -60,7 +60,7 @@ cdef class RawKernel:
 
     def __init__(self, str code, str name, tuple options=(),
                  str backend='nvrtc', *, bint translate_cucomplex=False,
-                 bint enable_cooperative_groups=False, bint jitify=False):
+                 bint enable_cooperative_groups=False, object jitify=None):
 
         self.code = code
         self.name = name
@@ -69,6 +69,9 @@ cdef class RawKernel:
         self.translate_cucomplex = translate_cucomplex
         self.enable_cooperative_groups = enable_cooperative_groups
         self.jitify = jitify
+        if jitify is not None:
+            from cupy.cuda.compiler import _jitify_deprecation_warning
+            _jitify_deprecation_warning(jitify)
 
         # only used when RawKernels are produced from RawModule
         self.file_path = None  # for cubin/ptx
@@ -361,7 +364,7 @@ cdef class RawModule:
     def __init__(self, *, str code=None, str path=None, tuple options=(),
                  str backend='nvrtc', bint translate_cucomplex=False,
                  bint enable_cooperative_groups=False,
-                 name_expressions=None, bint jitify=False):
+                 name_expressions=None, jitify=None):
         if (code is None) == (path is None):
             raise TypeError(
                 'Exactly one of `code` and `path` keyword arguments must be '
@@ -386,6 +389,9 @@ cdef class RawModule:
         self.file_path = path
         self.enable_cooperative_groups = enable_cooperative_groups
         self.jitify = jitify
+        if jitify is not None:
+            from cupy.cuda.compiler import _jitify_deprecation_warning
+            _jitify_deprecation_warning(jitify)
 
         if self.code is not None:
             self.options = options
@@ -482,7 +488,7 @@ cdef class RawModule:
             self.code, name, self.options, self.backend,
             translate_cucomplex=self.translate_cucomplex,
             enable_cooperative_groups=self.enable_cooperative_groups,
-            jitify=self.jitify)
+            jitify=self.jitify or None)
 
         # for lookup in case we loaded from cubin/ptx
         ker.file_path = self.file_path

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -319,9 +319,30 @@ def _hash_hexdigest(value):
 _hash_length = len(_hash_hexdigest(b''))  # 40 for SHA1
 
 
-def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
-                        name_expressions=None, log_stream=None,
-                        cache_in_memory=False, jitify=False, method=None):
+def _jitify_deprecation_warning(jitify):
+    if jitify:
+        warnings.warn(
+            'jitify=True is deprecated and its support is staged for '
+            'removal in CuPy v15.0.\n'
+            'Please try compiling without jitify using CCCL headers '
+            'as needed.\n'
+            'You may also check `cuda-cccl` e.g. for Thrust/CUB '
+            'algorithm support.',
+            DeprecationWarning, stacklevel=3)
+    else:
+        warnings.warn(
+            'The jitify argument is deprecated and staged for '
+            'removal in CuPy v15.0. '
+            'Avoid passing `jitify=False` to silence this warning.',
+            DeprecationWarning, stacklevel=3)
+
+
+def _compile_using_nvrtc_no_warning(
+    source, options=(), arch=None, filename='kern.cu',
+    name_expressions=None, log_stream=None,
+    cache_in_memory=False, jitify=None, method=None
+):
+
     def _compile(
             source, options, cu_path, name_expressions, log_stream, jitify,
             method):
@@ -369,6 +390,19 @@ def compile_using_nvrtc(source, options=(), arch=None, filename='kern.cu',
 
     return _compile(source, options, cu_path, name_expressions,
                     log_stream, jitify, method)
+
+
+def compile_using_nvrtc(
+    source, options=(), arch=None, filename='kern.cu',
+    name_expressions=None, log_stream=None,
+    cache_in_memory=False, jitify=None, method=None
+):
+    if jitify is not None:
+        _jitify_deprecation_warning(jitify)
+
+    return _compile_using_nvrtc_no_warning(
+        source, options, arch, filename, name_expressions, log_stream,
+        cache_in_memory, jitify, method)
 
 
 def compile_using_nvcc(source, options=(), arch=None,
@@ -623,7 +657,7 @@ def _compile_with_cache_cuda(
 
     if backend == 'nvrtc':
         cu_name = '' if cache_in_memory else name + '.cu'
-        ptx, mapping = compile_using_nvrtc(
+        ptx, mapping = _compile_using_nvrtc_no_warning(
             source, options, arch, cu_name, name_expressions,
             log_stream, cache_in_memory, jitify, 'lto' if to_ltoir else None)
         if _is_cudadevrt_needed(options) and not to_ltoir:

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -324,10 +324,10 @@ def _jitify_deprecation_warning(jitify):
         warnings.warn(
             'jitify=True is deprecated and its support is staged for '
             'removal in CuPy v15.0.\n'
-            'Please try compiling without jitify using CCCL headers '
+            'Please try compiling without jitify using the CCCL headers '
             'as needed.\n'
-            'You may also check `cuda-cccl` e.g. for Thrust/CUB '
-            'algorithm support.',
+            'Also see https://nvidia.github.io/cccl/python/ for e.g. '
+            'Thrust/CUB algorithm exposure to Python.',
             DeprecationWarning, stacklevel=3)
     else:
         warnings.warn(

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -1450,6 +1450,9 @@ class TestRawJitifyJitify(_TestRawJitify, unittest.TestCase):
     (True, ".*"),
     (False, "Avoid passing.*jitify=False")
 ])
+@unittest.skipIf(cupy.cuda.runtime.is_hip,
+                 'Jitify does not support ROCm/HIP')
+@testing.slow
 @pytest.mark.thread_unsafe(reason="uses temporary cache dir")
 @use_temporary_cache_dir()
 def test_jitify_deprecation_warning(jitify, match):


### PR DESCRIPTION
This deprecates support for jitify since normally the altneratives should now be better and jitify has been effectively unmaintained.