### PR TITLE
Guard against None conda prefix in _get_conda_cuda_path()

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -119,6 +119,8 @@ _PLATFORM_WIN32 = sys.platform.startswith('win32')
 def _get_conda_cuda_path():
     """This works since CUDA 12.0+."""
     conda_prefix = os.environ.get('CONDA_PREFIX')
+    if conda_prefix is None:
+        return None
     if _PLATFORM_LINUX:
         plat = platform.machine()
         if plat == 'aarch64':


### PR DESCRIPTION
Fix https://github.com/cupy/cupy/issues/9777