### PR TITLE
BUG: Fix regression for 32bit index flag in `.real` and broadcast

### DIFF
--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -499,6 +499,8 @@ cpdef _ndarray_base broadcast_to(_ndarray_base array, shape):
     view = array.view()
     # TODO(niboshi): Confirm update_x_contiguity flags
     view._set_shape_and_strides(_shape, strides, True, True)
+    if view.size * view.itemsize > 2**31:
+        view._index_32_bits = False
     return view
 
 

--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -15,7 +15,8 @@ cdef class _ndarray_base:
         public strides_t _strides
         readonly bint _c_contiguous
         readonly bint _f_contiguous
-        # To do fast indexing in the CArray class
+        # Whether the array memory can be addressed with 32bit signed
+        # integers. To do fast indexing in the CArray class.
         readonly bint _index_32_bits
         readonly object dtype
         readonly memory.MemoryPointer data

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -266,11 +266,13 @@ cdef class _ndarray_base:
                         f"contiguous size of {self.size * itemsize} but got "
                         f"{alloc_size}.")
             else:
-                alloc_size = self.size * itemsize
+                alloc_size = right - left  # actual memory extend
         else:
             self._set_contiguous_strides(itemsize, order_char == b'C')
-            alloc_size = self.size * itemsize
+            alloc_size = self.size * itemsize  # contiguous
 
+        # Arrays can e.g. broadcast, so check that all pointer offsets fit and
+        # the size fit int32. (seberg: `* itemsize` may be unnecessary)
         max_diff = max(alloc_size, self.size * itemsize)
         self._index_32_bits = max_diff <= <Py_ssize_t>(1 << 31)
 

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -369,7 +369,10 @@ cdef _broadcast_core(list arrays, shape_t& shape):
                 strides[j + nd - a_ndim] = a._strides[j]
 
         # TODO(niboshi): Confirm update_x_contiguity flags
-        arrays[i] = a._view(type(a), shape, strides, True, True, a)
+        a = a._view(type(a), shape, strides, True, True, a)
+        if a.size * a.itemsize > 2**31:
+            a._index_32_bits = False
+        arrays[i] = a
 
 
 @cython.boundscheck(False)

--- a/tests/cupy_tests/creation_tests/test_basic.py
+++ b/tests/cupy_tests/creation_tests/test_basic.py
@@ -318,32 +318,34 @@ class TestBasic:
 
     @pytest.mark.slow
     @pytest.mark.thread_unsafe(reason="large allocations")
-    @pytest.mark.parametrize('arr,expected', [
-        (cupy.empty(2**31 - 1, dtype=cupy.int8), True),
-        (cupy.empty(2**31, dtype=cupy.int8), True),
-        (cupy.empty(2**31 + 1, dtype=cupy.int8)[::2], False),
-        (cupy.empty(2**31 // 8, dtype=cupy.complex64), True),
-        (cupy.empty(2**31 // 8 + 1, dtype=cupy.complex64), False),
+    @pytest.mark.parametrize('arr_factory,expected', [
+        (lambda: cupy.empty(2**31 - 1, dtype=cupy.int8), True),
+        (lambda: cupy.empty(2**31, dtype=cupy.int8), True),
+        (lambda: cupy.empty(2**31 + 1, dtype=cupy.int8)[::2], False),
+        (lambda: cupy.empty(2**31 // 8, dtype=cupy.complex64), True),
+        (lambda: cupy.empty(2**31 // 8 + 1, dtype=cupy.complex64), False),
         # Regression test for gh-9750:
-        (cupy.empty(2**31 // 8, dtype=cupy.complex64).real, True),
-        (cupy.empty(2**31 // 8 + 1, dtype=cupy.complex64).real, False),
+        (lambda: cupy.empty(2**31 // 8, dtype=cupy.complex64).real, True),
+        (lambda: cupy.empty(2**31 // 8 + 1, dtype=cupy.complex64).real, False),
         # broadcasting also causes this, test both broadcast_to and normal:
-        (cupy.broadcast_to(
+        (lambda: cupy.broadcast_to(
             cupy.empty(2**30 + 1, dtype=cupy.int8), (2, 2**30 + 1)), False),
-        (cupy.broadcast_arrays(
+        (lambda: cupy.broadcast_arrays(
             cupy.empty(2**30 + 1, dtype=cupy.int8), cupy.empty((2, 1))
         )[0], False),
         # Also test raw "broadcasting path":
-        (cupy.ndarray(
+        (lambda: cupy.ndarray(
             shape=(2**30 + 1, 2), strides=(1, 0), dtype=cupy.int8), False),
         # These ones are debatable, the start pointers are OK, but the range
         # extends beyond 32bits on a byte level:
-        (cupy.empty((2**31 + 1) // 3, dtype="i1,i1,i1"), False),
+        (lambda: cupy.empty((2**31 + 1) // 3, dtype="i1,i1,i1"), False),
         # Same cupy.byte_bounds as above, but strided (size * itemsize is OK):
-        (cupy.empty((2**31 + 1) // 3, dtype="i1,i1,i1")[::2].view(), False),
+        (lambda: cupy.empty((2**31 + 1) // 3,
+         dtype="i1,i1,i1")[::2].view(), False),
     ])
-    def test_index_32_bits(self, arr, expected):
-        assert arr._index_32_bits == expected
+    def test_index_32_bits(self, arr_factory, expected):
+        assert arr_factory()._index_32_bits == expected
+        cupy.get_default_memory_pool().free_all_blocks()
 
 
 @testing.parameterize(


### PR DESCRIPTION
I suspect I misunderstood the flag, as the offset is used to calculate the pointer offset as well and not just for index manipulation.

Adding a few tests, I noticed that broadcasting also got things wrong, one could also proof it via something like:
```
arr = cp.broadcast_arrays(cp.random.randint(255, size=2**30+100, dtype=cp.uint8), cp.empty((2, 1)))[0]
cp.put(arr, cp.arange(arr.size//2, arr.size), 1)
print(arr)
```

I audited places for `._view()` and `_set_shape_and_strides()`, but I am a bit wondering whether it this couldn't use a bigger refactor

Maybe I should refactor this into a flag to `_view` and `_set_shape_and_strides`?

Closes gh-9750