### PR TITLE
ENH,BUG: Replace `int` with `size_t` in cub reduce/segmented reduce/scan

### DIFF
--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -335,7 +335,6 @@ cpdef inline tuple _can_use_cub_block_reduction(
     cdef bint full_reduction = True if len(out_axis) == 0 else False
 
     # check if the number of elements is too large
-    # (ref: cupy/cupy#3309 for CUB limit)
     for i in reduce_axis:
         contiguous_size *= in_arr.shape[i]
     if contiguous_size > 0x7fffffffffffffff or contiguous_size == 0:

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -51,25 +51,25 @@ CUB_sum_support_dtype = {}
 cdef extern from 'cupy_cub.h' nogil:
     ctypedef void* Stream_t 'cudaStream_t'
 
-    void cub_device_reduce(void*, size_t&, void*, void*, int, Stream_t,
+    void cub_device_reduce(void*, size_t&, void*, void*, size_t, Stream_t,
                            int, int)
-    void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, int,
+    void cub_device_segmented_reduce(void*, size_t&, void*, void*, size_t, size_t,
                                      Stream_t, int, int)
-    void cub_device_scan(void*, size_t&, void*, void*, int, Stream_t, int, int)
-    void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*,
+    void cub_device_scan(void*, size_t&, void*, void*, size_t, Stream_t, int, int)
+    void cub_device_histogram_range(void*, size_t&, void*, void*, size_t, void*,
                                     size_t, Stream_t, int)
-    void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int,
+    void cub_device_histogram_even(void*, size_t&, void*, void*, size_t, size_t, size_t,
                                    size_t, Stream_t, int)
-    size_t cub_device_reduce_get_workspace_size(void*, void*, int, Stream_t,
+    size_t cub_device_reduce_get_workspace_size(void*, void*, size_t, Stream_t,
                                                 int, int)
     size_t cub_device_segmented_reduce_get_workspace_size(
-        void*, void*, int, int, Stream_t, int, int)
+        void*, void*, size_t, size_t, Stream_t, int, int)
     size_t cub_device_scan_get_workspace_size(
-        void*, void*, int, Stream_t, int, int)
+        void*, void*, size_t, Stream_t, int, int)
     size_t cub_device_histogram_range_get_workspace_size(
-        void*, void*, int, void*, size_t, Stream_t, int)
+        void*, void*, size_t, void*, size_t, Stream_t, int)
     size_t cub_device_histogram_even_get_workspace_size(
-        void*, void*, int, int, int, size_t, Stream_t, int)
+        void*, void*, size_t, size_t, size_t, size_t, Stream_t, int)
 
     # Build-time version
     int CUPY_CUB_VERSION_CODE
@@ -138,7 +138,8 @@ def device_reduce(_ndarray_base x, op, tuple reduce_axis, tuple out_axis,
                   out=None, bint keepdims=False):
     cdef _ndarray_base y
     cdef memory.MemoryPointer ws
-    cdef int dtype_id, ndim_out, kv_bytes, x_size, op_code
+    cdef int dtype_id, ndim_out, kv_bytes, op_code
+    cdef size_t x_size
     cdef size_t ws_size
     cdef void *x_ptr
     cdef void *y_ptr
@@ -184,7 +185,7 @@ def device_reduce(_ndarray_base x, op, tuple reduce_axis, tuple out_axis,
     y_ptr = <void *>y.data.ptr
     dtype_id = common._get_dtype_id(x.dtype)
     s = <Stream_t>stream.get_current_stream_ptr()
-    x_size = <int>x.size
+    x_size = <size_t>x.size
     ws_size = cub_device_reduce_get_workspace_size(x_ptr, y_ptr, x.size, s,
                                                    op, dtype_id)
     ws = memory.alloc(ws_size)
@@ -216,7 +217,8 @@ def device_segmented_reduce(_ndarray_base x, op, tuple reduce_axis,
     cdef void* x_ptr
     cdef void* y_ptr
     cdef void* ws_ptr
-    cdef int dtype_id, n_segments, op_code
+    cdef int dtype_id, op_code
+    cdef size_t n_segments
     cdef size_t ws_size
     cdef tuple out_shape
     cdef Stream_t s
@@ -273,7 +275,8 @@ def device_segmented_reduce(_ndarray_base x, op, tuple reduce_axis,
 
 def device_scan(_ndarray_base x, op):
     cdef memory.MemoryPointer ws
-    cdef int dtype_id, x_size, op_code
+    cdef int dtype_id, op_code
+    cdef size_t x_size
     cdef size_t ws_size
     cdef void *x_ptr
     cdef void *ws_ptr
@@ -284,7 +287,7 @@ def device_scan(_ndarray_base x, op):
                          'are supported.')
 
     # determine shape: x is either 1D (with axis=None,0) or ND but ravelled.
-    x_size = <int>x.size
+    x_size = <size_t>x.size
     if x_size == 0:
         return x
 
@@ -307,7 +310,8 @@ def device_scan(_ndarray_base x, op):
 def device_histogram(_ndarray_base x, _ndarray_base y, bins):
     cdef memory.MemoryPointer ws
     cdef size_t ws_size, n_samples
-    cdef int dtype_id, n_bins
+    cdef int dtype_id
+    cdef size_t n_bins
     cdef void* x_ptr
     cdef void* bins_ptr
     cdef void* y_ptr
@@ -374,8 +378,7 @@ cdef bint can_use_device_reduce(
         _ndarray_base x, int op, tuple out_axis, dtype=None) except*:
     return (
         out_axis is ()
-        and _cub_reduce_dtype_compatible(x.dtype, op, dtype)
-        and x.size <= 0x7fffffff)  # until we resolve cupy/cupy#3309
+        and _cub_reduce_dtype_compatible(x.dtype, op, dtype))
 
 
 cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
@@ -390,10 +393,9 @@ cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
             return (False, 0)
     else:
         order = 'CF'  # for computing the contig size
-    # until we resolve cupy/cupy#3309
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
-    return (contiguous_size <= 0x7fffffff, contiguous_size)
+    return (True, contiguous_size)
 
 
 cdef _cub_support_dtype(bint sum_mode, int dev_id):

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -53,15 +53,16 @@ cdef extern from 'cupy_cub.h' nogil:
 
     void cub_device_reduce(void*, size_t&, void*, void*, size_t, Stream_t,
                            int, int)
-    void cub_device_segmented_reduce(void*, size_t&, void*, void*, size_t, size_t,
-                                     Stream_t, int, int)
-    void cub_device_scan(void*, size_t&, void*, void*, size_t, Stream_t, int, int)
-    void cub_device_histogram_range(void*, size_t&, void*, void*, size_t, void*,
-                                    size_t, Stream_t, int)
-    void cub_device_histogram_even(void*, size_t&, void*, void*, size_t, size_t, size_t,
-                                   size_t, Stream_t, int)
-    size_t cub_device_reduce_get_workspace_size(void*, void*, size_t, Stream_t,
-                                                int, int)
+    void cub_device_segmented_reduce(void*, size_t&, void*, void*,
+                                     size_t, size_t, Stream_t, int, int)
+    void cub_device_scan(void*, size_t&, void*, void*,
+                         size_t, Stream_t, int, int)
+    void cub_device_histogram_range(void*, size_t&, void*, void*,
+                                    size_t, void*, size_t, Stream_t, int)
+    void cub_device_histogram_even(void*, size_t&, void*, void*, size_t,
+                                   size_t, size_t, size_t, Stream_t, int)
+    size_t cub_device_reduce_get_workspace_size(void*, void*, size_t,
+                                                Stream_t, int, int)
     size_t cub_device_segmented_reduce_get_workspace_size(
         void*, void*, size_t, size_t, Stream_t, int, int)
     size_t cub_device_scan_get_workspace_size(
@@ -376,6 +377,10 @@ cpdef bint _cub_device_segmented_reduce_axis_compatible(
 
 cdef bint can_use_device_reduce(
         _ndarray_base x, int op, tuple out_axis, dtype=None) except*:
+    if op in (CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
+        # Argmin/argmax still use integer for their result key.
+        if x.size > 0x7fffffff:
+            return False
     return (
         out_axis is ()
         and _cub_reduce_dtype_compatible(x.dtype, op, dtype))
@@ -395,6 +400,10 @@ cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
         order = 'CF'  # for computing the contig size
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
+    if op in (CUPY_CUB_ARGMIN, CUPY_CUB_ARGMAX):
+        # Argmin/argmax still use integer for their result key.
+        if contiguous_size > 0x7fffffff:
+            return (False, 0)
     return (True, contiguous_size)
 
 

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -57,10 +57,10 @@ cdef extern from 'cupy_cub.h' nogil:
                                      size_t, size_t, Stream_t, int, int)
     void cub_device_scan(void*, size_t&, void*, void*,
                          size_t, Stream_t, int, int)
-    void cub_device_histogram_range(void*, size_t&, void*, void*,
-                                    size_t, void*, size_t, Stream_t, int)
-    void cub_device_histogram_even(void*, size_t&, void*, void*, size_t,
-                                   size_t, size_t, size_t, Stream_t, int)
+    void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*,
+                                    size_t, Stream_t, int)
+    void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int,
+                                   size_t, Stream_t, int)
     size_t cub_device_reduce_get_workspace_size(void*, void*, size_t,
                                                 Stream_t, int, int)
     size_t cub_device_segmented_reduce_get_workspace_size(
@@ -68,9 +68,9 @@ cdef extern from 'cupy_cub.h' nogil:
     size_t cub_device_scan_get_workspace_size(
         void*, void*, size_t, Stream_t, int, int)
     size_t cub_device_histogram_range_get_workspace_size(
-        void*, void*, size_t, void*, size_t, Stream_t, int)
+        void*, void*, int, void*, size_t, Stream_t, int)
     size_t cub_device_histogram_even_get_workspace_size(
-        void*, void*, size_t, size_t, size_t, size_t, Stream_t, int)
+        void*, void*, int, int, int, size_t, Stream_t, int)
 
     # Build-time version
     int CUPY_CUB_VERSION_CODE
@@ -311,8 +311,7 @@ def device_scan(_ndarray_base x, op):
 def device_histogram(_ndarray_base x, _ndarray_base y, bins):
     cdef memory.MemoryPointer ws
     cdef size_t ws_size, n_samples
-    cdef int dtype_id
-    cdef size_t n_bins
+    cdef int dtype_id, n_bins
     cdef void* x_ptr
     cdef void* bins_ptr
     cdef void* y_ptr

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -909,7 +909,7 @@ struct _cub_reduce_argmin {
         size_t num_items, cudaStream_t s)
     {
         DeviceReduce::ArgMin(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<KeyValuePair<int, T>*>(y), num_items, s);
+            static_cast<KeyValuePair<int, T>*>(y), (int)num_items, s);
     }
 };
 
@@ -924,7 +924,7 @@ struct _cub_reduce_argmax {
         size_t num_items, cudaStream_t s)
     {
         DeviceReduce::ArgMax(workspace, workspace_size, static_cast<T*>(x),
-            static_cast<KeyValuePair<int, T>*>(y), num_items, s);
+            static_cast<KeyValuePair<int, T>*>(y), (int)num_items, s);
     }
 };
 

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -249,11 +249,11 @@ using _multiply = cuda::std::multiplies<>;
 struct _arange
 {
     private:
-        int step_size;
+        size_t step_size;
 
     public:
-    __host__ __device__ __forceinline__ _arange(int i): step_size(i) {}
-    __host__ __device__ __forceinline__ int operator()(const int &in) const {
+    __host__ __device__ __forceinline__ _arange(size_t i): step_size(i) {}
+    __host__ __device__ __forceinline__ size_t operator()(const size_t &in) const {
         return step_size * in;
     }
 };
@@ -743,7 +743,7 @@ struct select_min<__half> {
 struct _cub_reduce_sum {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         DeviceReduce::Sum(workspace, workspace_size, static_cast<T*>(x),
             static_cast<T*>(y), num_items, s);
@@ -753,7 +753,7 @@ struct _cub_reduce_sum {
 struct _cub_segmented_reduce_sum {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         DeviceSegmentedReduce::Sum(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
@@ -767,7 +767,7 @@ struct _cub_segmented_reduce_sum {
 struct _cub_reduce_prod {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         _multiply product_op;
         // the init value is cast from 1.0f because on host __half can only be
@@ -780,7 +780,7 @@ struct _cub_reduce_prod {
 struct _cub_segmented_reduce_prod {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         _multiply product_op;
         // the init value is cast from 1.0f because on host __half can only be
@@ -798,7 +798,7 @@ struct _cub_segmented_reduce_prod {
 struct _cub_reduce_min {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
@@ -817,7 +817,7 @@ struct _cub_reduce_min {
 struct _cub_segmented_reduce_min {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
@@ -841,7 +841,7 @@ struct _cub_segmented_reduce_min {
 struct _cub_reduce_max {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
@@ -871,7 +871,7 @@ struct _cub_reduce_max {
 struct _cub_segmented_reduce_max {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, seg_offset_itr offset_start, cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
@@ -906,7 +906,7 @@ struct _cub_segmented_reduce_max {
 struct _cub_reduce_argmin {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         DeviceReduce::ArgMin(workspace, workspace_size, static_cast<T*>(x),
             static_cast<KeyValuePair<int, T>*>(y), num_items, s);
@@ -921,7 +921,7 @@ struct _cub_reduce_argmin {
 struct _cub_reduce_argmax {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         DeviceReduce::ArgMax(workspace, workspace_size, static_cast<T*>(x),
             static_cast<KeyValuePair<int, T>*>(y), num_items, s);
@@ -936,7 +936,7 @@ struct _cub_reduce_argmax {
 struct _cub_inclusive_sum {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         DeviceScan::InclusiveSum(workspace, workspace_size, static_cast<T*>(input),
             static_cast<T*>(output), num_items, s);
@@ -949,7 +949,7 @@ struct _cub_inclusive_sum {
 struct _cub_inclusive_product {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        int num_items, cudaStream_t s)
+        size_t num_items, cudaStream_t s)
     {
         _multiply product_op;
         DeviceScan::InclusiveScan(workspace, workspace_size, static_cast<T*>(input),
@@ -964,7 +964,7 @@ struct _cub_histogram_range {
     template <typename sampleT,
               typename binT = typename std::conditional<std::is_integral<sampleT>::value, double, sampleT>::type>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        int n_bins, void* bins, size_t n_samples, cudaStream_t s) const
+        size_t n_bins, void* bins, size_t n_samples, cudaStream_t s) const
     {
         // Ugly hack to avoid specializing complex types, which cub::DeviceHistogram does not support.
         // TODO(leofang): revisit this part when complex support is added to cupy.histogram()
@@ -981,7 +981,7 @@ struct _cub_histogram_range {
         // TODO(leofang): check if hipCUB has the same bug or not
 
         // if (n_samples < (1ULL << 31)) {
-            int num_samples = n_samples;
+            size_t num_samples = n_samples;
             DeviceHistogram::HistogramRange(workspace, workspace_size, static_cast<h_sampleT*>(input),
                 #ifndef CUPY_USE_HIP
                 static_cast<long long*>(output), n_bins, static_cast<h_binT*>(bins), num_samples, s);
@@ -1004,12 +1004,12 @@ struct _cub_histogram_range {
 struct _cub_histogram_even {
     template <typename sampleT>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        int& n_bins, int& lower, int& upper, size_t n_samples, cudaStream_t s) const
+        size_t& n_bins, size_t& lower, size_t& upper, size_t n_samples, cudaStream_t s) const
     {
         #ifndef CUPY_USE_HIP
         // Ugly hack to avoid specializing numerical types
-        typedef typename std::conditional<std::is_integral<sampleT>::value, sampleT, int>::type h_sampleT;
-        int num_samples = n_samples;
+        typedef typename std::conditional<std::is_integral<sampleT>::value, sampleT, size_t>::type h_sampleT;
+        size_t num_samples = n_samples;
         static_assert(sizeof(long long) == sizeof(intptr_t), "not supported");
         DeviceHistogram::HistogramEven(workspace, workspace_size, static_cast<h_sampleT*>(input),
             static_cast<long long*>(output), n_bins, lower, upper, num_samples, s);
@@ -1026,7 +1026,7 @@ struct _cub_histogram_even {
 /* -------- device reduce -------- */
 
 void cub_device_reduce(void* workspace, size_t& workspace_size, void* x, void* y,
-    int num_items, cudaStream_t stream, int op, int dtype_id)
+    size_t num_items, cudaStream_t stream, int op, int dtype_id)
 {
     switch(op) {
     case CUPY_CUB_SUM:      return dtype_dispatcher(dtype_id, _cub_reduce_sum(),
@@ -1045,7 +1045,7 @@ void cub_device_reduce(void* workspace, size_t& workspace_size, void* x, void* y
     }
 }
 
-size_t cub_device_reduce_get_workspace_size(void* x, void* y, int num_items,
+size_t cub_device_reduce_get_workspace_size(void* x, void* y, size_t num_items,
     cudaStream_t stream, int op, int dtype_id)
 {
     size_t workspace_size = 0;
@@ -1057,10 +1057,9 @@ size_t cub_device_reduce_get_workspace_size(void* x, void* y, int num_items,
 /* -------- device segmented reduce -------- */
 
 void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
-    void* x, void* y, int num_segments, int segment_size,
+    void* x, void* y, size_t num_segments, size_t segment_size,
     cudaStream_t stream, int op, int dtype_id)
 {
-    // CUB internally use int for offset...
     // This iterates over [0, segment_size, 2*segment_size, 3*segment_size, ...]
     #ifndef CUPY_USE_HIP
     thrust::counting_iterator<int> count_itr(0);
@@ -1089,7 +1088,7 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
 }
 
 size_t cub_device_segmented_reduce_get_workspace_size(void* x, void* y,
-    int num_segments, int segment_size,
+    size_t num_segments, size_t segment_size,
     cudaStream_t stream, int op, int dtype_id)
 {
     size_t workspace_size = 0;
@@ -1102,7 +1101,7 @@ size_t cub_device_segmented_reduce_get_workspace_size(void* x, void* y,
 /* -------- device scan -------- */
 
 void cub_device_scan(void* workspace, size_t& workspace_size, void* x, void* y,
-    int num_items, cudaStream_t stream, int op, int dtype_id)
+    size_t num_items, cudaStream_t stream, int op, int dtype_id)
 {
     switch(op) {
     case CUPY_CUB_CUMSUM:
@@ -1116,7 +1115,7 @@ void cub_device_scan(void* workspace, size_t& workspace_size, void* x, void* y,
     }
 }
 
-size_t cub_device_scan_get_workspace_size(void* x, void* y, int num_items,
+size_t cub_device_scan_get_workspace_size(void* x, void* y, size_t num_items,
     cudaStream_t stream, int op, int dtype_id)
 {
     size_t workspace_size = 0;
@@ -1128,7 +1127,7 @@ size_t cub_device_scan_get_workspace_size(void* x, void* y, int num_items,
 /* -------- device histogram -------- */
 
 void cub_device_histogram_range(void* workspace, size_t& workspace_size, void* x, void* y,
-    int n_bins, void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
+    size_t n_bins, void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     // TODO(leofang): support complex
     if (dtype_id == CUPY_TYPE_COMPLEX64 || dtype_id == CUPY_TYPE_COMPLEX128) {
@@ -1140,7 +1139,7 @@ void cub_device_histogram_range(void* workspace, size_t& workspace_size, void* x
                             workspace, workspace_size, x, y, n_bins, bins, n_samples, stream);
 }
 
-size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, int n_bins,
+size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, size_t n_bins,
     void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
@@ -1150,7 +1149,7 @@ size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, int n_bin
 }
 
 void cub_device_histogram_even(void* workspace, size_t& workspace_size, void* x, void* y,
-    int n_bins, int lower, int upper, size_t n_samples, cudaStream_t stream, int dtype_id)
+    size_t n_bins, size_t lower, size_t upper, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     #ifndef CUPY_USE_HIP
     return dtype_dispatcher(dtype_id, _cub_histogram_even(),
@@ -1158,8 +1157,8 @@ void cub_device_histogram_even(void* workspace, size_t& workspace_size, void* x,
     #endif
 }
 
-size_t cub_device_histogram_even_get_workspace_size(void* x, void* y, int n_bins,
-    int lower, int upper, size_t n_samples, cudaStream_t stream, int dtype_id)
+size_t cub_device_histogram_even_get_workspace_size(void* x, void* y, size_t n_bins,
+    size_t lower, size_t upper, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
     cub_device_histogram_even(NULL, workspace_size, x, y, n_bins, lower, upper, n_samples,

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -259,9 +259,9 @@ struct _arange
 };
 
 #ifndef CUPY_USE_HIP
-typedef thrust::transform_iterator<_arange, thrust::counting_iterator<int>> seg_offset_itr;
+typedef thrust::transform_iterator<_arange, thrust::counting_iterator<size_t>> seg_offset_itr;
 #else
-typedef TransformInputIterator<int, _arange, rocprim::counting_iterator<int>> seg_offset_itr;
+typedef TransformInputIterator<size_t, _arange, rocprim::counting_iterator<size_t>> seg_offset_itr;
 #endif
 
 /*
@@ -1062,9 +1062,9 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
 {
     // This iterates over [0, segment_size, 2*segment_size, 3*segment_size, ...]
     #ifndef CUPY_USE_HIP
-    thrust::counting_iterator<int> count_itr(0);
+    thrust::counting_iterator<size_t> count_itr(0);
     #else
-    rocprim::counting_iterator<int> count_itr(0);
+    rocprim::counting_iterator<size_t> count_itr(0);
     #endif
     _arange scaling(segment_size);
     seg_offset_itr itr(count_itr, scaling);

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -964,7 +964,7 @@ struct _cub_histogram_range {
     template <typename sampleT,
               typename binT = typename std::conditional<std::is_integral<sampleT>::value, double, sampleT>::type>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        size_t n_bins, void* bins, size_t n_samples, cudaStream_t s) const
+        int n_bins, void* bins, size_t n_samples, cudaStream_t s) const
     {
         // Ugly hack to avoid specializing complex types, which cub::DeviceHistogram does not support.
         // TODO(leofang): revisit this part when complex support is added to cupy.histogram()
@@ -981,7 +981,7 @@ struct _cub_histogram_range {
         // TODO(leofang): check if hipCUB has the same bug or not
 
         // if (n_samples < (1ULL << 31)) {
-            size_t num_samples = n_samples;
+            int num_samples = n_samples;
             DeviceHistogram::HistogramRange(workspace, workspace_size, static_cast<h_sampleT*>(input),
                 #ifndef CUPY_USE_HIP
                 static_cast<long long*>(output), n_bins, static_cast<h_binT*>(bins), num_samples, s);
@@ -1004,12 +1004,12 @@ struct _cub_histogram_range {
 struct _cub_histogram_even {
     template <typename sampleT>
     void operator()(void* workspace, size_t& workspace_size, void* input, void* output,
-        size_t& n_bins, size_t& lower, size_t& upper, size_t n_samples, cudaStream_t s) const
+        int& n_bins, int& lower, int& upper, size_t n_samples, cudaStream_t s) const
     {
         #ifndef CUPY_USE_HIP
         // Ugly hack to avoid specializing numerical types
-        typedef typename std::conditional<std::is_integral<sampleT>::value, sampleT, size_t>::type h_sampleT;
-        size_t num_samples = n_samples;
+        typedef typename std::conditional<std::is_integral<sampleT>::value, sampleT, int>::type h_sampleT;
+        int num_samples = n_samples;
         static_assert(sizeof(long long) == sizeof(intptr_t), "not supported");
         DeviceHistogram::HistogramEven(workspace, workspace_size, static_cast<h_sampleT*>(input),
             static_cast<long long*>(output), n_bins, lower, upper, num_samples, s);
@@ -1127,7 +1127,7 @@ size_t cub_device_scan_get_workspace_size(void* x, void* y, size_t num_items,
 /* -------- device histogram -------- */
 
 void cub_device_histogram_range(void* workspace, size_t& workspace_size, void* x, void* y,
-    size_t n_bins, void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
+    int n_bins, void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     // TODO(leofang): support complex
     if (dtype_id == CUPY_TYPE_COMPLEX64 || dtype_id == CUPY_TYPE_COMPLEX128) {
@@ -1139,7 +1139,7 @@ void cub_device_histogram_range(void* workspace, size_t& workspace_size, void* x
                             workspace, workspace_size, x, y, n_bins, bins, n_samples, stream);
 }
 
-size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, size_t n_bins,
+size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, int n_bins,
     void* bins, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
@@ -1149,7 +1149,7 @@ size_t cub_device_histogram_range_get_workspace_size(void* x, void* y, size_t n_
 }
 
 void cub_device_histogram_even(void* workspace, size_t& workspace_size, void* x, void* y,
-    size_t n_bins, size_t lower, size_t upper, size_t n_samples, cudaStream_t stream, int dtype_id)
+    int n_bins, int lower, int upper, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     #ifndef CUPY_USE_HIP
     return dtype_dispatcher(dtype_id, _cub_histogram_even(),
@@ -1157,8 +1157,8 @@ void cub_device_histogram_even(void* workspace, size_t& workspace_size, void* x,
     #endif
 }
 
-size_t cub_device_histogram_even_get_workspace_size(void* x, void* y, size_t n_bins,
-    size_t lower, size_t upper, size_t n_samples, cudaStream_t stream, int dtype_id)
+size_t cub_device_histogram_even_get_workspace_size(void* x, void* y, int n_bins,
+    int lower, int upper, size_t n_samples, cudaStream_t stream, int dtype_id)
 {
     size_t workspace_size = 0;
     cub_device_histogram_even(NULL, workspace_size, x, y, n_bins, lower, upper, n_samples,

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -28,13 +28,13 @@
 void cub_device_reduce(void*, size_t&, void*, void*, size_t, cudaStream_t, int, int);
 void cub_device_segmented_reduce(void*, size_t&, void*, void*, size_t, size_t, cudaStream_t, int, int);
 void cub_device_scan(void*, size_t&, void*, void*, size_t, cudaStream_t, int, int);
-void cub_device_histogram_range(void*, size_t&, void*, void*, size_t, void*, size_t, cudaStream_t, int);
-void cub_device_histogram_even(void*, size_t&, void*, void*, size_t, size_t, size_t, size_t, cudaStream_t, int);
+void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*, size_t, cudaStream_t, int);
+void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int, size_t, cudaStream_t, int);
 size_t cub_device_reduce_get_workspace_size(void*, void*, size_t, cudaStream_t, int, int);
 size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, size_t, size_t, cudaStream_t, int, int);
 size_t cub_device_scan_get_workspace_size(void*, void*, size_t, cudaStream_t, int, int);
-size_t cub_device_histogram_range_get_workspace_size(void*, void*, size_t, void*, size_t, cudaStream_t, int);
-size_t cub_device_histogram_even_get_workspace_size(void*, void*, size_t, size_t, size_t, size_t, cudaStream_t, int);
+size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
+size_t cub_device_histogram_even_get_workspace_size(void*, void*, int, int, int, size_t, cudaStream_t, int);
 
 // This is for CUB's HistogramRange; hipCUB does not need this (see comment in cupy_cub.cu)
 #ifdef __CUDA_ARCH__

--- a/cupy/cuda/cupy_cub.h
+++ b/cupy/cuda/cupy_cub.h
@@ -25,16 +25,16 @@
 #define cudaStream_t hipStream_t
 #endif
 
-void cub_device_reduce(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
-void cub_device_segmented_reduce(void*, size_t&, void*, void*, int, int, cudaStream_t, int, int);
-void cub_device_scan(void*, size_t&, void*, void*, int, cudaStream_t, int, int);
-void cub_device_histogram_range(void*, size_t&, void*, void*, int, void*, size_t, cudaStream_t, int);
-void cub_device_histogram_even(void*, size_t&, void*, void*, int, int, int, size_t, cudaStream_t, int);
-size_t cub_device_reduce_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
-size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, int, int, cudaStream_t, int, int);
-size_t cub_device_scan_get_workspace_size(void*, void*, int, cudaStream_t, int, int);
-size_t cub_device_histogram_range_get_workspace_size(void*, void*, int, void*, size_t, cudaStream_t, int);
-size_t cub_device_histogram_even_get_workspace_size(void*, void*, int, int, int, size_t, cudaStream_t, int);
+void cub_device_reduce(void*, size_t&, void*, void*, size_t, cudaStream_t, int, int);
+void cub_device_segmented_reduce(void*, size_t&, void*, void*, size_t, size_t, cudaStream_t, int, int);
+void cub_device_scan(void*, size_t&, void*, void*, size_t, cudaStream_t, int, int);
+void cub_device_histogram_range(void*, size_t&, void*, void*, size_t, void*, size_t, cudaStream_t, int);
+void cub_device_histogram_even(void*, size_t&, void*, void*, size_t, size_t, size_t, size_t, cudaStream_t, int);
+size_t cub_device_reduce_get_workspace_size(void*, void*, size_t, cudaStream_t, int, int);
+size_t cub_device_segmented_reduce_get_workspace_size(void*, void*, size_t, size_t, cudaStream_t, int, int);
+size_t cub_device_scan_get_workspace_size(void*, void*, size_t, cudaStream_t, int, int);
+size_t cub_device_histogram_range_get_workspace_size(void*, void*, size_t, void*, size_t, cudaStream_t, int);
+size_t cub_device_histogram_even_get_workspace_size(void*, void*, size_t, size_t, size_t, size_t, cudaStream_t, int);
 
 // This is for CUB's HistogramRange; hipCUB does not need this (see comment in cupy_cub.cu)
 #ifdef __CUDA_ARCH__

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -409,46 +409,58 @@ class TestReductionSizeOverInt32Max:
         cupy.get_default_memory_pool().free_all_blocks()
         cupy.get_default_pinned_memory_pool().free_all_blocks()
 
-    @pytest.mark.parametrize('shape,axis', [
-        ((INT32_MAX + 1024,), None),
-        ((4, 2**30 + 512), 1),
-        ((INT32_MAX + 1024, 2), 0),
-    ], ids=['full', 'axis1', 'axis0'])
+    @pytest.mark.parametrize('shape,axis,part', [
+        ((INT32_MAX + 1024,), None, "first-part"),
+        ((4, 2**30 + 512), 1, "second-part"),
+        ((INT32_MAX + 1024, 2), 0, "first-part"),
+    ])
     @pytest.mark.parametrize('dtype', [
         numpy.int8, numpy.int32, numpy.float32,
     ])
-    def test_sum_max_min_prod(self, shape, axis, dtype):
+    def test_sum_max_min_prod(self, shape, axis, dtype, part):
         try:
             a = cupy.ones(shape, dtype=dtype)
             # Make first and last element along each slice interesting
             if axis is None:
                 a[[0, -1]] = [3, -1]
             elif axis == 0:
-                a[[0, -1], :] = [3, -1]
+                a[[0, -1], :] = [[3], [-1]]
             else:
-                a[:, [0, -1]] = [3, -1]
+                a[:, [0, -1]] = [[3, -1]]
 
-            if axis is None:
-                # Full reduction: one segment, one 2 and (size-1) ones
-                assert a.sum() == a.size
-                assert a.max() == 3
-                assert a.min() == -1
-                assert a.prod() == -3
+            # Test only half of the reductions per test for better speed
+            # (it is still very slow.)
+            if part == "first-part":
+                if axis is None:
+                    # Full reduction: one segment, one 2 and (size-1) ones
+                    assert a.sum() == a.size
+                    assert a.max() == 3
+                    assert a.argmin() == a.size - 1
+                else:
+                    s = a.sum(axis=axis)
+                    expected_sum = shape[axis]
+                    testing.assert_array_equal(s, cupy.full(
+                        s.shape, expected_sum, dtype=s.dtype))
+                    testing.assert_array_equal(
+                        a.max(axis=axis), cupy.full(s.shape, 3, dtype=dtype))
+                    testing.assert_array_equal(
+                        a.argmin(axis), cupy.full(s.shape, a.shape[axis] - 1))
             else:
-                s = a.sum(axis=axis)
-                expected_sum = shape[axis]
-                testing.assert_array_equal(s, cupy.full(
-                    s.shape, expected_sum, dtype=s.dtype))
-                testing.assert_array_equal(
-                    a.max(axis=axis), cupy.full(s.shape, 3, dtype=dtype))
-                testing.assert_array_equal(
-                    a.min(axis=axis), cupy.full(s.shape, -1, dtype=dtype))
-                testing.assert_array_equal(
-                    a.prod(axis=axis), cupy.full(s.shape, -3, dtype=dtype))
+                if axis is None:
+                    # Full reduction: one segment, one 2 and (size-1) ones
+                    assert a.prod() == -3
+                    assert a.min() == -1
+                    assert a.argmax() == 0
+                else:
+                    p = a.prod(axis=axis)
+                    testing.assert_array_equal(p, cupy.full(
+                        p.shape, -3, dtype=p.dtype))
+                    testing.assert_array_equal(
+                        a.min(axis=axis), cupy.full(p.shape, -1, dtype=dtype))
+                    testing.assert_array_equal(
+                        a.argmax(axis), cupy.full(p.shape, 0))
         except MemoryError:
             pytest.skip("out of memory in test.")
-
-        cupy.get_default_memory_pool().free_all_blocks()
 
     @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
     def test_cumsum_size_over_int32_max(self, dtype):
@@ -467,8 +479,6 @@ class TestReductionSizeOverInt32Max:
         except MemoryError:
             pytest.skip("out of memory in test.")
 
-        cupy.get_default_memory_pool().free_all_blocks()
-
     @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
     def test_cumprod_size_over_int32_max(self, dtype):
         """CUB device_scan (cumprod) with size > INT32_MAX."""
@@ -481,8 +491,6 @@ class TestReductionSizeOverInt32Max:
             assert out[-1] == 6  # product of array
         except MemoryError:
             pytest.skip("out of memory in test.")
-
-        cupy.get_default_memory_pool().free_all_blocks()
 
 
 # This class compares cuTENSOR results against NumPy's

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -409,15 +409,13 @@ class TestReductionSizeOverInt32Max:
         cupy.get_default_memory_pool().free_all_blocks()
         cupy.get_default_pinned_memory_pool().free_all_blocks()
 
-    @pytest.mark.parametrize('shape,axis,part', [
-        ((INT32_MAX + 1024,), None, "first-part"),
-        ((4, 2**30 + 512), 1, "second-part"),
-        ((INT32_MAX + 1024, 2), 0, "first-part"),
+    @pytest.mark.parametrize('shape,axis,dtype,part', [
+        ((INT32_MAX + 1024,), None, "int8", "first_part"),
+        ((4, 2**30 + 512), 1, "float32", "second_part"),
+        ((INT32_MAX + 1024, 2), 0, "int8", "first_part"),
+        ((INT32_MAX + 1024, 2), 1, "int32", "second_part"),
     ])
-    @pytest.mark.parametrize('dtype', [
-        numpy.int8, numpy.int32, numpy.float32,
-    ])
-    def test_sum_max_min_prod(self, shape, axis, dtype, part):
+    def test_reduce(self, shape, axis, dtype, part):
         try:
             a = cupy.ones(shape, dtype=dtype)
             # Make first and last element along each slice interesting

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -387,6 +387,86 @@ class TestCubReduction:
         return result
 
 
+INT32_MAX = numpy.iinfo(numpy.int32).max
+
+
+@pytest.mark.skipif(
+    not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
+@testing.slow
+class TestReductionSizeOverInt32Max:
+
+    @pytest.fixture(autouse=True)
+    def _cub_device_and_memory(self):
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+        old_routine = _acc.get_routine_accelerators()
+        old_red = _acc.get_reduction_accelerators()
+        _acc.set_routine_accelerators(['cub'])
+        _acc.set_reduction_accelerators([])
+        yield
+        _acc.set_routine_accelerators(old_routine)
+        _acc.set_reduction_accelerators(old_red)
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+
+    @pytest.mark.parametrize('shape,axis', [
+        ((INT32_MAX + 1024,), None),
+        ((4, 2**30 + 512), 1),
+        ((INT32_MAX + 1024, 2), 0),
+    ], ids=['full', 'axis1', 'axis0'])
+    @pytest.mark.parametrize('dtype', [
+        numpy.int8, numpy.int32, numpy.float32,
+    ])
+    def test_sum_max_min_prod(self, shape, axis, dtype):
+        a = cupy.ones(shape, dtype=dtype)
+        # First element of each reduction segment = 2 (one pattern for all cases)
+        if len(shape) == 1:
+            a[0] = 2
+        else:
+            idx = [slice(None)] * len(shape)
+            idx[axis] = 0
+            a[tuple(idx)] = 2
+        if axis is None:
+            # Full reduction: one segment, one 2 and (size-1) ones
+            assert a.sum() == a.size + 1
+            assert a.max() == 2
+            assert a.min() == 1
+            assert a.prod() == 2
+        else:
+            s = a.sum(axis=axis)
+            expected_sum = shape[axis] + 1
+            testing.assert_array_equal(s, cupy.full(
+                s.shape, expected_sum, dtype=s.dtype))
+            testing.assert_array_equal(
+                a.max(axis=axis), cupy.full(s.shape, 2, dtype=dtype))
+            testing.assert_array_equal(
+                a.min(axis=axis), cupy.ones(s.shape, dtype=dtype))
+            testing.assert_array_equal(
+                a.prod(axis=axis), cupy.full(s.shape, 2, dtype=dtype))
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
+    def test_cumsum_size_over_int32_max(self, dtype):
+        """CUB device_scan with size > INT32_MAX."""
+        n = INT32_MAX + 1024
+        a = cupy.ones(n, dtype=dtype)
+        a[0] = 2
+        out = a.cumsum()
+        expected = n + 1
+        if dtype in (numpy.float32, numpy.float64):
+            testing.assert_allclose(float(out[-1]), expected, rtol=2e-4)
+        else:
+            assert int(out[-1]) == expected
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
+    def test_cumprod_size_over_int32_max(self, dtype):
+        """CUB device_scan (cumprod) with size > INT32_MAX."""
+        n = INT32_MAX + 1024
+        a = cupy.ones(n, dtype=dtype)
+        a[0] = 2
+        out = a.cumprod()
+        assert out[-1] == 2  # product of array
+
+
 # This class compares cuTENSOR results against NumPy's
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -418,53 +418,71 @@ class TestReductionSizeOverInt32Max:
         numpy.int8, numpy.int32, numpy.float32,
     ])
     def test_sum_max_min_prod(self, shape, axis, dtype):
-        a = cupy.ones(shape, dtype=dtype)
-        # First element of each reduction segment = 2 (one pattern for all cases)
-        if len(shape) == 1:
-            a[0] = 2
-        else:
-            idx = [slice(None)] * len(shape)
-            idx[axis] = 0
-            a[tuple(idx)] = 2
-        if axis is None:
-            # Full reduction: one segment, one 2 and (size-1) ones
-            assert a.sum() == a.size + 1
-            assert a.max() == 2
-            assert a.min() == 1
-            assert a.prod() == 2
-        else:
-            s = a.sum(axis=axis)
-            expected_sum = shape[axis] + 1
-            testing.assert_array_equal(s, cupy.full(
-                s.shape, expected_sum, dtype=s.dtype))
-            testing.assert_array_equal(
-                a.max(axis=axis), cupy.full(s.shape, 2, dtype=dtype))
-            testing.assert_array_equal(
-                a.min(axis=axis), cupy.ones(s.shape, dtype=dtype))
-            testing.assert_array_equal(
-                a.prod(axis=axis), cupy.full(s.shape, 2, dtype=dtype))
+        try:
+            a = cupy.ones(shape, dtype=dtype)
+            # Make first and last element along each slice interesting
+            if axis is None:
+                a[[0, -1]] = [3, -1]
+            elif axis == 0:
+                a[[0, -1], :] = [3, -1]
+            else:
+                a[:, [0, -1]] = [3, -1]
+
+            if axis is None:
+                # Full reduction: one segment, one 2 and (size-1) ones
+                assert a.sum() == a.size
+                assert a.max() == 3
+                assert a.min() == -1
+                assert a.prod() == -3
+            else:
+                s = a.sum(axis=axis)
+                expected_sum = shape[axis]
+                testing.assert_array_equal(s, cupy.full(
+                    s.shape, expected_sum, dtype=s.dtype))
+                testing.assert_array_equal(
+                    a.max(axis=axis), cupy.full(s.shape, 3, dtype=dtype))
+                testing.assert_array_equal(
+                    a.min(axis=axis), cupy.full(s.shape, -1, dtype=dtype))
+                testing.assert_array_equal(
+                    a.prod(axis=axis), cupy.full(s.shape, -3, dtype=dtype))
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+        cupy.get_default_memory_pool().free_all_blocks()
 
     @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
     def test_cumsum_size_over_int32_max(self, dtype):
         """CUB device_scan with size > INT32_MAX."""
-        n = INT32_MAX + 1024
-        a = cupy.ones(n, dtype=dtype)
-        a[0] = 2
-        out = a.cumsum()
-        expected = n + 1
-        if dtype in (numpy.float32, numpy.float64):
-            testing.assert_allclose(float(out[-1]), expected, rtol=2e-4)
-        else:
-            assert int(out[-1]) == expected
+        try:
+            n = INT32_MAX + 1024
+            a = cupy.ones(n, dtype=dtype)
+            a[0] = 3
+            a[-1] = -1
+            out = a.cumsum()
+            expected = n
+            if dtype in (numpy.float32, numpy.float64):
+                testing.assert_allclose(float(out[-1]), expected, rtol=2e-4)
+            else:
+                assert int(out[-1]) == expected
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+        cupy.get_default_memory_pool().free_all_blocks()
 
     @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
     def test_cumprod_size_over_int32_max(self, dtype):
         """CUB device_scan (cumprod) with size > INT32_MAX."""
-        n = INT32_MAX + 1024
-        a = cupy.ones(n, dtype=dtype)
-        a[0] = 2
-        out = a.cumprod()
-        assert out[-1] == 2  # product of array
+        try:
+            n = INT32_MAX + 1024
+            a = cupy.ones(n, dtype=dtype)
+            a[0] = 2
+            a[-1] = 3
+            out = a.cumprod()
+            assert out[-1] == 6  # product of array
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+        cupy.get_default_memory_pool().free_all_blocks()
 
 
 # This class compares cuTENSOR results against NumPy's


### PR DESCRIPTION
This replaces the `int` size related parameters with `size_t` parameters in CUB to remove call limitation and fix existing missing check.

Commit created in part with cursor.

---

Closes gh-9780, **note: if there is any uncertainty here or seems nontrivial to review, as discussed elsewhere: we can just close this and I'll instead do the one-line fix from the issue.  (the reasoning is that mid to long-term we'll want a more comprehensive fix anyway)**