### PR TITLE
fix(hip): use gcnArchName for cache keying and return sentinel compute_capability on HIP

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -215,10 +215,19 @@ def _get_extra_include_dir_opts():
 
 @_util.memoize(for_each_device=True)
 def _get_arch():
+    if runtime.is_hip:
+        # On HIP, compute_capability returns '9999' (a pass-all sentinel),
+        # so we read the real GCN arch name directly for cache keying.
+        props = runtime.getDeviceProperties(device.Device().id)
+        try:
+            arch_name = props['gcnArchName'].decode()
+        except KeyError:  # ROCm < 3.6.0
+            arch_name = 'gfx' + str(props['gcnArch'])
+        # Strip feature flags (e.g. "gfx906:sramecc+:xnack-" -> "gfx906")
+        return arch_name.split(':')[0]
     # See Supported Compile Options section of NVRTC User Guide for
     # the maximum value allowed for `--gpu-architecture`.
     nvrtc_max_compute_capability = _get_max_compute_capability()
-
     arch = device.Device().compute_capability
     if arch in _tegra_archs:
         return arch

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -205,9 +205,15 @@ cdef class Device:
     def compute_capability(self):
         """Compute capability of this device.
 
-        The capability is represented by a string containing the major index
-        and the minor index. For example, compute capability 3.5 is represented
-        by the string '35'.
+        On CUDA the capability is represented by a string containing the
+        major index and the minor index. For example, compute capability
+        3.5 is represented by the string ``'35'``.
+
+        On HIP/ROCm this returns ``'9999'`` so that all CUDA
+        feature-level threshold checks (e.g. ``int(cc) >= 70``) pass
+        unconditionally.  The real GCN architecture name is used
+        internally for kernel cache keying via
+        :func:`cupy.cuda.compiler._get_arch`.
 
         """
         if self.id in _compute_capabilities:
@@ -215,11 +221,19 @@ cdef class Device:
         prev_device = runtime.getDevice()
         try:
             runtime.setDevice(self.id)
-            major = runtime.deviceGetAttribute(
-                runtime.deviceAttributeComputeCapabilityMajor, self.id)
-            minor = runtime.deviceGetAttribute(
-                runtime.deviceAttributeComputeCapabilityMinor, self.id)
-            cc = '%d%d' % (major, minor)
+            if runtime_module.is_hip:
+                # On HIP, all CUDA feature-level checks (fp16, bf16, etc.)
+                # should pass, so return a large value that is always above
+                # any CUDA compute-capability threshold.
+                # The real GCN arch name is used for cache keying in
+                # compiler._get_arch() instead.
+                cc = '9999'
+            else:
+                major = runtime.deviceGetAttribute(
+                    runtime.deviceAttributeComputeCapabilityMajor, self.id)
+                minor = runtime.deviceGetAttribute(
+                    runtime.deviceAttributeComputeCapabilityMinor, self.id)
+                cc = '%d%d' % (major, minor)
             _compute_capabilities[self.id] = cc
             return cc
         finally:

--- a/tests/cupy_tests/cuda_tests/test_compiler.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler.py
@@ -91,6 +91,42 @@ class TestNvrtcArch(unittest.TestCase):
             compiler.CompileException, self._compile, '83')
 
 
+@unittest.skipUnless(cupy.cuda.runtime.is_hip, 'HIP specific tests')
+@pytest.mark.thread_unsafe(reason="Uses mock.patch.")
+class TestHIPArch(unittest.TestCase):
+    def setUp(self):
+        cupy.clear_memo()
+
+    def _check_get_arch(self, gcn_arch_name, expected_arch):
+        props = {'gcnArchName': gcn_arch_name.encode()}
+        with mock.patch('cupy.cuda.compiler.runtime') as mock_runtime, \
+                mock.patch('cupy.cuda.device.Device') as device_class:
+            mock_runtime.is_hip = True
+            mock_runtime.getDeviceProperties.return_value = props
+            device_class.return_value.id = 0
+            assert compiler._get_arch() == expected_arch
+        cupy.clear_memo()
+
+    def test_get_arch_hip_passthrough(self):
+        self._check_get_arch('gfx906', 'gfx906')
+
+    def test_get_arch_hip_other(self):
+        self._check_get_arch('gfx908', 'gfx908')
+
+    def test_get_arch_hip_hex(self):
+        self._check_get_arch('gfx90a', 'gfx90a')
+
+    def test_get_arch_hip_4digit(self):
+        self._check_get_arch('gfx1030', 'gfx1030')
+
+    def test_get_arch_hip_rdna3(self):
+        self._check_get_arch('gfx1100', 'gfx1100')
+
+    def test_get_arch_hip_strips_flags(self):
+        # Feature flags should be stripped from the arch name
+        self._check_get_arch('gfx906:sramecc+:xnack-', 'gfx906')
+
+
 class TestNvrtcStderr(unittest.TestCase):
 
     @unittest.skipIf(cupy.cuda.runtime.is_hip,

--- a/tests/cupy_tests/cuda_tests/test_device.py
+++ b/tests/cupy_tests/cuda_tests/test_device.py
@@ -154,6 +154,31 @@ class TestDeviceFromPointer(unittest.TestCase):
         assert cuda.device.from_pointer(cupy.empty(1).data.ptr).id == 0
 
 
+@pytest.mark.skipUnless(cuda.runtime.is_hip, 'HIP-specific test')
+class TestHIPComputeCapability(unittest.TestCase):
+    """Test that HIP compute_capability returns '9999' sentinel value."""
+
+    def test_compute_capability_is_sentinel(self):
+        d = cuda.Device(0)
+        cc = d.compute_capability
+        assert cc == '9999', (
+            f'Expected "9999" sentinel on HIP, got "{cc}"')
+
+    def test_compute_capability_int_castable(self):
+        d = cuda.Device(0)
+        cc = d.compute_capability
+        # Must be castable to int for threshold checks
+        assert int(cc) == 9999
+
+    @testing.multi_gpu(2)
+    def test_multi_gpu_same_sentinel(self):
+        d0 = cuda.Device(0)
+        d1 = cuda.Device(1)
+        # Both GPUs should return the same sentinel value
+        assert d0.compute_capability == '9999'
+        assert d1.compute_capability == '9999'
+
+
 @testing.multi_gpu(2)
 class TestDeviceSwitch(unittest.TestCase):
 


### PR DESCRIPTION
See Isssue https://github.com/cupy/cupy/issues/9830