### PR TITLE
Cython 'IF' statement deprecation

### DIFF
--- a/cupy_backends/cuda/libs/cusolver.pyx
+++ b/cupy_backends/cuda/libs/cusolver.pyx
@@ -1007,7 +1007,7 @@ ctypedef int (*f_type)(...) nogil  # NOQA
 
 cdef object _libname = None
 cdef object _handle = 0
-IF 12000 <= CUPY_CUDA_VERSION:
+if 12000 <= CUPY_CUDA_VERSION:
     # We let libname be None here to avoid loading the library twice,
     # which could potentially be loading different versions of the library.
     from cuda import pathfinder

--- a/cupy_backends/cuda/libs/cusparse.pyx
+++ b/cupy_backends/cuda/libs/cusparse.pyx
@@ -1376,13 +1376,13 @@ ctypedef Status (*f_type)(...) nogil  # NOQA
 # be removed entirely.
 cdef object _libname = None
 cdef object _handle = 0
-IF 12000 <= CUPY_CUDA_VERSION:
+if 12000 <= CUPY_CUDA_VERSION:
     # We let libname be None here to avoid loading the library twice,
     # which could potentially be loading different versions of the library.
     from cuda import pathfinder
     loaded_dl = pathfinder.load_nvidia_dynamic_lib('cusparse')
     _handle = loaded_dl._handle_uint
-ELIF 0 < CUPY_HIP_VERSION:
+elif 0 < CUPY_HIP_VERSION:
     _libname = __file__
 
 cdef SoftLink _lib = SoftLink(_libname, 'cusparse', handle=_handle)
@@ -4984,7 +4984,7 @@ cpdef void spSM_solve(
         size_t matA, size_t matB, size_t matC, DataType computeType,
         SpSMAlg alg, size_t spsmDescr, intptr_t externalBuffer=0) except *:
     _setStream(handle)
-    IF CUPY_HIP_VERSION > 0:
+    if CUPY_HIP_VERSION > 0:
         # hipsparseSpSM_solve has the extra `externalBuffer` parameter that
         # cusparseSpSM_solve does not require.
         status = cusparseSpSM_solve(<Handle> handle, opA, opB, <void*>alpha,
@@ -4992,7 +4992,7 @@ cpdef void spSM_solve(
                                     <DnMatDescr>matC, computeType, alg,
                                     <SpSMDescr>spsmDescr,
                                     <void*>externalBuffer)
-    ELSE:
+    else:
         status = cusparseSpSM_solve(<Handle> handle, opA, opB, <void*>alpha,
                                     <SpMatDescr>matA, <DnMatDescr>matB,
                                     <DnMatDescr>matC, computeType, alg,

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -115,6 +115,8 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
             # https://github.com/cupy/cupy/pull/8457#issuecomment-2656568499
             'binding': False,
             'legacy_implicit_noexcept': True,
+            'warn.deprecated.IF': False,   # suppress IF deprecation warning
+            'warn.deprecated.DEF': False,  # suppress DEF deprecation warning
         }
 
         # Compile-time constants to be used in Cython code


### PR DESCRIPTION
### Summary
This PR addresses part of the Cython deprecation warnings reported in https://github.com/cupy/cupy/issues/9559, specifically those related to `IF` deprecation warnings.

The work done so far focuses solely on resolving deprecation warnings. Functional or behavioral changes may need to be included, opening this PR as draft so we can discuss the changes.

The remaining #IFs can't be changed into Python's ifs since they include type definitions, imports, etc that need to be resolved at compile time.

### What was changed
- Fixed warnings of the form:
  - `"The 'IF' statement is deprecated and will be removed in a future Cython version."`

### Options
The options I have considered so far are:
- Separate extension modules per variant.
- Build-time code generation. A script that reads the config and generates the correct .pyx, .pxd files.

Do we have any preference? Maybe a mix of both strategies work best depending on the file.

### Remaining warnings
```
  warning: cupy/cuda/cufft.pxd:13:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy/cuda/cufft.pyx:1268:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy/cuda/cufft.pyx:191:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_enum.pxd:122:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_enum.pxd:239:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_extern.pxi:163:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_extern.pxi:91:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_typedef.pxi:120:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_typedef.pxi:135:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_typedef.pxi:157:4: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/_runtime_typedef.pxi:540:8: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/driver.pxd:8:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/driver.pyx:22:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/runtime.pxd:28:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/api/runtime.pyx:76:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/libs/nvrtc.pxd:8:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
  warning: cupy_backends/cuda/libs/nvrtc.pyx:24:0: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
```


