### PR TITLE
Avoid caching cuFFT legacy callback artifacts

### DIFF
--- a/.pfnci/linux/tests/actions/cleanup.sh
+++ b/.pfnci/linux/tests/actions/cleanup.sh
@@ -4,18 +4,21 @@ set -uex
 
 # Note: Linux CI image uses relatime.
 
-# Always remove cuFFT static library cache; .so files are sufficient at runtime.
-echo "Cleaning up cuFFT static library cache:"
-find "${CUPY_CACHE_DIR}" -type f \
-    -name "libcufft_static_*.a" \
-    -print -delete | wc -l
+# Always remove cuFFT static library and FFT callback caches.
+# .a files are only used to generate .so files and are not needed at runtime.
+# FFT callback .so files are for legacy callbacks (to be removed) and are too
+# large to cache; regenerating them every run only takes a few minutes.
+echo "Cleaning up cuFFT cache:"
+find "${CUPY_CACHE_DIR}" -type f \( \
+    -name "libcufft_static_*.a" -or \
+    -name "cupy_callback_*.so" \
+    \) -print -delete | wc -l
 
 # Expire misc cache in 30 days.
 echo "Cleaning up misc cache:"
-find "${CUPY_CACHE_DIR}" -type f \( \
-    -name "jitify_*.json" -or \
-    -name "cupy_callback_*.so" \
-    \) -atime +30 -mtime +30 -ctime +30 -print -delete | wc -l
+find "${CUPY_CACHE_DIR}" -type f \
+    -name "jitify_*.json" \
+    -atime +30 -mtime +30 -ctime +30 -print -delete | wc -l
 
 # Expire *.cubin cache in 30 days, and also limit by total size.
 python3 .pfnci/trim_cupy_kernel_cache.py --max-size $((3*1024*1024*1024)) --expiry $((30*24*60*60)) --rm


### PR DESCRIPTION
Close #9666.