### PR TITLE
fix(hip): use event-based sync for cross-device D2D copies

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -839,13 +839,23 @@ cdef class _ndarray_base:
 
         copy_context = _null_context
         if runtime._is_hip_environment:
-            # HIP requires changing the active device to the one where
-            # src data is before the copy. From the docs:
-            # it is recommended to set the current device to the device
-            # where the src data is physically located.
+            # From hip_runtime_api.h (hipMemcpyAsync): "For multi-gpu
+            # or peer-to-peer configurations, it is recommended to
+            # use a stream which is attached to the device where the
+            # src data is physically located."
             copy_context = self.device
         with copy_context:
             newarray.data.copy_from_device_async(x.data, x.nbytes)
+            if runtime._is_hip_environment:
+                # The copy ran on the source device's stream. Record an
+                # event so the destination device's stream waits for the
+                # copy to complete before any subsequent work uses
+                # newarray (e.g. .get() readback).
+                copy_event = stream_module.get_current_stream().record()
+        if runtime._is_hip_environment:
+            newarray.device.use()
+            stream_module.get_current_stream().wait_event(copy_event)
+            runtime.setDevice(prev_device)
         return newarray
 
     cpdef _ndarray_base view(self, dtype=None, array_class=None):

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -101,7 +101,7 @@ def copyto(dst, src, casting='same_kind', where=None):
         return
 
     if _can_memcpy(dst, src):
-        if src.device != dst.device and runtime.is_hip:
+        if runtime.is_hip and src.device != dst.device:
             # From hip_runtime_api.h (hipMemcpyAsync): "For multi-gpu
             # or peer-to-peer configurations, it is recommended to
             # use a stream which is attached to the device where the

--- a/cupy/_manipulation/basic.py
+++ b/cupy/_manipulation/basic.py
@@ -8,6 +8,7 @@ from cupy import _core
 from cupy._core import _fusion_interface
 from cupy._core import fusion
 from cupy._sorting import search
+from cupy.cuda import stream
 from cupy_backends.cuda.api import runtime
 
 
@@ -100,7 +101,21 @@ def copyto(dst, src, casting='same_kind', where=None):
         return
 
     if _can_memcpy(dst, src):
-        dst.data.copy_from_async(src.data, src.nbytes)
+        if src.device != dst.device and runtime.is_hip:
+            # From hip_runtime_api.h (hipMemcpyAsync): "For multi-gpu
+            # or peer-to-peer configurations, it is recommended to
+            # use a stream which is attached to the device where the
+            # src data is physically located."
+            # Issue the copy from the source device context, then
+            # make the destination device's stream wait for the copy
+            # to complete.
+            with src.device:
+                dst.data.copy_from_async(src.data, src.nbytes)
+                copy_event = stream.get_current_stream().record()
+            with dst.device:
+                stream.get_current_stream().wait_event(copy_event)
+        else:
+            dst.data.copy_from_async(src.data, src.nbytes)
         return
 
     device = dst.device


### PR DESCRIPTION
On HIP/ROCm, cross-device memcpy with hipMemcpyAsync requires the active device to be set to the source device, per hip_runtime_api.h: "For multi-gpu or peer-to-peer configurations, it is recommended to use a stream which is attached to the device where the src data is physically located."

Without this, the D2D copy runs on the caller's current stream with no ordering guarantee on the destination device's stream. Any subsequent operation on the destination device (e.g. a .get() readback) can race with the in-flight copy, producing corrupted data. This manifests as flaky failures in multi-GPU tests, especially when tests run in parallel.

Both ndarray.copy() and copyto() now:
1. Switch to the source device context before issuing the copy
2. Record an event on the source device's stream after the copy
3. Switch to the destination device and wait on that event

This ensures correct cross-stream ordering between the D2D copy and any subsequent work on the destination device.

Same-device copies and all CUDA paths are unaffected.