### PR TITLE
TST: Skip bfloat16 dlpack test on old CUDA versions

### DIFF
--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -97,6 +97,10 @@ class TestNewDLPackConversion:
     @pytest.mark.skipif(
         numpy.lib.NumpyVersion(numpy.__version__) < "2.1.2",
         reason="bfloat16 not enabled due to NumPy bug.")
+    @pytest.mark.skipif(
+        not cuda.runtime.is_hip and cuda.get_local_runtime_version() < 12020,
+        reason="bfloat16 is missing some features (__hisnan)"
+    )
     def test_conversion_bfloat16(self):
         ml_dtypes = pytest.importorskip('ml_dtypes')
         orig_array = _gen_array(numpy.dtype(ml_dtypes.bfloat16))


### PR DESCRIPTION
Yeah, this really needs a better solution.  But to be ready for release freeze, I think I prefer just to go with the simplest change.