### PR TITLE
Skip test_solve_singular_empty on NumPy >= 2.4

### DIFF
--- a/tests/cupy_tests/linalg_tests/test_solve.py
+++ b/tests/cupy_tests/linalg_tests/test_solve.py
@@ -63,6 +63,7 @@ class TestSolve(unittest.TestCase):
             with pytest.raises(error_type):
                 xp.linalg.solve(a, b)
 
+    @testing.with_requires('numpy<2.4')
     @testing.numpy_cupy_allclose()
     def test_solve_singular_empty(self, xp):
         a = xp.zeros((3, 3))  # singular


### PR DESCRIPTION
NumPy 2.4 changed `linalg.solve` to check for singularity even when `nrhs=0` (empty RHS), raising `LinAlgError("Singular matrix")`. CuPy intentionally skips the singularity check by default (`errstate(linalg='ignore')`) for performance, so the comparison test is no longer meaningful on NumPy >= 2.4.

See #9838 for the full fix plan when the NumPy baseline is bumped.

-- Leo's bot