### PR TITLE
Fix hip mask errors

### DIFF
--- a/cupy/_core/__init__.py
+++ b/cupy/_core/__init__.py
@@ -21,6 +21,9 @@ from cupy._core._kernel import create_ufunc  # NOQA
 from cupy._core._kernel import ElementwiseKernel  # NOQA
 from cupy._core._kernel import ufunc  # NOQA
 from cupy._core._kernel import _get_warpsize  # NOQA
+from cupy._core._kernel import _full_mask  # NOQA
+from cupy._core._kernel import _full_mask_hex  # NOQA
+from cupy._core._kernel import _is_hip_7_plus  # NOQA
 from cupy._core._reduction import create_reduction_func  # NOQA
 from cupy._core._reduction import ReductionKernel  # NOQA
 from cupy._core._routines_binary import bitwise_and  # NOQA

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -150,6 +150,8 @@ cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
                    default_casting=*, loop_prep=*, out_ops=*,
                    cutensor_op=*, scatter_op=*)
 
+cpdef str _full_mask_hex()
+
 cdef tuple _get_arginfos(list args)
 
 cdef str _get_kernel_params(tuple params, tuple arginfos, type_headers=*)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -64,7 +64,7 @@ else:
     _full_mask = 0xffffffff
 
 
-def _full_mask_hex():
+cpdef str _full_mask_hex():
     if runtime._is_hip_environment:
         return hex(_full_mask) + 'ULL'
     return hex(_full_mask)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -55,19 +55,24 @@ def _get_warpsize():
 _is_hip_7_plus = (runtime._is_hip_environment
                   and _driver.get_build_version() >= 7_00_00000)
 
-# Full-lane mask: value is warp-size-dependent on HIP, always 32-bit on CUDA.
-# On HIP the mask *type* must be 64-bit (ROCm 7+ enforces via static_assert),
-# so _full_mask_hex() appends 'ULL' to the C literal.
-if runtime._is_hip_environment:
-    _full_mask = (1 << _get_warpsize()) - 1
-else:
-    _full_mask = 0xffffffff
 
-
-cpdef str _full_mask_hex():
+# Full-lane mask: warp-size-dependent on HIP, always 32-bit on CUDA.
+# Computed lazily (per device) so that importing CuPy does not require a
+# functional ROCm/CUDA runtime.
+@_util.memoize(for_each_device=True)
+def _full_mask():
     if runtime._is_hip_environment:
-        return hex(_full_mask) + 'ULL'
-    return hex(_full_mask)
+        return (1 << _get_warpsize()) - 1
+    return 0xffffffff
+
+
+# On HIP the mask *type* must be 64-bit (ROCm 7+ enforces via static_assert),
+# so the C literal is suffixed with 'ULL'.
+cpdef str _full_mask_hex():
+    cdef str s = hex(_full_mask())
+    if runtime._is_hip_environment:
+        return s + 'ULL'
+    return s
 
 
 cdef str _get_simple_elementwise_kernel_code(

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -28,6 +28,7 @@ from cupy._core.core cimport compile_with_cache
 from cupy._core.core cimport _ndarray_base
 from cupy._core cimport internal
 from cupy_backends.cuda.api cimport runtime
+from cupy_backends.cuda.api import driver as _driver
 
 try:
     from cupy_backends.cuda.libs import cutensor as cuda_cutensor
@@ -48,6 +49,25 @@ cdef inline bint _contains_zero(const shape_t& v) except? -1:
 def _get_warpsize():
     device_id = runtime.getDevice()
     return runtime.getDeviceProperties(device_id)['warpSize']
+
+
+# ROCm 7+ requires a 64-bit mask type for __shfl_*_sync / __any_sync.
+_is_hip_7_plus = (runtime._is_hip_environment
+                  and _driver.get_build_version() >= 7_00_00000)
+
+# Full-lane mask: value is warp-size-dependent on HIP, always 32-bit on CUDA.
+# On HIP the mask *type* must be 64-bit (ROCm 7+ enforces via static_assert),
+# so _full_mask_hex() appends 'ULL' to the C literal.
+if runtime._is_hip_environment:
+    _full_mask = (1 << _get_warpsize()) - 1
+else:
+    _full_mask = 0xffffffff
+
+
+def _full_mask_hex():
+    if runtime._is_hip_environment:
+        return hex(_full_mask) + 'ULL'
+    return hex(_full_mask)
 
 
 cdef str _get_simple_elementwise_kernel_code(

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -6,7 +6,8 @@ import numpy
 import cupy
 import cupy._core.core as core
 from cupy.exceptions import AxisError
-from cupy._core._kernel import ElementwiseKernel, _get_warpsize, _full_mask_hex
+from cupy._core._kernel import ElementwiseKernel, _get_warpsize
+from cupy._core._kernel cimport _full_mask_hex
 from cupy._core._ufuncs import elementwise_copy
 
 from libcpp cimport vector

--- a/cupy/_core/_routines_indexing.pyx
+++ b/cupy/_core/_routines_indexing.pyx
@@ -6,7 +6,7 @@ import numpy
 import cupy
 import cupy._core.core as core
 from cupy.exceptions import AxisError
-from cupy._core._kernel import ElementwiseKernel, _get_warpsize
+from cupy._core._kernel import ElementwiseKernel, _get_warpsize, _full_mask_hex
 from cupy._core._ufuncs import elementwise_copy
 
 from libcpp cimport vector
@@ -490,7 +490,7 @@ def _nonzero_kernel_incomplete_scan(block_size, warp_size=32):
         S x = 0;
         if (i < a.size()) x = a[i];
         for (int j = 1; j < ${warp_size}; j *= 2) {
-            S tmp = __shfl_up_sync(0xffffffff, x, j, ${warp_size});
+            S tmp = __shfl_up_sync(${full_mask}, x, j, ${warp_size});
             if (lane_id - j >= 0) x += tmp;
         }
         if (lane_id == ${warp_size} - 1) smem[warp_id] = x;
@@ -499,7 +499,7 @@ def _nonzero_kernel_incomplete_scan(block_size, warp_size=32):
             S y = 0;
             if (lane_id < n_warp) y = smem[lane_id];
             for (int j = 1; j < n_warp; j *= 2) {
-                S tmp = __shfl_up_sync(0xffffffff, y, j, ${warp_size});
+                S tmp = __shfl_up_sync(${full_mask}, y, j, ${warp_size});
                 if (lane_id - j >= 0) y += tmp;
             }
             int block_id = i / ${block_size};
@@ -510,7 +510,7 @@ def _nonzero_kernel_incomplete_scan(block_size, warp_size=32):
         }
         __syncthreads();
         x += smem[warp_id];
-        S x0 = __shfl_up_sync(0xffffffff, x, 1, ${warp_size});
+        S x0 = __shfl_up_sync(${full_mask}, x, 1, ${warp_size});
         if (lane_id == 0) {
             x0 = smem[warp_id];
         }
@@ -523,7 +523,8 @@ def _nonzero_kernel_incomplete_scan(block_size, warp_size=32):
                 j = j_next;
             }
         }
-    """).substitute(block_size=block_size, warp_size=warp_size)
+    """).substitute(block_size=block_size, warp_size=warp_size,
+                    full_mask=_full_mask_hex())
     return cupy.ElementwiseKernel(in_params, out_params, loop_body,
                                   'cupy_nonzero_kernel_incomplete_scan',
                                   loop_prep=loop_prep)

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -5,7 +5,8 @@ import numpy
 
 import cupy
 from cupy._core._reduction import create_reduction_func
-from cupy._core._kernel import create_ufunc, _get_warpsize, _full_mask_hex
+from cupy._core._kernel import create_ufunc, _get_warpsize
+from cupy._core._kernel cimport _full_mask_hex
 from cupy._core._scalar import get_typename
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -5,7 +5,7 @@ import numpy
 
 import cupy
 from cupy._core._reduction import create_reduction_func
-from cupy._core._kernel import create_ufunc, _get_warpsize
+from cupy._core._kernel import create_ufunc, _get_warpsize, _full_mask_hex
 from cupy._core._scalar import get_typename
 from cupy._core._ufuncs import elementwise_copy
 import cupy._core.core as core
@@ -193,7 +193,7 @@ def _cupy_bsum_shfl(op, chunk_size, warp_size=32):
         if (2*i < a.size()) x = a[2*i];
         if (2*i + 1 < a.size()) x ${op}= a[2*i + 1];
         for (int j = 1; j < ${warp_size}; j *= 2) {
-            x ${op}= __shfl_xor_sync(0xffffffff, x, j, ${warp_size});
+            x ${op}= __shfl_xor_sync(${full_mask}, x, j, ${warp_size});
         }
         if (lane_id == 0) smem[warp_id] = x;
         __syncthreads();
@@ -201,13 +201,14 @@ def _cupy_bsum_shfl(op, chunk_size, warp_size=32):
             x = ${identity};
             if (lane_id < n_warp) x = smem[lane_id];
             for (int j = 1; j < n_warp; j *= 2) {
-                x ${op}= __shfl_xor_sync(0xffffffff, x, j, ${warp_size});
+                x ${op}= __shfl_xor_sync(${full_mask}, x, j, ${warp_size});
             }
             int block_id = i / ${block_size};
             if (lane_id == 0) b[block_id] = x;
         }
     """).substitute(block_size=block_size, warp_size=warp_size,
-                    op=_op_char[op], identity=_identity[op])
+                    op=_op_char[op], identity=_identity[op],
+                    full_mask=_full_mask_hex())
     return cupy.ElementwiseKernel(in_params, out_params, loop_body,
                                   'cupy_bsum_shfl', loop_prep=loop_prep)
 

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -6,7 +6,7 @@ import cupy
 from cupy.exceptions import AxisError
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core._ufuncs import elementwise_copy
-from cupy._core._kernel import _full_mask_hex
+from cupy._core._kernel cimport _full_mask_hex
 import cupy._core.core as core
 from cupy import _util
 from cupy.cuda import thrust

--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -6,6 +6,7 @@ import cupy
 from cupy.exceptions import AxisError
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core._ufuncs import elementwise_copy
+from cupy._core._kernel import _full_mask_hex
 import cupy._core.core as core
 from cupy import _util
 from cupy.cuda import thrust
@@ -387,7 +388,7 @@ def _partition_kernel(dtype):
             // If at least one thread in the warp has found t values that
             // can be selected, we update the first k elements.
     #if __CUDACC_VER_MAJOR__ >= 9
-            if (__any_sync(0xffffffff, x >= t)) {
+            if (__any_sync(${full_mask}, x >= t)) {
     #else
             if (__any(x >= t)) {
     #endif
@@ -419,7 +420,8 @@ def _partition_kernel(dtype):
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype,
-                    type_headers=type_headers)
+                    type_headers=type_headers,
+                    full_mask=_full_mask_hex())
     module = compile_with_cache(source)
     return module.get_function(name), module.get_function(merge_kernel)
 
@@ -513,7 +515,7 @@ def _argpartition_kernel(dtype):
             // If at least one thread in the warp has found t values that
             // can be selected, we update the first k elements.
     #if __CUDACC_VER_MAJOR__ >= 9
-            if (__any_sync(0xffffffff, x >= t)) {
+            if (__any_sync(${full_mask}, x >= t)) {
     #else
             if (__any(x >= t)) {
     #endif
@@ -546,6 +548,7 @@ def _argpartition_kernel(dtype):
     }
     }
     ''').substitute(name=name, merge_kernel=merge_kernel, dtype=dtype,
-                    type_headers=type_headers)
+                    type_headers=type_headers,
+                    full_mask=_full_mask_hex())
     module = compile_with_cache(source)
     return module.get_function(name), module.get_function(merge_kernel)

--- a/cupy/_core/include/cupy/hip_workaround.cuh
+++ b/cupy/_core/include/cupy/hip_workaround.cuh
@@ -3,17 +3,41 @@
 
 #ifdef __HIP_DEVICE_COMPILE__
 
-// As per the comment below, use workaround conditionally:
-// https://github.com/ROCm/clr/blob/68147fe9b20a72aa43e7898bdd9ba39bca4afd14/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h#L25
-#if (HIP_VERSION < 60200000) || defined(HIP_DISABLE_WARP_SYNC_BUILTINS)
+// Determine whether native __shfl_*_sync functions are available.
+// (defined in /opt/rocm/include/hip/amd_detail/amd_warp_sync_functions.h)
+//
+// The native builtins require a 64-bit mask and were introduced in ROCm 6.2
+// behind an opt-in macro:
+//   ROCm < 6.2   — not available at all
+//   ROCm 6.2–6.4 — available only if HIP_ENABLE_WARP_SYNC_BUILTINS is defined
+//   ROCm 7.0+    — available by default, disabled if HIP_DISABLE_WARP_SYNC_BUILTINS is defined
+//
+// When the native builtins are not available, we define compatibility macros
+// that rewrite __shfl_*_sync(mask, ...) to __shfl_*(...), stripping the mask.
+// This is safe because HIP wavefronts execute in lock-step.
+#if !defined(HIP_VERSION) || HIP_VERSION < 60200000
+  // ROCm < 6.2: no native builtins
+  #define CUPY_HIP_SHFL_WORKAROUND
+#elif HIP_VERSION < 70000000
+  // ROCm 6.2–6.4: native builtins only if user opted in
+  #if !defined(HIP_ENABLE_WARP_SYNC_BUILTINS)
+    #define CUPY_HIP_SHFL_WORKAROUND
+  #endif
+#else
+  // ROCm 7.0+: native builtins unless user opted out
+  #if defined(HIP_DISABLE_WARP_SYNC_BUILTINS)
+    #define CUPY_HIP_SHFL_WORKAROUND
+  #endif
+#endif
 
-// ignore mask
-#define __shfl_sync(mask, ...) __shfl(__VA_ARGS__)
-#define __shfl_up_sync(mask, ...) __shfl_up(__VA_ARGS__)
-#define __shfl_down_sync(mask, ...) __shfl_down(__VA_ARGS__)
-#define __shfl_xor_sync(mask, ...) __shfl_xor(__VA_ARGS__)
-
-#endif  // (HIP_VERSION < 60200000) || defined(HIP_DISABLE_WARP_SYNC_BUILTINS)
+#ifdef CUPY_HIP_SHFL_WORKAROUND
+  // ignore mask
+  #define __shfl_sync(mask, ...) __shfl(__VA_ARGS__)
+  #define __shfl_up_sync(mask, ...) __shfl_up(__VA_ARGS__)
+  #define __shfl_down_sync(mask, ...) __shfl_down(__VA_ARGS__)
+  #define __shfl_xor_sync(mask, ...) __shfl_xor(__VA_ARGS__)
+  #undef CUPY_HIP_SHFL_WORKAROUND
+#endif
 
 // In ROCm, threads in a warp march in lock-step, so we don't need to
 // synchronize the threads. But it doesn't guarantee the memory order,

--- a/cupy_backends/cuda/api/_runtime_typedef.pxi
+++ b/cupy_backends/cuda/api/_runtime_typedef.pxi
@@ -94,8 +94,8 @@ cdef extern from *:
 
     ctypedef struct TextureDesc 'cudaTextureDesc':
         TextureAddressMode addressMode[3]
-        int filterMode
-        int readMode
+        TextureFilterMode filterMode
+        TextureReadMode readMode
         int sRGB
         float borderColor[4]
         int normalizedCoords

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -383,7 +383,7 @@ class WarpShuffleOp(BuiltinFunc):
         _hip_7_plus = cupy._core._is_hip_7_plus
         if runtime.is_hip and not _hip_7_plus:
             warnings.warn(f'mask {mask} is ignored on HIP', RuntimeWarning)
-        if not (0x0 <= mask <= cupy._core._full_mask):
+        if not (0x0 <= mask <= cupy._core._full_mask()):
             raise ValueError('mask is out of range')
 
         # val_id refers to "delta" for shfl_{up, down}, "srcLane" for shfl, and

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -379,9 +379,11 @@ class WarpShuffleOp(BuiltinFunc):
             mask = mask.obj
         except Exception:
             raise TypeError('mask must be an integer')
-        if runtime.is_hip:
+
+        _hip_7_plus = cupy._core._is_hip_7_plus
+        if runtime.is_hip and not _hip_7_plus:
             warnings.warn(f'mask {mask} is ignored on HIP', RuntimeWarning)
-        elif not (0x0 <= mask <= 0xffffffff):
+        if not (0x0 <= mask <= cupy._core._full_mask):
             raise ValueError('mask is out of range')
 
         # val_id refers to "delta" for shfl_{up, down}, "srcLane" for shfl, and
@@ -398,12 +400,14 @@ class WarpShuffleOp(BuiltinFunc):
                 if width.obj not in (2, 4, 8, 16, 32):
                     raise ValueError('width needs to be power of 2')
         else:
-            width = Constant(64) if runtime.is_hip else Constant(32)
+            width = Constant(cupy._core._get_warpsize())
         width = _compile._astype_scalar(
             width, _cuda_types.int32, 'same_kind', env)
         width = Data.init(width, env)
 
-        code = f'{name}({hex(mask)}, {var.code}, {val_id.code}'
+        mask_str = (f'(unsigned long long){hex(mask)}'
+                    if _hip_7_plus else hex(mask))
+        code = f'{name}({mask_str}, {var.code}, {val_id.code}'
         code += f', {width.code})'
         return Data(code, ctype)
 

--- a/examples/finance/monte_carlo.py
+++ b/examples/finance/monte_carlo.py
@@ -45,9 +45,7 @@ monte_carlo_kernel = cupy.ElementwiseKernel(
     call = discount_factor * call_sum / n_samples;
     ''',
     preamble='''
-    #ifndef __HIPCC__
     typedef unsigned long long uint64_t;
-    #endif
 
     __device__
     inline T get_call_value(T s, T x, T p, T mu_by_t, T v_by_sqrt_t) {

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -654,10 +654,11 @@ class TestRaw:
         N = 5
         # __shfl_down() on HIP does not seem to have the same behavior...
         block = cupy._core._get_warpsize()
+        full_mask = (1 << block) - 1
 
         @jit.rawkernel()
         def f(a):
-            value = jit.shfl_down_sync(0xffffffff, a[jit.threadIdx.x], N)
+            value = jit.shfl_down_sync(full_mask, a[jit.threadIdx.x], N)
             a[jit.threadIdx.x] = value
 
         a = cupy.arange(block, dtype=dtype)

--- a/tests/cupyx_tests/jit_tests/test_raw.py
+++ b/tests/cupyx_tests/jit_tests/test_raw.py
@@ -654,7 +654,7 @@ class TestRaw:
         N = 5
         # __shfl_down() on HIP does not seem to have the same behavior...
         block = cupy._core._get_warpsize()
-        full_mask = (1 << block) - 1
+        full_mask = cupy._core._full_mask()
 
         @jit.rawkernel()
         def f(a):


### PR DESCRIPTION
There are many crashes related to using an incorrect parameter for some of the shfl intrinsics when setting a full mask. This PR adds support for hip by defining a full mask when the warp/wavefront size is 64.