### PR TITLE
runtime: compact multiline errors in show_config output

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -24,7 +24,18 @@ def _eval_or_error(func, errors):
     try:
         return func()
     except errors as e:
-        return repr(e)
+        return _format_error(e)
+
+
+def _format_error(error):
+    msg = str(error)
+    if '\n' not in msg and '\r' not in msg:
+        return repr(error)
+
+    first_line = msg.splitlines()[0].strip()
+    if not first_line:
+        return type(error).__name__
+    return f'{type(error).__name__}: {first_line}'
 
 
 def _load_and_get_path(lib_name):

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import cupy
 import cupyx
+import cupyx._runtime as runtime_module
 
 
 def _get_error_func(error, *args, **kwargs):
@@ -36,3 +37,29 @@ class TestRuntime(unittest.TestCase):
                     cupy.cuda.runtime.CUDARuntimeError, 0)):
             runtime = cupyx.get_runtime_info()
             assert 'CUDARuntimeError' in str(runtime)
+
+    def test_error_message_is_compact(self):
+        with mock.patch(
+                'cupy_backends.cuda.api.runtime.driverGetVersion',
+                side_effect=RuntimeError(
+                    'Failed to load library from many locations\n'
+                    'candidate_path_1\ncandidate_path_2')):
+            runtime = cupyx.get_runtime_info()
+            output = str(runtime)
+            assert (
+                'CUDA Driver Version'
+                '  : RuntimeError: Failed to load library from many locations'
+            ) in output
+            assert 'candidate_path_1' not in output
+            assert 'candidate_path_2' not in output
+
+
+class TestFormatError(unittest.TestCase):
+
+    def test_single_line(self):
+        err = RuntimeError('oops')
+        assert runtime_module._format_error(err) == repr(err)
+
+    def test_multi_line(self):
+        err = RuntimeError('oops\ntraceback line')
+        assert runtime_module._format_error(err) == 'RuntimeError: oops'


### PR DESCRIPTION
## Summary
This PR makes `cupy.show_config()` output less noisy when runtime library probing fails with multiline exceptions.

## What changed
- Updated `_eval_or_error()` in `cupyx/_runtime.py` to format multiline exceptions via `_format_error()`.
- Added `_format_error()` helper:
  - keeps existing behavior for single-line exceptions (`repr(error)`)
  - collapses multiline exceptions to one concise line (`<ErrorType>: <first line>`)
- Added tests in `tests/cupyx_tests/test_runtime.py`:
  - checks compact runtime output for multiline driver errors
  - unit tests for `_format_error()` single-line and multiline behavior

## Why
When libraries are missing, some backend exceptions include long multiline diagnostics/path lists. Those currently get dumped directly into `show_config`, making it overly verbose and harder to read.

## Validation
- `python -m py_compile cupyx/_runtime.py tests/cupyx_tests/test_runtime.py`
