### PR TITLE
MAINT: add missing names to linalg.__all__

### DIFF
--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -68,5 +68,7 @@ __all__ = [
     "inv",
     "pinv",
     "tensorinv",
+    "lstsq",
+    "cross",
     "LinAlgError",
 ]


### PR DESCRIPTION
fixes https://github.com/cupy/cupy/issues/9749