### PR TITLE
Implement `ndarray.byteswap()`

### DIFF
--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -35,6 +35,7 @@ cdef class _ndarray_base:
         self, dtype, order=*, casting=*, subok=*, copy=*)
     cpdef _ndarray_base astype(
         self, dtype, order=*, casting=*, subok=*, copy=*)
+    cpdef _ndarray_base byteswap(self, inplace=*)
     cpdef _ndarray_base copy(self, order=*)
     cpdef _ndarray_base view(self, dtype=*, array_class=*)
     cpdef fill(self, value)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2606,43 +2606,43 @@ cdef str _id = 'out0 = in0'
 
 cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
-cdef _byteswap_kernel_2 = ElementwiseKernel(
-    'uint16 x', 'uint16 y',
-    'y = __byte_perm(x, 0u, 0x3201u)',
-    'cupy_byteswap_2')
+cdef str _byteswap_preamble = '#include <cuda/std/bit>'
 
-cdef _byteswap_kernel_4 = ElementwiseKernel(
-    'uint32 x', 'uint32 y',
-    'y = __byte_perm(x, 0u, 0x0123u)',
-    'cupy_byteswap_4')
+cdef _byteswap_kernel = ElementwiseKernel(
+    'T x', 'T y',
+    'y = cuda::std::byteswap(x)',
+    'cupy_byteswap',
+    preamble=_byteswap_preamble)
 
-cdef _byteswap_kernel_8 = ElementwiseKernel(
-    'uint64 x', 'uint64 y',
+# 16-byte (__uint128_t) path: ElementwiseKernel's type system has no uint128,
+# so take a raw uint64 view and reinterpret as __uint128_t inside the kernel.
+cdef _byteswap_kernel_16 = ElementwiseKernel(
+    'raw uint64 x', 'raw uint64 y',
     '''
-    unsigned int lo = (unsigned int)(x);
-    unsigned int hi = (unsigned int)(x >> 32);
-    y = ((unsigned long long)__byte_perm(lo, 0u, 0x0123u) << 32) |
-        (unsigned long long)__byte_perm(hi, 0u, 0x0123u);
+    reinterpret_cast<__uint128_t*>(&y[0])[i] = cuda::std::byteswap(
+        reinterpret_cast<const __uint128_t*>(&x[0])[i]);
     ''',
-    'cupy_byteswap_8')
+    'cupy_byteswap_16',
+    preamble=_byteswap_preamble)
+
 
 cdef _byteswap_dispatch(_ndarray_base a):
     cdef int itemsize = a.dtype.itemsize
-    cdef _ndarray_base u, result
+    cdef _ndarray_base u, result, out
     dtype = a.dtype
-    uint_dtype = numpy.dtype('uint{}'.format(itemsize * 8))
-    u = _internal_ascontiguousarray(a).view(uint_dtype)
-    if itemsize == 2:
-        result = _byteswap_kernel_2(u)
-    elif itemsize == 4:
-        result = _byteswap_kernel_4(u)
-    elif itemsize == 8:
-        result = _byteswap_kernel_8(u)
-    else:
-        raise TypeError(
-            'byteswap not supported for dtype with '
-            'itemsize {}'.format(itemsize))
-    return result.view(dtype)
+    if itemsize == 2 or itemsize == 4 or itemsize == 8:
+        uint_dtype = numpy.dtype('uint{}'.format(itemsize * 8))
+        u = _internal_ascontiguousarray(a).view(uint_dtype)
+        result = _byteswap_kernel(u)
+        return result.view(dtype)
+    if itemsize == 16:
+        u = _internal_ascontiguousarray(a).ravel().view(numpy.uint64)
+        out = _ndarray_init(ndarray, u._shape, u.dtype, None)
+        _byteswap_kernel_16(u, out, size=a.size)
+        return out.view(dtype).reshape(a.shape)
+    raise TypeError(
+        'byteswap not supported for dtype with '
+        'itemsize {}'.format(itemsize))
 
 
 cdef str _divmod_float = '''

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2606,40 +2606,22 @@ cdef str _id = 'out0 = in0'
 
 cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
-cdef str _byteswap_preamble = '#include <cuda/std/bit>'
-
 cdef _byteswap_kernel = ElementwiseKernel(
     'T x', 'T y',
     'y = cuda::std::byteswap(x)',
     'cupy_byteswap',
-    preamble=_byteswap_preamble)
-
-# 16-byte (__uint128_t) path: ElementwiseKernel's type system has no uint128,
-# so take a raw uint64 view and reinterpret as __uint128_t inside the kernel.
-cdef _byteswap_kernel_16 = ElementwiseKernel(
-    'raw uint64 x', 'raw uint64 y',
-    '''
-    reinterpret_cast<__uint128_t*>(&y[0])[i] = cuda::std::byteswap(
-        reinterpret_cast<const __uint128_t*>(&x[0])[i]);
-    ''',
-    'cupy_byteswap_16',
-    preamble=_byteswap_preamble)
+    preamble='#include <cuda/std/bit>')
 
 
 cdef _byteswap_dispatch(_ndarray_base a):
     cdef int itemsize = a.dtype.itemsize
-    cdef _ndarray_base u, result, out
+    cdef _ndarray_base u, result
     dtype = a.dtype
     if itemsize == 2 or itemsize == 4 or itemsize == 8:
         uint_dtype = numpy.dtype('uint{}'.format(itemsize * 8))
         u = _internal_ascontiguousarray(a).view(uint_dtype)
         result = _byteswap_kernel(u)
         return result.view(dtype)
-    if itemsize == 16:
-        u = _internal_ascontiguousarray(a).ravel().view(numpy.uint64)
-        out = _ndarray_init(ndarray, u._shape, u.dtype, None)
-        _byteswap_kernel_16(u, out, size=a.size)
-        return out.view(dtype).reshape(a.shape)
     raise TypeError(
         'byteswap not supported for dtype with '
         'itemsize {}'.format(itemsize))

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -822,8 +822,8 @@ cdef class _ndarray_base:
             contig = _internal_ascontiguousarray(self).ravel()
             float_view = contig.view(component_dtype)
             swapped = _byteswap_dispatch(float_view)
-            result = _internal_ascontiguousarray(swapped).view(dtype).reshape(
-                self.shape)
+            result = _internal_ascontiguousarray(swapped)
+            result = result.view(dtype).reshape(self.shape)
             if inplace:
                 elementwise_copy(result, self)
                 return self
@@ -2630,8 +2630,8 @@ cdef _byteswap_dispatch(_ndarray_base a):
     cdef int itemsize = a.dtype.itemsize
     cdef _ndarray_base u, result
     dtype = a.dtype
-    u = _internal_ascontiguousarray(a).view(
-        numpy.dtype('uint{}'.format(itemsize * 8)))
+    uint_dtype = numpy.dtype('uint{}'.format(itemsize * 8))
+    u = _internal_ascontiguousarray(a).view(uint_dtype)
     if itemsize == 2:
         result = _byteswap_kernel_2(u)
     elif itemsize == 4:
@@ -2640,8 +2640,8 @@ cdef _byteswap_dispatch(_ndarray_base a):
         result = _byteswap_kernel_8(u)
     else:
         raise TypeError(
-            'byteswap not supported for dtype with itemsize {}'.format(
-                itemsize))
+            'byteswap not supported for dtype with '
+            'itemsize {}'.format(itemsize))
     return result.view(dtype)
 
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -819,7 +819,7 @@ cdef class _ndarray_base:
         # Complex types: byteswap real and imaginary components independently
         if numpy.issubdtype(dtype, numpy.complexfloating):
             component_dtype = numpy.finfo(dtype).dtype
-            contig = _internal_ascontiguousarray(self)
+            contig = _internal_ascontiguousarray(self).ravel()
             float_view = contig.view(component_dtype)
             swapped = _byteswap_dispatch(float_view)
             result = _internal_ascontiguousarray(swapped).view(dtype).reshape(

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2608,12 +2608,12 @@ cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
 cdef _byteswap_kernel_2 = ElementwiseKernel(
     'uint16 x', 'uint16 y',
-    'y = __byte_perm(x, 0, 0x3201)',
+    'y = __byte_perm(x, 0u, 0x3201u)',
     'cupy_byteswap_2')
 
 cdef _byteswap_kernel_4 = ElementwiseKernel(
     'uint32 x', 'uint32 y',
-    'y = __byte_perm(x, 0, 0x0123)',
+    'y = __byte_perm(x, 0u, 0x0123u)',
     'cupy_byteswap_4')
 
 cdef _byteswap_kernel_8 = ElementwiseKernel(
@@ -2621,8 +2621,8 @@ cdef _byteswap_kernel_8 = ElementwiseKernel(
     '''
     unsigned int lo = (unsigned int)(x);
     unsigned int hi = (unsigned int)(x >> 32);
-    y = ((unsigned long long)__byte_perm(lo, 0, 0x0123) << 32) |
-        (unsigned long long)__byte_perm(hi, 0, 0x0123);
+    y = ((unsigned long long)__byte_perm(lo, 0u, 0x0123u) << 32) |
+        (unsigned long long)__byte_perm(hi, 0u, 0x0123u);
     ''',
     'cupy_byteswap_8')
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -811,6 +811,10 @@ cdef class _ndarray_base:
         dtype = self.dtype
         itemsize = dtype.itemsize
 
+        if dtype.names is not None:
+            raise TypeError(
+                'byteswap is not supported for structured dtypes')
+
         if itemsize == 1:
             if inplace:
                 return self

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2607,20 +2607,20 @@ cdef str _id = 'out0 = in0'
 cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
 cdef _byteswap_kernel_2 = ElementwiseKernel(
-    'raw uint16 x', 'uint16 y',
-    'y = __byte_perm(x[i], 0, 0x0010)',
+    'uint16 x', 'uint16 y',
+    'y = __byte_perm(x, 0, 0x0010)',
     'cupy_byteswap_2')
 
 cdef _byteswap_kernel_4 = ElementwiseKernel(
-    'raw uint32 x', 'uint32 y',
-    'y = __byte_perm(x[i], 0, 0x0123)',
+    'uint32 x', 'uint32 y',
+    'y = __byte_perm(x, 0, 0x0123)',
     'cupy_byteswap_4')
 
 cdef _byteswap_kernel_8 = ElementwiseKernel(
-    'raw uint64 x', 'uint64 y',
+    'uint64 x', 'uint64 y',
     '''
-    unsigned int lo = (unsigned int)(x[i]);
-    unsigned int hi = (unsigned int)(x[i] >> 32);
+    unsigned int lo = (unsigned int)(x);
+    unsigned int hi = (unsigned int)(x >> 32);
     y = ((unsigned long long)__byte_perm(lo, 0, 0x0123) << 32) |
         (unsigned long long)__byte_perm(hi, 0, 0x0123);
     ''',

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -791,7 +791,49 @@ cdef class _ndarray_base:
         copy_ = True if copy else None
         return self._astype(dtype, order, casting, subok, copy_)
 
-    # TODO(okuta): Implement byteswap
+    cpdef _ndarray_base byteswap(self, inplace=False):
+        """Swap the bytes of the array elements.
+
+        Toggle between low-endian and big-endian data representation by
+        returning a byteswapped array, optionally swapped in-place.
+
+        Args:
+            inplace (bool): If ``True``, swap bytes in-place. Default is
+                ``False``.
+
+        Returns:
+            cupy.ndarray: The byteswapped array. If ``inplace`` is ``True``,
+            this is a view to self.
+
+        .. seealso:: :meth:`numpy.ndarray.byteswap`
+
+        """
+        dtype = self.dtype
+        itemsize = dtype.itemsize
+
+        if itemsize == 1:
+            if inplace:
+                return self
+            return self.copy()
+
+        # Complex types: byteswap real and imaginary components independently
+        if numpy.issubdtype(dtype, numpy.complexfloating):
+            component_dtype = numpy.finfo(dtype).dtype
+            contig = _internal_ascontiguousarray(self)
+            float_view = contig.view(component_dtype)
+            swapped = _byteswap_dispatch(float_view)
+            result = _internal_ascontiguousarray(swapped).view(dtype).reshape(
+                self.shape)
+            if inplace:
+                elementwise_copy(result, self)
+                return self
+            return result
+
+        result = _byteswap_dispatch(self)
+        if inplace:
+            elementwise_copy(result, self)
+            return self
+        return result
 
     cpdef _ndarray_base copy(self, order='C'):
         """Returns a copy of the array.
@@ -2563,6 +2605,45 @@ cpdef function.Module compile_with_cache(
 cdef str _id = 'out0 = in0'
 
 cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
+
+cdef _byteswap_kernel_2 = ElementwiseKernel(
+    'raw uint16 x', 'uint16 y',
+    'y = __byte_perm(x[i], 0, 0x0010)',
+    'cupy_byteswap_2')
+
+cdef _byteswap_kernel_4 = ElementwiseKernel(
+    'raw uint32 x', 'uint32 y',
+    'y = __byte_perm(x[i], 0, 0x0123)',
+    'cupy_byteswap_4')
+
+cdef _byteswap_kernel_8 = ElementwiseKernel(
+    'raw uint64 x', 'uint64 y',
+    '''
+    unsigned int lo = (unsigned int)(x[i]);
+    unsigned int hi = (unsigned int)(x[i] >> 32);
+    y = ((unsigned long long)__byte_perm(lo, 0, 0x0123) << 32) |
+        (unsigned long long)__byte_perm(hi, 0, 0x0123);
+    ''',
+    'cupy_byteswap_8')
+
+cdef _byteswap_dispatch(_ndarray_base a):
+    cdef int itemsize = a.dtype.itemsize
+    cdef _ndarray_base u, result
+    dtype = a.dtype
+    u = _internal_ascontiguousarray(a).view(
+        numpy.dtype('uint{}'.format(itemsize * 8)))
+    if itemsize == 2:
+        result = _byteswap_kernel_2(u)
+    elif itemsize == 4:
+        result = _byteswap_kernel_4(u)
+    elif itemsize == 8:
+        result = _byteswap_kernel_8(u)
+    else:
+        raise TypeError(
+            'byteswap not supported for dtype with itemsize {}'.format(
+                itemsize))
+    return result.view(dtype)
+
 
 cdef str _divmod_float = '''
     out0_type a = _floor_divide(in0, in1);

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2608,7 +2608,7 @@ cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
 cdef _byteswap_kernel_2 = ElementwiseKernel(
     'uint16 x', 'uint16 y',
-    'y = __byte_perm(x, 0, 0x0010)',
+    'y = __byte_perm(x, 0, 0x3201)',
     'cupy_byteswap_2')
 
 cdef _byteswap_kernel_4 = ElementwiseKernel(

--- a/docs/source/_comparison_generator.py
+++ b/docs/source/_comparison_generator.py
@@ -209,7 +209,6 @@ def generate():
         'numpy', 'cupy', klass='ndarray', footnotes={
             'tostring': _deprecated,
 
-            'byteswap': _byte_order,
             'newbyteorder': _byte_order,
         })
     buf += [

--- a/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
@@ -23,10 +23,7 @@ class TestByteswap:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
     def test_byteswap(self, xp, dtype, shape, inplace, order):
-        a = xp.array(
-            testing.shaped_arange(shape, xp, dtype),
-            order=order,
-        )
+        a = testing.shaped_arange(shape, xp, dtype, order)
         b = a.byteswap(inplace=inplace)
         if inplace:
             assert b is a

--- a/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
@@ -8,10 +8,13 @@ from cupy import testing
 @pytest.mark.parametrize('shape', [
     (),
     (0,),
+    (1,),
     (10,),
     (2, 3),
+    (2, 0, 4),
     (2, 3, 4),
     (2, 3, 4, 5),
+    (1, 1, 1, 1),
 ])
 @pytest.mark.parametrize('inplace', [False, True])
 @pytest.mark.parametrize('order', ['C', 'F'])
@@ -28,3 +31,49 @@ class TestByteswap:
         if inplace:
             assert b is a
         return b
+
+
+@pytest.mark.parametrize('slices', [
+    (slice(None, None, 2),),
+    (slice(None, None, 3),),
+    (slice(1, None, 2),),
+    (slice(None, None, -1),),
+])
+@pytest.mark.parametrize('inplace', [False, True])
+class TestByteswapNonContiguous:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap_strided_1d(self, xp, dtype, slices, inplace):
+        a = testing.shaped_arange((12,), xp, dtype)
+        b = a[slices].byteswap(inplace=inplace)
+        return b
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap_strided_2d(self, xp, dtype, slices, inplace):
+        a = testing.shaped_arange((4, 6), xp, dtype)
+        b = a[slices + slices].byteswap(inplace=inplace)
+        return b
+
+
+@pytest.mark.parametrize('inplace', [False, True])
+class TestByteswapTransposed:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap_transposed_2d(self, xp, dtype, inplace):
+        a = testing.shaped_arange((3, 4), xp, dtype)
+        return a.T.byteswap(inplace=inplace)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap_transposed_3d(self, xp, dtype, inplace):
+        a = testing.shaped_arange((2, 3, 4), xp, dtype)
+        return a.transpose(2, 0, 1).byteswap(inplace=inplace)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap_transposed_4d(self, xp, dtype, inplace):
+        a = testing.shaped_arange((2, 3, 4, 5), xp, dtype)
+        return a.transpose(3, 1, 0, 2).byteswap(inplace=inplace)

--- a/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_byteswap.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from cupy import testing
+
+
+@pytest.mark.parametrize('shape', [
+    (),
+    (0,),
+    (10,),
+    (2, 3),
+    (2, 3, 4),
+    (2, 3, 4, 5),
+])
+@pytest.mark.parametrize('inplace', [False, True])
+@pytest.mark.parametrize('order', ['C', 'F'])
+class TestByteswap:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_byteswap(self, xp, dtype, shape, inplace, order):
+        a = xp.array(
+            testing.shaped_arange(shape, xp, dtype),
+            order=order,
+        )
+        b = a.byteswap(inplace=inplace)
+        if inplace:
+            assert b is a
+        return b


### PR DESCRIPTION
Closes https://github.com/cupy/cupy/issues/9854

I'd really appreciate feedback. My idea was to write kernels using byte permutation that I kinda stole from https://github.com/NVIDIA/cccl/blob/c0121ac78e03fab778d4a30b2bbb8e4b82bcbfdc/libcudacxx/include/cuda/std/__bit/byteswap.h which you vendor under `third_party`.
For complex numbers, I thought swapping the real and imaginary parts individually instead of an explicit kernel would be fine.