### PR TITLE
Fill bfloat16 gaps around arange and some reduction

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -807,6 +807,7 @@ _sum_keep_dtype = create_reduction_func(
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
      'q->q', 'Q->Q',
      ('e->e', (None, None, None, 'float')),
+     *bf16_loop(code=(None, None, None, 'float')),
      'f->f', 'd->d', 'F->F', 'D->D'),
     ('in0', 'a + b', 'out0 = type_out0_raw(a)', None), 0)
 
@@ -848,6 +849,7 @@ _prod_keep_dtype = create_reduction_func(
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
      'q->q', 'Q->Q',
      ('e->e', (None, None, None, 'float')),
+     *bf16_loop(code=(None, None, None, 'float')),
      'f->f', 'd->d', 'F->F', 'D->D'),
     ('in0', 'a * b', 'out0 = type_out0_raw(a)', None), 1)
 
@@ -863,6 +865,7 @@ _nanprod_keep_dtype = create_reduction_func(
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
      'q->q', 'Q->Q',
      ('e->e', (None, None, None, 'float')),
+     *bf16_loop(code=(None, None, None, 'float')),
      'f->f', 'd->d', 'F->F', 'D->D'),
     ('(in0 == in0) ? in0 : type_in0_raw(1)',
      'a * b', 'out0 = type_out0_raw(a)', None), 1)

--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -310,7 +310,7 @@ cdef _amax = create_reduction_func(
 nanmin = create_reduction_func(
     'cupy_nanmin',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+     'q->q', 'Q->Q', 'e->e', *bf16_loop(), 'f->f', 'd->d', 'F->F', 'D->D'),
     ('min_max_st<type_in0_raw>(in0)', 'my_min(a, b)', 'out0 = a.value',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)
@@ -319,7 +319,7 @@ nanmin = create_reduction_func(
 nanmax = create_reduction_func(
     'cupy_nanmax',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+     'q->q', 'Q->Q', 'e->e', *bf16_loop(), 'f->f', 'd->d', 'F->F', 'D->D'),
     ('min_max_st<type_in0_raw>(in0)', 'my_max(a, b)', 'out0 = a.value',
      'min_max_st<type_in0_raw>'),
     None, _min_max_preamble)

--- a/cupy/_creation/ranges.py
+++ b/cupy/_creation/ranges.py
@@ -6,6 +6,7 @@ import numpy
 
 import cupy
 from cupy import _core
+from cupy._util import bf16_loop
 
 
 def arange(start, stop=None, step=1, dtype=None):
@@ -428,7 +429,7 @@ ogrid = nd_grid(sparse=True)
 _arange_ufunc = _core.create_ufunc(
     'cupy_arange',
     ('bb->b', 'BB->B', 'hh->h', 'HH->H', 'ii->i', 'II->I', 'll->l', 'LL->L',
-     'qq->q', 'QQ->Q', 'ee->e', 'ff->f', 'dd->d',
+     'qq->q', 'QQ->Q', 'ee->e', *bf16_loop(2), 'ff->f', 'dd->d',
      ('FF->F', 'out0 = in0 + float(i) * in1'),
      ('DD->D', 'out0 = in0 + double(i) * in1')),
     'out0 = in0 + i * in1')

--- a/tests/cupy_tests/core_tests/test_bfloat16.py
+++ b/tests/cupy_tests/core_tests/test_bfloat16.py
@@ -30,6 +30,17 @@ TEST_VALUES = numpy.array(
     dtype=BF16)
 
 
+@pytest.mark.parametrize("start,stop,step", [
+    (0, 10, 1),
+    (0, 10, 2),
+    (0, 10, -1),
+    (0, 50, 0.5),
+])
+@testing.numpy_cupy_allclose()
+def test_arange(xp, start, stop, step):
+    return xp.arange(start, stop, step, dtype=BF16)
+
+
 @pytest.mark.parametrize('func', [
     'positive', 'negative', 'absolute', 'sqrt', 'conjugate',
     'isnan', 'isinf', 'isfinite', 'signbit',
@@ -168,12 +179,29 @@ def test_matmul(xp, shapes):
     return res
 
 
-@pytest.mark.parametrize('func', ['sum', 'prod', 'min', 'max', 'mean'])
+@pytest.mark.parametrize('func', [
+    'sum', 'prod', 'min', 'max', 'mean',
+    'nansum', 'nanmin', 'nanmax',
+    # For some reason, NumPy result includes NaN:
+    pytest.param('nanprod', marks=[pytest.mark.xfail]),
+])
 @testing.numpy_cupy_allclose(rtol=TOL, atol=TOL)
 def test_reductions(xp, func):
     a = xp.asarray(TEST_VALUES.reshape(3, 4))
     with numpy.errstate(all='ignore'):
         return getattr(xp, func)(a, axis=1)
+
+
+@pytest.mark.parametrize('func', [
+    'sum', 'prod', 'mean', 'nansum',
+    # For some reason, NumPy result includes NaN:
+    pytest.param('nanprod', marks=[pytest.mark.xfail]),
+])
+@testing.numpy_cupy_allclose(rtol=TOL, atol=TOL)
+def test_reductions_dtype(xp, func):
+    a = xp.asarray(TEST_VALUES.reshape(3, 4))
+    with numpy.errstate(all='ignore'):
+        return getattr(xp, func)(a, axis=1, dtype=BF16)
 
 
 @pytest.mark.parametrize('func', ['sum', 'prod', 'min', 'max', 'mean'])


### PR DESCRIPTION
There are a few more ufunc gaps, notably rounding (but ml_dtypes won't support that either) and possible another 1-2 (I hope) that are more niche (I think maybe divmod, but I think that one isn't the end of the world either way).

Maybe arange isn't all that critical in actual code, but is just very obvious to try :(
(I didn't want to do much here, but especially arange seemed a bit embarrassing.)