### PR TITLE
docs: fix possessive typo in private reference docs

### DIFF
--- a/docs/source/reference/_private.rst
+++ b/docs/source/reference/_private.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 .. This page is to generate documentation for private classes exposed to users,
-   i.e., users cannot instantiate it by themselves but may use it's properties
+   i.e., users cannot instantiate it by themselves but may use its properties
    or methods via returned values from CuPy methods.
    These classes must be referred in public APIs returning their instances.
 


### PR DESCRIPTION
This PR fixes a small typo in docs/source/reference/_private.rst: "it's properties" -> "its properties".