### PR TITLE
fix: raise AttributeError for NumPy 2.0 removed type aliases

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -939,7 +939,7 @@ def show_config(*, _full=False):
     _sys.stdout.flush()
 
 
-_deprecated_apis = []
+_deprecated_apis: list[str] = []
 
 # APIs removed in NumPy 2.0 that we previously shimmed
 _removed_apis = {

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -939,11 +939,14 @@ def show_config(*, _full=False):
     _sys.stdout.flush()
 
 
-_deprecated_apis = [
-    'int0',
-    'uint0',
-    'bool8',
-]
+_deprecated_apis = []
+
+# APIs removed in NumPy 2.0 that we previously shimmed
+_removed_apis = {
+    'bool8': 'bool',
+    'int0': 'int',
+    'uint0': 'uint',
+}
 
 
 # np 2.0: XXX shims for things removed in np 2.0
@@ -1130,6 +1133,11 @@ Use {recommendation} instead.
 
 
 def __getattr__(name):
+    if name in _removed_apis:
+        raise AttributeError(
+            f"module 'cupy' has no attribute {name!r}. "
+            f"Use '{_removed_apis[name]}' instead."
+        )
     if name in _deprecated_apis:
         return getattr(_numpy, name)
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -939,16 +939,6 @@ def show_config(*, _full=False):
     _sys.stdout.flush()
 
 
-_deprecated_apis: list[str] = []
-
-# APIs removed in NumPy 2.0 that we previously shimmed
-_removed_apis = {
-    'bool8': 'bool',
-    'int0': 'int',
-    'uint0': 'uint',
-}
-
-
 # np 2.0: XXX shims for things removed in np 2.0
 alltrue = all
 sometrue = any
@@ -1133,14 +1123,6 @@ Use {recommendation} instead.
 
 
 def __getattr__(name):
-    if name in _removed_apis:
-        raise AttributeError(
-            f"module 'cupy' has no attribute {name!r}. "
-            f"Use '{_removed_apis[name]}' instead."
-        )
-    if name in _deprecated_apis:
-        return getattr(_numpy, name)
-
     raise AttributeError(f"module 'cupy' has no attribute {name!r}")
 
 

--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -1122,10 +1122,6 @@ Use {recommendation} instead.
         raise RuntimeError(mesg)
 
 
-def __getattr__(name):
-    raise AttributeError(f"module 'cupy' has no attribute {name!r}")
-
-
 def _embed_signatures(dirs):
     for name, value in dirs.items():
         if isinstance(value, ufunc):


### PR DESCRIPTION
Fixes #9818

bool8, int0, and uint0 were removed in NumPy 2.0. The module
__getattr__ shim still tried to forward these to numpy via
getattr(np, name), which raises TypeError in NumPy 2.0 instead of
the expected AttributeError.

This moves them out of the general deprecated list into a separate
_removed_apis dict that raises AttributeError with a helpful message
suggesting the replacement type.