### PR TITLE
DOC: Fix `scipy.linalg.*` comparison table

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -251,7 +251,7 @@ def generate():
     buf += _section(
         'Advanced Linear Algebra',
         'scipy.linalg', 'cupyx.scipy.linalg', 'SciPy',
-        exclude_mod='numpy.linalg', exclude=['test'])
+        exclude=['test'])
     buf += _section(
         'Multidimensional Image Processing',
         'scipy.ndimage', 'cupyx.scipy.ndimage', 'SciPy', exclude=['test'])
@@ -304,3 +304,7 @@ def generate():
     ]
 
     return '\n'.join(buf)
+
+
+if __name__ == '__main__':
+    print(generate())


### PR DESCRIPTION
When generating a comparison table, we've been assuming `numpy.linalg.*` functions are directly exposed under `scipy.linalg.*`, but it seems no longer the case (https://github.com/scipy/scipy/pull/24085). Thus all `scipy.linalg.*` functions must be enumerated.

This PR also made the generator to self-executable to make testing easier.