### PR TITLE
ENH: Reduce overheads for flags and imports related to FFT

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -14,7 +14,6 @@ from cupy import _environment
 from cupy._core._kernel import create_ufunc
 from cupy._core._kernel import ElementwiseKernel
 from cupy._core._ufuncs import elementwise_copy
-from cupy._core import flags as _flags
 from cupy._core import syncdetect
 from cupy import cuda
 from cupy.cuda import memory as memory_module
@@ -35,6 +34,7 @@ from cupy._core cimport _dtype
 from cupy._core._dtype cimport get_dtype
 from cupy._core._dtype cimport populate_format
 from cupy._core._kernel cimport create_ufunc
+from cupy._core cimport flags as _flags
 from cupy._core cimport _memory_range
 from cupy._core cimport _routines_binary as _binary
 from cupy._core cimport _routines_indexing as _indexing
@@ -482,8 +482,8 @@ cdef class _ndarray_base:
         .. seealso:: :attr:`numpy.ndarray.flags`
 
         """
-        return _flags.Flags(self._c_contiguous, self._f_contiguous,
-                            self.base is None)
+        return _flags.Flags._create(
+            self._c_contiguous, self._f_contiguous, self.base is None)
 
     property shape:
         """Lengths of axes.

--- a/cupy/_core/flags.pxd
+++ b/cupy/_core/flags.pxd
@@ -1,0 +1,17 @@
+# distutils: language = c++
+
+
+cdef class Flags:
+    cdef readonly bint c_contiguous
+    cdef readonly bint f_contiguous
+    cdef readonly bint owndata
+
+    @staticmethod
+    cdef inline Flags _create(
+        bint c_contiguous, bint f_contiguous, bint owndata
+    ):
+        cdef Flags self = <Flags>Flags.__new__(Flags)
+        self.c_contiguous = c_contiguous
+        self.f_contiguous = f_contiguous
+        self.owndata = owndata
+        return self

--- a/cupy/_core/flags.pxd
+++ b/cupy/_core/flags.pxd
@@ -5,6 +5,9 @@ cdef class Flags:
     cdef readonly bint c_contiguous
     cdef readonly bint f_contiguous
     cdef readonly bint owndata
+    # NOTE(seberg): CuPy used a Python type previously allowing
+    # arbitray monkeypatching.  (one cupyx test was relying on this)
+    cdef dict __dict__
 
     @staticmethod
     cdef inline Flags _create(

--- a/cupy/_core/flags.pyx
+++ b/cupy/_core/flags.pyx
@@ -1,24 +1,11 @@
 # distutils: language = c++
 
 
-class Flags(object):
-
+cdef class Flags:
     def __init__(self, c_contiguous, f_contiguous, owndata):
         self._c_contiguous = c_contiguous
         self._f_contiguous = f_contiguous
         self._owndata = owndata
-
-    @property
-    def c_contiguous(self):
-        return self._c_contiguous
-
-    @property
-    def f_contiguous(self):
-        return self._f_contiguous
-
-    @property
-    def owndata(self):
-        return self._owndata
 
     @property
     def fnc(self):

--- a/cupy/_core/flags.pyx
+++ b/cupy/_core/flags.pyx
@@ -3,9 +3,9 @@
 
 cdef class Flags:
     def __init__(self, c_contiguous, f_contiguous, owndata):
-        self._c_contiguous = c_contiguous
-        self._f_contiguous = f_contiguous
-        self._owndata = owndata
+        self.c_contiguous = c_contiguous
+        self.f_contiguous = f_contiguous
+        self.owndata = owndata
 
     @property
     def fnc(self):

--- a/cupy/fft/_fft.py
+++ b/cupy/fft/_fft.py
@@ -62,7 +62,7 @@ def _cook_shape(a, s, axes, value_type, order='C'):
 
 
 def _convert_fft_type(dtype, value_type):
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     if value_type == 'C2C' and dtype == np.complex64:
         return cufft.CUFFT_C2C
@@ -82,7 +82,7 @@ def _convert_fft_type(dtype, value_type):
 
 def _exec_fft(a, direction, value_type, norm, axis, overwrite_x,
               out_size=None, out=None, plan=None):
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     fft_type = _convert_fft_type(a.dtype, value_type)
 
@@ -331,7 +331,7 @@ def _get_cufft_plan_nd(
     Returns:
         plan (cufft.PlanNd): A cuFFT Plan for the chosen `fft_type`.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     ndim = len(shape)
 
@@ -496,7 +496,7 @@ def _get_fftn_out_size(in_shape, s, last_axis, value_type):
 
 def _exec_fftn(a, direction, value_type, norm, axes, overwrite_x,
                plan=None, out=None, out_size=None):
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     fft_type = _convert_fft_type(a.dtype, value_type)
 
@@ -634,7 +634,7 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
 
 
 def _default_fft_func(a, s=None, axes=None, plan=None, value_type='C2C'):
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     curr_plan = cufft.get_current_plan()
     if curr_plan is not None:
@@ -699,7 +699,7 @@ def fft(a, n=None, axis=-1, norm=None):
 
     .. seealso:: :func:`numpy.fft.fft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(a, (n,), (axis,), norm, cufft.CUFFT_FORWARD)
 
 
@@ -723,7 +723,7 @@ def ifft(a, n=None, axis=-1, norm=None):
 
     .. seealso:: :func:`numpy.fft.ifft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(a, (n,), (axis,), norm, cufft.CUFFT_INVERSE)
 
 
@@ -747,7 +747,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
 
     .. seealso:: :func:`numpy.fft.fft2`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes)
     return func(a, s, axes, norm, cufft.CUFFT_FORWARD)
@@ -773,7 +773,7 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
 
     .. seealso:: :func:`numpy.fft.ifft2`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes)
     return func(a, s, axes, norm, cufft.CUFFT_INVERSE)
@@ -799,7 +799,7 @@ def fftn(a, s=None, axes=None, norm=None):
 
     .. seealso:: :func:`numpy.fft.fftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes)
     return func(a, s, axes, norm, cufft.CUFFT_FORWARD)
@@ -825,7 +825,7 @@ def ifftn(a, s=None, axes=None, norm=None):
 
     .. seealso:: :func:`numpy.fft.ifftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes)
     return func(a, s, axes, norm, cufft.CUFFT_INVERSE)
@@ -852,7 +852,7 @@ def rfft(a, n=None, axis=-1, norm=None):
 
     .. seealso:: :func:`numpy.fft.rfft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     return _fft(a, (n,), (axis,), norm, cufft.CUFFT_FORWARD, 'R2C')
 
@@ -880,7 +880,7 @@ def irfft(a, n=None, axis=-1, norm=None):
 
     .. seealso:: :func:`numpy.fft.irfft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     caster = _compat_caster(a, (axis,))
     return caster(_fft(a, (n,), (axis,), norm, cufft.CUFFT_INVERSE, 'C2R'))
@@ -907,7 +907,7 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
 
     .. seealso:: :func:`numpy.fft.rfft2`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes, value_type='R2C')
     return func(a, s, axes, norm, cufft.CUFFT_FORWARD, 'R2C')
@@ -936,7 +936,7 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
 
     .. seealso:: :func:`numpy.fft.irfft2`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     caster = _compat_caster(a, axes)
     func = _default_fft_func(a, s, axes, value_type='C2R')
@@ -964,7 +964,7 @@ def rfftn(a, s=None, axes=None, norm=None):
 
     .. seealso:: :func:`numpy.fft.rfftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(a, s, axes, value_type='R2C')
     return func(a, s, axes, norm, cufft.CUFFT_FORWARD, 'R2C')
@@ -1002,7 +1002,7 @@ def irfftn(a, s=None, axes=None, norm=None):
 
     .. seealso:: :func:`numpy.fft.irfftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     caster = _compat_caster(a, axes)
     func = _default_fft_func(a, s, axes, value_type='C2R')

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -105,7 +105,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.fft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_FORWARD,
                 overwrite_x=overwrite_x, plan=plan)
 
@@ -139,7 +139,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.ifft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_INVERSE,
                 overwrite_x=overwrite_x, plan=plan)
 
@@ -238,7 +238,7 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.fftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     s = _assequence(s)
     axes = _assequence(axes)
@@ -276,7 +276,7 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.ifftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     s = _assequence(s)
     axes = _assequence(axes)
@@ -318,7 +318,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
     .. seealso:: :func:`scipy.fft.rfft`
 
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_FORWARD, 'R2C',
                 overwrite_x=overwrite_x, plan=plan)
@@ -353,7 +353,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.irfft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(x, (n,), (axis,), norm, cufft.CUFFT_INVERSE, 'C2R',
                 overwrite_x=overwrite_x, plan=plan)
 
@@ -461,7 +461,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.rfftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     s = _assequence(s)
     axes = _assequence(axes)
@@ -503,7 +503,7 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, *, plan=None):
 
     .. seealso:: :func:`scipy.fft.irfftn`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     s = _assequence(s)
     axes = _assequence(axes)

--- a/cupyx/scipy/fftpack/_fft.py
+++ b/cupyx/scipy/fftpack/_fft.py
@@ -63,7 +63,7 @@ def get_fft_plan(a, shape=None, axes=None, value_type='C2C'):
         This API is a deviation from SciPy's, is currently experimental, and
         may be changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     # check input array
     if a.flags.c_contiguous:
@@ -197,7 +197,7 @@ def fft(x, n=None, axis=-1, overwrite_x=False, plan=None):
 
     .. seealso:: :func:`scipy.fftpack.fft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(x, (n,), (axis,), None, cufft.CUFFT_FORWARD,
                 overwrite_x=overwrite_x, plan=plan)
 
@@ -231,7 +231,7 @@ def ifft(x, n=None, axis=-1, overwrite_x=False, plan=None):
 
     .. seealso:: :func:`scipy.fftpack.ifft`
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
     return _fft(x, (n,), (axis,), None, cufft.CUFFT_INVERSE,
                 overwrite_x=overwrite_x, plan=plan)
 
@@ -265,7 +265,7 @@ def fft2(x, shape=None, axes=(-2, -1), overwrite_x=False, plan=None):
        The argument `plan` is currently experimental and the interface may be
        changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(x, shape, axes, plan)
     return func(x, shape, axes, None, cufft.CUFFT_FORWARD,
@@ -301,7 +301,7 @@ def ifft2(x, shape=None, axes=(-2, -1), overwrite_x=False, plan=None):
        The argument `plan` is currently experimental and the interface may be
        changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(x, shape, axes, plan)
     return func(x, shape, axes, None, cufft.CUFFT_INVERSE,
@@ -337,7 +337,7 @@ def fftn(x, shape=None, axes=None, overwrite_x=False, plan=None):
        The argument `plan` is currently experimental and the interface may be
        changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(x, shape, axes, plan)
     return func(x, shape, axes, None, cufft.CUFFT_FORWARD,
@@ -373,7 +373,7 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False, plan=None):
        The argument `plan` is currently experimental and the interface may be
        changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     func = _default_fft_func(x, shape, axes, plan)
     return func(x, shape, axes, None, cufft.CUFFT_INVERSE,
@@ -416,7 +416,7 @@ def rfft(x, n=None, axis=-1, overwrite_x=False, plan=None):
        The argument `plan` is currently experimental and the interface may be
        changed in the future version.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     if n is None:
         n = x.shape[axis]
@@ -467,7 +467,7 @@ def irfft(x, n=None, axis=-1, overwrite_x=False):
        capability, please consider using :func:`cupy.fft.irfft` or :func:`
        cupyx.scipy.fft.irfft`.
     """
-    from cupy.cuda import cufft
+    cufft = cupy.cuda.cufft  # lazy import
 
     if n is None:
         n = x.shape[axis]

--- a/tests/cupy_tests/core_tests/test_flags.py
+++ b/tests/cupy_tests/core_tests/test_flags.py
@@ -13,25 +13,25 @@ from cupy import testing
 class TestFlags(unittest.TestCase):
 
     def setUp(self):
-        self.flags = flags.Flags(1, 2, 3)
+        self.flags = flags.Flags(1, 2, 0)
 
     def test_c_contiguous(self):
-        assert 1 == self.flags['C_CONTIGUOUS']
+        assert self.flags['C_CONTIGUOUS'] is True
 
     def test_f_contiguous(self):
-        assert 2 == self.flags['F_CONTIGUOUS']
+        assert self.flags['F_CONTIGUOUS'] is True
 
     def test_owndata(self):
-        assert 3 == self.flags['OWNDATA']
+        assert self.flags['OWNDATA'] is False
 
     def test_key_error(self):
         with self.assertRaises(KeyError):
             self.flags['unknown key']
 
     def test_repr(self):
-        assert '''  C_CONTIGUOUS : 1
-  F_CONTIGUOUS : 2
-  OWNDATA : 3''' == repr(self.flags)
+        assert '''  C_CONTIGUOUS : True
+  F_CONTIGUOUS : True
+  OWNDATA : False''' == repr(self.flags)
 
 
 @testing.parameterize(


### PR DESCRIPTION
The flags is worth it I think.  Avoiding the import is surprisingly worthwhile but of course also a micro-optimization, but for light-weight FFT calls a noticable one.
(The import is 160ns vs 30ns for the attribute lookups for me.)

---

Not like it is much of a difference, but it struck me in the profiling (array creation is a far bigger chunk for example).  And since I had done most of the change, let's just do it.

I think flags cythonizing just makes sense even if pretty minor too.