### PR TITLE
Fix `cupy_backends.cuda.libs` not raising AttributeError

### DIFF
--- a/cupy_backends/cuda/libs/__init__.py
+++ b/cupy_backends/cuda/libs/__init__.py
@@ -21,7 +21,7 @@ _submodules = (
     'cusparselt',
 )
 _submodules_runtime_link = (
-    'nvrtc',
+    'nvrtc', 'nvtx'
 )
 
 


### PR DESCRIPTION
xref #9704. According to [PEP 562](https://peps.python.org/pep-0562/) module-level getattr must raise AttributeError. xref #9444.

Reproducer:

```py
import unittest
import warnings

import cupy

class TestUnitTest(unittest.TestCase):
    def test_trigger_bug(self):
        with self.assertWarnsRegex(UserWarning, "X"):
            warnings.warn("X", UserWarning)
```

Output:

```
============================================================================ FAILURES =============================================================================
__________________________________________________________________ TestUnitTest.test_trigger_bug __________________________________________________________________

self = <test.TestUnitTest testMethod=test_trigger_bug>

    def test_trigger_bug(self):
>       with self.assertWarnsRegex(UserWarning, "X"):

test.py:8: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../cupy_backends/cuda/libs/__init__.py:36: in __getattr__
    return _importlib.import_module(f'cupy_backends.cuda.libs.{name}')
../../../.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'cupy_backends.cuda.libs.__warningregistry__', import_ = <function _gcd_import at 0x7fbd8f0540e0>

>   ???
E   ModuleNotFoundError: No module named 'cupy_backends.cuda.libs.__warningregistry__'
```