### PR TITLE
Issues #8434 fixed.

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1024,7 +1024,29 @@ inline __device__ T integral_power(T in0, T in1) {
 
 template <typename T>
 inline __device__ T complex_power(T in0, T in1) {
-    return in1 == T(0) ? T(1): pow(in0, in1);
+    if (in1 == T(0)) {
+        return T(1);
+    }
+
+    if (in1 == T(1)) {
+        return in0;
+    }
+
+    using value_type = decltype(in0.real());
+    if (in0 == T(0)) {
+        if (in1.real() > value_type(0)) {
+            return T(0);
+        }
+
+        value_type nanv = value_type(nan(""));
+        return T(nanv, nanv);
+    }
+
+    if (in0.imag() == value_type(0) && in1.imag() == value_type(0) && (in0.real() > value_type(0) | in1.real() > value_type(1))) {
+        return T(pow(in0.real(), in1.real()), value_type(0));
+    }
+
+    return pow(in0, in1);
 }
 '''
 

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1042,7 +1042,8 @@ inline __device__ T complex_power(T in0, T in1) {
         return T(nanv, nanv);
     }
 
-    if (in0.imag() == value_type(0) && in1.imag() == value_type(0) && (in0.real() > value_type(0) | in1.real() > value_type(1))) {
+    if (in0.imag() == value_type(0) && in1.imag() == value_type(0) &&
+        (in0.real() > value_type(0) | in1.real() > value_type(1))) {
         return T(pow(in0.real(), in1.real()), value_type(0));
     }
 

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -377,6 +377,59 @@ class TestArithmeticBinary3(ArithmeticBinaryBase):
         return y
 
 
+class TestPowerComplexBranchCut:
+
+    @testing.numpy_cupy_allclose(rtol=1e-14, atol=0)
+    def test_negative_zero_imag_squared(self, xp):
+        a = xp.asarray([
+            complex(-1.0, -0.0),
+            complex(-10.0, -0.0),
+            complex(-100.0, -0.0),
+        ], dtype=xp.complex128)
+        b = xp.float64(2.0)
+        return a ** b
+
+    @testing.numpy_cupy_allclose(rtol=0, atol=0)
+    def test_null_exponent(self, xp):
+        a = xp.asarray([
+            complex(-1.0, -0.0),
+            complex(-10.0, -0.0),
+            complex(-100.0, -0.0),
+        ], dtype=xp.complex128)
+        b = xp.float64(0.0)
+        return a ** b
+
+    @testing.numpy_cupy_allclose(rtol=0, atol=0)
+    def test_null_base(self, xp):
+        a = xp.asarray([
+            complex(0.0, 0.0),
+            complex(0.0, -0.0),
+            complex(-0.0, 0.0),
+            complex(-0.0, -0.0),
+        ], dtype=xp.complex128)
+        b = xp.float64(2.0)
+        return a ** b
+
+    @testing.numpy_cupy_array_equal()
+    def test_null_base_negative_exponent(self, xp):
+        a = xp.asarray([
+            complex(0.0, 0.0),
+            complex(0.0, -0.0),
+            complex(-0.0, 0.0),
+            complex(-0.0, -0.0),
+        ], dtype=xp.complex128)
+        b = xp.float64(-2.0)
+        y = a ** b
+        return xp.stack([
+            xp.isfinite(y.real),
+            xp.isfinite(y.imag),
+            xp.isinf(y.real),
+            xp.isinf(y.imag),
+            xp.isnan(y.real),
+            xp.isnan(y.imag),
+        ])
+
+
 class UfuncTestBase:
 
     @testing.numpy_cupy_allclose(accept_error=TypeError)


### PR DESCRIPTION
This PR fixes the power operator issues:

Added fast paths in cupy.power for cases where complex inputs lie on the real axis, reducing complex computation to real pow when possible. The change preserves complex edge-case behavior more carefully.

Fixes #8434 