### PR TITLE
CI: Fix cuda-rapids CI

### DIFF
--- a/.pfnci/linux/tests/cuda-rapids.sh
+++ b/.pfnci/linux/tests/cuda-rapids.sh
@@ -19,6 +19,10 @@ echo "======================================================="
 
 
 trap "$ACTIONS/cleanup.sh" EXIT
+
+# Remove CuPy installed in base Docker image
+conda remove --force cupy cupy-core
+
 # Overwrite:
 #  - CUPY_NVCC_GENERATE_CODE to accelerate build
 #  - CXX to use ccache

--- a/.pfnci/linux/tests/cuda-rapids.sh
+++ b/.pfnci/linux/tests/cuda-rapids.sh
@@ -1,19 +1,30 @@
 #!/bin/bash
 
+# Based on cuda129.sh
+
 set -uex
 
 ACTIONS="$(dirname $0)/actions"
 . "$ACTIONS/_environment.sh"
 
-export CUPY_NVCC_GENERATE_CODE="current"
+nvidia-smi
+
 export NVCC="ccache nvcc"
 
+export CUPY_ACCELERATORS="cub,cutensor"
+
+echo "================ Environment Variables ================"
+env
+echo "======================================================="
+
+
+trap "$ACTIONS/cleanup.sh" EXIT
 # Overwrite:
+#  - CUPY_NVCC_GENERATE_CODE to accelerate build
 #  - CXX to use ccache
 #  - CUDA_PATH set in conda to build CuPy
-CXX=/usr/lib/ccache/g++ CUDA_PATH="/usr/local/cuda" pip install -v ".[test]"
+CUPY_NVCC_GENERATE_CODE="current" CXX=/usr/lib/ccache/g++ CUDA_PATH="/usr/local/cuda" pip install -v ".[test]"
 "$ACTIONS/unittest.sh" "not slow" \
     "cupyx_tests/scipy_tests/sparse_tests/csgraph_tests" \
     "cupyx_tests/scipy_tests/spatial_tests/test_kdtree_cuvs.py" \
     "cupyx_tests/scipy_tests/spatial_tests/test_distance.py"
-"$ACTIONS/cleanup.sh"

--- a/.pfnci/linux/tests/cuda-rapids.sh
+++ b/.pfnci/linux/tests/cuda-rapids.sh
@@ -22,8 +22,7 @@ trap "$ACTIONS/cleanup.sh" EXIT
 # Overwrite:
 #  - CUPY_NVCC_GENERATE_CODE to accelerate build
 #  - CXX to use ccache
-#  - CUDA_PATH set in conda to build CuPy
-CUPY_NVCC_GENERATE_CODE="current" CXX=/usr/lib/ccache/g++ CUDA_PATH="/usr/local/cuda" pip install -v ".[test]"
+CUPY_NVCC_GENERATE_CODE="current" CXX=/usr/lib/ccache/g++ pip install -v ".[test]"
 "$ACTIONS/unittest.sh" "not slow" \
     "cupyx_tests/scipy_tests/sparse_tests/csgraph_tests" \
     "cupyx_tests/scipy_tests/spatial_tests/test_kdtree_cuvs.py" \


### PR DESCRIPTION
The important part is `conda remove --force cupy cupy-core`. This CI try to install CuPy via pip into conda environment, and it seems this caused environment misdetection, causing the error:

https://ci.preferred.jp/cupy.linux.cuda-rapids/209411/#L19215
```
00:08:03.000207 STDOUT 1482]	Traceback (most recent call last):	
00:08:03.000213 STDOUT 1482]	  File "<string>", line 1, in <module>	
00:08:03.000223 STDOUT 1482]	  File "/opt/conda/lib/python3.11/site-packages/cupy/__init__.py", line 938, in show_config	
00:08:03.000225 STDOUT 1482]	    _sys.stdout.write(str(cupyx.get_runtime_info(full=_full)))	
00:08:03.000228 STDOUT 1482]	                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^	
00:08:03.000240 STDOUT 1482]	  File "/opt/conda/lib/python3.11/site-packages/cupyx/_runtime.py", line 419, in get_runtime_info	
00:08:03.000241 STDOUT 1482]	    return _RuntimeInfo(full=full)	
00:08:03.000245 STDOUT 1482]	           ^^^^^^^^^^^^^^^^^^^^^^^	
00:08:03.000250 STDOUT 1482]	  File "/opt/conda/lib/python3.11/site-packages/cupyx/_runtime.py", line 238, in __init__	
00:08:03.000252 STDOUT 1482]	    cupy._environment._get_include_dir_from_conda_or_wheel(	
00:08:03.000255 STDOUT 1482]	  File "/opt/conda/lib/python3.11/site-packages/cupy/_environment.py", line 596, in _get_include_dir_from_conda_or_wheel	
00:08:03.000259 STDOUT 1482]	    cuda_path = _get_conda_cuda_path()	
00:08:03.000260 STDOUT 1482]	                ^^^^^^^^^^^^^^^^^^^^^^	
00:08:03.000262 STDOUT 1482]	  File "/opt/conda/lib/python3.11/site-packages/cupy/_environment.py", line 130, in _get_conda_cuda_path	
00:08:03.000266 STDOUT 1482]	    cuda_path = os.path.join(conda_prefix, 'targets', arch)	
00:08:03.000267 STDOUT 1482]	                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^	
00:08:03.000270 STDOUT 1482]	  File "<frozen posixpath>", line 76, in join	
00:08:03.000273 STDOUT 1482]	TypeError: expected str, bytes or os.PathLike object, not NoneType
```