### PR TITLE
BUG: Introduce a "promotion" step and fix integer comparisons

### DIFF
--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -131,9 +131,10 @@ cdef class _Ops:
         readonly tuple ops
         readonly int nin
         readonly int nout
+        readonly object promote_types
 
     @staticmethod
-    cdef _Ops from_tuples(object ops, routine)
+    cdef _Ops from_tuples(object ops, routine, object promote_types=*)
 
     # Queries a single op from input arguments.
     cpdef _Op guess_routine(
@@ -148,7 +149,7 @@ cdef class _Ops:
 
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
                    default_casting=*, loop_prep=*, out_ops=*,
-                   cutensor_op=*, scatter_op=*)
+                   cutensor_op=*, scatter_op=*, promote_types=*)
 
 cdef tuple _get_arginfos(list args)
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1573,7 +1573,7 @@ cdef class _Op:
 
 cdef class _Ops:
 
-    def __init__(self, tuple ops):
+    def __init__(self, tuple ops, promote_types=None):
         assert len(ops) > 0
         nin = ops[0].nin
         nout = ops[0].nout
@@ -1583,9 +1583,10 @@ cdef class _Ops:
         self.ops = ops
         self.nin = nin
         self.nout = nout
+        self.promote_types = promote_types
 
     @staticmethod
-    cdef _Ops from_tuples(object ops, routine):
+    cdef _Ops from_tuples(object ops, routine, object promote_types=None):
         ops_ = []
         for t in ops:
             if isinstance(t, tuple):
@@ -1607,7 +1608,7 @@ cdef class _Ops:
                         f"invalid op {t}, expected string or list")
                 typ, rt = t, routine
             ops_.append(_Op.from_type_and_routine(typ, rt))
-        return _Ops(tuple(ops_))
+        return _Ops(tuple(ops_), promote_types=promote_types)
 
     cpdef _Op guess_routine(
             self, str name, dict cache, list in_args, dtype, _Ops out_ops):
@@ -1671,15 +1672,17 @@ cdef class _Ops:
         cdef Py_ssize_t n = len(in_types)
         cdef Py_ssize_t i
 
+        if self.promote_types is not None:
+            # NOTE(seberg): This works fine, but should maybe be considered
+            # in flux. NumPy needs more (but mostly for loop registration).
+            in_types, weaks = self.promote_types(in_types, weaks)
+
         for op in self.ops:
             op_types = op.in_types
             for i in range(n):
                 it = in_types[i]
                 ot = op_types[i]
                 weak_t = weaks[i] if weaks is not None else False
-
-                # XXX: Remove assert (reachable only for pre NEP 50 logic)
-                assert(not isinstance(it, tuple))
 
                 if not can_cast(it, ot):
                     if not weak_t:
@@ -1711,9 +1714,11 @@ cdef class _Ops:
 
 cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
                    default_casting=None, loop_prep='', out_ops=None,
-                   cutensor_op=None, scatter_op=None):
-    ops_ = _Ops.from_tuples(ops, routine)
-    _out_ops = None if out_ops is None else _Ops.from_tuples(out_ops, routine)
+                   cutensor_op=None, scatter_op=None,
+                   promote_types=None):
+    ops_ = _Ops.from_tuples(ops, routine, promote_types)
+    _out_ops = None if out_ops is None else _Ops.from_tuples(
+        out_ops, routine, promote_types)
     return ufunc(
         name, ops_.nin, ops_.nout, ops_, preamble,
         loop_prep, doc, default_casting=default_casting, out_ops=_out_ops,

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1711,8 +1711,7 @@ cdef class _Ops:
     ):
         cdef _Op op
         cdef tuple op_types
-        cdef Py_ssize_t n = len(in_types)
-        cdef Py_ssize_t i
+        cdef int i
 
         if self.promote_types is not None:
             # NOTE(seberg): This works fine, but should maybe be considered
@@ -1721,7 +1720,7 @@ cdef class _Ops:
 
         for op in self.ops:
             op_types = op.in_types
-            for i in range(n):
+            for i in range(self.nin):
                 it = in_types[i]
                 ot = op_types[i]
                 weak_t = weaks[i] if weaks is not None else False

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -53,21 +53,31 @@ cdef _any = create_reduction_func(
     'false', '')
 
 
-cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
+def promote_weak_int(in_types, weaks):
+    # Python integers can be originally discovered as uint or int.
+    # For comparison we define loops for both so take whatever it is.
+    if weaks is None:
+        return in_types, weaks
 
-    if no_complex_dtype:
-        ops = ('??->?', 'qq->?', 'qQ->?', 'Qq->?', 'QQ->?',
-               'ee->?', *bf16_loop(2, '?'), 'ff->?', 'dd->?')
-    else:
-        ops = ('??->?', 'qq->?', 'qQ->?', 'Qq->?', 'QQ->?',
-               'ee->?', *bf16_loop(2, '?'), 'ff->?', 'dd->?',
-               'FF->?', 'DD->?')
+    return in_types, tuple([w if w is not int else False for w in weaks])
+
+
+cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
+    ops = (
+        '??->?',
+        'qq->?', 'QQ->?',
+        ('qQ->?', f'out0 = in0 < 0 ? in0 {op} 0 : in0 {op} in1'),
+        ('Qq->?', f'out0 = in1 < 0 ? 0 {op} in1 : in0 {op} in1'),
+        'ee->?', *bf16_loop(2, '?'), 'ff->?', 'dd->?')
+
+    if not no_complex_dtype:
+        ops += ('FF->?', 'DD->?')
 
     return create_ufunc(
         'cupy_' + name,
         ops,
         'out0 = in0 %s in1' % op,
-        doc=doc)
+        doc=doc, promote_types=promote_weak_int)
 
 
 cdef _greater = create_comparison(

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -57,14 +57,17 @@ cdef _any = create_reduction_func(
 
 
 def promote_weak_int(in_types, weaks):
-    # Python integers can be originally discovered as uint or int.
-    # For comparison we define loops for both so take whatever it is.
     if weaks is None:
         return in_types, weaks
 
-    if weaks[0] is int and weaks[1] is False and in_types[0].kind in "biu":
+    # Python integers can be originally discovered as uint or int.
+    # E.g. for int32(-2**31) == 2**32 we need to promote, rather than try
+    # to use the NEP 50 style and use int32 (failing the conversion).
+    # For float this is currently not what NumPy does (debatable).
+    # For bool, NumPy uses the default integer while we make it work (ignore).
+    if weaks[0] is int and weaks[1] is False and in_types[1].kind in "iu":
         return in_types, (False, weaks[1])
-    elif weaks[1] is int and weaks[0] is False and in_types[1].kind in "biu":
+    elif weaks[1] is int and weaks[0] is False and in_types[0].kind in "iu":
         return in_types, (weaks[0], False)
 
     return in_types, weaks

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -62,7 +62,12 @@ def promote_weak_int(in_types, weaks):
     if weaks is None:
         return in_types, weaks
 
-    return in_types, tuple([w if w is not int else False for w in weaks])
+    if weaks[0] is int and weaks[1] is False and in_types[0].kind in "biu":
+        return in_types, (False, weaks[1])
+    elif weaks[1] is int and weaks[0] is False and in_types[1].kind in "biu":
+        return in_types, (weaks[0], False)
+
+    return in_types, weaks
 
 
 def struct_compare_resolution(op, in_dtypes, out_dtypes):
@@ -92,7 +97,8 @@ def struct_compare_resolution(op, in_dtypes, out_dtypes):
     return (cmp_dtype, cmp_dtype), out_dtypes
 
 
-cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
+cpdef create_comparison(
+        name, op, doc='', no_complex_dtype=True, allow_structured=False):
     ops = (
         '??->?',
         'qq->?', 'QQ->?',

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -4,6 +4,7 @@ import operator
 import unittest
 
 import numpy
+import pytest
 
 import cupy
 from cupy import testing
@@ -37,13 +38,15 @@ class TestComparison(unittest.TestCase):
         self.check_binary('equal')
 
 
-class TestComparisonOperator(unittest.TestCase):
+operators = [
+    operator.lt, operator.le,
+    operator.eq, operator.ne,
+    operator.gt, operator.ge,
+]
 
-    operators = [
-        operator.lt, operator.le,
-        operator.eq, operator.ne,
-        operator.gt, operator.ge,
-    ]
+
+class TestComparisonOperator:
+    operators = operators
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
@@ -72,6 +75,21 @@ class TestComparisonOperator(unittest.TestCase):
         a = testing.shaped_arange((2, 3), xp, dtype)
         b = 3
         return [op(a, b) for op in self.operators]
+
+    @pytest.mark.parametrize('dtype', [
+        numpy.int8, numpy.int64, numpy.uint8, numpy.uint64])
+    @pytest.mark.parametrize('scalar', [-1, 0, 2**32, 2**63, 2**64-1])
+    @pytest.mark.parametrize('op', operators)
+    @testing.numpy_cupy_array_equal()
+    def test_binary_array_pyscalar_int(self, xp, dtype, scalar, op):
+        # This test also checks large mixed unsigned/signed comparisons.
+        min_, max_ = numpy.iinfo(dtype).min, numpy.iinfo(dtype).max
+
+        a = xp.array(
+            [min_, 0, max_, xp.dtype(dtype).type(0) - 1],
+            dtype=dtype)
+        b = scalar
+        return [op(a, b), op(b, a)]
 
 
 class TestArrayEqual(unittest.TestCase):

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -77,7 +77,7 @@ class TestComparisonOperator:
         return [op(a, b) for op in self.operators]
 
     @pytest.mark.parametrize('dtype', [
-        numpy.int8, numpy.int64, numpy.uint8, numpy.uint64])
+        numpy.bool, numpy.int8, numpy.int64, numpy.uint8, numpy.uint64])
     @pytest.mark.parametrize('scalar', [-1, 0, 2**32, 2**63, 2**64-1])
     @pytest.mark.parametrize('op', operators)
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -81,6 +81,7 @@ class TestComparisonOperator:
     @pytest.mark.parametrize('scalar', [-1, 0, 2**32, 2**63, 2**64-1])
     @pytest.mark.parametrize('op', operators)
     @testing.numpy_cupy_array_equal()
+    @numpy.errstate(over='ignore')
     def test_binary_array_pyscalar_int(self, xp, dtype, scalar, op):
         # This test also checks large mixed unsigned/signed comparisons.
         min_, max_ = numpy.iinfo(dtype).min, numpy.iinfo(dtype).max
@@ -97,6 +98,7 @@ class TestComparisonOperator:
                              [-1, 0, 2**32, 2**31-1, 2**31+1, 2**63, 2**64-1])
     @pytest.mark.parametrize('op', operators)
     @testing.numpy_cupy_array_equal()
+    @numpy.errstate(over='ignore')
     def test_binary_array_pyscalar_int_and_float(self, xp, dtype, scalar, op):
         a = xp.array([-1, 0, 2**31-1, 2**31+1, 2**32, 2**63-1, 2**62, 2**62+1])
         a = a.astype(dtype)  # cast (overflow OK)
@@ -246,6 +248,7 @@ class TestAllclose(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_equal()
+    @numpy.errstate(over='ignore')
     def test_allclose_min_int(self, xp, dtype):
         a = xp.array([0]).astype(dtype)
         b = xp.array([numpy.iinfo('i').min]).astype(dtype)
@@ -291,6 +294,7 @@ class TestIsclose(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_array_equal()
+    @numpy.errstate(over='ignore')
     def test_is_close_min_int(self, xp, dtype):
         # In numpy<1.10 this test fails when dtype is bool
         a = xp.array([0]).astype(dtype)

--- a/tests/cupy_tests/logic_tests/test_comparison.py
+++ b/tests/cupy_tests/logic_tests/test_comparison.py
@@ -77,7 +77,7 @@ class TestComparisonOperator:
         return [op(a, b) for op in self.operators]
 
     @pytest.mark.parametrize('dtype', [
-        numpy.bool, numpy.int8, numpy.int64, numpy.uint8, numpy.uint64])
+        numpy.int8, numpy.int64, numpy.uint8, numpy.uint64])
     @pytest.mark.parametrize('scalar', [-1, 0, 2**32, 2**63, 2**64-1])
     @pytest.mark.parametrize('op', operators)
     @testing.numpy_cupy_array_equal()
@@ -90,6 +90,29 @@ class TestComparisonOperator:
             dtype=dtype)
         b = scalar
         return [op(a, b), op(b, a)]
+
+    @pytest.mark.parametrize('dtype', [
+        numpy.float16, numpy.float32, numpy.float64])
+    @pytest.mark.parametrize('scalar',
+                             [-1, 0, 2**32, 2**31-1, 2**31+1, 2**63, 2**64-1])
+    @pytest.mark.parametrize('op', operators)
+    @testing.numpy_cupy_array_equal()
+    def test_binary_array_pyscalar_int_and_float(self, xp, dtype, scalar, op):
+        a = xp.array([-1, 0, 2**31-1, 2**31+1, 2**32, 2**63-1, 2**62, 2**62+1])
+        a = a.astype(dtype)  # cast (overflow OK)
+        b = scalar
+        return [op(a, b), op(b, a)]
+
+    @pytest.mark.parametrize('scalar,safe_scalar',
+                             [(2**63, 2), (2**63+100, 2), (-2**63, -1)])
+    @pytest.mark.parametrize('op', operators)
+    def test_binary_array_pyscalar_int_and_bool(
+            self, scalar, safe_scalar, op):
+        # As of 2.5, NumPy uses the default integer and fails for very large
+        # Python scalars. But CuPy uses uint64 and succeeds.
+        a = cupy.array([True, False])
+        testing.assert_array_equal(op(a, scalar), op(a, safe_scalar))
+        testing.assert_array_equal(op(scalar, a), op(safe_scalar, a))
 
 
 class TestArrayEqual(unittest.TestCase):


### PR DESCRIPTION
This does two things (both are needed to some degree):
* Introduce a `promote_types` function to customize the normal linear type lookup loop.  I could modify that (to do a double pass) but I prefer this (so long it is not considered public, in which case I would think more about the signature).
* Fix the actual mixed comparison, which unfortunately needs some branching here.  C promotes to unsigned which gives incorrect results.

(This will be incompatible with the caching changes in 9673, but that can be adjusted and is inivetable..)

Closes gh-9753