### PR TITLE
Fix DistributedArray missing NotImplementedError overrides for `mdspan` and `mT`

### DIFF
--- a/cupyx/distributed/array/_array.py
+++ b/cupyx/distributed/array/_array.py
@@ -561,6 +561,11 @@ class DistributedArray(ndarray):
         raise NotImplementedError(
             'DistributedArray currently does not support mean.')
 
+    def mdspan(self, *args, **kwargs):
+        """Not supported."""
+        raise NotImplementedError(
+            'DistributedArray currently does not support mdspan.')
+
     def min(self, axis=None, out=None, keepdims=False):
         """Return the minimum along a given axis.
 
@@ -751,6 +756,12 @@ class DistributedArray(ndarray):
         """Not supported."""
         raise NotImplementedError(
             'DistributedArray currently does not support T.')
+
+    @property
+    def mT(self):
+        """Not supported."""
+        raise NotImplementedError(
+            'DistributedArray currently does not support mT.')
 
     @property
     def base(self):


### PR DESCRIPTION
Close https://github.com/cupy/cupy/issues/9773.