### PR TITLE
scipy.ndimage.label index overflow

### DIFF
--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -45,9 +45,14 @@ def label(input, structure=None, output=None):
     structure = numpy.array(structure, dtype=bool)
     if structure.ndim != input.ndim:
         raise RuntimeError('structure and input must have equal rank')
-    for i in structure.shape:
-        if i != 3:
+    for ii in structure.shape:
+        if ii != 3:
             raise ValueError('structure dimensions must be equal to 3')
+
+    # Use 32 bits if it's large enough for this image.
+    # _ni_label.label() needs two entries for background and
+    # foreground tracking
+    need_64bits = input.size >= (2**31 - 2)
 
     if isinstance(output, cupy.ndarray):
         if output.shape != input.shape:
@@ -56,30 +61,40 @@ def label(input, structure=None, output=None):
     else:
         caller_provided_output = False
         if output is None:
-            output = cupy.empty(input.shape, numpy.int32)
+            output = cupy.empty(input.shape, cupy.intp if need_64bits else cupy.int32)
         else:
+            if output not in (cupy.int32, cupy.int64):
+                # Guard against invalid atomicAdd calls
+                raise TypeError("output dtype must be int32 or int64")
             output = cupy.empty(input.shape, output)
 
-    if input.size == 0:
-        # empty
-        maxlabel = 0
-    elif input.ndim == 0:
-        # 0-dim array
-        maxlabel = 0 if input.item() == 0 else 1
-        output.fill(maxlabel)
-    else:
-        if output.dtype != numpy.int32:
-            y = cupy.empty(input.shape, numpy.int32)
+    # handle scalars, 0-D arrays
+    if input.ndim == 0 or input.size == 0:
+        if input.ndim == 0:
+            # scalar
+            maxlabel = 1 if (input != 0) else 0
+            output.fill(maxlabel)
         else:
-            y = output
-        maxlabel = _label(input, structure, y)
-        if output.dtype != numpy.int32:
-            _core.elementwise_copy(y, output)
+            # 0-D
+            maxlabel = 0
+        if caller_provided_output:
+            return maxlabel
+        else:
+            return output, maxlabel
+
+    if not (need_64bits and output.dtype != cupy.int64):
+        max_label = _label(input, structure, output)
+    else:
+        # Allocate temporary 64-bit array, then copy results to output buffer
+        tmp_output = cupy.empty(input.shape, cupy.int64 if need_64bits else cupy.int32)
+        max_label = _label(input, structure, tmp_output, max_label=2**31 - 1)
+        _core.elementwise_copy(tmp_output, output)
 
     if caller_provided_output:
-        return maxlabel
+        # result was written in-place
+        return max_label
     else:
-        return output, maxlabel
+        return output, max_label
 
 
 def _generate_binary_structure(rank, connectivity):
@@ -92,7 +107,7 @@ def _generate_binary_structure(rank, connectivity):
     return output <= connectivity
 
 
-def _label(x, structure, y):
+def _label(x, structure, y, max_label=None):
     elems = numpy.where(structure != 0)
     vecs = [elems[dm] - 1 for dm in range(x.ndim)]
     offset = vecs[0]
@@ -103,15 +118,19 @@ def _label(x, structure, y):
     dirs = cupy.array(dirs, dtype=numpy.int32)
     ndirs = indxs.shape[0]
     y_shape = cupy.array(y.shape, dtype=numpy.int32)
-    count = cupy.zeros(2, dtype=numpy.int32)
+    count = cupy.zeros(2, dtype=y.dtype)
+
     _kernel_init()(x, y)
-    _kernel_connect()(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
+    atomic_t = "unsigned long long" if y.dtype == cupy.int64 else "unsigned int"
+    _kernel_connect(atomic_t)(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     _kernel_count()(y, count, size=y.size)
-    maxlabel = int(count[0])
-    labels = cupy.empty(maxlabel, dtype=numpy.int32)
+    nlabels = int(count[0])
+    if max_label and nlabels > max_label:
+        raise RuntimeError("insufficient bit-depth in requested output type")
+    labels = cupy.empty(nlabels, dtype=y.dtype)
     _kernel_labels()(y, count, labels, size=y.size)
-    _kernel_finalize()(maxlabel, cupy.sort(labels), y, size=y.size)
-    return maxlabel
+    _kernel_finalize()(nlabels, cupy.sort(labels), y, size=y.size)
+    return nlabels
 
 
 def _kernel_init():
@@ -120,19 +139,20 @@ def _kernel_init():
         'cupyx_scipy_ndimage_label_init')
 
 
-def _kernel_connect():
+def _kernel_connect(atomic_t):
     return _core.ElementwiseKernel(
         'raw int32 shape, raw int32 dirs, int32 ndirs, int32 ndim',
         'raw Y y',
+        f"typedef {atomic_t} atomic_t;"
         '''
         if (y[i] < 0) continue;
         for (int dr = 0; dr < ndirs; dr++) {
-            int j = i;
-            int rest = j;
-            int stride = 1;
-            int k = 0;
-            for (int dm = ndim-1; dm >= 0; dm--) {
-                int pos = rest % shape[dm] + dirs[dm + dr * ndim];
+            Y j = i;
+            Y rest = j;
+            Y stride = 1;
+            Y k = 0;
+            for (int dm = ndim - 1; dm >= 0; dm--) {
+                Y pos = rest % shape[dm] + dirs[dm + dr * ndim];
                 if (pos < 0 || pos >= shape[dm]) {
                     k = -1;
                     break;
@@ -143,17 +163,18 @@ def _kernel_connect():
             }
             if (k < 0) continue;
             if (y[k] < 0) continue;
+
             while (1) {
                 while (j != y[j]) { j = y[j]; }
                 while (k != y[k]) { k = y[k]; }
                 if (j == k) break;
                 if (j < k) {
-                    int old = atomicCAS( &y[k], k, j );
+                    Y old = atomicCAS((atomic_t*)&y[k], k, j);
                     if (old == k) break;
                     k = old;
                 }
                 else {
-                    int old = atomicCAS( &y[j], j, k );
+                    Y old = atomicCAS((atomic_t*)&y[j], j, k);
                     if (old == j) break;
                     j = old;
                 }
@@ -165,10 +186,10 @@ def _kernel_connect():
 
 def _kernel_count():
     return _core.ElementwiseKernel(
-        '', 'raw Y y, raw int32 count',
+        '', 'raw Y y, raw Y count',
         '''
         if (y[i] < 0) continue;
-        int j = i;
+        Y j = i;
         while (j != y[j]) { j = y[j]; }
         if (j != i) y[i] = j;
         else atomicAdd(&count[0], 1);
@@ -178,10 +199,10 @@ def _kernel_count():
 
 def _kernel_labels():
     return _core.ElementwiseKernel(
-        '', 'raw Y y, raw int32 count, raw int32 labels',
+        '', 'raw Y y, raw Y count, raw Y labels',
         '''
         if (y[i] != i) continue;
-        int j = atomicAdd(&count[1], 1);
+        Y j = atomicAdd(&count[1], 1);
         labels[j] = i;
         ''',
         'cupyx_scipy_ndimage_label_labels')
@@ -189,16 +210,16 @@ def _kernel_labels():
 
 def _kernel_finalize():
     return _core.ElementwiseKernel(
-        'int32 maxlabel', 'raw int32 labels, raw Y y',
+        'Y maxlabel', 'raw Y labels, raw Y y',
         '''
         if (y[i] < 0) {
             y[i] = 0;
             continue;
         }
-        int yi = y[i];
-        int j_min = 0;
-        int j_max = maxlabel - 1;
-        int j = (j_min + j_max) / 2;
+        Y yi = y[i];
+        Y j_min = 0;
+        Y j_max = maxlabel - 1;
+        Y j = (j_min + j_max) / 2;
         while (j_min < j_max) {
             if (yi == labels[j]) break;
             if (yi < labels[j]) j_max = j - 1;

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -61,7 +61,9 @@ def label(input, structure=None, output=None):
     else:
         caller_provided_output = False
         if output is None:
-            output = cupy.empty(input.shape, cupy.intp if need_64bits else cupy.int32)
+            output = cupy.empty(
+                input.shape, cupy.intp if need_64bits else cupy.int32
+            )
         else:
             if output not in (cupy.int32, cupy.int64):
                 # Guard against invalid atomicAdd calls
@@ -86,7 +88,9 @@ def label(input, structure=None, output=None):
         max_label = _label(input, structure, output)
     else:
         # Allocate temporary 64-bit array, then copy results to output buffer
-        tmp_output = cupy.empty(input.shape, cupy.int64 if need_64bits else cupy.int32)
+        tmp_output = cupy.empty(
+            input.shape, cupy.int64 if need_64bits else cupy.int32
+        )
         max_label = _label(input, structure, tmp_output, max_label=2**31 - 1)
         _core.elementwise_copy(tmp_output, output)
 
@@ -121,7 +125,9 @@ def _label(x, structure, y, max_label=None):
     count = cupy.zeros(2, dtype=y.dtype)
 
     _kernel_init()(x, y)
-    atomic_t = "unsigned long long" if y.dtype == cupy.int64 else "unsigned int"
+    atomic_t = (
+        "unsigned long long" if y.dtype == cupy.int64 else "unsigned int"
+    )
     _kernel_connect(atomic_t)(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     _kernel_count()(y, count, size=y.size)
     nlabels = int(count[0])

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -65,10 +65,9 @@ def label(input, structure=None, output=None):
                 input.shape, cupy.intp if need_64bits else cupy.int32
             )
         else:
-            if output not in (cupy.int32, cupy.int64):
-                # Guard against invalid atomicAdd calls
-                raise TypeError("output dtype must be int32 or int64")
             output = cupy.empty(input.shape, output)
+    if output.dtype.kind not in 'iu':
+        raise TypeError("output dtype must be an integer type")
 
     # handle scalars, 0-D arrays
     if input.ndim == 0 or input.size == 0:
@@ -84,12 +83,16 @@ def label(input, structure=None, output=None):
         else:
             return output, maxlabel
 
-    if not need_64bits or output.dtype == cupy.int64:
+    tmp_dtype = cupy.int64 if need_64bits else cupy.int32
+    if output.dtype == tmp_dtype or output.dtype == cupy.int64:
         max_label = _label(input, structure, output)
     else:
-        # Allocate temporary 64-bit array, then copy results to output buffer
-        tmp_output = cupy.empty(input.shape, cupy.int64)
-        max_label = _label(input, structure, tmp_output, max_label=2**31 - 1)
+        tmp_output = cupy.empty(input.shape, tmp_dtype)
+        max_label = _label(input, structure, tmp_output)
+        try:
+            output.dtype.type(max_label)
+        except (OverflowError, ValueError):
+            raise ValueError("insufficient bit-depth in output type")
         _core.elementwise_copy(tmp_output, output)
 
     if caller_provided_output:
@@ -109,7 +112,7 @@ def _generate_binary_structure(rank, connectivity):
     return output <= connectivity
 
 
-def _label(x, structure, y, max_label=None):
+def _label(x, structure, y):
     elems = numpy.where(structure != 0)
     vecs = [elems[dm] - 1 for dm in range(x.ndim)]
     offset = vecs[0]
@@ -126,8 +129,6 @@ def _label(x, structure, y, max_label=None):
     _kernel_connect()(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     _kernel_count()(y, count, size=y.size)
     nlabels = int(count[0])
-    if max_label and nlabels > max_label:
-        raise RuntimeError("insufficient bit-depth in requested output type")
     labels = cupy.empty(nlabels, dtype=y.dtype)
     _kernel_labels()(y, count, labels, size=y.size)
     _kernel_finalize()(nlabels, cupy.sort(labels), y, size=y.size)

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -61,9 +61,7 @@ def label(input, structure=None, output=None):
     else:
         caller_provided_output = False
         if output is None:
-            output = cupy.empty(
-                input.shape, cupy.intp if need_64bits else cupy.int32
-            )
+            output = cupy.empty(input.shape, cupy.intp if need_64bits else cupy.int32)
         else:
             if output not in (cupy.int32, cupy.int64):
                 # Guard against invalid atomicAdd calls
@@ -84,13 +82,11 @@ def label(input, structure=None, output=None):
         else:
             return output, maxlabel
 
-    if not (need_64bits and output.dtype != cupy.int64):
+    if not need_64bits or output.dtype == cupy.int64:
         max_label = _label(input, structure, output)
     else:
         # Allocate temporary 64-bit array, then copy results to output buffer
-        tmp_output = cupy.empty(
-            input.shape, cupy.int64 if need_64bits else cupy.int32
-        )
+        tmp_output = cupy.empty(input.shape, cupy.int64)
         max_label = _label(input, structure, tmp_output, max_label=2**31 - 1)
         _core.elementwise_copy(tmp_output, output)
 
@@ -125,10 +121,7 @@ def _label(x, structure, y, max_label=None):
     count = cupy.zeros(2, dtype=y.dtype)
 
     _kernel_init()(x, y)
-    atomic_t = (
-        "unsigned long long" if y.dtype == cupy.int64 else "unsigned int"
-    )
-    _kernel_connect(atomic_t)(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
+    _kernel_connect()(y_shape, dirs, ndirs, x.ndim, y, size=y.size)
     _kernel_count()(y, count, size=y.size)
     nlabels = int(count[0])
     if max_label and nlabels > max_label:
@@ -145,12 +138,16 @@ def _kernel_init():
         'cupyx_scipy_ndimage_label_init')
 
 
-def _kernel_connect(atomic_t):
+def _kernel_connect():
     return _core.ElementwiseKernel(
         'raw int32 shape, raw int32 dirs, int32 ndirs, int32 ndim',
         'raw Y y',
-        f"typedef {atomic_t} atomic_t;"
         '''
+        using atomic_t = typename cupy::type_traits::conditional<
+            cupy::type_traits::is_same<Y, long long>::value,
+            unsigned long long,
+            Y
+        >::type;
         if (y[i] < 0) continue;
         for (int dr = 0; dr < ndirs; dr++) {
             Y j = i;

--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -61,7 +61,9 @@ def label(input, structure=None, output=None):
     else:
         caller_provided_output = False
         if output is None:
-            output = cupy.empty(input.shape, cupy.intp if need_64bits else cupy.int32)
+            output = cupy.empty(
+                input.shape, cupy.intp if need_64bits else cupy.int32
+            )
         else:
             if output not in (cupy.int32, cupy.int64):
                 # Guard against invalid atomicAdd calls

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -676,7 +676,7 @@ class TestFindObjectsBasic:
 
 @pytest.mark.slow
 class TestLabelInt32Overflow:
-    """Tests for ndimage.label on arrays large enough to trigger int32 overflow."""
+    """Tests ndimage.label on arrays that trigger int32 overflow."""
 
     _CELL_SIZE = 10
     _RADIUS = 4
@@ -691,8 +691,8 @@ class TestLabelInt32Overflow:
         return cupy.tile(cupy.asarray(cell), tile_counts)
 
     @pytest.mark.parametrize('tile_counts', [
-        ((100, 100, 100)),  # ~1e9 voxels — below int32 limit, baseline correctness
-        ((130, 130, 130)),  # ~2.197e9 voxels — above int32 limit (2^31 = 2,147,483,648)
+        ((100, 100, 100)),  # ~1e9 voxels — below int32 limit
+        ((130, 130, 130)),  # ~2.197e9 voxels — above int32 limit
     ])
     @pytest.mark.parametrize('output', [None, numpy.int32, numpy.int64])
     def test_label_dtype_output(self, tile_counts, output):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -672,3 +672,55 @@ class TestFindObjectsBasic:
         if contiguous_type == "strided":
             data = data[::2, ::2]
         return scp.ndimage.find_objects(data)
+
+
+@pytest.mark.slow
+class TestLabelInt32Overflow:
+    """Tests for ndimage.label on arrays large enough to trigger int32 overflow."""
+
+    _CELL_SIZE = 10
+    _RADIUS = 4
+    _INT32_MAX = 2**31 - 1
+
+    def _make_sphere_pack(self, tile_counts):
+        s = self._CELL_SIZE
+        c = s // 2
+        r = self._RADIUS
+        ix, iy, iz = numpy.mgrid[:s, :s, :s]
+        cell = (ix - c) ** 2 + (iy - c) ** 2 + (iz - c) ** 2 <= r ** 2
+        return cupy.tile(cupy.asarray(cell), tile_counts)
+
+    @pytest.mark.parametrize('tile_counts', [
+        ((100, 100, 100)),  # ~1e9 voxels — below int32 limit, baseline correctness
+        ((130, 130, 130)),  # ~2.197e9 voxels — above int32 limit (2^31 = 2,147,483,648)
+    ])
+    @pytest.mark.parametrize('output', [None, numpy.int32, numpy.int64])
+    def test_label_dtype_output(self, tile_counts, output):
+        """Correct label count with dtype-type output argument"""
+        img = self._make_sphere_pack(tile_counts)
+        _, n_labels = cupyx.scipy.ndimage.label(img, output=output)
+        assert n_labels == numpy.prod(tile_counts)
+
+    @pytest.mark.parametrize('tile_counts', [
+        ((100, 100, 100)),
+        ((130, 130, 130)),
+    ])
+    @pytest.mark.parametrize('output_dtype', [numpy.int32, numpy.int64])
+    def test_label_array_output(self, tile_counts, output_dtype):
+        """Correct label count with pre-allocated array output argument"""
+        img = self._make_sphere_pack(tile_counts)
+        out = cupy.empty_like(img, dtype=output_dtype)
+        n_labels = cupyx.scipy.ndimage.label(img, output=out)
+        assert n_labels == numpy.prod(tile_counts)
+
+    def test_label_int32_overflow_error(self):
+        """Raises RuntimeError when n_labels > INT32_MAX with int32 output."""
+        img = cupy.ones((1300, 1300, 1300))
+        assert img.size > self._INT32_MAX
+
+        # every voxel becomes its own component with zero structure
+        structure = numpy.zeros((3, 3, 3), dtype=bool)
+        out = cupy.empty_like(img, dtype=numpy.int32)
+
+        with pytest.raises(RuntimeError):
+            cupyx.scipy.ndimage.label(img, output=out, structure=structure)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -675,7 +675,7 @@ class TestFindObjectsBasic:
 
 
 @pytest.mark.slow
-class TestLabelInt32Overflow:
+class TestLabelOverflow:
     """Tests ndimage.label on arrays that trigger int32 overflow."""
 
     _CELL_SIZE = 10
@@ -688,7 +688,7 @@ class TestLabelInt32Overflow:
         r = self._RADIUS
         ix, iy, iz = numpy.mgrid[:s, :s, :s]
         cell = (ix - c) ** 2 + (iy - c) ** 2 + (iz - c) ** 2 <= r ** 2
-        return cupy.tile(cupy.asarray(cell), tile_counts)
+        return cupy.tile(cupy.asarray(cell, dtype=cupy.float16), tile_counts)
 
     #   cell grid | image dimensions | voxel count | above int32 limit?
     # 100x100x100 |    1000x10001000 |        ~1e9 | no
@@ -700,9 +700,12 @@ class TestLabelInt32Overflow:
     @pytest.mark.parametrize('output', [None, numpy.int32, numpy.int64])
     def test_label_dtype_output(self, tile_counts, output):
         """Correct label count with dtype-type output argument"""
-        img = self._make_sphere_pack(tile_counts)
-        _, n_labels = cupyx.scipy.ndimage.label(img, output=output)
-        assert n_labels == numpy.prod(tile_counts)
+        try:
+            img = self._make_sphere_pack(tile_counts)
+            _, n_labels = cupyx.scipy.ndimage.label(img, output=output)
+            assert n_labels == numpy.prod(tile_counts)
+        except MemoryError:
+            pytest.skip("Test needs a massive amount of GPU memory to pass")
 
     @pytest.mark.parametrize('tile_counts', [
         ((100, 100, 100)),
@@ -711,19 +714,46 @@ class TestLabelInt32Overflow:
     @pytest.mark.parametrize('output_dtype', [numpy.int32, numpy.int64])
     def test_label_array_output(self, tile_counts, output_dtype):
         """Correct label count with pre-allocated array output argument"""
-        img = self._make_sphere_pack(tile_counts)
+        try:
+            img = self._make_sphere_pack(tile_counts)
+            out = cupy.empty_like(img, dtype=output_dtype)
+            n_labels = cupyx.scipy.ndimage.label(img, output=out)
+            assert n_labels == numpy.prod(tile_counts)
+        except MemoryError:
+            pytest.skip("Test needs a massive amount of GPU memory to pass")
+
+    @pytest.mark.parametrize('output_dtype', [numpy.int16, numpy.uint16])
+    def test_label_array_output_non_default_dtype(self, output_dtype):
+        img = cupy.asarray([[1, 0, 1], [0, 1, 0]], dtype=numpy.int8)
         out = cupy.empty_like(img, dtype=output_dtype)
         n_labels = cupyx.scipy.ndimage.label(img, output=out)
-        assert n_labels == numpy.prod(tile_counts)
+        assert n_labels == 3
+
+    @pytest.mark.parametrize('output_dtype', [numpy.int16, numpy.uint16])
+    def test_label_dtype_output_non_default_dtype(self, output_dtype):
+        img = cupy.asarray([[1, 0, 1], [0, 1, 0]], dtype=numpy.int8)
+        out, n_labels = cupyx.scipy.ndimage.label(img, output=output_dtype)
+        assert out.dtype == output_dtype
+        assert n_labels == 3
 
     def test_label_int32_overflow_error(self):
-        """Raises RuntimeError when n_labels > INT32_MAX with int32 output."""
-        img = cupy.ones((1300, 1300, 1300))
-        assert img.size > self._INT32_MAX
+        """Raises ValueError when n_labels > INT32_MAX with int32 output."""
+        try:
+            img = cupy.ones((1300, 1300, 1300), dtype=cupy.float16)
+            assert img.size > self._INT32_MAX
 
-        # every voxel becomes its own component with zero structure
-        structure = numpy.zeros((3, 3, 3), dtype=bool)
-        out = cupy.empty_like(img, dtype=numpy.int32)
+            # every voxel becomes its own component with zero structure
+            structure = numpy.zeros((3, 3, 3), dtype=bool)
+            out = cupy.empty_like(img, dtype=numpy.int32)
 
-        with pytest.raises(RuntimeError):
-            cupyx.scipy.ndimage.label(img, output=out, structure=structure)
+            with pytest.raises(ValueError):
+                cupyx.scipy.ndimage.label(img, output=out, structure=structure)
+        except MemoryError:
+            pytest.skip("Test needs a massive amount of GPU memory to pass")
+
+    @pytest.mark.parametrize('output', [numpy.int8, 'int8'])
+    def test_label_small_integer_output_overflow_error(self, output):
+        img = cupy.ones((130,), dtype=numpy.int8)
+        structure = numpy.zeros((3,), dtype=bool)
+        with pytest.raises(ValueError):
+            cupyx.scipy.ndimage.label(img, output=output, structure=structure)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -690,9 +690,12 @@ class TestLabelInt32Overflow:
         cell = (ix - c) ** 2 + (iy - c) ** 2 + (iz - c) ** 2 <= r ** 2
         return cupy.tile(cupy.asarray(cell), tile_counts)
 
+    #   cell grid | image dimensions | voxel count | above int32 limit?
+    # 100x100x100 |    1000x10001000 |        ~1e9 | no
+    # 130x130x130 |    1300x13001300 |    ~2.197e9 | yes
     @pytest.mark.parametrize('tile_counts', [
-        ((100, 100, 100)),  # ~1e9 voxels — below int32 limit
-        ((130, 130, 130)),  # ~2.197e9 voxels — above int32 limit
+        ((100, 100, 100)),
+        ((130, 130, 130)),
     ])
     @pytest.mark.parametrize('output', [None, numpy.int32, numpy.int64])
     def test_label_dtype_output(self, tile_counts, output):


### PR DESCRIPTION
## Summary

Fixes an index overflow bug in `cupyx.scipy.ndimage.label` that leads to incorrect results or CUDA illegal memory access errors for large images.

### Root cause

The union-find implementation in `_kernel_connect` and `_kernel_count` uses 32-bit integers (`int`) for indexing flattened array positions. For sufficiently large arrays, these indices overflow, leading to incorrect connectivity, silent mislabeling, or GPU memory access errors.

## What changed

- Promote indexing variables (`j`, `k`, `rest`, `stride`, `pos`) to 64-bit (`long long`)
- Store intermediate label array `y` as `int64` to support large flattened indices
- Upgrade 'local' array to int64 (stores flat indices of roots)
- Use explicit 64-bit casting for `atomicCAS`, since it only supports `unsigned long long` for 64-bit (link: [CUDA docs](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html?highlight=atomicCAS#atomiccas)):
  ```cpp
  atomicCAS((unsigned long long*)&y[k],
            (unsigned long long)k,
            (unsigned long long)j);

## Validation
The following test constructs a tiled 3D sphere packing where each tile should become a single connected component.
```python
#!/usr/bin/env python3

import time
import cupy as cp
import cupyx.scipy.ndimage as ndi
import numpy as np


INT32_MAX = 2**31 - 1  # 2,147,483,647


def _make_sphere_cell(cell_size, radius):
    c = cell_size // 2
    ix, iy, iz = np.mgrid[:cell_size, :cell_size, :cell_size]
    return (ix - c) ** 2 + (iy - c) ** 2 + (iz - c) ** 2 <= radius**2


def make_sphere_pack(tile_counts, cell_size=10, radius=4):
    cell = _make_sphere_cell(cell_size, radius)
    return cp.tile(cp.asarray(cell), tile_counts)


def run_test(tile_counts):
    cell_size = 10
    expected = tile_counts[0] * tile_counts[1] * tile_counts[2]

    img = make_sphere_pack(tile_counts, cell_size=cell_size)
    print(img.shape)

    t0 = time.perf_counter()
    _, n_labels = ndi.label(img)
    cp.cuda.Device().synchronize()
    dt = time.perf_counter() - t0

    status = "PASS" if int(n_labels) == expected else "FAIL"
    print(
        f"  expected={expected:,}  got={int(n_labels):,}  " f"[{status}]  ({dt:.1f}s)"
    )


SIZES = [
    ((100, 100, 100), "1.0e9 voxels — below int32 overflow threshold (baseline)"),
    ((130, 130, 130), "2.197e9 voxels — exceeds int32 max (overflow case)"),
]


print(f"CuPy {cp.__version__}")
print(f"GPU: {cp.cuda.runtime.getDeviceProperties(0)['name'].decode()}\n")

for tile_counts, desc in SIZES:
    print(f"[{desc}]")
    run_test(tile_counts)
```
### Before fix
```text
CuPy 15.0.0a1
GPU: NVIDIA H100 80GB HBM3

[1.0e9 voxels — below int32 overflow threshold (baseline)]
(1000, 1000, 1000)
  expected=1,000,000  got=1,000,000  [PASS]  (0.1s)
[2.197e9 voxels — exceeds int32 max (overflow case)]
(1300, 1300, 1300)
  expected=2,197,000  got=2,146,300  [FAIL]  (0.1s)
```

### After fix
```text
CuPy 15.0.0a1
GPU: NVIDIA H100 80GB HBM3

[1.0e9 voxels — below int32 overflow threshold (baseline)]
(1000, 1000, 1000)
  expected=1,000,000  got=1,000,000  [PASS]  (0.5s)
[2.197e9 voxels — exceeds int32 max (overflow case)]
(1300, 1300, 1300)
  expected=2,197,000  got=2,197,000  [PASS]  (0.4s)
```

## Related issue

Fixes: #9851