### PR TITLE
MAINT,ENH: Refactor kernel argument handling into `KernelArguments` class

### DIFF
--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -87,7 +87,6 @@ cdef class _TypeMap:
     cdef str get_typedef_code(self, type_headers=*)
 
 
-
 cdef class KernelArguments:
     # A kernels friendly helper to organize preparation of input and
     # output arguments.
@@ -97,7 +96,6 @@ cdef class KernelArguments:
         # `args` is the argument storage, may micro-optimize this
         # but right now it's a list and that is used in broadcasting.
         list args
-        shape_t broadcast_shape
         bint has_where
         bint is_ufunc
 
@@ -110,12 +108,14 @@ cdef class KernelArguments:
 
     cdef _preprocess_args(self, dev_id)
 
-    cdef find_shape(self)
-    cdef find_shape_raw(self, tuple params, Py_ssize_t size)
+    cdef find_and_apply_shape(
+        self, tuple params, shape_t& shape, bint shape_fixed)
 
-    cdef create_out_args_with_types(self, tuple out_types, casting)
+    cdef create_out_args_with_types(
+        self, tuple out_types, casting, const shape_t& shape)
     cdef create_out_args_with_params(
-            self, tuple out_types, tuple out_params, bint is_size_specified)
+        self, tuple out_types, tuple out_params, bint is_size_specified,
+        const shape_t& shape)
 
     cdef result(self, bint tuple_return)
     cdef finalize_scalars(self, tuple in_types)

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -87,6 +87,67 @@ cdef class _TypeMap:
     cdef str get_typedef_code(self, type_headers=*)
 
 
+
+cdef class KernelArguments:
+    # A kernels friendly helper to organize preparation of input and
+    # output arguments.
+    cdef:
+        Py_ssize_t nin
+        Py_ssize_t nout
+        # `args` is the argument storage, may micro-optimize this
+        # but right now it's a list and that is used in broadcasting.
+        list args
+        shape_t broadcast_shape
+        bint has_where
+        bint is_ufunc
+
+    @staticmethod
+    cdef KernelArguments create(
+            Py_ssize_t nin, Py_ssize_t nout, tuple args, out,
+            where, bint is_ufunc, int dev_id, str name)
+
+    cdef _copy_in_args_if_needed(self)
+
+    cdef _preprocess_args(self, dev_id)
+
+    cdef find_shape(self)
+    cdef find_shape_raw(self, tuple params, Py_ssize_t size)
+
+    cdef create_out_args_with_types(self, tuple out_types, casting)
+    cdef create_out_args_with_params(
+            self, tuple out_types, tuple out_params, bint is_size_specified)
+
+    cdef result(self, bint tuple_return)
+    cdef finalize_scalars(self, tuple in_types)
+    cdef tuple get_ndarray_dtypes(self)
+
+    # Helpers to access arguments (makes offsets simpler and also may allow
+    # to simplify changing the storage in the future).
+    cdef inline get_in(self, Py_ssize_t i):
+        return self.args[i]
+
+    cdef inline set_in(self, Py_ssize_t i, arg):
+        self.args[i] = arg
+
+    cdef inline get_out(self, Py_ssize_t i):
+        return self.args[self.nin + i + self.has_where]
+
+    cdef inline set_out(self, Py_ssize_t i, arg):
+        # We skip one for `where`
+        self.args[self.nin + i + self.has_where] = arg
+
+    cdef inline get_where(self):
+        assert self.has_where
+        return self.args[self.nin]
+
+    cdef inline set_where(self, arg):
+        assert self.has_where
+        self.args[self.nin] = arg
+
+    cdef inline set_indexer(self, indexer):
+        self.args[self.nin + self.nout + self.has_where] = indexer
+
+
 cdef class _Op:
     """Simple data structure that represents a kernel routine with single \
 concrete dtype mapping.
@@ -154,18 +215,6 @@ cdef tuple _get_arginfos(list args)
 
 cdef str _get_kernel_params(tuple params, tuple arginfos, type_headers=*)
 
-cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape)
-
-cdef list _get_out_args_from_optionals(
-    subtype, list out_args, tuple out_types, const shape_t& out_shape, casting,
-    obj)
-
-cdef list _get_out_args_with_params(
-    list out_args, tuple out_types,
-    const shape_t& out_shape, tuple out_params, bint is_size_specified)
-
 cpdef _check_peer_access(_ndarray_base arr, int device_id)
-
-cdef list _preprocess_args(int dev_id, args)
 
 cdef shape_t _reduce_dims(list args, tuple params, const shape_t& shape)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1011,6 +1011,11 @@ cdef class ElementwiseKernel:
         if block_size <= 0:
             raise ValueError('block_size must be greater than zero')
 
+        for arg in args:
+            if hasattr(arg, '__cupy_override_elementwise_kernel__'):
+                return arg.__cupy_override_elementwise_kernel__(
+                    self, *args, **kwargs)
+
         dev_id = device.get_device_id()
 
         kargs = KernelArguments.create(

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -493,14 +493,14 @@ cdef class KernelArguments:
                     'Wrong number of arguments for {!r}. '
                     'It must be either {} or {} (with outputs), '
                     'but given {}.'.format(
-                        self.name, self.nin, nargs, len_args))
+                        name, self.nin, nargs, len_args))
         else:
             if len_args < self.nin or len_args > nargs:
                 raise TypeError(
                     'Wrong number of arguments for {!r}. '
                     'It must be between {} and {} (with outputs), '
                     'but given {}.'.format(
-                        self.name, self.nin, nargs, len_args))
+                        name, self.nin, nargs, len_args))
 
         for i in range(nin):
             self.set_in(i, args[i])

--- a/cupy/_core/_reduction.pxd
+++ b/cupy/_core/_reduction.pxd
@@ -26,7 +26,7 @@ cdef class _AbstractReductionKernel:
         readonly dict _cached_codes
 
     cpdef _ndarray_base _call(
-        self, KernelArguments kargs, axis, dtype,
+        self, KernelArguments kargs, shape_t& in_shape, axis, dtype,
         bint keepdims, bint reduce_dims, int device_id,
         stream, bint try_use_cub=*, bint sort_reduce_axis=*)
 
@@ -39,7 +39,9 @@ cdef class _AbstractReductionKernel:
     cdef tuple _get_expressions_and_types(
         self, KernelArguments kargs, dtype)
 
-    cdef _create_out_args(self, KernelArguments kargs, tuple out_types)
+    cdef _create_out_args(
+        self, KernelArguments kargs, tuple out_types,
+        shape_t& shape)
 
     cdef function.Function _get_function(
         self,

--- a/cupy/_core/_reduction.pxd
+++ b/cupy/_core/_reduction.pxd
@@ -1,5 +1,6 @@
 from cupy._core._carray cimport shape_t
 from cupy._core cimport _kernel
+from cupy._core._kernel cimport KernelArguments
 from cupy._core.core cimport _ndarray_base
 from cupy.cuda cimport function
 
@@ -25,23 +26,20 @@ cdef class _AbstractReductionKernel:
         readonly dict _cached_codes
 
     cpdef _ndarray_base _call(
-        self,
-        list in_args, list out_args,
-        const shape_t& a_shape, axis, dtype,
+        self, KernelArguments kargs, axis, dtype,
         bint keepdims, bint reduce_dims, int device_id,
         stream, bint try_use_cub=*, bint sort_reduce_axis=*)
 
-    cdef void _launch(
+    cdef _launch(
         self, out_block_num, block_size, block_stride,
         in_args, out_args, in_shape, out_shape, types,
         map_expr, reduce_expr, post_map_expr, reduce_type,
         stream, params)
 
     cdef tuple _get_expressions_and_types(
-        self, list in_args, list out_args, dtype)
+        self, KernelArguments kargs, dtype)
 
-    cdef list _get_out_args(
-        self, list out_args, tuple out_types, const shape_t& out_shape)
+    cdef _create_out_args(self, KernelArguments kargs, tuple out_types)
 
     cdef function.Function _get_function(
         self,
@@ -69,7 +67,7 @@ cdef class ReductionKernel(_AbstractReductionKernel):
 cdef shape_t _set_permuted_args(
     list args, tuple axis_permutes, const shape_t& shape, tuple params)
 
-cdef tuple _get_shape_and_strides(list in_args, list out_args)
+cdef tuple _get_shape_and_strides(KernelArguments kargs)
 
 cdef _optimizer_copy_arg(a)
 

--- a/cupy/_core/internal.pxd
+++ b/cupy/_core/internal.pxd
@@ -43,6 +43,12 @@ cpdef size_t clp2(size_t x)
 
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
 
+# Low-level broadcasting helpers:
+cdef bint _broadcast_shape(shape_t& bshape, const shape_t& next_shape)
+cdef _raise_broadcast_error(list arrays)
+cdef _ndarray_base _broadcast_to_unchecked(
+        _ndarray_base a, const shape_t& shape)
+
 cdef _broadcast_core(list arrays, shape_t& shape)
 
 cpdef bint _contig_axes(tuple axes)


### PR DESCRIPTION
This is a bit related to gh-9586 and the previous attempt on it in gh-2920. I.e. to make ElementWise kernels and ufuncs (and reductions) more similar one part of the old PR was also to introduce a new `Args` class to encapsulate kernel arguments.

This PR introduces a `KernelArguments` and merges the broadcasting logic into `find_and_apply_shape()`.
There is still quite a bit of duplication, but it helps to make the main `__call__` paths easier to follow, I think.  I opted for `.get_in(0)` getters for many things, because I would like to hide a bit how the arguments are stored.

---

Should reduce overheads for simple ufuncs by around 5-10%, but for me it is more about helping with follow-ups on merging the ufunc/elementwise kernel code or just moving more things into `KernelArguments`.

Two concrete thoughts I have here is that `KernelArguments` could already create `CArray`s, which could give us a pretty big boost when broadcasting or `reduce_dims()` happens (avoid creating more `ndarray`s).
Another thought I have is to speed up `ArgInfo`s a bit by merging them (the cache lookup takes quite a lot longer than it should).
