### PR TITLE
Fix `delete` incompatibilities with NumPy

### DIFF
--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -9,39 +9,14 @@ import math
 from cupy import _core
 
 
-def _delete_mask(obj, size):
-    if isinstance(obj, slice):
-        mask = cupy.ones(size, dtype=cupy.bool_)
-        mask[obj] = False
-        return mask
-
-    raw_obj = obj
-    obj = cupy.asarray(obj)
-
-    if obj.dtype == cupy.bool_:
-        if obj.ndim != 1 or obj.shape[0] != size:
-            raise ValueError(
-                'boolean array argument obj to delete must be one '
-                f'dimensional and match the axis length of {size}')
-        return ~obj
-
-    # Match NumPy behavior for empty Python lists/tuples.
-    if obj.size == 0 and not isinstance(raw_obj, cupy.ndarray):
-        obj = obj.astype(cupy.intp)
-
-    mask = cupy.ones(size, dtype=cupy.bool_)
-    mask[obj] = False
-    return mask
-
-
-def delete(arr, obj, axis=None):
+def delete(arr, indices, axis=None):
     """
     Delete values from an array along the specified axis.
 
     Args:
         arr (cupy.ndarray):
             Values are deleted from a copy of this array.
-        obj (slice, int or array of ints):
+        indices (slice, int or array of ints):
             These indices correspond to values that will be deleted from the
             copy of `arr`.
             Boolean indices are treated as a mask of elements to remove.
@@ -59,18 +34,40 @@ def delete(arr, obj, axis=None):
     .. seealso:: :func:`numpy.delete`.
     """
 
-    arr = cupy.asarray(arr)
-    ndim = arr.ndim
+    if not isinstance(arr, cupy.ndarray):
+        raise ValueError('delete(): arr must be a cupy.ndarray')
 
     if axis is None:
-        if ndim != 1:
+        if arr.ndim != 1:
             arr = arr.ravel()
         axis = 0
     else:
         axis = _core.internal._normalize_axis_index(axis, arr.ndim)
 
     size = arr.shape[axis]
-    mask = _delete_mask(obj, size)
+    if not (
+            isinstance(indices, slice) or (
+                isinstance(indices, (int, numpy.integer))
+                and not isinstance(indices, bool)
+            )):
+        # NOTE(seberg): Delete is a utility function, but we could optimize
+        # it for slices and scalar integers (that are not bools).
+        # NumPy specializes slices, integers and boolean arrays.
+        idx_arr = cupy.asarray(indices)
+        if idx_arr.dtype == cupy.bool_:
+            if idx_arr.ndim != 1 or idx_arr.shape[0] != size:
+                raise ValueError(
+                    'boolean array argument indices to delete must be one '
+                    f'dimensional and match the axis length of {size}')
+            if arr.ndim == 1:
+                return arr[~idx_arr]
+
+        # Use array unless it is e.g. an empty lists that indexing accepts.
+        if idx_arr.size != 0:
+            indices = idx_arr
+
+    mask = cupy.ones(size, dtype=cupy.bool_)
+    mask[indices,] = False
     return cupy.compress(mask, arr, axis=axis)
 
 

--- a/cupy/_manipulation/add_remove.py
+++ b/cupy/_manipulation/add_remove.py
@@ -9,14 +9,39 @@ import math
 from cupy import _core
 
 
-def delete(arr, indices, axis=None):
+def _delete_mask(obj, size):
+    if isinstance(obj, slice):
+        mask = cupy.ones(size, dtype=cupy.bool_)
+        mask[obj] = False
+        return mask
+
+    raw_obj = obj
+    obj = cupy.asarray(obj)
+
+    if obj.dtype == cupy.bool_:
+        if obj.ndim != 1 or obj.shape[0] != size:
+            raise ValueError(
+                'boolean array argument obj to delete must be one '
+                f'dimensional and match the axis length of {size}')
+        return ~obj
+
+    # Match NumPy behavior for empty Python lists/tuples.
+    if obj.size == 0 and not isinstance(raw_obj, cupy.ndarray):
+        obj = obj.astype(cupy.intp)
+
+    mask = cupy.ones(size, dtype=cupy.bool_)
+    mask[obj] = False
+    return mask
+
+
+def delete(arr, obj, axis=None):
     """
     Delete values from an array along the specified axis.
 
     Args:
         arr (cupy.ndarray):
             Values are deleted from a copy of this array.
-        indices (slice, int or array of ints):
+        obj (slice, int or array of ints):
             These indices correspond to values that will be deleted from the
             copy of `arr`.
             Boolean indices are treated as a mask of elements to remove.
@@ -34,25 +59,19 @@ def delete(arr, indices, axis=None):
     .. seealso:: :func:`numpy.delete`.
     """
 
+    arr = cupy.asarray(arr)
+    ndim = arr.ndim
+
     if axis is None:
-
-        arr = arr.ravel()
-
-        if isinstance(indices, cupy.ndarray) and indices.dtype == cupy.bool_:
-            return arr[~indices]
-
-        mask = cupy.ones(arr.size, dtype=bool)
-        mask[indices] = False
-        return arr[mask]
-
+        if ndim != 1:
+            arr = arr.ravel()
+        axis = 0
     else:
+        axis = _core.internal._normalize_axis_index(axis, arr.ndim)
 
-        if isinstance(indices, cupy.ndarray) and indices.dtype == cupy.bool_:
-            return cupy.compress(~indices, arr, axis=axis)
-
-        mask = cupy.ones(arr.shape[axis], dtype=bool)
-        mask[indices] = False
-        return cupy.compress(mask, arr, axis=axis)
+    size = arr.shape[axis]
+    mask = _delete_mask(obj, size)
+    return cupy.compress(mask, arr, axis=axis)
 
 
 # TODO(okuta): Implement insert

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -46,12 +46,98 @@ class TestDelete(unittest.TestCase):
         return xp.delete(arr, indices)
 
     @testing.numpy_cupy_array_equal()
+    def test_delete_with_empty_indices(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        return xp.delete(arr, [])
+
+    @testing.numpy_cupy_array_equal()
     def test_delete_with_indices_as_int(self, xp):
         arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         indices = 5
         if cupy.cuda.runtime.is_hip:
             pytest.xfail('HIP may have a bug')
         return xp.delete(arr, indices)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_array_like_input(self, xp):
+        arr = [[0, 1, 2], [3, 4, 5]]
+        return xp.delete(arr, [1], axis=1)
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_bool_scalar_error(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4])
+        xp.delete(arr, xp.array(True))
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_mixed_obj_input(self, xp):
+        arr = [1, 2, 3]
+        return xp.delete(arr, (0, True), axis=None)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_negative_indices(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4, 5])
+        indices = xp.array([-1, -3])
+        return xp.delete(arr, indices)
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_wrong_size_bool_mask_error(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4])
+        xp.delete(arr, xp.array([True, False]))
+
+    @testing.numpy_cupy_array_equal(accept_error=IndexError)
+    def test_delete_with_wrong_dtype_indices_error(self, xp):
+        arr = xp.array([0, 1, 2, 3, 4])
+        xp.delete(arr, xp.array([1.5]))
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_empty_tuple_obj(self, xp):
+        arr = xp.array([10, 20, 30])
+        return xp.delete(arr, ())
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_empty_bool_array_obj_error(self, xp):
+        arr = xp.array([10, 20, 30])
+        xp.delete(arr, xp.array([], dtype=xp.bool_))
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_empty_int_array_obj(self, xp):
+        arr = xp.array([10, 20, 30])
+        return xp.delete(arr, xp.array([], dtype=xp.int_))
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_bool_list_obj_matching_size(self, xp):
+        arr = xp.array([10, 20, 30])
+        return xp.delete(arr, [True, False, True])
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_bool_list_obj_wrong_size_error(self, xp):
+        arr = xp.array([10, 20, 30])
+        xp.delete(arr, [True, False])
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_bool_scalar_true_obj_error(self, xp):
+        arr = xp.array([10, 20, 30])
+        xp.delete(arr, True)
+
+    @testing.numpy_cupy_array_equal(accept_error=ValueError)
+    def test_delete_with_bool_scalar_false_obj_error(self, xp):
+        arr = xp.array([10, 20, 30])
+        xp.delete(arr, False)
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_int_list_obj(self, xp):
+        arr = xp.array([10, 20, 30])
+        return xp.delete(arr, [0, 2])
+
+    @testing.numpy_cupy_array_equal()
+    def test_delete_with_int_array_obj(self, xp):
+        arr = xp.array([10, 20, 30])
+        return xp.delete(arr, xp.array([0, 2]))
+
+    @testing.numpy_cupy_array_equal(accept_error=IndexError)
+    def test_delete_with_float_array_obj_error(self, xp):
+        arr = xp.array([10, 20, 30])
+        xp.delete(arr, xp.array([0., 2.]))
 
 
 class TestAppend(unittest.TestCase):

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -8,7 +8,7 @@ import cupy
 from cupy import testing
 
 
-class TestDelete(unittest.TestCase):
+class TestDelete:
 
     @testing.numpy_cupy_array_equal()
     def test_delete_with_no_axis(self, xp):
@@ -46,11 +46,6 @@ class TestDelete(unittest.TestCase):
         return xp.delete(arr, indices)
 
     @testing.numpy_cupy_array_equal()
-    def test_delete_with_empty_indices(self, xp):
-        arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        return xp.delete(arr, [])
-
-    @testing.numpy_cupy_array_equal()
     def test_delete_with_indices_as_int(self, xp):
         arr = xp.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
         indices = 5
@@ -63,81 +58,34 @@ class TestDelete(unittest.TestCase):
         with pytest.raises(ValueError):
             cupy.delete(arr, [1], axis=1)
 
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_bool_scalar_error(self, xp):
-        arr = xp.array([0, 1, 2, 3, 4])
-        xp.delete(arr, xp.array(True))
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_mixed_obj_input(self, xp):
-        arr = xp.array([1, 2, 3])
-        return xp.delete(arr, (0, True), axis=None)
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_negative_indices(self, xp):
-        arr = xp.array([0, 1, 2, 3, 4, 5])
-        indices = xp.array([-1, -3])
-        return xp.delete(arr, indices)
-
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_wrong_size_bool_mask_error(self, xp):
-        arr = xp.array([0, 1, 2, 3, 4])
-        xp.delete(arr, xp.array([True, False]))
-
-    @testing.numpy_cupy_array_equal(accept_error=IndexError)
-    def test_delete_with_wrong_dtype_indices_error(self, xp):
-        arr = xp.array([0, 1, 2, 3, 4])
-        xp.delete(arr, xp.array([1.5]))
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_empty_tuple_obj(self, xp):
+    @pytest.mark.parametrize('make_obj', [
+        pytest.param(lambda xp: [], id='empty_list'),
+        pytest.param(lambda xp: (), id='empty_tuple'),
+        pytest.param(lambda xp: [0, 2], id='int_list'),
+        pytest.param(lambda xp: [True, False, True], id='matching_bool_list'),
+        pytest.param(lambda xp: (0, True), id='mixed_tuple'),
+        pytest.param(lambda xp: xp.array([], dtype=xp.int_),
+                     id='empty_int_array'),
+        pytest.param(lambda xp: xp.array([0, 2]), id='int_array'),
+        pytest.param(lambda xp: xp.array([-1, -3]),
+                     id='negative_int_array'),
+        # The following raise ValueError (wrong-size or scalar bool masks).
+        pytest.param(lambda xp: True, id='scalar_true'),
+        pytest.param(lambda xp: False, id='scalar_false'),
+        pytest.param(lambda xp: [True, False], id='wrong_size_bool_list'),
+        pytest.param(lambda xp: xp.array(True), id='zerodim_bool_array'),
+        pytest.param(lambda xp: xp.array([True, False]),
+                     id='wrong_size_bool_array'),
+        pytest.param(lambda xp: xp.array([], dtype=xp.bool_),
+                     id='empty_bool_array'),
+        # The following raise IndexError (non-integer index arrays).
+        pytest.param(lambda xp: xp.array([1.5]), id='float_array_single'),
+        pytest.param(lambda xp: xp.array([0., 2.]), id='float_array_multi'),
+    ])
+    @testing.numpy_cupy_array_equal(accept_error=(ValueError, IndexError))
+    def test_delete_obj_variants(self, xp, make_obj):
         arr = xp.array([10, 20, 30])
-        return xp.delete(arr, ())
-
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_empty_bool_array_obj_error(self, xp):
-        arr = xp.array([10, 20, 30])
-        xp.delete(arr, xp.array([], dtype=xp.bool_))
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_empty_int_array_obj(self, xp):
-        arr = xp.array([10, 20, 30])
-        return xp.delete(arr, xp.array([], dtype=xp.int_))
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_bool_list_obj_matching_size(self, xp):
-        arr = xp.array([10, 20, 30])
-        return xp.delete(arr, [True, False, True])
-
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_bool_list_obj_wrong_size_error(self, xp):
-        arr = xp.array([10, 20, 30])
-        xp.delete(arr, [True, False])
-
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_bool_scalar_true_obj_error(self, xp):
-        arr = xp.array([10, 20, 30])
-        xp.delete(arr, True)
-
-    @testing.numpy_cupy_array_equal(accept_error=ValueError)
-    def test_delete_with_bool_scalar_false_obj_error(self, xp):
-        arr = xp.array([10, 20, 30])
-        xp.delete(arr, False)
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_int_list_obj(self, xp):
-        arr = xp.array([10, 20, 30])
-        return xp.delete(arr, [0, 2])
-
-    @testing.numpy_cupy_array_equal()
-    def test_delete_with_int_array_obj(self, xp):
-        arr = xp.array([10, 20, 30])
-        return xp.delete(arr, xp.array([0, 2]))
-
-    @testing.numpy_cupy_array_equal(accept_error=IndexError)
-    def test_delete_with_float_array_obj_error(self, xp):
-        arr = xp.array([10, 20, 30])
-        xp.delete(arr, xp.array([0., 2.]))
+        return xp.delete(arr, make_obj(xp))
 
 
 class TestAppend(unittest.TestCase):

--- a/tests/cupy_tests/manipulation_tests/test_add_remove.py
+++ b/tests/cupy_tests/manipulation_tests/test_add_remove.py
@@ -58,10 +58,10 @@ class TestDelete(unittest.TestCase):
             pytest.xfail('HIP may have a bug')
         return xp.delete(arr, indices)
 
-    @testing.numpy_cupy_array_equal()
-    def test_delete_array_like_input(self, xp):
+    def test_delete_array_like_input(self):
         arr = [[0, 1, 2], [3, 4, 5]]
-        return xp.delete(arr, [1], axis=1)
+        with pytest.raises(ValueError):
+            cupy.delete(arr, [1], axis=1)
 
     @testing.numpy_cupy_array_equal(accept_error=ValueError)
     def test_delete_with_bool_scalar_error(self, xp):
@@ -70,7 +70,7 @@ class TestDelete(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()
     def test_delete_mixed_obj_input(self, xp):
-        arr = [1, 2, 3]
+        arr = xp.array([1, 2, 3])
         return xp.delete(arr, (0, True), axis=None)
 
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
This PR fixes `cupy.delete` compatibility issues for:
- boolean mask inputs
- empty Python list/tuple `obj`
- bool scalar error behavior
- mixed tuple input such as `(0, True)`

It also adds tests covering these cases.

Fixes #9035