### PR TITLE
CI: Adjust wait/retry in PyPI upload workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,17 @@ jobs:
         python-version: '3.10'
     - name: Check
       run: |
-        sleep 60s  # wait for PyPI to be updated
         pip install distlib
         CHECK_WHEEL="${{ inputs.branch != 'main' && '--pypi-wheel' || '' }}"
-        ./check_release_assets.py --version "${{ inputs.release }}" --pypi-sdist ${CHECK_WHEEL}
+
+        for i in 1 2 3 4 5; do
+          echo "Attempt ${i}: waiting for PyPI propagation..."
+          sleep 120s
+          if ./check_release_assets.py --version "${{ inputs.release }}" --pypi-sdist ${CHECK_WHEEL}; then
+            echo "Check succeeded on attempt ${i}."
+            exit 0
+          fi
+        done
+
+        echo "All attempts failed; consider rerunning after few minutes."
+        exit 1


### PR DESCRIPTION
The current workflow verifies whether all assets are uploaded correctly to PyPI. However, there is a propagation delay between the file upload and its availability via the PyPI API. Our current 60-second sleep is often insufficient, frequently requiring manual retries. This PR increases the sleep duration to 120 seconds and implements an automated retry mechanism.
