### PR TITLE
TST: Fixup some more tests (mainly cupyx) for free-threading

### DIFF
--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 from unittest import mock
 
@@ -570,8 +571,9 @@ class _TestRawBase:
             code = compiler._convert_to_hip_source(_test_source5, None, False)
         # split() is needed because nvcc could come from the env var NVCC
         cmd = cc.split()
-        source = '{}/test_load_cubin.cu'.format(self.cache_dir)
-        file_path = self.cache_dir + 'test_load_cubin'
+        thread_id = threading.get_ident()
+        source = f'{self.cache_dir}/test_load_cubin_{thread_id}.cu'
+        file_path = self.cache_dir + f'test_load_cubin_{thread_id}'
         with open(source, 'w') as f:
             f.write(code)
         if not cupy.cuda.runtime.is_hip:

--- a/tests/cupy_tests/cuda_tests/test_driver.py
+++ b/tests/cupy_tests/cuda_tests/test_driver.py
@@ -19,15 +19,16 @@ class TestDriver(unittest.TestCase):
     def test_ctxGetCurrent_thread(self):
         # Make sure to create context in main thread.
         cupy.arange(1)
+        _result0 = None
+        _result1 = None
 
         def f(self):
-            self._result0 = driver.ctxGetCurrent()
+            nonlocal _result0, _result1
+            _result0 = driver.ctxGetCurrent()
             cupy.cuda.Device().use()
             cupy.arange(1)
-            self._result1 = driver.ctxGetCurrent()
+            _result1 = driver.ctxGetCurrent()
 
-        self._result0 = None
-        self._result1 = None
         t = threading.Thread(target=f, args=(self,))
         t.daemon = True
         t.start()
@@ -35,11 +36,11 @@ class TestDriver(unittest.TestCase):
 
         # The returned context pointer must be NULL on sub thread
         # without valid context.
-        assert 0 == self._result0
+        assert 0 == _result0
 
         # After the context is created, it should return the valid
         # context pointer.
-        assert 0 != self._result1
+        assert 0 != _result1
 
     @testing.multi_gpu(2)
     def test_ctxGetDevice(self):

--- a/tests/cupy_tests/statistics_tests/test_order.py
+++ b/tests/cupy_tests/statistics_tests/test_order.py
@@ -63,6 +63,7 @@ class TestQuantile:
 
     # See gh-4453
     @testing.for_float_dtypes()
+    @pytest.mark.thread_unsafe(reason="allocator setting not thread-safe")
     def test_percentile_memory_access(self, dtype):
         # Create an allocator that guarantees array allocated in
         # cupy.percentile call will be followed by a NaN

--- a/tests/cupyx_tests/profiler_tests/test_timeit_magic.py
+++ b/tests/cupyx_tests/profiler_tests/test_timeit_magic.py
@@ -65,6 +65,7 @@ def _verify_benchmark_output(output):
         number_pattern, output), "Output should contain timing numbers"
 
 
+@pytest.mark.thread_unsafe(reason="ipython_shell fixture not thread-safe")
 class TestGPUTimeitMagic:
     """Test %gpu_timeit magic functionality."""
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
@@ -210,17 +210,17 @@ class TestInterp:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_shapes(self, xp, scp):
-        xp.random.seed(1234)
+        rng = xp.random.RandomState(1234)
         k, n = 3, 22
-        x = xp.sort(xp.random.random(size=n))
-        y = xp.random.random(size=(n, 5, 6, 7))
+        x = xp.sort(rng.uniform(size=n))
+        y = rng.uniform(size=(n, 5, 6, 7))
 
         b1 = scp.interpolate.make_interp_spline(x, y, k)
         assert b1.c.shape == (n, 5, 6, 7)
 
         # now throw in some derivatives
-        d_l = [(1, xp.random.random((5, 6, 7)))]
-        d_r = [(1, xp.random.random((5, 6, 7)))]
+        d_l = [(1, rng.uniform(size=(5, 6, 7)))]
+        d_r = [(1, rng.uniform(size=(5, 6, 7)))]
         b2 = scp.interpolate.make_interp_spline(x, y, k, bc_type=(d_l, d_r))
         assert b2.c.shape == (n + k - 1, 5, 6, 7)
 
@@ -343,10 +343,10 @@ class TestInterp:
     def test_full_matrix(self):
         from cupyx.scipy.interpolate._bspline2 import (
             _make_interp_spline_full_matrix)
-        cupy.random.seed(1234)
+        rng = cupy.random.RandomState(1234)
         k, n = 3, 7
-        x = cupy.sort(cupy.random.random(size=n))
-        y = cupy.random.random(size=n)
+        x = cupy.sort(rng.uniform(size=n))
+        y = rng.uniform(size=n)
 
         # test not-a-knot
         b = csi.make_interp_spline(x, y, k=3)
@@ -397,9 +397,9 @@ class TestInterpPeriodic:
     def test_periodic_random(self, xp, scp, k):
         # tests for both cases (k > n and k <= n)
         n = 15
-        _np.random.seed(1234)
-        x = _np.sort(_np.random.random_sample(n) * 10)
-        y = _np.random.random_sample(n) * 100
+        rng = _np.random.RandomState(1234)
+        x = _np.sort(rng.random_sample(n) * 10)
+        y = rng.random_sample(n) * 100
         if xp is cupy:
             x = cupy.asarray(x)
             y = cupy.asarray(y)
@@ -413,8 +413,8 @@ class TestInterpPeriodic:
     def test_periodic_axis(self, xp, scp):
         x, y = self.get_xy(xp)
         n = x.shape[0]
-        _np.random.seed(1234)
-        x = _np.random.random_sample(n) * 2 * _np.pi
+        rng = _np.random.RandomState(1234)
+        x = rng.random_sample(n) * 2 * _np.pi
         x = _np.sort(x)
         if xp is cupy:
             x = cupy.asarray(x)
@@ -449,9 +449,9 @@ class TestInterpPeriodic:
         # edge case: Cubic interpolation on 3 points
         # TODO: refactor when PPoly / CubicHermiteSpline is available
         n = 3
-        cupy.random.seed(1234)
-        x = cupy.sort(cupy.random.random_sample(n) * 10)
-        y = cupy.random.random_sample(n) * 100
+        rng = cupy.random.RandomState(1234)
+        x = cupy.sort(rng.random_sample(n) * 10)
+        y = rng.random_sample(n) * 100
         y[0] = y[-1]
         b = csi.make_interp_spline(x, y, k=3, bc_type='periodic')
 
@@ -479,9 +479,9 @@ class TestLSQ:
     """
 
     def _get_xytk(self, xp, n=13, k=3):
-        _np.random.seed(1234)
-        x = _np.sort(_np.random.random(n))
-        y = _np.random.random(n)
+        rng = _np.random.RandomState(1234)
+        x = _np.sort(rng.random(n))
+        y = rng.random(n)
         t = _np.r_[(x[0],)*k,
                    _np.linspace(x[0], x[-1], 7),
                    (x[-1],)*k]
@@ -513,10 +513,10 @@ class TestLSQ:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_multiple_rhs(self, xp, scp):
-        _np.random.seed(1234)
+        rng = _np.random.RandomState(1234)
         n = 11
         x, y, t, k = self._get_xytk(xp, n=n)
-        y = _np.random.random(size=(n, 5, 6, 7))
+        y = rng.random(size=(n, 5, 6, 7))
         y = xp.asarray(y)
 
         b = scp.interpolate.make_lsq_spline(x, y, t, k)

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ppoly.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ppoly.py
@@ -54,12 +54,12 @@ class TestPPolyCommon:
     def test_extend(self, xp, scp, cls):
         # Test adding new points to the piecewise polynomial
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(1234)
+        rng = numpy.random.RandomState(1234)
 
         order = 3
-        x = numpy.unique(numpy.r_[0, 10 * numpy.random.rand(30), 10])
+        x = numpy.unique(numpy.r_[0, 10 * rng.uniform(size=30), 10])
         x = xp.asarray(x)
-        c = 2*numpy.random.rand(order+1, len(x)-1, 2, 3) - 1
+        c = 2*rng.uniform(size=(order+1, len(x)-1, 2, 3)) - 1
         c = xp.asarray(c)
 
         pp = cls(c[:, :9], x[:10])
@@ -77,13 +77,13 @@ class TestPPolyCommon:
     def test_extend_diff_orders(self, xp, scp, cls):
         # Test extending polynomial with different order one
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
         x = xp.linspace(0, 1, 6)
-        c = xp.asarray(numpy.random.rand(2, 5))
+        c = xp.asarray(rng.rand(2, 5))
 
         x2 = xp.linspace(1, 2, 6)
-        c2 = xp.asarray(numpy.random.rand(4, 5))
+        c2 = xp.asarray(rng.rand(4, 5))
 
         pp1 = cls(c, x)
         pp2 = cls(c2, x2)
@@ -102,12 +102,12 @@ class TestPPolyCommon:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_extend_descending(self, xp, scp, cls):
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(0)
+        rng = np.random.RandomState(0)
 
         order = 3
-        x = numpy.sort(numpy.random.uniform(0, 10, 20))
+        x = numpy.sort(rng.uniform(0, 10, 20))
         x = xp.asarray(x)
-        c = numpy.random.rand(order + 1, x.shape[0] - 1, 2, 3)
+        c = rng.rand(order + 1, x.shape[0] - 1, 2, 3)
         c = xp.asarray(c)
 
         p1 = cls(c[:, :9], x[:10])
@@ -122,13 +122,13 @@ class TestPPolyCommon:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_shape(self, xp, scp, cls):
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(1234)
+        rng = np.random.RandomState(1234)
 
-        c = numpy.random.rand(8, 12, 5, 6, 7)
+        c = rng.rand(8, 12, 5, 6, 7)
         c = xp.asarray(c)
-        x = numpy.sort(numpy.random.rand(13))
+        x = numpy.sort(rng.rand(13))
         x = xp.asarray(x)
-        xpts = numpy.random.rand(3, 4)
+        xpts = rng.rand(3, 4)
         xpts = xp.asarray(xpts)
 
         p = cls(c, x)
@@ -138,11 +138,11 @@ class TestPPolyCommon:
     def test_shape_2(self, cls):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             cls1 = getattr(scp.interpolate, cls)
-            numpy.random.seed(1234)
+            rng = np.random.RandomState(1234)
 
-            c = numpy.random.rand(8, 12, 5, 6, 7)
+            c = rng.rand(8, 12, 5, 6, 7)
             c = xp.asarray(c)
-            x = numpy.sort(numpy.random.rand(13))
+            x = numpy.sort(rng.rand(13))
             x = xp.asarray(x)
 
             # 'scalars'
@@ -162,13 +162,13 @@ class TestPPolyCommon:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_complex_coef(self, xp, scp, cls):
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(12345)
-        x = numpy.sort(numpy.random.random(13))
+        rng = np.random.RandomState(12345)
+        x = numpy.sort(rng.random(13))
         x = xp.array(x)
-        c = numpy.random.random((8, 12)) * (1. + 0.3j)
+        c = rng.random((8, 12)) * (1. + 0.3j)
         c = xp.array(c)
         # c_re, c_im = c.real, c.imag
-        xpt = xp.array(numpy.random.random(5))
+        xpt = xp.array(rng.random(5))
 
         p = cls(c, x)
         return [p(xpt, nu) for nu in [0, 1, 2]]
@@ -178,15 +178,15 @@ class TestPPolyCommon:
     def test_axis(self, cls, axis):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             cls1 = getattr(scp.interpolate, cls)
-            numpy.random.seed(12345)
-            c = numpy.random.rand(3, 4, 5, 6, 7, 8)
+            rng = np.random.RandomState(12345)
+            c = rng.rand(3, 4, 5, 6, 7, 8)
             c = xp.asarray(c)
             c_s = c.shape
-            xpt = numpy.random.random((1, 2))
+            xpt = rng.random((1, 2))
             xpt = xp.asarray(xpt)
 
             m = c.shape[axis+1]
-            x = numpy.sort(numpy.random.rand(m+1))
+            x = numpy.sort(rng.rand(m+1))
             x = xp.asarray(x)
 
             p = cls1(c, x, axis=axis)
@@ -209,11 +209,11 @@ class TestPPolyCommon:
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=ValueError)
     def test_axis_2(self, xp, scp, cls, axis):
         cls = getattr(scp.interpolate, cls)
-        numpy.random.seed(12345)
-        c = numpy.random.rand(3, 4, 5, 6, 7, 8)
+        rng = np.random.RandomState(12345)
+        c = rng.rand(3, 4, 5, 6, 7, 8)
         c = xp.asarray(c)
 
-        x = numpy.sort(numpy.random.rand(c.shape[-1]))
+        x = numpy.sort(rng.rand(c.shape[-1]))
         x = xp.asarray(x)
 
         # c array needs two axes for the coefficients and intervals, so
@@ -258,7 +258,8 @@ class TestPPoly:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_multi_shape(self, xp, scp):
-        c = numpy.random.rand(6, 2, 1, 2, 3)
+        rng = np.random.RandomState(1234)
+        c = rng.rand(6, 2, 1, 2, 3)
         c = xp.asarray(c)
         x = xp.array([0, 0.5, 1])
         p = scp.interpolate.PPoly(c, x)
@@ -689,11 +690,11 @@ class TestPPoly:
             B = cupy.asarray(B)
         return B[::-1, ::-1]
 
-    def _prepare_descending(self, m, xp, scp):
+    def _prepare_descending(self, m, xp, scp, rng):
         power = 3
-        x = numpy.sort(numpy.random.uniform(0, 10, m + 1))
+        x = numpy.sort(rng.uniform(0, 10, m + 1))
         x = xp.asarray(x)
-        ca = numpy.random.uniform(-2, 2, size=(power + 1, m))
+        ca = rng.uniform(-2, 2, size=(power + 1, m))
         ca = xp.asarray(ca)
 
         h = xp.diff(x)
@@ -710,30 +711,30 @@ class TestPPoly:
     @pytest.mark.parametrize('m', [10, 20, 30])
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13)
     def test_descending(self, m, xp, scp):
-        numpy.random.seed(0)
-        pa, pd = self._prepare_descending(m, xp, scp)
+        rng = numpy.random.RandomState(0)
+        pa, pd = self._prepare_descending(m, xp, scp, rng)
 
-        x_test = numpy.random.uniform(-10, 20, 100)
+        x_test = rng.uniform(-10, 20, size=100)
         x_test = xp.asarray(x_test)
         return pa(x_test), pa(x_test, 1)
 
     @pytest.mark.parametrize('m', [10, 20, 30])
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13)
     def test_descending_derivative(self, m, xp, scp):
-        numpy.random.seed(0)
-        pa, pd = self._prepare_descending(m, xp, scp)
+        rng = numpy.random.RandomState(0)
+        pa, pd = self._prepare_descending(m, xp, scp, rng)
         pa_d = pa.derivative()
         pd_d = pd.derivative()
 
-        x_test = numpy.random.uniform(-10, 20, 100)
+        x_test = rng.uniform(-10, 20, size=100)
         x_test = xp.asarray(x_test)
         return pa_d(x_test), pd_d(x_test)
 
     @pytest.mark.parametrize('m', [10, 20, 30])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_descending_antiderivative(self, m, xp, scp):
-        numpy.random.seed(0)
-        pa, pd = self._prepare_descending(m, xp, scp)
+        rng = numpy.random.RandomState(0)
+        pa, pd = self._prepare_descending(m, xp, scp, rng)
 
         # Antiderivatives won't be equal because fixing continuity is
         # done in the reverse order, but surely the differences should be
@@ -741,7 +742,7 @@ class TestPPoly:
         pa_i = pa.antiderivative()
         pd_i = pd.antiderivative()
         results = []
-        for a, b in numpy.random.uniform(-10, 20, (5, 2)):
+        for a, b in rng.uniform(-10, 20, size=(5, 2)):
             int_a = pa.integrate(a, b)
             int_d = pd.integrate(a, b)
             results += [int_a, int_d]
@@ -752,8 +753,8 @@ class TestPPoly:
     @pytest.mark.parametrize('m', [10, 20, 30])
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-12)
     def test_descending_roots(self, m, xp, scp):
-        numpy.random.seed(0)
-        pa, pd = self._prepare_descending(m, xp, scp)
+        rng = numpy.random.RandomState(0)
+        pa, pd = self._prepare_descending(m, xp, scp, rng)
 
         roots_d = pd.roots()
         roots_a = pa.roots()

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -93,6 +93,12 @@ class FilterTestCaseBase:
         args = [getattr(self, param)
                 for param in FilterTestCaseBase.ARGS_PARAMS
                 if hasattr(self, param)]
+
+        # Some tests use a different "function" for NumPy vs. CuPy.
+        if hasattr(self, "func_or_kernel"):
+            assert not hasattr(self, "function")
+            args.append(self.get_func_or_kernel(xp))
+
         if wghts is not None:
             args.append(wghts)
 
@@ -660,9 +666,6 @@ class TestGenericFilter(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
-        # Need to deal with the different versions of the functions given to
-        # numpy vs cupy
-        self.function = self.get_func_or_kernel(xp)
         return self._filter(xp, scp)
 
 
@@ -702,9 +705,6 @@ class TestGenericFilterAxes(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
-        # Need to deal with the different versions of the functions given to
-        # numpy vs cupy
-        self.function = self.get_func_or_kernel(xp)
         return self._filter(xp, scp)
 
 
@@ -762,9 +762,6 @@ class TestGeneric1DFilter(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
-        # Need to deal with the different versions of the functions given to
-        # numpy vs cupy
-        self.function = self.get_func_or_kernel(xp)
         return self._filter(xp, scp)
 
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -533,16 +533,18 @@ class TestBinaryMorphologyAxes:
                 structure = scp.ndimage.generate_binary_structure(
                     len(self.axes), self.connectivity)
         if len(self.origin) > len(self.axes):
-            self.origin = [self.origin[ax] for ax in self.axes]
+            origin = [self.origin[ax] for ax in self.axes]
+        else:
+            origin = self.origin
 
         if self.filter not in ["binary_hit_or_miss", "binary_fill_holes"]:
             kwargs["border_value"] = self.border_value
 
         if self.filter == "binary_hit_or_miss":
-            kwargs["origin1"] = self.origin
-            kwargs["origin2"] = self.origin
+            kwargs["origin1"] = origin
+            kwargs["origin2"] = origin
         else:
-            kwargs["origin"] = self.origin
+            kwargs["origin"] = origin
         return filter(x, structure, axes=self.axes, **kwargs)
 
     @testing.numpy_cupy_array_equal(scipy_name='scp')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -265,9 +265,9 @@ class TestFreqz:
     def test_broadcasting1(self, xp, scp, whole, worN):
         # Test broadcasting with worN an integer or a 1-D array,
         # b and a are n-dimensional arrays.
-        np.random.seed(123)
-        b = np.random.rand(3, 5, 1)
-        a = np.random.rand(2, 1)
+        rng = np.random.RandomState(123)
+        b = rng.rand(3, 5, 1)
+        a = rng.rand(2, 1)
         if xp == cupy:
             a = cupy.asarray(a)
             b = cupy.asarray(b)
@@ -284,8 +284,8 @@ class TestFreqz:
     def test_broadcasting2(self, xp, scp, whole, worN):
         # Test broadcasting with worN an integer or a 1-D array,
         # b is an n-dimensional array, and a is left at the default value.
-        np.random.seed(123)
-        b = np.random.rand(3, 5, 1)
+        rng = np.random.RandomState(123)
+        b = rng.rand(3, 5, 1)
 
         if xp == cupy:
             b = cupy.asarray(b)
@@ -308,9 +308,9 @@ class TestFreqz:
     def test_broadcasting3(self, xp, scp, whole, worN):
         # Test broadcasting where b.shape[-1] is the same length
         # as worN, and a is left at the default value.
-        np.random.seed(123)
+        rng = np.random.RandomState(123)
         N = 16
-        b = np.random.rand(3, N)     # XXX: N is worN or len(worN) !
+        b = rng.rand(3, N)     # XXX: N is worN or len(worN) !
 
         if xp == cupy:
             b = cupy.asarray(b)
@@ -323,13 +323,13 @@ class TestFreqz:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_broadcasting4(self, xp, scp, whole):
         # Test broadcasting with worN a 2-D array.
-        np.random.seed(123)
-        b = np.random.rand(4, 2, 1, 1)
-        a = np.random.rand(5, 2, 1, 1)
+        rng = np.random.RandomState(123)
+        b = rng.rand(4, 2, 1, 1)
+        a = rng.rand(5, 2, 1, 1)
 
         wh = []
 
-        for worN in [np.random.rand(6, 7), np.empty((6, 0))]:
+        for worN in [rng.rand(6, 7), np.empty((6, 0))]:
             if xp == cupy:
                 a = cupy.asarray(a)
                 b = cupy.asarray(b)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_polyutils.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_polyutils.py
@@ -66,8 +66,8 @@ class TestUniqueRoots:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_single_unique_root(self, xp, scp):
-        np.random.seed(1234)
-        p = np.random.rand(100) + 1j * np.random.rand(100)
+        rng = np.random.RandomState(1234)
+        p = rng.rand(100) + 1j * rng.rand(100)
         p = xp.asarray(p)
 
         unique, multiplicity = scp.signal.unique_roots(p, 2)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -48,15 +48,16 @@ def _check_shares_memory(xp, sp, x, y):
 @testing.with_requires('scipy>=1.4.0')
 class TestSetitemIndexing:
 
-    def _run(self, maj, min=None, data=5):
-
+    def _run(self, maj, min=None, data=5, density=None):
+        if density is None:
+            density = self.density
         import scipy.sparse
         for i in range(2):
             shape = self.n_rows, self.n_cols
             a = testing.shaped_sparse_random(
-                shape, sparse, self.dtype, self.density, self.format)
+                shape, sparse, self.dtype, density, self.format)
             expected = testing.shaped_sparse_random(
-                shape, scipy.sparse, self.dtype, self.density, self.format)
+                shape, scipy.sparse, self.dtype, density, self.format)
 
             maj_h = maj.get() if isinstance(maj, cupy.ndarray) else maj
             min_h = min.get() if isinstance(min, cupy.ndarray) else min
@@ -320,11 +321,11 @@ class TestSetitemIndexing:
         # ref: https://github.com/cupy/cupy/issues/3836
         # Starting with an empty array for now, since insertions
         # use `last-in-wins`.
-        self.density = 0.0  # Zeroing out density to force only insertions
         for maj, min, data in zip(_get_index_combos([0, 5, 10, 2, 0, 10]),
                                   _get_index_combos([1, 2, 3, 4, 1, 3]),
                                   _get_index_combos([1, 2, 3, 4, 5, 6])):
-            self._run(maj, min, data)
+            # Zeroing out density to force only insertions:
+            self._run(maj, min, data, density=0.0)
 
 
 class IndexingTestBase:

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -31,7 +31,7 @@ class TestGesv(unittest.TestCase):
             a = a + 1j * self._make_array(shape, alpha, beta)
         return a
 
-    def setUp(self):
+    def setup(self):
         self.dtype = numpy.dtype(self.dtype)
         n = self.n
         nrhs = 1 if self.nrhs is None else self.nrhs
@@ -47,43 +47,47 @@ class TestGesv(unittest.TestCase):
         if self.nrhs is not None:
             b_shape.append(nrhs)
         b = b.reshape(b_shape)
-        self.a = a
+
         if self.nrhs is None or self.nrhs == 1:
-            self.b = b.copy(order=self.order)
+            b = b.copy(order=self.order)
         else:
-            self.b = b.copy(order='F')
+            b = b.copy(order='F')
         self.x_ref = x.reshape(b_shape)
         self.tol = self._tol[self.dtype.char.lower()]
 
+        return a, b
+
     def test_gesv(self):
-        lapack.gesv(self.a, self.b)
-        cupy.testing.assert_allclose(self.b, self.x_ref,
+        a, b = self.setup()
+        lapack.gesv(a, b)
+        cupy.testing.assert_allclose(b, self.x_ref,
                                      rtol=self.tol, atol=self.tol)
 
     def test_invalid_cases(self):
+        a, b = self.setup()
         if self.nrhs is None or self.nrhs == 1:
             raise unittest.SkipTest()
-        ng_a = self.a.reshape(1, self.n, self.n)
+        ng_a = a.reshape(1, self.n, self.n)
         with pytest.raises(ValueError):
-            lapack.gesv(ng_a, self.b)
-        ng_b = self.b.reshape(1, self.n, self.nrhs)
+            lapack.gesv(ng_a, b)
+        ng_b = b.reshape(1, self.n, self.nrhs)
         with pytest.raises(ValueError):
-            lapack.gesv(self.a, ng_b)
+            lapack.gesv(a, ng_b)
         ng_a = cupy.ones((self.n, self.n+1), dtype=self.dtype)
         with pytest.raises(ValueError):
-            lapack.gesv(ng_a, self.b)
+            lapack.gesv(ng_a, b)
         ng_a = cupy.ones((self.n+1, self.n+1), dtype=self.dtype)
         with pytest.raises(ValueError):
-            lapack.gesv(ng_a, self.b)
-        ng_a = cupy.ones(self.a.shape, dtype='i')
+            lapack.gesv(ng_a, b)
+        ng_a = cupy.ones(a.shape, dtype='i')
         with pytest.raises(TypeError):
-            lapack.gesv(ng_a, self.b)
+            lapack.gesv(ng_a, b)
         ng_a = cupy.ones((2, self.n, self.n), dtype=self.dtype, order='F')[0]
         with pytest.raises(ValueError):
-            lapack.gesv(ng_a, self.b)
-        ng_b = self.b.copy(order='C')
+            lapack.gesv(ng_a, b)
+        ng_b = b.copy(order='C')
         with pytest.raises(ValueError):
-            lapack.gesv(self.a, ng_b)
+            lapack.gesv(a, ng_b)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Fixes a few smaller things, mainly two categories:
* Accidental changes of `self.` which are incompatible but commonly arise for non-unittest custom parametrization.
* Use of `RandomState` rather than global seeding.

And a few smaller ones.  This covers cupyx, but two other small things flushed up when I was running things now.
(Since this can be flaky, there is a bit of a long tail.)