### PR TITLE
MAINT: A few small micro-optimizations

### DIFF
--- a/cupy/_core/_carray.pyx
+++ b/cupy/_core/_carray.pyx
@@ -53,7 +53,7 @@ cdef class mdspan(function.CPointer):
         self.ptr = <intptr_t>data
 
         cdef size_t offset = 0
-        memcpy(<char*>(data) + offset, &data_ptr, sizeof(data_ptr))
+        (<void**>(<char*>(data) + offset))[0] = data_ptr
         offset += sizeof(data_ptr)
         if ndim != 0:
             try:
@@ -104,10 +104,11 @@ cdef class CArray(function.CPointer):
         self.ptr = <intptr_t>data
 
         cdef size_t offset = 0
-        memcpy(<char*>(data) + offset, &data_ptr, sizeof(data_ptr))
+        (<void **>(<char*>(data) + offset))[0] = data_ptr
         offset += sizeof(data_ptr)
-        memcpy(<char*>(data) + offset, &data_size, sizeof(data_size))
+        (<Py_ssize_t*>(<char*>(data) + offset))[0] = data_size
         offset += sizeof(data_size)
+
         if ndim != 0:
             memcpy(<char*>(data) + offset,
                    shape.data(),
@@ -142,7 +143,7 @@ cdef class CIndexer(function.CPointer):
         self.ptr = <intptr_t>data
 
         cdef size_t offset = 0
-        memcpy(<char*>(data) + offset, &size, sizeof(size))
+        (<Py_ssize_t*>(<char*>(data) + offset))[0] = size
         offset += sizeof(size)
         if ndim != 0:
             memcpy(<char*>(data) + offset,
@@ -165,7 +166,7 @@ cdef class Indexer:
     cdef void init(self, const shape_t& shape):
         self.shape = shape
         self.size = internal.prod(shape)
-        self._index_32_bits = self.size <= (1 << 31)
+        self._index_32_bits = self.size <= <Py_ssize_t>(1 << 31)
 
     @property
     def ndim(self):

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -77,9 +77,9 @@ cdef class _ndarray_base:
     cpdef get(self, stream=*, order=*, out=*, blocking=*)
     cpdef set(self, arr, stream=*)
     cpdef _ndarray_base reduced_view(self, dtype=*)
-    cpdef _update_c_contiguity(self)
-    cpdef _update_f_contiguity(self)
-    cpdef _update_contiguity(self)
+    cdef _update_c_contiguity(self)
+    cdef _update_f_contiguity(self)
+    cdef _update_contiguity(self)
     cpdef _set_shape_and_strides(self, const shape_t& shape,
                                  const strides_t& strides,
                                  bint update_c_contiguity,
@@ -88,7 +88,7 @@ cdef class _ndarray_base:
                              const strides_t& strides,
                              bint update_c_contiguity,
                              bint update_f_contiguity, obj)
-    cpdef _set_contiguous_strides(
+    cdef _set_contiguous_strides(
         self, Py_ssize_t itemsize, bint is_c_contiguous)
     cdef CPointer get_pointer(self)
     cpdef object toDlpack(self)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -270,7 +270,7 @@ cdef class _ndarray_base:
             alloc_size = self.size * itemsize
 
         max_diff = max(alloc_size, self.size * itemsize)
-        self._index_32_bits = max_diff <= (1 << 31)
+        self._index_32_bits = max_diff <= <Py_ssize_t>(1 << 31)
 
         # data
         if memptr is None:
@@ -293,7 +293,7 @@ cdef class _ndarray_base:
             dtype, check_support=True)
         self._set_contiguous_strides(itemsize, c_order)
         self.data = memory.alloc(self.size * itemsize)
-        self._index_32_bits = (self.size * itemsize) <= (1 << 31)
+        self._index_32_bits = (self.size * itemsize) <= <Py_ssize_t>(1 << 31)
 
     @property
     def __cuda_array_interface__(self):
@@ -2173,14 +2173,14 @@ cdef class _ndarray_base:
         # TODO(niboshi): Confirm update_x_contiguity flags
         return self._view(type(self), shape, strides, False, True, self)
 
-    cpdef _update_c_contiguity(self):
+    cdef _update_c_contiguity(self):
         if self.size == 0:
             self._c_contiguous = True
             return
         self._c_contiguous = internal.get_c_contiguity(
             self._shape, self._strides, self.dtype.itemsize)
 
-    cpdef _update_f_contiguity(self):
+    cdef _update_f_contiguity(self):
         if self.size == 0:
             self._f_contiguous = True
             return
@@ -2199,7 +2199,7 @@ cdef class _ndarray_base:
         self._f_contiguous = internal.get_c_contiguity(
             rev_shape, rev_strides, self.dtype.itemsize)
 
-    cpdef _update_contiguity(self):
+    cdef _update_contiguity(self):
         self._update_c_contiguity()
         self._update_f_contiguity()
 
@@ -2241,7 +2241,7 @@ cdef class _ndarray_base:
             v.__array_finalize__(self)
         return v
 
-    cpdef _set_contiguous_strides(
+    cdef _set_contiguous_strides(
             self, Py_ssize_t itemsize, bint is_c_contiguous):
         self.size = internal.get_contiguous_strides_inplace(
             self._shape, self._strides, itemsize, is_c_contiguous, True)


### PR DESCRIPTION
I was looking a bit at launch overheads end of last week. Bigger fish will come in other PRs eventually. This one does:
* `cpdef` is actually slowish on hot paths for light-weight functions. (It checks for monkey-patching, which is _some_ work.)
* `1 << 31` overflows int's. Cython needs a hint to use a 64bit integer (or it uses Python).
* I think due to `memcpy` alignment, the `memcpy` seemed not inlined. Barely noticable, but I also prefered this pattern slightly.

All of this is maybe 5% of the overhead int `cp.add(arr1d, arr1d)`. Not much, but after a while a few 5% improvements will add up.

---

No rush just thought I'd get the ball rolling.  More interesting will be e.g. less trivial refactors in `kernel.pyx` mostly.