### PR TITLE
TST: Slightly bump SVD test tolerance (but tighten it for float64)

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_decomposition.py
+++ b/tests/cupy_tests/linalg_tests/test_decomposition.py
@@ -224,7 +224,9 @@ class TestSVD(unittest.TestCase):
                                         vh_gpu[..., :k, :])
             else:
                 a_gpu_usv = cupy.matmul(u_gpu*s_gpu[..., None, :], vh_gpu)
-        cupy.testing.assert_allclose(a_gpu, a_gpu_usv, rtol=1e-4, atol=1e-4)
+
+        tol = numpy.finfo(a_gpu_usv.dtype).eps * 1024
+        cupy.testing.assert_allclose(a_gpu, a_gpu_usv, rtol=tol, atol=tol)
 
         # assert unitary
         u_len = u_gpu.shape[-1]


### PR DESCRIPTION
Locally, I see a very slightly larger need for tolerance, 1.2e-4 seems to be sufficient (even just on atol).
Those finfo values come down to:
* 2.2737367544323206e-13  (float64/complex128)
* 0.00012207031 (float32/complex64)

while I am not sure about the history, that seems like an OK relaxation to me, and it is good to tighten it for float64.