### PR TITLE
Expose lane mask helper builtins in cupyx.jit

### DIFF
--- a/cupyx/jit/__init__.py
+++ b/cupyx/jit/__init__.py
@@ -24,10 +24,15 @@ from cupyx.jit._builtin_funcs import atomic_xor  # NOQA
 from cupyx.jit._builtin_funcs import grid  # NOQA
 from cupyx.jit._builtin_funcs import gridsize  # NOQA
 from cupyx.jit._builtin_funcs import laneid  # NOQA
+from cupyx.jit._builtin_funcs import activemask  # NOQA
+from cupyx.jit._builtin_funcs import popc  # NOQA
+from cupyx.jit._builtin_funcs import ffs  # NOQA
 from cupyx.jit._builtin_funcs import shfl_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_up_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_down_sync  # NOQA
 from cupyx.jit._builtin_funcs import shfl_xor_sync  # NOQA
+from cupyx.jit._builtin_funcs import match_any_sync  # NOQA
+from cupyx.jit._builtin_funcs import match_all_sync  # NOQA
 
 from cupyx.jit import cg  # NOQA
 from cupyx.jit import cub  # NOQA

--- a/cupyx/jit/_builtin_funcs.py
+++ b/cupyx/jit/_builtin_funcs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from typing import Any
 from collections.abc import Mapping
 import warnings
@@ -350,6 +351,147 @@ class GridFunc(BuiltinFunc):
             return Data(f'STD::make_tuple({elts_code})', ctype)
 
 
+def _get_warp_mask_ctype():
+    return _cuda_types.uint64 if runtime.is_hip else _cuda_types.uint32
+
+
+def _parse_warp_mask(mask):
+    try:
+        mask = operator.index(mask.obj)
+    except Exception:
+        raise TypeError('mask must be an integer')
+    mask_max = 0xffffffffffffffff if runtime.is_hip else 0xffffffff
+    if not (0x0 <= mask <= mask_max):
+        raise ValueError('mask is out of range')
+    return mask
+
+
+class ActiveMask(BuiltinFunc):
+
+    def __call__(self):
+        """Returns a bit-mask of all currently active threads in the warp.
+
+        .. seealso:: `Warp Vote Functions`_
+
+        .. _Warp Vote Functions:
+            https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-vote-functions
+        """
+        super().__call__()
+
+    def call_const(self, env):
+        return Data('__activemask()', _get_warp_mask_ctype())
+
+
+class BitwisePopulationCount(BuiltinFunc):
+
+    def __call__(self, value):
+        """Returns the number of set bits in an integer value."""
+        super().__call__()
+
+    def call(self, env, value):
+        value = Data.init(value, env)
+        if not isinstance(value.ctype, _cuda_types.Scalar):
+            raise TypeError('`popc` supports only scalar input.')
+
+        dtype = value.ctype.dtype
+        if dtype.kind not in 'iu':
+            raise TypeError('`popc` supports only integer input.')
+
+        if dtype.itemsize <= 4:
+            code = f'__popc(static_cast<unsigned int>({value.code}))'
+        elif dtype.itemsize == 8:
+            code = (
+                '__popcll('
+                f'static_cast<unsigned long long>({value.code}))'
+            )
+        else:
+            raise TypeError('`popc` supports only integer input.')
+        return Data(code, _cuda_types.int32)
+
+
+class FindFirstSet(BuiltinFunc):
+
+    def __call__(self, value):
+        """Returns the position of the first set bit in an integer value."""
+        super().__call__()
+
+    def call(self, env, value):
+        value = Data.init(value, env)
+        if not isinstance(value.ctype, _cuda_types.Scalar):
+            raise TypeError('`ffs` supports only scalar input.')
+
+        dtype = value.ctype.dtype
+        if dtype.kind not in 'iu':
+            raise TypeError('`ffs` supports only integer input.')
+
+        if dtype.itemsize <= 4:
+            code = f'__ffs(static_cast<int>({value.code}))'
+        elif dtype.itemsize == 8:
+            code = f'__ffsll(static_cast<long long>({value.code}))'
+        else:
+            raise TypeError('`ffs` supports only integer input.')
+        return Data(code, _cuda_types.int32)
+
+
+class WarpMatchAny(BuiltinFunc):
+    _dtypes = (
+        'int32', 'uint32', 'int64', 'uint64', 'float32', 'float64')
+
+    def __call__(self, mask, value):
+        """Returns a mask of active lanes whose values equal ``value``.
+
+        .. note::
+            This function follows the convention of Numba's
+            :func:`numba.cuda.match_any_sync`.
+        """
+        super().__call__()
+
+    def call(self, env, mask, value):
+        mask = _parse_warp_mask(mask)
+        value = Data.init(value, env)
+        if not isinstance(value.ctype, _cuda_types.Scalar):
+            raise TypeError('`match_any_sync` supports only scalar input.')
+        if value.ctype.dtype.name not in self._dtypes:
+            raise TypeError(
+                f'`match_any_sync` does not support {value.ctype.dtype} '
+                'input.')
+        code = f'__match_any_sync({hex(mask)}, {value.code})'
+        return Data(code, _get_warp_mask_ctype())
+
+
+class WarpMatchAll(BuiltinFunc):
+    _dtypes = WarpMatchAny._dtypes
+
+    def __call__(self, mask, value):
+        """Returns ``(mask, pred)`` for lanes whose values all equal ``value``.
+
+        .. note::
+            This function follows the convention of Numba's
+            :func:`numba.cuda.match_all_sync`.
+        """
+        super().__call__()
+
+    def call(self, env, mask, value):
+        mask = _parse_warp_mask(mask)
+        value = Data.init(value, env)
+        if not isinstance(value.ctype, _cuda_types.Scalar):
+            raise TypeError('`match_all_sync` supports only scalar input.')
+        if value.ctype.dtype.name not in self._dtypes:
+            raise TypeError(
+                f'`match_all_sync` does not support {value.ctype.dtype} '
+                'input.')
+        code = (
+            '([&]() { '
+            'int pred; '
+            f'auto match = __match_all_sync({hex(mask)}, {value.code}, '
+            '&pred); '
+            'return STD::make_pair(match, pred != 0); '
+            '})()'
+        )
+        ctype = _cuda_types.Tuple([_get_warp_mask_ctype(), _cuda_types.bool_])
+        return Data(code, ctype)
+
+
 class WarpShuffleOp(BuiltinFunc):
 
     def __init__(self, op, dtypes):
@@ -454,6 +596,11 @@ shared_memory = SharedMemory()
 grid = GridFunc('grid')
 gridsize = GridFunc('gridsize')
 laneid = LaneID()
+activemask = ActiveMask()
+popc = BitwisePopulationCount()
+ffs = FindFirstSet()
+match_any_sync = WarpMatchAny()
+match_all_sync = WarpMatchAll()
 
 # atomic functions
 atomic_add = AtomicOp(

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -29,6 +29,9 @@ Supported Python built-in functions include: :obj:`range`, :func:`len`, :func:`m
    cupyx.jit.grid
    cupyx.jit.gridsize
    cupyx.jit.laneid
+   cupyx.jit.activemask
+   cupyx.jit.popc
+   cupyx.jit.ffs
    cupyx.jit.warpsize
    cupyx.jit.range
    cupyx.jit.syncthreads
@@ -37,6 +40,8 @@ Supported Python built-in functions include: :obj:`range`, :func:`len`, :func:`m
    cupyx.jit.shfl_up_sync
    cupyx.jit.shfl_down_sync
    cupyx.jit.shfl_xor_sync
+   cupyx.jit.match_any_sync
+   cupyx.jit.match_all_sync
    cupyx.jit.shared_memory
    cupyx.jit.atomic_add
    cupyx.jit.atomic_sub

--- a/tests/cupyx_tests/jit_tests/test_builtin_funcs.py
+++ b/tests/cupyx_tests/jit_tests/test_builtin_funcs.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy
+
+from cupy.cuda import runtime
+from cupyx import jit
+from cupyx.jit import _compile
+from cupyx.jit import _cuda_types
+
+
+def _transpile(func, *in_types):
+    result = _compile.transpile(
+        func,
+        ['extern "C"', '__global__'],
+        'cuda',
+        in_types,
+        _cuda_types.void,
+    )
+    return result.code
+
+
+class TestWarpMaskBuiltins(unittest.TestCase):
+
+    def test_public_exports(self):
+        for name in (
+                'activemask', 'popc', 'ffs',
+                'match_any_sync', 'match_all_sync'):
+            assert hasattr(jit, name)
+
+    def test_activemask_codegen(self):
+        def kernel(x):
+            _ = jit.activemask()
+
+        code = _transpile(kernel, _cuda_types.int32)
+        assert '__activemask()' in code
+
+    def test_popc_codegen(self):
+        def kernel(x):
+            _ = jit.popc(x)
+
+        code32 = _transpile(kernel, _cuda_types.uint32)
+        assert '__popc(' in code32
+
+        code64 = _transpile(kernel, _cuda_types.Scalar(numpy.uint64))
+        assert '__popcll(' in code64
+
+    def test_ffs_codegen(self):
+        def kernel(x):
+            _ = jit.ffs(x)
+
+        code32 = _transpile(kernel, _cuda_types.int32)
+        assert '__ffs(' in code32
+
+        code64 = _transpile(kernel, _cuda_types.Scalar(numpy.int64))
+        assert '__ffsll(' in code64
+
+    def test_match_any_sync_codegen(self):
+        mask = 0xffffffffffffffff if runtime.is_hip else 0xffffffff
+
+        def kernel(x):
+            _ = jit.match_any_sync(mask, x)
+
+        code = _transpile(kernel, _cuda_types.int32)
+        assert '__match_any_sync(' in code
+        assert hex(mask) in code
+
+    def test_match_all_sync_codegen(self):
+        mask = 0xffffffffffffffff if runtime.is_hip else 0xffffffff
+
+        def kernel(x):
+            matches, pred = jit.match_all_sync(mask, x)
+            _ = matches
+            _ = pred
+
+        code = _transpile(kernel, _cuda_types.int32)
+        assert '__match_all_sync(' in code
+        assert 'STD::make_pair' in code
+        assert 'pred != 0' in code


### PR DESCRIPTION
## Summary

Expose the following helper builtins from cupyx.jit:
- activemask()
- popc()
- ffs()
- match_any_sync()
- match_all_sync()

This extends the existing builtin lowering path in cupyx.jit with the lane-mask helpers requested in #9677.

## What changed

- added the new builtin lowerings in cupyx/jit/_builtin_funcs.py
- exported the public API from cupyx/jit/__init__.py
- documented the new functions in docs/source/reference/kernel.rst
- added codegen-only tests in tests/cupyx_tests/jit_tests/test_builtin_funcs.py

## Validation

- ruff check cupyx/jit/_builtin_funcs.py cupyx/jit/__init__.py tests/cupyx_tests/jit_tests/test_builtin_funcs.py
- python -m py_compile cupyx/jit/_builtin_funcs.py cupyx/jit/__init__.py tests/cupyx_tests/jit_tests/test_builtin_funcs.py
- python -m pytest tests/cupyx_tests/jit_tests/test_builtin_funcs.py -q

Closes #9677.
