### PR TITLE
Use expected precision in `cupyx.scipy.ndimage` interpolation functions (zoom, shift, rotate, affine_transform, map_coordinates)

### DIFF
--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -252,7 +252,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     """
 
     ops = []
-    float_type = 'float' if float_dtype == cupy.float32 else 'double'
+    float_type = cupy._core._scalar.get_typename(float_dtype)
     internal_dtype = float_type if integer_output else 'Y'
     ops.append(f'{internal_dtype} out = 0.0;')
 

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -17,7 +17,7 @@ math_constants_preamble = r'''
 spline_weights_inline = _spline_kernel_weights.spline_weights_inline
 
 
-def _get_coord_map(ndim, nprepad=0):
+def _get_coord_map(ndim, nprepad=0, float_type=None):
     """Extract target coordinate from coords array (for map_coordinates).
 
     Notes
@@ -46,7 +46,7 @@ def _get_coord_map(ndim, nprepad=0):
     return ops
 
 
-def _get_coord_zoom_and_shift(ndim, nprepad=0):
+def _get_coord_zoom_and_shift(ndim, nprepad=0, float_type=None):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the center of the edge pixels.
@@ -72,7 +72,7 @@ def _get_coord_zoom_and_shift(ndim, nprepad=0):
     return ops
 
 
-def _get_coord_zoom_and_shift_grid(ndim, nprepad=0):
+def _get_coord_zoom_and_shift_grid(ndim, nprepad=0, float_type=None):
     """Compute target coordinate based on a shift followed by a zoom.
 
     This version zooms from the outer edges of the grid pixels.
@@ -94,12 +94,12 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0):
     pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + (W)0.5)
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + ({float_type})0.5)
               - (W)0.5{pre};''')
     return ops
 
 
-def _get_coord_zoom(ndim, nprepad=0):
+def _get_coord_zoom(ndim, nprepad=0, float_type=None):
     """Compute target coordinate based on a zoom.
 
     This version zooms from the center of the edge pixels.
@@ -124,7 +124,7 @@ def _get_coord_zoom(ndim, nprepad=0):
     return ops
 
 
-def _get_coord_zoom_grid(ndim, nprepad=0):
+def _get_coord_zoom_grid(ndim, nprepad=0, float_type='double'):
     """Compute target coordinate based on a zoom (grid_mode=True version).
 
     This version zooms from the outer edges of the grid pixels.
@@ -145,11 +145,12 @@ def _get_coord_zoom_grid(ndim, nprepad=0):
     pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + (W)0.5) - (W)0.5{pre};''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + ({float_type})0.5)
+                           - ({float_type})0.5{pre};''')
     return ops
 
 
-def _get_coord_shift(ndim, nprepad=0):
+def _get_coord_shift(ndim, nprepad=0, float_type=None):
     """Compute target coordinate based on a shift.
 
     Notes
@@ -172,7 +173,7 @@ def _get_coord_shift(ndim, nprepad=0):
     return ops
 
 
-def _get_coord_affine(ndim, nprepad=0):
+def _get_coord_affine(ndim, nprepad=0, float_type=None):
     """Compute target coordinate based on a homogeneous transformation matrix.
 
     The homogeneous matrix has shape (ndim, ndim + 1). It corresponds to
@@ -227,7 +228,8 @@ def _unravel_loop_index(shape, uint_t='unsigned int'):
 
 
 def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
-                            order, name='', integer_output=False, nprepad=0):
+                            order, name='', integer_output=False, nprepad=0,
+                            float_dtype=cupy.float64):
     """
     Args:
         coord_func (function): generates code to do the coordinate
@@ -250,7 +252,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     """
 
     ops = []
-    internal_dtype = 'W' if integer_output else 'Y'
+    float_type = 'float' if float_dtype == cupy.float32 else 'double'
+    internal_dtype = float_type if integer_output else 'Y'
     ops.append(f'{internal_dtype} out = 0.0;')
 
     if large_int:
@@ -272,7 +275,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         ops.append(_unravel_loop_index(yshape, uint_t))
 
     # compute the transformed (target) coordinates, c_j
-    ops = ops + coord_func(ndim, nprepad)
+    ops = ops + coord_func(ndim, nprepad, float_type)
 
     if cval is numpy.nan:
         cval = '(Y)CUDART_NAN'
@@ -297,7 +300,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
 
     if order == 0:
         if mode == 'wrap':
-            ops.append('double dcoord;')  # mode 'wrap' requires this to work
+            # mode 'wrap' requires this to work
+            ops.append(f'{float_type} dcoord;')
         for j in range(ndim):
             # determine nearest neighbor
             if mode == 'wrap':
@@ -305,8 +309,9 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 dcoord = c_{j};''')
             else:
                 ops.append(
-                    f'''{int_t} cf_{j} = ({int_t})floor(
-                                          ({internal_dtype})c_{j} + (W)0.5);'''
+                    f'''{int_t} cf_{j} = (
+                            {int_t})floor(({float_type})c_{j}
+                                          + ({float_type})0.5);'''
                 )
 
             # handle boundary
@@ -322,7 +327,8 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                         mode, ixvar, f'xsize_{j}', int_t, float_ix))
                 if mode == 'wrap':
                     ops.append(f'''
-                {int_t} cf_{j} = ({int_t})floor(dcoord + (W)0.5);''')
+                {int_t} cf_{j} = ({int_t})floor(dcoord
+                                  + ({float_type})0.5);''')
 
             # sum over ic_j will give the raveled coordinate in the input
             ops.append(f'''
@@ -344,15 +350,15 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         for j in range(ndim):
             # get coordinates for linear interpolation along axis j
             ops.append(f'''
-            {int_t} cf_{j} = ({int_t})floor(({internal_dtype})c_{j});
+            {int_t} cf_{j} = ({int_t})floor(({float_type})c_{j});
             {int_t} cc_{j} = cf_{j} + 1;
             {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
             ''')
 
             if mode == 'wrap':
                 ops.append(f'''
-                double dcoordf = c_{j};
-                double dcoordc = c_{j} + 1;''')
+                {float_type} dcoordf = c_{j};
+                {float_type} dcoordc = c_{j} + 1;''')
             else:
                 # handle boundaries for extension modes.
                 ops.append(f'''
@@ -377,8 +383,9 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 if mode == 'wrap':
                     ops.append(
                         f'''
-                    {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);;
-                    {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf + 1);;
+                    {int_t} cf_bounded_{j} = ({int_t})floor(dcoordf);
+                    {int_t} cc_bounded_{j} = ({int_t})floor(dcoordf
+                                              + ({float_type})1.0);
                     '''
                     )
 
@@ -412,27 +419,30 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
             # determine weights along the current axis
             ops.append(f'''
             W weights_{j}[{order + 1}];''')
-            ops.append(spline_weights_inline[order].format(j=j, order=order))
+            ops.append(spline_weights_inline[order].format(j=j, order=order,
+                                                           F=float_type))
 
             # get starting coordinate for spline interpolation along axis j
             if mode in ['wrap']:
-                ops.append(f'double dcoord = c_{j};')
+                ops.append(f'{float_type} dcoord = c_{j};')
                 coord_var = 'dcoord'
                 ops.append(
                     _util._generate_boundary_condition_ops(
                         mode, coord_var, f'xsize_{j}', int_t, True))
             else:
-                coord_var = f'({internal_dtype})c_{j}'
+                coord_var = f'({float_type})c_{j}'
 
             if order & 1:
                 op_str = '''
                 start = ({int_t})floor({coord_var}) - {order_2};'''
             else:
                 op_str = '''
-                start = ({int_t})floor({coord_var} + ((W)0.5) - {order_2};'''
+                start = ({int_t})floor(
+                    {coord_var} + ({float_type})0.5) - {order_2};'''
             ops.append(
                 op_str.format(
-                    int_t=int_t, coord_var=coord_var, order_2=order // 2
+                    int_t=int_t, float_type=float_type, coord_var=coord_var,
+                    order_2=order // 2
                 ))
 
             # set of coordinate values within spline footprint along axis j
@@ -479,7 +489,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         ops.append('}')
 
     if integer_output:
-        ops.append('y = (Y)rint(({internal_dtype})out);')
+        ops.append(f'y = (Y)rint(({float_type})out);')
     else:
         ops.append('y = (Y)out;')
     operation = '\n'.join(ops)
@@ -499,7 +509,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_map_kernel(ndim, large_int, mode, cval=0.0, order=1,
-                    integer_output=False, nprepad=0):
+                    integer_output=False, nprepad=0, float_dtype=cupy.double):
     in_params = 'raw X x, raw W coords'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -513,6 +523,7 @@ def _get_map_kernel(ndim, large_int, mode, cval=0.0, order=1,
         name='map',
         integer_output=integer_output,
         nprepad=nprepad,
+        float_dtype=float_dtype,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -520,7 +531,8 @@ def _get_map_kernel(ndim, large_int, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                      integer_output=False, nprepad=0):
+                      integer_output=False, nprepad=0,
+                      float_dtype=cupy.double):
     in_params = 'raw X x, raw W shift'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -534,6 +546,7 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='shift',
         integer_output=integer_output,
         nprepad=nprepad,
+        float_dtype=float_dtype,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -541,7 +554,8 @@ def _get_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                           integer_output=False, grid_mode=False, nprepad=0):
+                           integer_output=False, grid_mode=False, nprepad=0,
+                           float_dtype=cupy.double):
     in_params = 'raw X x, raw W shift, raw W zoom'
     out_params = 'Y y'
     if grid_mode:
@@ -559,6 +573,7 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_shift_grid" if grid_mode else "zoom_shift",
         integer_output=integer_output,
         nprepad=nprepad,
+        float_dtype=float_dtype,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -566,7 +581,8 @@ def _get_zoom_shift_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                     integer_output=False, grid_mode=False, nprepad=0):
+                     integer_output=False, grid_mode=False, nprepad=0,
+                     float_dtype=cupy.double):
     in_params = 'raw X x, raw W zoom'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -580,6 +596,7 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name="zoom_grid" if grid_mode else "zoom",
         integer_output=integer_output,
         nprepad=nprepad,
+        float_dtype=float_dtype,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)
@@ -587,7 +604,8 @@ def _get_zoom_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
 
 @cupy._util.memoize(for_each_device=True)
 def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
-                       integer_output=False, nprepad=0):
+                       integer_output=False, nprepad=0,
+                       float_dtype=cupy.double):
     in_params = 'raw X x, raw W mat'
     out_params = 'Y y'
     operation, name = _generate_interp_custom(
@@ -601,6 +619,7 @@ def _get_affine_kernel(ndim, large_int, yshape, mode, cval=0.0, order=1,
         name='affine',
         integer_output=integer_output,
         nprepad=nprepad,
+        float_dtype=float_dtype,
     )
     return cupy.ElementwiseKernel(in_params, out_params, operation, name,
                                   preamble=math_constants_preamble)

--- a/cupyx/scipy/ndimage/_interp_kernels.py
+++ b/cupyx/scipy/ndimage/_interp_kernels.py
@@ -94,7 +94,8 @@ def _get_coord_zoom_and_shift_grid(ndim, nprepad=0):
     pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + 0.5) - 0.5{pre};''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] - shift[j] + (W)0.5)
+              - (W)0.5{pre};''')
     return ops
 
 
@@ -144,7 +145,7 @@ def _get_coord_zoom_grid(ndim, nprepad=0):
     pre = f" + (W){nprepad}" if nprepad > 0 else ''
     for j in range(ndim):
         ops.append(f'''
-    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + 0.5) - 0.5{pre};''')
+    W c_{j} = zoom[{j}] * ((W)in_coord[{j}] + (W)0.5) - (W)0.5{pre};''')
     return ops
 
 
@@ -249,7 +250,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
     """
 
     ops = []
-    internal_dtype = 'double' if integer_output else 'Y'
+    internal_dtype = 'W' if integer_output else 'Y'
     ops.append(f'{internal_dtype} out = 0.0;')
 
     if large_int:
@@ -303,8 +304,10 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                 ops.append(f'''
                 dcoord = c_{j};''')
             else:
-                ops.append(f'''
-                {int_t} cf_{j} = ({int_t})floor((double)c_{j} + 0.5);''')
+                ops.append(
+                    f'''{int_t} cf_{j} = ({int_t})floor(
+                                          ({internal_dtype})c_{j} + (W)0.5);'''
+                )
 
             # handle boundary
             if mode != 'constant':
@@ -319,7 +322,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                         mode, ixvar, f'xsize_{j}', int_t, float_ix))
                 if mode == 'wrap':
                     ops.append(f'''
-                {int_t} cf_{j} = ({int_t})floor(dcoord + 0.5);''')
+                {int_t} cf_{j} = ({int_t})floor(dcoord + (W)0.5);''')
 
             # sum over ic_j will give the raveled coordinate in the input
             ops.append(f'''
@@ -341,7 +344,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         for j in range(ndim):
             # get coordinates for linear interpolation along axis j
             ops.append(f'''
-            {int_t} cf_{j} = ({int_t})floor((double)c_{j});
+            {int_t} cf_{j} = ({int_t})floor(({internal_dtype})c_{j});
             {int_t} cc_{j} = cf_{j} + 1;
             {int_t} n_{j} = (c_{j} == cf_{j}) ? 1 : 2;  // points needed
             ''')
@@ -419,14 +422,14 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
                     _util._generate_boundary_condition_ops(
                         mode, coord_var, f'xsize_{j}', int_t, True))
             else:
-                coord_var = f'(double)c_{j}'
+                coord_var = f'({internal_dtype})c_{j}'
 
             if order & 1:
                 op_str = '''
                 start = ({int_t})floor({coord_var}) - {order_2};'''
             else:
                 op_str = '''
-                start = ({int_t})floor({coord_var} + 0.5) - {order_2};'''
+                start = ({int_t})floor({coord_var} + ((W)0.5) - {order_2};'''
             ops.append(
                 op_str.format(
                     int_t=int_t, coord_var=coord_var, order_2=order // 2
@@ -476,7 +479,7 @@ def _generate_interp_custom(coord_func, ndim, large_int, yshape, mode, cval,
         ops.append('}')
 
     if integer_output:
-        ops.append('y = (Y)rint((double)out);')
+        ops.append('y = (Y)rint(({internal_dtype})out);')
     else:
         ops.append('y = (Y)out;')
     operation = '\n'.join(ops)

--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -429,10 +429,11 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if output_shape is None:
         output_shape = input.shape
 
+    float_dtype = cupy.promote_types(input.dtype, cupy.float32)
     if mode == 'opencv' or mode == '_opencv_edge':
         if matrix.ndim == 1:
             matrix = cupy.diag(matrix)
-        coordinates = cupy.indices(output_shape, dtype=cupy.float64)
+        coordinates = cupy.indices(output_shape, dtype=float_dtype)
         coordinates = cupy.dot(matrix, coordinates.reshape((input.ndim, -1)))
         coordinates += cupy.expand_dims(cupy.asarray(offset), -1)
         ret = _util._get_output(output, input, shape=output_shape)
@@ -440,7 +441,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
                                  cval, prefilter).reshape(output_shape)
         return ret
 
-    matrix = matrix.astype(cupy.float64, copy=False)
+    matrix = matrix.astype(float_dtype, copy=False)
     ndim = input.ndim
     output = _util._get_output(output, input, shape=output_shape)
     if input.dtype.kind in 'iu':
@@ -451,7 +452,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     _util._check_cval(mode, cval, integer_output)
     large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
     if matrix.ndim == 1:
-        offset = cupy.asarray(offset, dtype=cupy.float64)
+        offset = cupy.asarray(offset, dtype=float_dtype)
         offset = -offset / matrix
         kern = _interp_kernels._get_zoom_shift_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
@@ -461,9 +462,9 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
         kern = _interp_kernels._get_affine_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
             integer_output=integer_output, nprepad=nprepad)
-        m = cupy.zeros((ndim, ndim + 1), dtype=cupy.float64)
+        m = cupy.zeros((ndim, ndim + 1), dtype=float_dtype)
         m[:, :-1] = matrix
-        m[:, -1] = cupy.asarray(offset, dtype=cupy.float64)
+        m[:, -1] = cupy.asarray(offset, dtype=float_dtype)
         kern(filtered, m, output)
     return output
 
@@ -541,10 +542,11 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     rad = numpy.deg2rad(angle)
     sin = math.sin(rad)
     cos = math.cos(rad)
+    float_dtype = cupy.promote_types(input_arr, cupy.float32)
 
     # determine offsets and output shape as in scipy.ndimage.rotate
     rot_matrix = numpy.array([[cos, sin],
-                              [-sin, cos]])
+                              [-sin, cos]], dtype=float_dtype)
 
     img_shape = numpy.asarray(input_arr.shape)
     in_plane_shape = img_shape[axes]
@@ -566,13 +568,13 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     output_shape[axes] = out_plane_shape
     output_shape = tuple(output_shape)
 
-    matrix = numpy.identity(ndim)
+    matrix = numpy.identity(ndim, dtype=float_dtype)
     matrix[axes[0], axes[0]] = cos
     matrix[axes[0], axes[1]] = sin
     matrix[axes[1], axes[0]] = -sin
     matrix[axes[1], axes[1]] = cos
 
-    offset = numpy.zeros(ndim, dtype=cupy.float64)
+    offset = numpy.zeros(ndim, dtype=float_dtype)
     offset[axes] = in_center - out_center
 
     matrix = cupy.asarray(matrix)

--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -310,17 +310,19 @@ def map_coordinates(input, coordinates, output=None, order=3,
         input = input.astype(cupy.float32)
     coordinates = _check_coordinates(coordinates, order)
     filtered, nprepad = _filter_input(input, prefilter, mode, cval, order)
+    float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
     large_int = max(_prod(input.shape), coordinates.shape[0]) > 1 << 31
     kern = _interp_kernels._get_map_kernel(
         input.ndim, large_int, mode=mode, cval=cval,
-        order=order, integer_output=integer_output, nprepad=nprepad)
+        order=order, integer_output=integer_output, nprepad=nprepad,
+        float_dtype=float_dtype)
     kern(filtered, coordinates, ret)
     return ret
 
 
 def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
                      order=3, mode='constant', cval=0.0, prefilter=True, *,
-                     texture_memory=False):
+                     texture_memory=False, float64_coords=True):
     """Apply an affine transformation.
 
     Given an output image pixel index vector ``o``, the pixel value is
@@ -429,19 +431,21 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     if output_shape is None:
         output_shape = input.shape
 
-    float_dtype = cupy.promote_types(input.dtype, cupy.float32)
+    float_dtype = cupy.float64
+    if not float64_coords:
+        float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
     if mode == 'opencv' or mode == '_opencv_edge':
         if matrix.ndim == 1:
             matrix = cupy.diag(matrix)
-        coordinates = cupy.indices(output_shape, dtype=float_dtype)
+        coordinates = cupy.indices(output_shape, dtype=cupy.float64)
         coordinates = cupy.dot(matrix, coordinates.reshape((input.ndim, -1)))
         coordinates += cupy.expand_dims(cupy.asarray(offset), -1)
+        coordinates = coordinates.astype(float_dtype, copy=False)
         ret = _util._get_output(output, input, shape=output_shape)
         ret[:] = map_coordinates(input, coordinates, ret.dtype, order, mode,
                                  cval, prefilter).reshape(output_shape)
         return ret
 
-    matrix = matrix.astype(float_dtype, copy=False)
     ndim = input.ndim
     output = _util._get_output(output, input, shape=output_shape)
     if input.dtype.kind in 'iu':
@@ -451,17 +455,20 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
     integer_output = output.dtype.kind in 'iu'
     _util._check_cval(mode, cval, integer_output)
     large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
+    matrix = matrix.astype(float_dtype, copy=False)
     if matrix.ndim == 1:
         offset = cupy.asarray(offset, dtype=float_dtype)
         offset = -offset / matrix
         kern = _interp_kernels._get_zoom_shift_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            float_dtype=float_dtype)
         kern(filtered, offset, matrix, output)
     else:
         kern = _interp_kernels._get_affine_kernel(
             ndim, large_int, output_shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            float_dtype=float_dtype)
         m = cupy.zeros((ndim, ndim + 1), dtype=float_dtype)
         m[:, :-1] = matrix
         m[:, -1] = cupy.asarray(offset, dtype=float_dtype)
@@ -542,7 +549,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     rad = numpy.deg2rad(angle)
     sin = math.sin(rad)
     cos = math.cos(rad)
-    float_dtype = cupy.promote_types(input_arr, cupy.float32)
+    float_dtype = cupy.promote_types(input_arr.real.dtype, cupy.float32)
 
     # determine offsets and output shape as in scipy.ndimage.rotate
     rot_matrix = numpy.array([[cos, sin],
@@ -581,7 +588,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
     offset = cupy.asarray(offset)
 
     return affine_transform(input, matrix, offset, output_shape, output, order,
-                            mode, cval, prefilter)
+                            mode, cval, prefilter, float64_coords=False)
 
 
 def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
@@ -649,9 +656,11 @@ def shift(input, shift, output=None, order=3, mode='constant', cval=0.0,
         integer_output = output.dtype.kind in 'iu'
         _util._check_cval(mode, cval, integer_output)
         large_int = _prod(input.shape) > 1 << 31
+        float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
         kern = _interp_kernels._get_shift_kernel(
             input.ndim, large_int, input.shape, mode, cval=cval, order=order,
-            integer_output=integer_output, nprepad=nprepad)
+            integer_output=integer_output, nprepad=nprepad,
+            float_dtype=float_dtype)
         shift = cupy.asarray(shift, dtype=cupy.float64, order='C')
         if shift.ndim != 1:
             raise ValueError('shift must be 1d')
@@ -775,10 +784,11 @@ def zoom(input, zoom, output=None, order=3, mode='constant', cval=0.0,
         integer_output = output.dtype.kind in 'iu'
         _util._check_cval(mode, cval, integer_output)
         large_int = max(_prod(input.shape), _prod(output_shape)) > 1 << 31
+        float_dtype = cupy.promote_types(input.real.dtype, cupy.float32)
         kern = _interp_kernels._get_zoom_kernel(
             input.ndim, large_int, output_shape, mode, order=order,
             integer_output=integer_output, grid_mode=grid_mode,
-            nprepad=nprepad)
+            nprepad=nprepad, float_dtype=float_dtype)
         zoom = cupy.asarray(zoom, dtype=cupy.float64)
         kern(filtered, zoom, output)
     return output

--- a/cupyx/scipy/ndimage/_spline_kernel_weights.py
+++ b/cupyx/scipy/ndimage/_spline_kernel_weights.py
@@ -15,66 +15,68 @@ spline_weights_inline = {}
 # path in _interp_kernels.py). I think that existing code is a bit more
 # efficient.
 spline_weights_inline[1] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
-weights_{j}[0] = (W)1.0 - wx;
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + ({F})0.5);
+weights_{j}[0] = ({F})1.0 - wx;
 weights_{j}[1] = wx;
 '''
 
 spline_weights_inline[2] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
-weights_{j}[1] = (W)0.75 - wx * wx;
-wy = (W)0.5 - wx;
-weights_{j}[0] = (W)0.5 * wy * wy;
-weights_{j}[2] = (W)1.0 - weights_{j}[0] - weights_{j}[1];
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + ({F})0.5);
+weights_{j}[1] = ({F})0.75 - wx * wx;
+wy = ({F})0.5 - wx;
+weights_{j}[0] = ({F})0.5 * wy * wy;
+weights_{j}[2] = ({F})1.0 - weights_{j}[0] - weights_{j}[1];
 '''
 
 spline_weights_inline[3] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
-wy = (W)1.0 - wx;
-weights_{j}[1] = (wx * wx * (wx - (W)2.0) * (W)3.0 + (W)4.0) / (W)6.0;
-weights_{j}[2] = (wy * wy * (wy - (W)2.0) * (W)3.0 + (W)4.0) / (W)6.0;
-weights_{j}[0] = wy * wy * wy / (W)6.0;
-weights_{j}[3] = (W)1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + ({F})0.5);
+wy = ({F})1.0 - wx;
+weights_{j}[1] = (wx * wx * (wx - ({F})2.0) * ({F})3.0 + ({F})4.0) / ({F})6.0;
+weights_{j}[2] = (wy * wy * (wy - ({F})2.0) * ({F})3.0 + ({F})4.0) / ({F})6.0;
+weights_{j}[0] = wy * wy * wy / ({F})6.0;
+weights_{j}[3] = ({F})1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
 '''
 
 spline_weights_inline[4] = '''
 wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
 wy = wx * wx;
-weights_{j}[2] = wy * (wy * (W)0.25 - (W)0.625) + (W)115.0 / (W)192.0;
-wy = (W)1.0 + wx;
+weights_{j}[2] = wy * (wy * ({F})0.25 - ({F})0.625) + ({F})115.0 / ({F})192.0;
+wy = ({F})1.0 + wx;
 weights_{j}[1] =
-    wy * (wy * (wy * ((W)5.0 - wy) / (W)6.0 - (W)1.25) + (W)5.0 / (W)24.0) +
-    (W)55.0 / (W)96.0;
-wy = (W)1.0 - wx;
+    wy * (wy * (wy * (({F})5.0 - wy) / ({F})6.0 - ({F})1.25)
+    + ({F})5.0 / ({F})24.0) + ({F})55.0 / ({F})96.0;
+wy = ({F})1.0 - wx;
 weights_{j}[3] =
-    wy * (wy * (wy * ((W)5.0 - wy) / (W)6.0 - (W)1.25) + (W)5.0 / (W)24.0) +
-    (W)55.0 / (W)96.0;
-wy = (W)0.5 - wx;
+    wy * (wy * (wy * (({F})5.0 - wy) / ({F})6.0 - ({F})1.25)
+    + ({F})5.0 / ({F})24.0) + ({F})55.0 / ({F})96.0;
+wy = ({F})0.5 - wx;
 wy = wy * wy;
-weights_{j}[0] = wy * wy / (W)24.0;
-weights_{j}[4] = (W)1.0 - weights_{j}[0] - weights_{j}[1]
+weights_{j}[0] = wy * wy / ({F})24.0;
+weights_{j}[4] = ({F})1.0 - weights_{j}[0] - weights_{j}[1]
                         - weights_{j}[2] - weights_{j}[3];
 '''
 
 spline_weights_inline[5] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + ({F})0.5);
 wy = wx * wx;
-weights_{j}[2] = wy * (wy * ((W)0.25 - wx / (W)12.0) - (W)0.5) + (W)0.55;
-wy = (W)1.0 - wx;
+weights_{j}[2] =
+    wy * (wy * (({F})0.25 - wx / ({F})12.0) - ({F})0.5) + ({F})0.55;
+wy = ({F})1.0 - wx;
 wy = wy * wy;
 weights_{j}[3] =
-    wy * (wy * ((W)0.25 - ((W)1.0 - wx) / (W)12.0) - (W)0.5) + (W)0.55;
-wy = wx + (W)1.0;
+    wy * (wy * (({F})0.25 - (({F})1.0 - wx) / ({F})12.0) - ({F})0.5)
+    + ({F})0.55;
+wy = wx + ({F})1.0;
 weights_{j}[1] =
-    wy * (wy * (wy * (wy * (wy / (W)24.0 - (W)0.375) + (W)1.25) - (W)1.75)
-   + (W)0.625) + (W)0.425;
-wy = (W)2.0 - wx;
+    wy * (wy * (wy * (wy * (wy / ({F})24.0 - ({F})0.375) + ({F})1.25)
+    - ({F})1.75) + ({F})0.625) + ({F})0.425;
+wy = ({F})2.0 - wx;
 weights_{j}[4] =
-    wy * (wy * (wy * (wy * (wy / (W)24.0 - (W)0.375) + (W)1.25) - (W)1.75)
-    + (W)0.625) + (W)0.425;
-wy = (W)1.0 - wx;
+    wy * (wy * (wy * (wy * (wy / ({F})24.0 - ({F})0.375) + ({F})1.25)
+    - ({F})1.75) + ({F})0.625) + ({F})0.425;
+wy = ({F})1.0 - wx;
 wy = wy * wy;
-weights_{j}[0] = ((W)1.0 - wx) * wy * wy / 120.0;
-weights_{j}[5] = (W)1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
+weights_{j}[0] = (({F})1.0 - wx) * wy * wy / 120.0;
+weights_{j}[5] = ({F})1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
                         - weights_{j}[3] - weights_{j}[4];
 '''

--- a/cupyx/scipy/ndimage/_spline_kernel_weights.py
+++ b/cupyx/scipy/ndimage/_spline_kernel_weights.py
@@ -38,7 +38,7 @@ weights_{j}[3] = ({F})1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
 '''
 
 spline_weights_inline[4] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + ({F})0.5);
 wy = wx * wx;
 weights_{j}[2] = wy * (wy * ({F})0.25 - ({F})0.625) + ({F})115.0 / ({F})192.0;
 wy = ({F})1.0 + wx;
@@ -76,7 +76,7 @@ weights_{j}[4] =
     - ({F})1.75) + ({F})0.625) + ({F})0.425;
 wy = ({F})1.0 - wx;
 wy = wy * wy;
-weights_{j}[0] = (({F})1.0 - wx) * wy * wy / 120.0;
+weights_{j}[0] = (({F})1.0 - wx) * wy * wy / ({F})120.0;
 weights_{j}[5] = ({F})1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
                         - weights_{j}[3] - weights_{j}[4];
 '''

--- a/cupyx/scipy/ndimage/_spline_kernel_weights.py
+++ b/cupyx/scipy/ndimage/_spline_kernel_weights.py
@@ -15,61 +15,66 @@ spline_weights_inline = {}
 # path in _interp_kernels.py). I think that existing code is a bit more
 # efficient.
 spline_weights_inline[1] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
-weights_{j}[0] = 1.0 - wx;
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
+weights_{j}[0] = (W)1.0 - wx;
 weights_{j}[1] = wx;
 '''
 
 spline_weights_inline[2] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
-weights_{j}[1] = 0.75 - wx * wx;
-wy = 0.5 - wx;
-weights_{j}[0] = 0.5 * wy * wy;
-weights_{j}[2] = 1.0 - weights_{j}[0] - weights_{j}[1];
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
+weights_{j}[1] = (W)0.75 - wx * wx;
+wy = (W)0.5 - wx;
+weights_{j}[0] = (W)0.5 * wy * wy;
+weights_{j}[2] = (W)1.0 - weights_{j}[0] - weights_{j}[1];
 '''
 
 spline_weights_inline[3] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
-wy = 1.0 - wx;
-weights_{j}[1] = (wx * wx * (wx - 2.0) * 3.0 + 4.0) / 6.0;
-weights_{j}[2] = (wy * wy * (wy - 2.0) * 3.0 + 4.0) / 6.0;
-weights_{j}[0] = wy * wy * wy / 6.0;
-weights_{j}[3] = 1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
+wy = (W)1.0 - wx;
+weights_{j}[1] = (wx * wx * (wx - (W)2.0) * (W)3.0 + (W)4.0) / (W)6.0;
+weights_{j}[2] = (wy * wy * (wy - (W)2.0) * (W)3.0 + (W)4.0) / (W)6.0;
+weights_{j}[0] = wy * wy * wy / (W)6.0;
+weights_{j}[3] = (W)1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2];
 '''
 
 spline_weights_inline[4] = '''
 wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
 wy = wx * wx;
-weights_{j}[2] = wy * (wy * 0.25 - 0.625) + 115.0 / 192.0;
-wy = 1.0 + wx;
-weights_{j}[1] = wy * (wy * (wy * (5.0 - wy) / 6.0 - 1.25) + 5.0 / 24.0) +
-             55.0 / 96.0;
-wy = 1.0 - wx;
-weights_{j}[3] = wy * (wy * (wy * (5.0 - wy) / 6.0 - 1.25) + 5.0 / 24.0) +
-             55.0 / 96.0;
-wy = 0.5 - wx;
+weights_{j}[2] = wy * (wy * (W)0.25 - (W)0.625) + (W)115.0 / (W)192.0;
+wy = (W)1.0 + wx;
+weights_{j}[1] =
+    wy * (wy * (wy * ((W)5.0 - wy) / (W)6.0 - (W)1.25) + (W)5.0 / (W)24.0) +
+    (W)55.0 / (W)96.0;
+wy = (W)1.0 - wx;
+weights_{j}[3] =
+    wy * (wy * (wy * ((W)5.0 - wy) / (W)6.0 - (W)1.25) + (W)5.0 / (W)24.0) +
+    (W)55.0 / (W)96.0;
+wy = (W)0.5 - wx;
 wy = wy * wy;
-weights_{j}[0] = wy * wy / 24.0;
-weights_{j}[4] = 1.0 - weights_{j}[0] - weights_{j}[1]
-                     - weights_{j}[2] - weights_{j}[3];
+weights_{j}[0] = wy * wy / (W)24.0;
+weights_{j}[4] = (W)1.0 - weights_{j}[0] - weights_{j}[1]
+                        - weights_{j}[2] - weights_{j}[3];
 '''
 
 spline_weights_inline[5] = '''
-wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + 0.5);
+wx = c_{j} - floor({order} & 1 ? c_{j} : c_{j} + (W)0.5);
 wy = wx * wx;
-weights_{j}[2] = wy * (wy * (0.25 - wx / 12.0) - 0.5) + 0.55;
-wy = 1.0 - wx;
+weights_{j}[2] = wy * (wy * ((W)0.25 - wx / (W)12.0) - (W)0.5) + (W)0.55;
+wy = (W)1.0 - wx;
 wy = wy * wy;
-weights_{j}[3] = wy * (wy * (0.25 - (1.0 - wx) / 12.0) - 0.5) + 0.55;
-wy = wx + 1.0;
-weights_{j}[1] = wy * (wy * (wy * (wy * (wy / 24.0 - 0.375) + 1.25) - 1.75)
-                   + 0.625) + 0.425;
-wy = 2.0 - wx;
-weights_{j}[4] = wy * (wy * (wy * (wy * (wy / 24.0 - 0.375) + 1.25) - 1.75)
-                  + 0.625) + 0.425;
-wy = 1.0 - wx;
+weights_{j}[3] =
+    wy * (wy * ((W)0.25 - ((W)1.0 - wx) / (W)12.0) - (W)0.5) + (W)0.55;
+wy = wx + (W)1.0;
+weights_{j}[1] =
+    wy * (wy * (wy * (wy * (wy / (W)24.0 - (W)0.375) + (W)1.25) - (W)1.75)
+   + (W)0.625) + (W)0.425;
+wy = (W)2.0 - wx;
+weights_{j}[4] =
+    wy * (wy * (wy * (wy * (wy / (W)24.0 - (W)0.375) + (W)1.25) - (W)1.75)
+    + (W)0.625) + (W)0.425;
+wy = (W)1.0 - wx;
 wy = wy * wy;
-weights_{j}[0] = (1.0 - wx) * wy * wy / 120.0;
-weights_{j}[5] = 1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
-                     - weights_{j}[3] - weights_{j}[4];
+weights_{j}[0] = ((W)1.0 - wx) * wy * wy / 120.0;
+weights_{j}[5] = (W)1.0 - weights_{j}[0] - weights_{j}[1] - weights_{j}[2]
+                        - weights_{j}[3] - weights_{j}[4];
 '''

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -482,13 +482,16 @@ class TestRotate:
                           self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.float32: 1e-5},
+                                 atol=1e-5,
+                                 scipy_name='scp')
     def test_rotate_float(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, scp, a)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.complex64: 1e-5},
+                                 atol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.6.0')
     def test_rotate_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -192,14 +192,14 @@ class TestAffineTransform:
                                     self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_affine_transform_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-6, atol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.6.0')
     def test_affine_transform_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
@@ -210,7 +210,7 @@ class TestAffineTransform:
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-3, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
     def test_affine_transform_fortran_order(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         a = xp.asfortranarray(a)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -180,14 +180,14 @@ class TestAffineTransform:
                                     self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, scipy_name='scp')
     def test_affine_transform_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = testing.shaped_random(self.matrix_shape, xp, dtype)
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose(rtol=1e-6, atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.6.0')
     def test_affine_transform_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
@@ -198,7 +198,7 @@ class TestAffineTransform:
         return self._affine_transform(xp, scp, a, matrix)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(atol=1e-3, scipy_name='scp')
     def test_affine_transform_fortran_order(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         a = xp.asfortranarray(a)
@@ -470,13 +470,13 @@ class TestRotate:
                           self.mode, self.cval, self.prefilter)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
     def test_rotate_float(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, scp, a)
 
     @testing.for_complex_dtypes()
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
     @testing.with_requires('scipy>=1.6.0')
     def test_rotate_complex_float(self, xp, scp, dtype):
         if self.output == numpy.float64:
@@ -485,7 +485,7 @@ class TestRotate:
         return self._rotate(xp, scp, a)
 
     @testing.for_float_dtypes(no_float16=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
     def test_rotate_fortran_order(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
         a = xp.asfortranarray(a)
@@ -505,7 +505,7 @@ class TestRotate:
                 pytest.xfail('ROCm/HIP may have a bug')
 
     @testing.for_int_dtypes(no_bool=True)
-    @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, scipy_name='scp')
     def test_rotate_int(self, xp, scp, dtype):
         self._hip_skip_invalid_condition()
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -141,16 +141,28 @@ class TestMapCoordinatesHalfInteger:
         return self._map_coordinates(xp, scp, a, coordinates)
 
 
-@testing.parameterize(*testing.product({
-    'matrix_shape': [(2,), (2, 2), (2, 3), (3, 3)],
-    'offset': [0.3, [-1.3, 1.3]],
-    'output_shape': [None],
-    'output': [None, numpy.float64, 'empty'],
-    'order': [0, 1, 2, 3, 4, 5],
-    'mode': legacy_modes + scipy16_modes,
-    'cval': [1.0],
-    'prefilter': [False, True],
-}))
+@testing.parameterize(*(
+    testing.product({
+        'matrix_shape': [(3, 3)],
+        'offset': [[-1.3, 1.3]],
+        'output_shape': [None],
+        'output': [None, numpy.float64, 'empty'],
+        'order': [0, 1, 2, 3, 4, 5],
+        'mode': legacy_modes,
+        'cval': [1.0],
+        'prefilter': [False, True],
+    }) + testing.product({
+        'matrix_shape': [(2,), (2, 2), (2, 3)],
+        'offset': [0.3],
+        'output_shape': [None],
+        'output': [None],
+        'order': [0, 1, 3],
+        'mode': legacy_modes + scipy16_modes,
+        'cval': [1.0],
+        'prefilter': [True],
+
+    })
+))
 @testing.with_requires('scipy')
 class TestAffineTransform:
 


### PR DESCRIPTION
It is expected that ndimage interpolation functions use:
- float32 precision for float32 inputs and 8 or 16-bit integer or unsigned integer inputs
- float64 precision for float64 inputs and larger integer dtypes

Currently, the expected precision is being used during spline prefiltering, but the main interpolation kernels involve many undesired promotion to double dtypes. This is due to a combination of double precision floating point literals and some variables being declared with `double` type regardless of image precision.

## Benchmark results

The results below are for `rotate` with various interpolation orders. `prefilter` was set to False to better isolation the kernel being changed in this MR. As expected, changing computations from float64->float32 when applicable results in substantial performance benefit (on RTX A6000). There is no regression in performance for the 64-bit case.


| shape         | order | prefilter | dtype   | duration (ms) | duration, main (ms) | acceleration |
|---------------|-------|-----------|---------|---------------|---------------------|--------------|
| (3840, 2160)) |   0   | False     | uint8   |     0.489     |        1.043        |     2.13     |
| (3840, 2160)) |   1   | False     | uint8   |     0.502     |        1.682        |     3.35     |
| (3840, 2160)) |   2   | False     | uint8   |     0.620     |        2.874        |     4.64     |
| (3840, 2160)) |   3   | False     | uint8   |     0.722     |        5.873        |     8.13     |
| (3840, 2160)) |   4   | False     | uint8   |     0.836     |        7.935        |     9.49     |
| (3840, 2160)) |   5   | False     | uint8   |     1.397     |       11.010        |     7.88     |
| (3840, 2160)) |   0   | False     | float32 |     0.417     |        0.870        |     2.09     |
| (3840, 2160)) |   1   | False     | float32 |     0.420     |        1.489        |     3.54     |
| (3840, 2160)) |   2   | False     | float32 |     0.518     |        2.494        |     4.81     |
| (3840, 2160)) |   3   | False     | float32 |     0.621     |        5.244        |     8.44     |
| (3840, 2160)) |   4   | False     | float32 |     0.746     |        7.049        |     9.45     |
| (3840, 2160)) |   5   | False     | float32 |     1.312     |        9.784        |     7.46     |
| (3840, 2160)) |   0   | False     | float64 |     0.891     |        0.876        |     ~same    |
| (3840, 2160)) |   1   | False     | float64 |     1.451     |        1.435        |     ~same    |
| (3840, 2160)) |   2   | False     | float64 |     2.511     |        2.505        |     ~same    |
| (3840, 2160)) |   3   | False     | float64 |     5.237     |        5.265        |     ~same    |
| (3840, 2160)) |   4   | False     | float64 |     7.013     |        7.050        |     ~same    |
| (3840, 2160)) |   5   | False     | float64 |     9.724     |        9.759        |     ~same    |
