### PR TITLE
9804: Prevent hypergeometric infinite loops and other consequences of invalid inputs

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -248,12 +248,24 @@ class RandomState:
     def hypergeometric(self, ngood, nbad, nsample, size=None, dtype='l'):
         """Returns an array of samples drawn from the hypergeometric distribution.
 
+        .. warning::
+
+            This function may synchronize the device.
+
         .. seealso::
             - :func:`cupy.random.hypergeometric` for full documentation
             - :meth:`numpy.random.RandomState.hypergeometric`
         """  # NOQA
         ngood, nbad, nsample = \
             cupy.asarray(ngood), cupy.asarray(nbad), cupy.asarray(nsample)
+        if cupy.any(ngood < 0):  # synchronize!
+            raise ValueError('ngood < 0')
+        if cupy.any(nbad < 0):  # synchronize!
+            raise ValueError('nbad < 0')
+        if cupy.any(nsample < 1):  # synchronize!
+            raise ValueError('nsample < 1')
+        if cupy.any(ngood + nbad < nsample):  # synchronize!
+            raise ValueError('ngood + nbad < nsample')
         if size is None:
             size = cupy.broadcast(ngood, nbad, nsample).shape
         y = cupy.empty(shape=size, dtype=dtype)

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -592,6 +592,10 @@ class Generator:
         Returns:
             cupy.ndarray: Samples drawn from the hypergeometric distribution.
 
+        .. warning::
+
+            This function may synchronize the device.
+
         .. seealso::
             :meth:`numpy.random.Generator.hypergeometric`
         """
@@ -633,6 +637,14 @@ class Generator:
         else:
             nsample = nsample.astype(numpy.int64, copy=False)
 
+        if cupy.any(ngood < 0):  # synchronize!
+            raise ValueError('ngood < 0')
+        if cupy.any(nbad < 0):  # synchronize!
+            raise ValueError('nbad < 0')
+        if cupy.any(nsample < 0):  # synchronize!
+            raise ValueError('nsample < 0')
+        if cupy.any(ngood + nbad < nsample):  # synchronize!
+            raise ValueError('ngood + nbad < nsample')
         if size is not None and not isinstance(size, tuple):
             size = (size,)
         if size is None:

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -791,8 +791,7 @@ __device__ long rk_hypergeometric(
     rk_state *state, long good, long bad, long sample)
 {
     if (sample <= 0) return 0;
-    if (sample >= good + bad) return good;
-    if (sample > 10)
+    if ((sample > 10) && (sample <= good + bad - 10))
     {
         return rk_hypergeometric_hrua(state, good, bad, sample);
     } else

--- a/cupy/random/_kernels.py
+++ b/cupy/random/_kernels.py
@@ -790,6 +790,8 @@ __device__ long rk_hypergeometric_hrua(
 __device__ long rk_hypergeometric(
     rk_state *state, long good, long bad, long sample)
 {
+    if (sample <= 0) return 0;
+    if (sample >= good + bad) return good;
     if (sample > 10)
     {
         return rk_hypergeometric_hrua(state, good, bad, sample);

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -332,8 +332,7 @@ __device__ int64_t rk_hypergeometric_hrua(T& state, int64_t good, int64_t bad, i
 template<typename T>
 __device__ int64_t rk_hypergeometric(T& state, int64_t good, int64_t bad, int64_t sample) {
     if (sample <= 0) return 0;
-    if (sample >= good + bad) return good;
-    if (sample > 10) {
+    if ((sample > 10) && (sample <= good + bad - 10)) {
         return rk_hypergeometric_hrua(state, good, bad, sample);
     }
     else {

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -331,6 +331,8 @@ __device__ int64_t rk_hypergeometric_hrua(T& state, int64_t good, int64_t bad, i
 
 template<typename T>
 __device__ int64_t rk_hypergeometric(T& state, int64_t good, int64_t bad, int64_t sample) {
+    if (sample <= 0) return 0;
+    if (sample >= good + bad) return good;
     if (sample > 10) {
         return rk_hypergeometric_hrua(state, good, bad, sample);
     }

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -245,29 +245,30 @@ class TestHypergeometric(
     pass
 
 
-class TestHypergeometricValidation(unittest.TestCase):
+class TestHypergeometricValidation:
 
-    def setUp(self):
-        self.rs = _generator.RandomState(seed=testing.generate_seed())
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.rs = _generator.RandomState(seed=0)
 
     def test_hypergeometric_ngood_negative(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.rs.hypergeometric(-1, 10, 5, size=10)
 
     def test_hypergeometric_nbad_negative(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.rs.hypergeometric(10, -1, 5, size=10)
 
     def test_hypergeometric_nsample_zero(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.rs.hypergeometric(10, 10, 0, size=10)
 
     def test_hypergeometric_nsample_negative(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.rs.hypergeometric(10, 10, -1, size=10)
 
     def test_hypergeometric_nsample_too_large(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.rs.hypergeometric(5, 10, 16, size=10)
 
     def test_hypergeometric_nsample_equals_total(self):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -245,6 +245,45 @@ class TestHypergeometric(
     pass
 
 
+class TestHypergeometricValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.rs = _generator.RandomState(seed=testing.generate_seed())
+
+    def test_hypergeometric_ngood_negative(self):
+        with self.assertRaises(ValueError):
+            self.rs.hypergeometric(-1, 10, 5, size=10)
+
+    def test_hypergeometric_nbad_negative(self):
+        with self.assertRaises(ValueError):
+            self.rs.hypergeometric(10, -1, 5, size=10)
+
+    def test_hypergeometric_nsample_zero(self):
+        with self.assertRaises(ValueError):
+            self.rs.hypergeometric(10, 10, 0, size=10)
+
+    def test_hypergeometric_nsample_negative(self):
+        with self.assertRaises(ValueError):
+            self.rs.hypergeometric(10, 10, -1, size=10)
+
+    def test_hypergeometric_nsample_too_large(self):
+        with self.assertRaises(ValueError):
+            self.rs.hypergeometric(5, 10, 16, size=10)
+
+    def test_hypergeometric_nsample_equals_total(self):
+        # nsample == ngood + nbad is valid (deterministic)
+        out = self.rs.hypergeometric(5, 10, 15, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5))
+
+    def test_hypergeometric_ngood_zero(self):
+        out = self.rs.hypergeometric(0, 10, 5, size=10)
+        testing.assert_array_equal(out, cupy.zeros(10))
+
+    def test_hypergeometric_nbad_zero(self):
+        out = self.rs.hypergeometric(5, 0, 5, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5))
+
+
 @testing.fix_random()
 class TestLaplace(RandomGeneratorTestCase):
 

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -292,10 +292,11 @@ class TestHypergeometric(
     pass
 
 
-class TestHypergeometricValidation(unittest.TestCase):
+class TestHypergeometricValidation:
 
-    def setUp(self):
-        self.gen = random.default_rng(seed=testing.generate_seed())
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.gen = random.default_rng(seed=0)
 
     def test_hypergeometric_ngood_negative(self):
         with pytest.raises(ValueError):

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -292,6 +292,45 @@ class TestHypergeometric(
     pass
 
 
+class TestHypergeometricValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = random.default_rng(seed=testing.generate_seed())
+
+    def test_hypergeometric_ngood_negative(self):
+        with pytest.raises(ValueError):
+            self.gen.hypergeometric(-1, 10, 5, size=10)
+
+    def test_hypergeometric_nbad_negative(self):
+        with pytest.raises(ValueError):
+            self.gen.hypergeometric(10, -1, 5, size=10)
+
+    def test_hypergeometric_nsample_negative(self):
+        with pytest.raises(ValueError):
+            self.gen.hypergeometric(10, 10, -1, size=10)
+
+    def test_hypergeometric_nsample_too_large(self):
+        with pytest.raises(ValueError):
+            self.gen.hypergeometric(5, 10, 16, size=10)
+
+    def test_hypergeometric_nsample_zero(self):
+        # Generator API allows nsample=0 (returns zeros), unlike legacy API
+        out = self.gen.hypergeometric(5, 10, 0, size=10)
+        testing.assert_array_equal(out, cupy.zeros(10, dtype=cupy.int64))
+
+    def test_hypergeometric_nsample_equals_total(self):
+        out = self.gen.hypergeometric(5, 10, 15, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5, dtype=cupy.int64))
+
+    def test_hypergeometric_ngood_zero(self):
+        out = self.gen.hypergeometric(0, 10, 5, size=10)
+        testing.assert_array_equal(out, cupy.zeros(10, dtype=cupy.int64))
+
+    def test_hypergeometric_nbad_zero(self):
+        out = self.gen.hypergeometric(5, 0, 5, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5, dtype=cupy.int64))
+
+
 @testing.parameterize(*common_distributions.power_params)
 @testing.fix_random()
 class TestPower(


### PR DESCRIPTION
Should fix https://github.com/cupy/cupy/issues/9804 and also https://github.com/cupy/cupy/issues/9239.

Context: If `nsample > (ngood + nbad)` and `nsample > 10` we would end up in an infinite loop. Good news is that that's invalid input, and numpy just checks this case and some others before running the kernel.

I basically tried to port numpy's checks here. Added both Python-level and kernel level input validation for defense in depth, but I'm happy to change the approach though. I understand raising validation exceptions from Python at that point will sync the device, but given that this only happens on invalid input, I think it's ok?

Full disclosure: I had claude (opus 4.6) write the test cases. I think they look pretty good and match the overall style, but happy to tweak!

**EDIT(seberg): Marked as no-compat, since the random stream could change here, just for a brief note in release notes.**