### PR TITLE
CI: Fix cuda120 CI failures due to `FutureWarning`

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -205,7 +205,6 @@ class LinuxGenerator:
             raise ValueError('Python cannot be null')
 
         py_spec = self.schema['python'][matrix.python]['spec']
-        # For GCP kernel cache backend, install google-cloud-storage.
         lines += [
             'RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv',
             'ENV PYENV_ROOT "/opt/pyenv"',
@@ -213,6 +212,7 @@ class LinuxGenerator:
             f'RUN pyenv install {py_spec} && \\',
             f'    pyenv global {py_spec} && \\',
             '    pip install -U setuptools pip wheel && \\',
+            # For GCP kernel cache backend
             '    pip install -U google-cloud-storage',
             '',
         ]


### PR DESCRIPTION
After #9739 I noticed the cuda120 CIs were broken, because they use Python 3.10 which trigger a `FutureWarning`.