### PR TITLE
DOC: note in Comparison Table that np.ma is not implemented; suggest alternative

### DIFF
--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -219,6 +219,7 @@ def generate():
         'An alternative is `MArray <https://github.com/mdhaber/marray>`__, '
         'which adds mask support to Python Array API Standard-compatible '
         'array backends, including CuPy.'
+        ''
     ]
     buf += _section(
         'Linear Algebra',

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -215,6 +215,7 @@ def generate():
     buf += [
         'Masked Arrays',
         '~~~~~~~~~~~~~',
+        '',
         'CuPy does not implement the NumPy masked array API. ',
         'An alternative is `MArray <https://github.com/mdhaber/marray>`__, '
         'which adds mask support to Python Array API Standard-compatible '

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -220,7 +220,7 @@ def generate():
         'An alternative is `MArray <https://github.com/mdhaber/marray>`__, '
         'which adds mask support to Python Array API Standard-compatible '
         'array backends, including CuPy.'
-        ''
+        '',
     ]
     buf += _section(
         'Linear Algebra',

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -216,10 +216,10 @@ def generate():
         'Masked Arrays',
         '~~~~~~~~~~~~~',
         '',
-        'CuPy does not implement the NumPy masked array API. ',
+        'CuPy does not implement the NumPy masked array API. '
         'An alternative is `MArray <https://github.com/mdhaber/marray>`__, '
         'which adds mask support to Python Array API Standard-compatible '
-        'array backends, including CuPy.'
+        'array backends, including CuPy.',
         '',
     ]
     buf += _section(

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -212,6 +212,14 @@ def generate():
             'byteswap': _byte_order,
             'newbyteorder': _byte_order,
         })
+    buf += [
+        'Masked Arrays',
+        '~~~~~~~~~~~~~',
+        'CuPy does not implement the NumPy masked array API. ',
+        'An alternative is `MArray <https://github.com/mdhaber/marray>`__, '
+        'which adds mask support to Python Array API Standard-compatible '
+        'array backends, including CuPy.'
+    ]
     buf += _section(
         'Linear Algebra',
         'numpy.linalg', 'cupy.linalg', exclude=['test'])

--- a/docs/source/user_guide/interoperability.rst
+++ b/docs/source/user_guide/interoperability.rst
@@ -25,6 +25,23 @@ This enables code using NumPy to be directly operated on CuPy arrays.
 ``__array_function__`` feature requires NumPy 1.16 or later; As of NumPy 1.17, ``__array_function__`` is enabled by default.
 
 
+MArray
+------
+
+`MArray <https://github.com/mdhaber/marray>`__ adds missing data mask support to `Python Array API Standard <https://data-apis.org/array-api/latest/>`__ compatible array libraries.
+
+For example, to make CuPy arrays mask-aware:
+
+.. code:: python
+
+    from marray import cupy as mcp
+    x = mcp.asarray([1, 2, 3], mask=[False, True, False])
+    print(x)  # =>  [1 _ 3]
+    mcp.sum(x)  # => MArray(array(4), array(False))
+
+For more information, please see the `MArray tutorial <https://mdhaber.github.io/marray/tutorial.html>`__.
+
+
 Numba
 -----
 


### PR DESCRIPTION
This PR adds a note to the [Comparison Table](https://docs.cupy.dev/en/stable/reference/comparison.html#comparison-table) that CuPy does not implement NumPy's masked array interface, but that [MArray](https://github.com/mdhaber/marray) provides an alternative.

MArray-wrapped CuPy arrays are currently supported by almost all `scipy.stats` functions that support CuPy . For example:

```python3
from marray import cupy as xp
from scipy import stats
x = xp.asarray([1, 2, 3, 4])
y = xp.asarray([2, 3, 4, 5, 1000, xp.inf, xp.nan], 
               mask=[False]*4 + [True]*3)
res = stats.ttest_ind(x, y)
# TtestResult(statistic=MArray(array(-1.09544512), array(False)), 
#             pvalue=MArray(array(0.3153336), array(False)), 
#             df=MArray(array(6.), array(False)))
```
See SciPy's ["Support for the array API standard"](https://scipy.github.io/devdocs/dev/api-dev/array_api.html#support-for-the-array-api-standard) page and ["Support on GPU"](https://scipy.github.io/devdocs/dev/api-dev/array_api_modules_tables/stats.html#support-on-gpu) table for more information about MArray and CuPy support in SciPy.

Closes gh-2225.