### PR TITLE
Remove old Python 2 buffer protocol functions to remove warnings

### DIFF
--- a/cupy/cuda/pinned_memory.pyx
+++ b/cupy/cuda/pinned_memory.pyx
@@ -113,23 +113,6 @@ cdef class PinnedMemoryPointer:
     def __releasebuffer__(self, Py_buffer *buffer):
         pass
 
-    def __getsegcount__(self, Py_ssize_t *lenp):
-        if lenp != NULL:
-            lenp[0] = self.size()
-        return 1
-
-    def __getreadbuffer__(self, Py_ssize_t idx, void **p):
-        if idx != 0:
-            raise SystemError('accessing non-existent buffer segment')
-        p[0] = <void*>self.ptr
-        return self.size()
-
-    def __getwritebuffer__(self, Py_ssize_t idx, void **p):
-        if idx != 0:
-            raise SystemError('accessing non-existent buffer segment')
-        p[0] = <void*>self.ptr
-        return self.size()
-
 
 cdef class _EventWatcher:
     cdef:


### PR DESCRIPTION
I've opened this as a separate, targeted PR to handle the legacy buffer protocol removals. Little changes in effort to Make Cython compilation warning free: https://github.com/cupy/cupy/issues/9559. 

Removal of functions to address warnings of deprecated functions:
```
  warning: cupy/cuda/pinned_memory.pyx:116:4: '__getsegcount__' relates to the old Python 2 buffer protocol and is no longer used.
  warning: cupy/cuda/pinned_memory.pyx:121:4: '__getreadbuffer__' relates to the old Python 2 buffer protocol and is no longer used.
  warning: cupy/cuda/pinned_memory.pyx:127:4: '__getwritebuffer__' relates to the old Python 2 buffer protocol and is no longer used.
```


Should we have this PR open to address the small warning/details that may arise? The main areas I have identified for fixing Cython compilation warnings until now are the following:

- Implicit noexcept (WIP) https://github.com/cupy/cupy/pull/9654
- 'IF' statement deprecation

Which will require big PRs for addressing those set of warnings. 