### PR TITLE
BUG: Don't use `--device-as-default-execution-space` for hip

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -375,7 +375,8 @@ def _compile_using_nvrtc_no_warning(
                 source, options, cu_path)
         else:
             # Some tests/kernels require the following option:
-            options += ('--device-as-default-execution-space',)
+            if not runtime.is_hip:
+                options += ('--device-as-default-execution-space',)
 
             headers = include_names = ()
             major_version, minor_version = _get_nvrtc_version()


### PR DESCRIPTION
We removed a version check here, but running rocm tests once showed that this option isn't supported there.