### PR TITLE
cupyx.scipy.sparse.linalg.gmres: report non-convergence when maxiter is not divisible by restart

### DIFF
--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -189,7 +189,7 @@ def gmres(A, b, x0=None, *, rtol=1e-5, atol=0.0, restart=None, maxiter=None,
         iters += restart
 
     info = 0
-    if iters == maxiter and not (r_norm <= atol):
+    if iters >= maxiter and not (r_norm <= atol):
         info = iters
     return mx, info
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -627,6 +627,26 @@ class TestGmres:
             sp.linalg.gmres(ng_a, b)
 
 
+@testing.with_requires('scipy>=1.4')
+class TestGmresInfo:
+
+    def test_nonconvergence_with_restart_maxiter_mismatch(self):
+        n = 48
+        indices = numpy.arange(n, dtype=numpy.float64)
+        a_cpu = 1.0 / (indices[:, None] + indices[None, :] + 1.0)
+        a = sparse.csr_matrix(cupy.asarray(a_cpu))
+        x_true = cupy.asarray(numpy.random.default_rng(0).standard_normal(n))
+        b = a @ x_true
+        tol = 1e-12
+
+        x, info = sparse.linalg.gmres(
+            a, b, restart=2, maxiter=3, atol=tol, rtol=tol)
+        rel_res = cupy.linalg.norm(a @ x - b) / cupy.linalg.norm(b)
+
+        assert rel_res > tol
+        assert info != 0
+
+
 def skip_HIP_spMM_error(outer=()):
     def decorator(impl):
         @functools.wraps(impl)


### PR DESCRIPTION
## Summary

Fix `cupyx.scipy.sparse.linalg.gmres` so that it reports non-convergence correctly when the solver stops because `iters >= maxiter`.

Before this change, the outer loop stopped on:

```python
if r_norm <= atol or iters >= maxiter:
    break
```

but the [final failure check](https://github.com/cupy/cupy/blob/v14.0.1/cupyx/scipy/sparse/linalg/_iterative.py#L192C8-L192C24) only set `info` when:

```python
if iters == maxiter and not (r_norm <= atol):
    info = iters
```

With restarted GMRES, `iters` increases in steps of `restart`, so it can overshoot `maxiter`. In that case CuPy could return `info = 0` even though the final residual was still above tolerance.

This PR changes the final condition to use `iters >= maxiter`.

## Reproducer

A small deterministic reproducer is:

- `A = scipy.sparse.csr_matrix(scipy.linalg.hilbert(48))`
- `b = A @ np.random.default_rng(0).standard_normal(48)`
- `restart = 2`
- `atol = rtol = 1e-12`

With `maxiter = 3`, the current implementation returns `info = 0` even though the true relative residual is about `1.705e-01`, so the solve has not converged. With `maxiter = 4`, nonzero `info` is returned with the same residual. So it only reports nonzero `info` when `maxiter` is a multiple of `restart`.

## Test

Add a regression test that covers the non-converged case with `maxiter` not divisible by `restart` and asserts that `info != 0`.
