### PR TITLE
Making show_config less verbose when libraries don't exist

### DIFF
--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -23,6 +23,8 @@ def _eval_or_error(func, errors):
     # representing the error.
     try:
         return func()
+    except ImportError:
+        return None
     except errors as e:
         return repr(e)
 
@@ -405,6 +407,8 @@ class _RuntimeInfo:
                     arch = ('Device {} Compute Capability'.format(device_id),
                             device.compute_capability)
                 records += [name, arch, pci_bus]
+
+        records = [(k, v) for (k, v) in records if v is not None]
 
         width = max([len(r[0]) for r in records]) + 2
         fmt = '{:' + str(width) + '}: {}\n'


### PR DESCRIPTION
Addressing issue: [show_config is too verbose when libraries do not exist](https://github.com/cupy/cupy/issues/9723)

If the value of a path, version, etc is None it won't be printed.

Also as @leofang mentioned in the comment the `ImportError` should be `None`, hence with the current implementation excluded from the information. Let me know if this is the desired behavior.