### PR TITLE
Validate hypergeometric inputs without syncing

### DIFF
--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -254,19 +254,12 @@ class RandomState:
         """  # NOQA
         # Array inputs are not validated here; the kernel dispatcher
         # handles out-of-range values safely.
-        if isinstance(ngood, (int, float)):
-            if ngood < 0:
-                raise ValueError('ngood < 0')
-        if isinstance(nbad, (int, float)):
-            if nbad < 0:
-                raise ValueError('nbad < 0')
-        if isinstance(nsample, (int, float)):
-            if nsample < 1:
-                raise ValueError('nsample < 1')
-        if (isinstance(ngood, (int, float)) and isinstance(nbad, (int, float))
-                and isinstance(nsample, (int, float))):
-            if ngood + nbad < nsample:
-                raise ValueError('ngood + nbad < nsample')
+        if isinstance(ngood, (int, float)) and ngood < 0:
+            raise ValueError('ngood < 0')
+        if isinstance(nbad, (int, float)) and nbad < 0:
+            raise ValueError('nbad < 0')
+        if isinstance(nsample, (int, float)) and nsample < 1:
+            raise ValueError('nsample < 1')
         ngood, nbad, nsample = \
             cupy.asarray(ngood), cupy.asarray(nbad), cupy.asarray(nsample)
         if size is None:

--- a/cupy/random/_generator.py
+++ b/cupy/random/_generator.py
@@ -248,24 +248,27 @@ class RandomState:
     def hypergeometric(self, ngood, nbad, nsample, size=None, dtype='l'):
         """Returns an array of samples drawn from the hypergeometric distribution.
 
-        .. warning::
-
-            This function may synchronize the device.
-
         .. seealso::
             - :func:`cupy.random.hypergeometric` for full documentation
             - :meth:`numpy.random.RandomState.hypergeometric`
         """  # NOQA
+        # Array inputs are not validated here; the kernel dispatcher
+        # handles out-of-range values safely.
+        if isinstance(ngood, (int, float)):
+            if ngood < 0:
+                raise ValueError('ngood < 0')
+        if isinstance(nbad, (int, float)):
+            if nbad < 0:
+                raise ValueError('nbad < 0')
+        if isinstance(nsample, (int, float)):
+            if nsample < 1:
+                raise ValueError('nsample < 1')
+        if (isinstance(ngood, (int, float)) and isinstance(nbad, (int, float))
+                and isinstance(nsample, (int, float))):
+            if ngood + nbad < nsample:
+                raise ValueError('ngood + nbad < nsample')
         ngood, nbad, nsample = \
             cupy.asarray(ngood), cupy.asarray(nbad), cupy.asarray(nsample)
-        if cupy.any(ngood < 0):  # synchronize!
-            raise ValueError('ngood < 0')
-        if cupy.any(nbad < 0):  # synchronize!
-            raise ValueError('nbad < 0')
-        if cupy.any(nsample < 1):  # synchronize!
-            raise ValueError('nsample < 1')
-        if cupy.any(ngood + nbad < nsample):  # synchronize!
-            raise ValueError('ngood + nbad < nsample')
         if size is None:
             size = cupy.broadcast(ngood, nbad, nsample).shape
         y = cupy.empty(shape=size, dtype=dtype)

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -592,10 +592,6 @@ class Generator:
         Returns:
             cupy.ndarray: Samples drawn from the hypergeometric distribution.
 
-        .. warning::
-
-            This function may synchronize the device.
-
         .. seealso::
             :meth:`numpy.random.Generator.hypergeometric`
         """
@@ -603,6 +599,19 @@ class Generator:
         cdef _ndarray_base ngood_a
         cdef _ndarray_base nbad_a
         cdef _ndarray_base nsample_a
+
+        # Array inputs are not validated here; the kernel dispatcher
+        # handles out-of-range values safely.
+        if (type(ngood) in (float, int) and type(nbad) in (float, int)
+                and type(nsample) in (float, int)):
+            if ngood < 0:
+                raise ValueError('ngood < 0')
+            if nbad < 0:
+                raise ValueError('nbad < 0')
+            if nsample < 0:
+                raise ValueError('nsample < 0')
+            if ngood + nbad < nsample:
+                raise ValueError('ngood + nbad < nsample')
 
         if not isinstance(ngood, _ndarray_base):
             if type(ngood) in (float, int):
@@ -636,15 +645,6 @@ class Generator:
                                 ' or a scalar')
         else:
             nsample = nsample.astype(numpy.int64, copy=False)
-
-        if cupy.any(ngood < 0):  # synchronize!
-            raise ValueError('ngood < 0')
-        if cupy.any(nbad < 0):  # synchronize!
-            raise ValueError('nbad < 0')
-        if cupy.any(nsample < 0):  # synchronize!
-            raise ValueError('nsample < 0')
-        if cupy.any(ngood + nbad < nsample):  # synchronize!
-            raise ValueError('ngood + nbad < nsample')
         if size is not None and not isinstance(size, tuple):
             size = (size,)
         if size is None:

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -602,14 +602,14 @@ class Generator:
 
         # Array inputs are not validated here; the kernel dispatcher
         # handles out-of-range values safely.
+        if type(ngood) in (float, int) and ngood < 0:
+            raise ValueError('ngood < 0')
+        if type(nbad) in (float, int) and nbad < 0:
+            raise ValueError('nbad < 0')
+        if type(nsample) in (float, int) and nsample < 0:
+            raise ValueError('nsample < 0')
         if (type(ngood) in (float, int) and type(nbad) in (float, int)
                 and type(nsample) in (float, int)):
-            if ngood < 0:
-                raise ValueError('ngood < 0')
-            if nbad < 0:
-                raise ValueError('nbad < 0')
-            if nsample < 0:
-                raise ValueError('nsample < 0')
             if ngood + nbad < nsample:
                 raise ValueError('ngood + nbad < nsample')
 

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -608,10 +608,6 @@ class Generator:
             raise ValueError('nbad < 0')
         if type(nsample) in (float, int) and nsample < 0:
             raise ValueError('nsample < 0')
-        if (type(ngood) in (float, int) and type(nbad) in (float, int)
-                and type(nsample) in (float, int)):
-            if ngood + nbad < nsample:
-                raise ValueError('ngood + nbad < nsample')
 
         if not isinstance(ngood, _ndarray_base):
             if type(ngood) in (float, int):

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -267,13 +267,16 @@ class TestHypergeometricValidation:
         with pytest.raises(ValueError):
             self.rs.hypergeometric(10, 10, -1, size=10)
 
-    def test_hypergeometric_nsample_too_large(self):
-        with pytest.raises(ValueError):
-            self.rs.hypergeometric(5, 10, 16, size=10)
-
     def test_hypergeometric_nsample_equals_total(self):
         # nsample == ngood + nbad is valid (deterministic)
         out = self.rs.hypergeometric(5, 10, 15, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5))
+
+    def test_hypergeometric_nsample_exceeds_total(self):
+        # nsample > ngood + nbad would previously cause an infinite
+        # loop in the HRUA kernel. The kernel now routes this through
+        # the HYP path which handles it safely.
+        out = self.rs.hypergeometric(5, 10, 16, size=10)
         testing.assert_array_equal(out, cupy.full(10, 5))
 
     def test_hypergeometric_ngood_zero(self):

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -310,10 +310,6 @@ class TestHypergeometricValidation:
         with pytest.raises(ValueError):
             self.gen.hypergeometric(10, 10, -1, size=10)
 
-    def test_hypergeometric_nsample_too_large(self):
-        with pytest.raises(ValueError):
-            self.gen.hypergeometric(5, 10, 16, size=10)
-
     def test_hypergeometric_nsample_zero(self):
         # Generator API allows nsample=0 (returns zeros), unlike legacy API
         out = self.gen.hypergeometric(5, 10, 0, size=10)
@@ -321,6 +317,13 @@ class TestHypergeometricValidation:
 
     def test_hypergeometric_nsample_equals_total(self):
         out = self.gen.hypergeometric(5, 10, 15, size=10)
+        testing.assert_array_equal(out, cupy.full(10, 5, dtype=cupy.int64))
+
+    def test_hypergeometric_nsample_exceeds_total(self):
+        # nsample > ngood + nbad would previously cause an infinite
+        # loop in the HRUA kernel. The kernel now routes this through
+        # the HYP path which handles it safely.
+        out = self.gen.hypergeometric(5, 10, 16, size=10)
         testing.assert_array_equal(out, cupy.full(10, 5, dtype=cupy.int64))
 
     def test_hypergeometric_ngood_zero(self):


### PR DESCRIPTION
Improve upon https://github.com/cupy/cupy/pull/9805, which had more extensive host-side checks but synced the device on every call. Now we only check scalars, and leave it to the kernel dispatcher to handle anything else.