### PR TITLE
fix(hip): cap linear_launch grid dim to prevent AQL work-item overflow

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -157,6 +157,12 @@ cdef class Function:
         cdef size_t gridx = min(
             0x7fffffffUL, (size + block_max_size - 1) // block_max_size)
         cdef size_t blockx = min(block_max_size, size)
+        IF CUPY_HIP_VERSION > 0:
+            # The HSA AQL dispatch packet stores the grid size as total
+            # work-items (gridDimX * blockDimX) in a uint32_t field, so the
+            # product must not overflow.
+            if blockx > 0:
+                gridx = min(gridx, 0xffffffffUL // blockx)
         s = _get_stream(stream)
         _launch(
             self.ptr,


### PR DESCRIPTION
The linear_launch method hardcoded the maximum grid dimension to 0x7fffffff (INT_MAX). On HIP/ROCm this is insufficient because AMD GPUs use HSA AQL dispatch packets, which store the grid size as total work-items (gridDimX * blockDimX) in a uint32_t field. When launching kernels on large arrays the product can overflow this field, causing hipModuleLaunchKernel to fail with hipErrorInvalidValue.

For example, cp.ones(2**33, dtype=cp.complex128) requires 67,108,864 blocks of 128 threads, giving 8,589,934,592 total work-items — which exceeds the uint32_t maximum of 4,294,967,295.

On HIP builds, cap the grid dimension to UINT32_MAX // blockDimX so the product stays within the AQL packet field. This is safe because all elementwise and reduction kernels use CUPY_FOR grid-stride loops, so a smaller grid still processes all elements correctly. CUDA builds are unaffected (compile-time IF).