### PR TITLE
BUG: Fix bug with minimum_phase

### DIFF
--- a/cupyx/scipy/signal/_fir_filter_design.py
+++ b/cupyx/scipy/signal/_fir_filter_design.py
@@ -918,8 +918,8 @@ def minimum_phase(h, method='homomorphic', n_fft=None, half=True):
         win[0] = 1
         stop = n_fft // 2
         win[1:stop] = 2
-        if n_fft % 2:
-            win[stop] = 1
+        # Nyquist freq: odd use 2, even use 1
+        win[stop] = 1 + (n_fft % 2)
         h_temp *= win
         h_temp = ifft(cupy.exp(fft(h_temp)))
         h_minimum = h_temp.real

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -447,3 +447,15 @@ class TestMinimumPhase:
         if xp == cupy:
             h_linear = cupy.asarray(h_linear)
         return scp.signal.minimum_phase(h_linear, method="hilbert")
+
+    @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-6)
+    @pytest.mark.parametrize("N", (963, 964))
+    @pytest.mark.parametrize("dtype", ("float32", "float64"))
+    def test_nyquist(self, N, dtype, xp, scp):
+        fc = xp.asarray(10)
+        fs = 100
+        h = scp.signal.firwin(
+            N, fc, window="hann", pass_zero="lowpass", scale=False, fs=fs
+        )
+        h = h.astype(dtype)
+        return scp.signal.minimum_phase(h, method="homomorphic", n_fft=N, half=False)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -408,7 +408,7 @@ class TestMinimumPhase:
         assert_raises(ValueError, signal.minimum_phase,
                       cupy.ones(10), method='foo')
 
-    @testing.with_requires("scipy>=1.14")
+    @testing.with_requires("scipy>=1.18.0")
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_homomorphic(self, xp, scp):
         # check that it can recover frequency responses of arbitrary
@@ -419,7 +419,7 @@ class TestMinimumPhase:
         h_new = scp.signal.minimum_phase(xp.convolve(h, h[::-1]))
         return h_new
 
-    @testing.with_requires("scipy>=1.14")
+    @testing.with_requires("scipy>=1.18.0")
     @pytest.mark.parametrize("half", [True, False])
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_homomorphic_half(self, xp, scp, half):
@@ -448,10 +448,10 @@ class TestMinimumPhase:
             h_linear = cupy.asarray(h_linear)
         return scp.signal.minimum_phase(h_linear, method="hilbert")
 
+    @testing.with_requires("scipy>=1.18.0")
     @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-6)
     @pytest.mark.parametrize("N", (963, 964))
     @pytest.mark.parametrize("dtype", ("float32", "float64"))
-    @testing.with_requires("scipy>=1.18.0")
     def test_nyquist(self, N, dtype, xp, scp):
         fc = xp.asarray(10)
         fs = 100

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -455,7 +455,10 @@ class TestMinimumPhase:
         fc = xp.asarray(10)
         fs = 100
         h = scp.signal.firwin(
-            N, fc, window="hann", pass_zero="lowpass", scale=False, fs=fs
+            N, fc, window="hann", pass_zero="lowpass",
+            scale=False, fs=fs
         )
         h = h.astype(dtype)
-        return scp.signal.minimum_phase(h, method="homomorphic", n_fft=N, half=False)
+        return scp.signal.minimum_phase(
+            h, method="homomorphic", n_fft=N, half=False
+        )

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_fir_filter_design.py
@@ -451,6 +451,7 @@ class TestMinimumPhase:
     @testing.numpy_cupy_allclose(scipy_name="scp", atol=1e-6)
     @pytest.mark.parametrize("N", (963, 964))
     @pytest.mark.parametrize("dtype", ("float32", "float64"))
+    @testing.with_requires("scipy>=1.18.0")
     def test_nyquist(self, N, dtype, xp, scp):
         fc = xp.asarray(10)
         fs = 100


### PR DESCRIPTION
Meant as a companion to https://github.com/scipy/scipy/pull/24749 . TL;DR is that there is a bug with how Nyquist is handled and this fixes it.

No idea if I've implemented the test correctly, and I expect it to fail until https://github.com/scipy/scipy/pull/24749 is merged and it's tested against that.

Maintainers feel free to push commits to fix this as needed (or close and open your own PR), figured getting the ball rolling was better than just opening an issue!