### PR TITLE
Add bicgstab solver for sparse linear systems

### DIFF
--- a/cupyx/scipy/sparse/linalg/__init__.py
+++ b/cupyx/scipy/sparse/linalg/__init__.py
@@ -22,3 +22,4 @@ from cupyx.scipy.sparse.linalg._iterative import cgs  # NOQA
 from cupyx.scipy.sparse.linalg._interface import LinearOperator  # NOQA
 from cupyx.scipy.sparse.linalg._interface import aslinearoperator  # NOQA
 from cupyx.scipy.sparse.linalg._lobpcg import lobpcg  # NOQA
+from cupyx.scipy.sparse.linalg._iterative import bicgstab  # NOQA

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -342,7 +342,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
     rtilde = r.copy()
 
     # Initialize vars to prevent linter warnings
-    rho_prev, omega, alpha, p, v = None, None, None, None, None
+    rho_prev, omega, alpha, p, v = 0.0, 0.0, 0.0, 0.0, 0.0
     s = cupy.empty_like(r)
 
     iters = 0
@@ -353,14 +353,15 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         if iters >= maxiter:  # reached max iters
             break
 
-        rho = dotprod(rtilde, r)
+        # pull from device to host
+        rho = dotprod(rtilde, r).item()
 
-        # Breakdown checks ensure CuPy doesn't generate NaNs
-        if cupy.abs(rho) < rhotol:  # rho tol breakdown
+        # Breakdown checks ensure no NaNs
+        if abs(rho) < rhotol:  # rho tol breakdown on host
             return x, -10
 
         if iters > 0:
-            if cupy.abs(omega) < omegatol:  # omega tol breakdown
+            if abs(omega) < omegatol:  # omega tol breakdown
                 return x, -11
 
             beta = (rho / rho_prev) * (alpha / omega)
@@ -372,24 +373,25 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
 
         phat = psolve(p)
         v = matvec(phat)
-        rv = dotprod(rtilde, v)
+        rv = dotprod(rtilde, v).item()  # pull to host
 
         if rv == 0:
             return x, -11
 
         alpha = rho / rv
         r -= alpha * v
-        s[:] = r[:]
 
         # does a half-step check
         if cupy.linalg.norm(s) <= atol:
             x += alpha * phat
             break
 
-        shat = psolve(s)
+        shat = psolve(r)
         t = matvec(shat)
-        omega = dotprod(t, s) / dotprod(t, t)
 
+        omega = dotprod(t, r).item() / dotprod(t, t).item
+
+        # host scalar times device array
         x += alpha * phat
         x += omega * shat
         r -= omega * t

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -343,7 +343,6 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
 
     # Initialize vars to prevent linter warnings
     rho_prev, omega, alpha, p, v = 0.0, 0.0, 0.0, 0.0, 0.0
-    s = cupy.empty_like(r)
 
     iters = 0
     while True:
@@ -382,14 +381,14 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         r -= alpha * v
 
         # does a half-step check
-        if cupy.linalg.norm(s) <= atol:
+        if cupy.linalg.norm(r) <= atol:
             x += alpha * phat
             break
 
         shat = psolve(r)
         t = matvec(shat)
 
-        omega = dotprod(t, r).item() / dotprod(t, t).item
+        omega = dotprod(t, r).item() / dotprod(t, t).item()
 
         # host scalar times device array
         x += alpha * phat

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -388,7 +388,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         shat = psolve(r)
         t = matvec(shat)
 
-        omega = dotprod(t, r).item() / dotprod(t, t).item()
+        omega = (dotprod(t, r) / dotprod(t, t)).item()
 
         # host scalar times device array
         x += alpha * phat

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -323,11 +323,11 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
     n = A.shape[0]
     if n == 0:
         return cupy.empty_like(b), 0
-    
+
     b_norm = cupy.linalg.norm(b)
     if b_norm == 0:
         return b, 0
-        
+
     atol = max(float(atol), rtol * float(b_norm))
     if maxiter is None:
         maxiter = 10 * n
@@ -348,19 +348,19 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
     iters = 0
     while True:
         r_norm = cupy.linalg.norm(r)
-        if r_norm <= atol: # reached abs tol
+        if r_norm <= atol:  # reached abs tol
             break
-        if iters >= maxiter: # reached max iters
+        if iters >= maxiter:  # reached max iters
             break
 
         rho = dotprod(rtilde, r)
-        
+
         # Breakdown checks ensure CuPy doesn't generate NaNs
-        if cupy.abs(rho) < rhotol: # rho tol breakdown
+        if cupy.abs(rho) < rhotol:  # rho tol breakdown
             return x, -10
 
         if iters > 0:
-            if cupy.abs(omega) < omegatol: # omega tol breakdown
+            if cupy.abs(omega) < omegatol:  # omega tol breakdown
                 return x, -11
 
             beta = (rho / rho_prev) * (alpha / omega)
@@ -373,7 +373,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         phat = psolve(p)
         v = matvec(phat)
         rv = dotprod(rtilde, v)
-        
+
         if rv == 0:
             return x, -11
 
@@ -381,7 +381,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         r -= alpha * v
         s[:] = r[:]
 
-        # does a half-step check 
+        # does a half-step check
         if cupy.linalg.norm(s) <= atol:
             x += alpha * phat
             break
@@ -393,15 +393,15 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
         x += alpha * phat
         x += omega * shat
         r -= omega * t
-        
+
         rho_prev = rho
         iters += 1
-        
+
         if callback is not None:
             callback(x)
 
     info = 0
-    # If the loop maxed out and it didn't converge, 
+    # If the loop maxed out and it didn't converge,
     # return iter count as error code
     if iters >= maxiter and not (r_norm <= atol):
         info = iters

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -286,6 +286,128 @@ def cgs(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
     return x, info
 
 
+def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
+             callback=None):
+    """Uses BIConjugate Gradient STABilized iteration to solve ``Ax = b``.
+
+    Args:
+        A (ndarray, spmatrix or LinearOperator): The real or complex matrix of
+            the linear system with shape ``(n, n)``.
+        b (cupy.ndarray): Right hand side of the linear system with shape
+            ``(n,)`` or ``(n, 1)``.
+        x0 (cupy.ndarray): Starting guess for the solution.
+        rtol, atol (float): Tolerance for convergence.
+        maxiter (int): Maximum number of iterations.
+        M (ndarray, spmatrix or LinearOperator): Preconditioner for ``A``.
+            The preconditioner should approximate the inverse of ``A``.
+            ``M`` must be :class:`cupy.ndarray`,
+            :class:`cupyx.scipy.sparse.spmatrix` or
+            :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
+        callback (function): User-specified function to call after each
+            iteration. It is called as ``callback(xk)``, where ``xk`` is the
+            current solution vector.
+
+    Returns:
+        tuple:
+            It returns ``x`` (cupy.ndarray) and ``info`` (int) where ``x`` is
+            the converged solution and ``info`` provides convergence
+            information.
+
+    .. seealso:: :func:`scipy.sparse.linalg.bicgstab`
+    """
+    A, M, x, b = _make_system(A, M, x0, b)
+
+    matvec = A.matvec
+    psolve = M.matvec
+
+    n = A.shape[0]
+    if n == 0:
+        return cupy.empty_like(b), 0
+    
+    b_norm = cupy.linalg.norm(b)
+    if b_norm == 0:
+        return b, 0
+        
+    atol = max(float(atol), rtol * float(b_norm))
+    if maxiter is None:
+        maxiter = 10 * n
+
+    # Handle complex dot products appropriately like SciPy version
+    dotprod = cupy.vdot if x.dtype.kind == 'c' else cupy.dot
+
+    rhotol = cupy.finfo(x.dtype.char).eps ** 2
+    omegatol = rhotol
+
+    r = b - matvec(x)
+    rtilde = r.copy()
+
+    # Initialize vars to prevent linter warnings
+    rho_prev, omega, alpha, p, v = None, None, None, None, None
+    s = cupy.empty_like(r)
+
+    iters = 0
+    while True:
+        r_norm = cupy.linalg.norm(r)
+        if r_norm <= atol: # reached abs tol
+            break
+        if iters >= maxiter: # reached max iters
+            break
+
+        rho = dotprod(rtilde, r)
+        
+        # Breakdown checks ensure CuPy doesn't generate NaNs
+        if cupy.abs(rho) < rhotol: # rho tol breakdown
+            return x, -10
+
+        if iters > 0:
+            if cupy.abs(omega) < omegatol: omega tol breakdown
+                return x, -11
+
+            beta = (rho / rho_prev) * (alpha / omega)
+            p -= omega * v
+            p *= beta
+            p += r
+        else:
+            p = r.copy()
+
+        phat = psolve(p)
+        v = matvec(phat)
+        rv = dotprod(rtilde, v)
+        
+        if rv == 0:
+            return x, -11
+
+        alpha = rho / rv
+        r -= alpha * v
+        s[:] = r[:]
+
+        # does a half-step check 
+        if cupy.linalg.norm(s) <= atol:
+            x += alpha * phat
+            break
+
+        shat = psolve(s)
+        t = matvec(shat)
+        omega = dotprod(t, s) / dotprod(t, t)
+
+        x += alpha * phat
+        x += omega * shat
+        r -= omega * t
+        
+        rho_prev = rho
+        iters += 1
+        
+        if callback is not None:
+            callback(x)
+
+    info = 0
+    # If the loop maxed out and it didn't converge, return iter count as error code
+    if iters >= maxiter and not (r_norm <= atol):
+        info = iters
+
+    return x, info
+
+
 def _make_system(A, M, x0, b):
     """Make a linear system Ax = b
 

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -401,7 +401,8 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
             callback(x)
 
     info = 0
-    # If the loop maxed out and it didn't converge, return iter count as error code
+    # If the loop maxed out and it didn't converge, 
+    # return iter count as error code
     if iters >= maxiter and not (r_norm <= atol):
         info = iters
 

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -360,7 +360,7 @@ def bicgstab(A, b, x0=None, *, rtol=1e-5, atol=0.0, maxiter=None, M=None,
             return x, -10
 
         if iters > 0:
-            if cupy.abs(omega) < omegatol: omega tol breakdown
+            if cupy.abs(omega) < omegatol: # omega tol breakdown
                 return x, -11
 
             beta = (rho / rho_prev) * (alpha / omega)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -466,8 +466,6 @@ class TestCg:
         with pytest.raises(TypeError):
             sp.linalg.cg(ng_a, b, atol=self.atol)
 
-
-
 @testing.parameterize(*testing.product({
     'x0': [None, 'ones'],
     'M': [None, 'jacobi'],

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -467,6 +467,146 @@ class TestCg:
             sp.linalg.cg(ng_a, b, atol=self.atol)
 
 
+
+@testing.parameterize(*testing.product({
+    'x0': [None, 'ones'],
+    'M': [None, 'jacobi'],
+    'atol': [None, 'select-by-dtype'],
+    'b_ndim': [1, 2],
+    'use_linear_operator': [False, True],
+}))
+@testing.with_requires('scipy')
+class TestBicgstab:
+    n = 30
+    density = 0.33
+    _atol = {'f': 1e-5, 'd': 1e-12}
+
+    def _make_matrix(self, dtype, xp):
+        dtype = numpy.dtype(dtype)
+        shape = (self.n, 10)
+        a = testing.shaped_random(shape, xp, dtype=dtype.char.lower(), scale=1)
+        if dtype.char in 'FD':
+            a = a + 1j * testing.shaped_random(
+                shape, xp, dtype=dtype.char.lower(), scale=1)
+        mask = testing.shaped_random(shape, xp, dtype='f', scale=1)
+        a[mask > self.density] = 0
+        a = a @ a.conj().T
+        a = a + xp.diag(xp.ones((self.n,), dtype=dtype.char.lower()))
+        M = None
+        if self.M == 'jacobi':
+            M = xp.diag(1.0 / xp.diag(a))
+        return a, M
+
+    def _make_normalized_vector(self, dtype, xp):
+        b = testing.shaped_random((self.n,), xp, dtype=dtype)
+        return b / xp.linalg.norm(b)
+
+    def _test_bicgstab(self, dtype, xp, sp, a, M):
+        dtype = numpy.dtype(dtype)
+        b = self._make_normalized_vector(dtype, xp)
+        if self.b_ndim == 2:
+            b = b.reshape(self.n, 1)
+        x0 = None
+        if self.x0 == 'ones':
+            x0 = xp.ones((self.n,), dtype=dtype)
+        atol = 0.0
+        if self.atol == 'select-by-dtype':
+            atol = self._atol[dtype.char.lower()]
+        return sp.linalg.bicgstab(a, b, x0=x0, M=M, atol=atol)
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_dense(self, dtype, xp, sp):
+        a, M = self._make_matrix(dtype, xp)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+            if M is not None:
+                M = sp.linalg.aslinearoperator(M)
+        return self._test_bicgstab(dtype, xp, sp, a, M)
+
+    @pytest.mark.parametrize('format', ['csr', 'csc', 'coo'])
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_sparse(self, format, dtype, xp, sp):
+        if runtime.is_hip and format == 'csc':
+            pytest.xfail('may be buggy')  # trans=True
+
+        a, M = self._make_matrix(dtype, xp)
+        a = sp.coo_matrix(a).asformat(format)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+        if M is not None:
+            M = sp.coo_matrix(M).asformat(format)
+            if self.use_linear_operator:
+                M = sp.linalg.aslinearoperator(M)
+        return self._test_bicgstab(dtype, xp, sp, a, M)
+
+    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_empty(self, dtype, xp, sp):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
+            pytest.skip()
+        a = xp.empty((0, 0), dtype=dtype)
+        b = xp.empty((0,), dtype=dtype)
+        if self.atol is None and xp == numpy:
+            return sp.linalg.bicgstab(a, b)
+        else:
+            return sp.linalg.bicgstab(a, b)
+
+    @testing.for_dtypes('fdFD')
+    def test_callback(self, dtype):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
+            pytest.skip()
+        xp, sp = cupy, sparse
+        a, M = self._make_matrix(dtype, xp)
+        b = self._make_normalized_vector(dtype, xp)
+        is_called = False
+
+        def callback(x):
+            print(xp.linalg.norm(b - a @ x))
+            nonlocal is_called
+            is_called = True
+        sp.linalg.bicgstab(a, b, callback=callback)
+        assert is_called
+
+    def test_invalid(self):
+        if not (self.x0 is None and self.M is None and self.atol is None and
+                self.use_linear_operator is False):
+            pytest.skip()
+        for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
+            a, M = self._make_matrix('f', xp)
+            b = self._make_normalized_vector('f', xp)
+            ng_a = xp.ones((self.n, ), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(ng_a, b, atol=self.atol)
+            ng_a = xp.ones((self.n, self.n + 1), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(ng_a, b, atol=self.atol)
+            ng_a = xp.ones((self.n, self.n, 1), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(ng_a, b, atol=self.atol)
+            ng_b = xp.ones((self.n + 1,), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(a, ng_b, atol=self.atol)
+            ng_b = xp.ones((self.n, 2), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(a, ng_b, atol=self.atol)
+            ng_x0 = xp.ones((self.n + 1,), dtype='f')
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(a, b, x0=ng_x0, atol=self.atol)
+            ng_M = xp.diag(xp.ones((self.n + 1,), dtype='f'))
+            with pytest.raises(ValueError):
+                sp.linalg.bicgstab(a, b, M=ng_M, atol=self.atol)
+        xp, sp = cupy, sparse
+        b = self._make_normalized_vector('f', xp)
+        ng_a = xp.ones((self.n, self.n), dtype='i')
+        with pytest.raises(TypeError):
+            sp.linalg.bicgstab(ng_a, b, atol=self.atol)
+
+
 @testing.parameterize(*testing.product({
     'x0': [None, 'ones'],
     'M': [None, 'jacobi'],

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -466,6 +466,7 @@ class TestCg:
         with pytest.raises(TypeError):
             sp.linalg.cg(ng_a, b, atol=self.atol)
 
+
 @testing.parameterize(*testing.product({
     'x0': [None, 'ones'],
     'M': [None, 'jacobi'],


### PR DESCRIPTION
added bicgstab in the sparse solvers directory. This feature was missing, and was adapted from scipy's https://github.com/scipy/scipy/blob/main/scipy/sparse/linalg/_isolve/iterative.py 

The solver build on the cgs solver which has some issues in converging. feature needed for some solver benchmarking in nonlinear PDEs using single and double precisions. test passed on cuda device tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py::TestBicgstab