### PR TITLE
sparse: work around cuSPARSE SpMM gridDim.y overflow (#9850)

### DIFF
--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -1439,9 +1439,7 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
 
 # cuSPARSE csrmm_alg1 gridDim.y overflow threshold (#9850).
 # The kernel sets gridDim.y = ceil(n / 16); hardware max is 65535.
-# Fixed in CUDA 13.2+; affects all CUDA 12.x. Applied unconditionally
-# since the chunking overhead is negligible and there is no reliable
-# way to detect the fix at runtime (cusparseGetVersion doesn't change).
+# Fixed in cuSPARSE 12.7.20+ (CUDA 13.2+).
 _SPMM_MAX_DENSE_COLS = 65535 * 16  # 1,048,560
 
 
@@ -1499,7 +1497,7 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
         c.fill(0)
         return c
 
-    if n > _SPMM_MAX_DENSE_COLS:
+    if n > _SPMM_MAX_DENSE_COLS and getVersion() < 12720:
         # Workaround for cuSPARSE csrmm_alg1 gridDim.y overflow (#9850)
         for col0 in range(0, n, _SPMM_MAX_DENSE_COLS):
             col1 = min(col0 + _SPMM_MAX_DENSE_COLS, n)

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -1437,6 +1437,11 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
     return y
 
 
+# cuSPARSE csrmm_alg1 gridDim.y overflow threshold on CUDA <13.1 (see #9850).
+# The kernel sets gridDim.y = ceil(n / 16); hardware max is 65535.
+_SPMM_MAX_DENSE_COLS = 65535 * 16  # 1,048,560
+
+
 def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
     """Multiplication of sparse matrix and dense matrix.
 
@@ -1489,6 +1494,19 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
         raise ValueError('dimension mismatch')
     if a.nnz == 0:
         c.fill(0)
+        return c
+
+    if n > _SPMM_MAX_DENSE_COLS and _runtime.runtimeGetVersion() < 13020:
+        # Workaround for cuSPARSE csrmm_alg1 gridDim.y overflow (see #9850)
+        for col0 in range(0, n, _SPMM_MAX_DENSE_COLS):
+            col1 = min(col0 + _SPMM_MAX_DENSE_COLS, n)
+            if transb:
+                b_chunk = _cupy.asfortranarray(b[col0:col1, :])
+            else:
+                b_chunk = b[:, col0:col1]
+            c_chunk = c[:, col0:col1]
+            spmm(a, b_chunk, c=c_chunk, alpha=alpha, beta=beta,
+                 transa=transa, transb=transb)
         return c
 
     desc_a = SpMatDescriptor.create(a)

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -1437,8 +1437,11 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
     return y
 
 
-# cuSPARSE csrmm_alg1 gridDim.y overflow threshold on CUDA <13.1 (see #9850).
+# cuSPARSE csrmm_alg1 gridDim.y overflow threshold (#9850).
 # The kernel sets gridDim.y = ceil(n / 16); hardware max is 65535.
+# Fixed in CUDA 13.2+; affects all CUDA 12.x. Applied unconditionally
+# since the chunking overhead is negligible and there is no reliable
+# way to detect the fix at runtime (cusparseGetVersion doesn't change).
 _SPMM_MAX_DENSE_COLS = 65535 * 16  # 1,048,560
 
 
@@ -1496,13 +1499,15 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
         c.fill(0)
         return c
 
-    if n > _SPMM_MAX_DENSE_COLS and _runtime.runtimeGetVersion() < 13020:
-        # Workaround for cuSPARSE csrmm_alg1 gridDim.y overflow (see #9850)
+    if n > _SPMM_MAX_DENSE_COLS:
+        # Workaround for cuSPARSE csrmm_alg1 gridDim.y overflow (#9850)
         for col0 in range(0, n, _SPMM_MAX_DENSE_COLS):
             col1 = min(col0 + _SPMM_MAX_DENSE_COLS, n)
             if transb:
+                # Row slice of F-contiguous is not F-contiguous; copy needed
                 b_chunk = _cupy.asfortranarray(b[col0:col1, :])
             else:
+                # Column slice of F-contiguous is F-contiguous; no copy
                 b_chunk = b[:, col0:col1]
             c_chunk = c[:, col0:col1]
             spmm(a, b_chunk, c=c_chunk, alpha=alpha, beta=beta,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -867,17 +867,13 @@ class TestCsrMatrixScipyComparison:
         return m * x
 
     @testing.slow
-    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
-    def test_mul_dense_matrix_large_rows(self, dtype):
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_mul_dense_matrix_large_rows(self, xp, sp):
         """cuSPARSE SpMM gridDim.y overflow (#9850)."""
-        n_grid = 1048561  # just above 65535 * 16
-        n_ao = 5
-        dm = sparse.random(n_ao, n_ao, density=0.5,
-                           format='csr', dtype=dtype)
-        ao = cupy.ones((n_grid, n_ao), dtype=dtype)
-        result = ao @ dm
-        expected = ao @ dm.toarray()
-        cupy.testing.assert_allclose(result, expected, rtol=1e-5)
+        n = 1048561  # just above 65535 * 16
+        m = self.make(xp, sp, self.dtype)
+        x = xp.ones((n, m.shape[0]), dtype=self.dtype)
+        return x @ m
 
     def test_mul_dense_matrix_invalid_shape(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2154,7 +2154,3 @@ class TestCsrMatrixDiagonal:
                 scipy_a.setdiag(x, k=k)
             with pytest.raises(ValueError):
                 cupyx_a.setdiag(x, k=k)
-
-
-class TestSpMMLargeColumns:
-    """Regression test for cuSPARSE SpMM gridDim.y overflow (#9850)."""

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2158,4 +2158,3 @@ class TestCsrMatrixDiagonal:
 
 class TestSpMMLargeColumns:
     """Regression test for cuSPARSE SpMM gridDim.y overflow (#9850)."""
-

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -866,6 +866,19 @@ class TestCsrMatrixScipyComparison:
         x = xp.arange(8).reshape(4, 2).astype(self.dtype)
         return m * x
 
+    @testing.slow
+    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+    def test_mul_dense_matrix_large_rows(self, dtype):
+        """cuSPARSE SpMM gridDim.y overflow (#9850)."""
+        n_grid = 1048561  # just above 65535 * 16
+        n_ao = 5
+        dm = sparse.random(n_ao, n_ao, density=0.5,
+                           format='csr', dtype=dtype)
+        ao = cupy.ones((n_grid, n_ao), dtype=dtype)
+        result = ao @ dm
+        expected = ao @ dm.toarray()
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5)
+
     def test_mul_dense_matrix_invalid_shape(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -2146,13 +2159,3 @@ class TestCsrMatrixDiagonal:
 class TestSpMMLargeColumns:
     """Regression test for cuSPARSE SpMM gridDim.y overflow (#9850)."""
 
-    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
-    def test_dense_at_sparse_large_rows(self, dtype):
-        n_grid = 1048561  # just above 65535 * 16
-        n_ao = 5
-        dm = sparse.random(n_ao, n_ao, density=0.5,
-                           format='csr', dtype=dtype)
-        ao = cupy.ones((n_grid, n_ao), dtype=dtype)
-        result = ao @ dm
-        expected = ao @ dm.toarray()
-        cupy.testing.assert_allclose(result, expected, rtol=1e-5)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -2141,3 +2141,18 @@ class TestCsrMatrixDiagonal:
                 scipy_a.setdiag(x, k=k)
             with pytest.raises(ValueError):
                 cupyx_a.setdiag(x, k=k)
+
+
+class TestSpMMLargeColumns:
+    """Regression test for cuSPARSE SpMM gridDim.y overflow (#9850)."""
+
+    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+    def test_dense_at_sparse_large_rows(self, dtype):
+        n_grid = 1048561  # just above 65535 * 16
+        n_ao = 5
+        dm = sparse.random(n_ao, n_ao, density=0.5,
+                           format='csr', dtype=dtype)
+        ao = cupy.ones((n_grid, n_ao), dtype=dtype)
+        result = ao @ dm
+        expected = ao @ dm.toarray()
+        cupy.testing.assert_allclose(result, expected, rtol=1e-5)

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -798,20 +798,22 @@ class TestSpmm:
         testing.assert_array_almost_equal(y, expect)
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
 class TestSpmmLargeColumns:
     """cuSPARSE SpMM gridDim.y overflow (#9850)."""
 
     @testing.slow
-    @pytest.mark.parametrize('dtype',
-                             [numpy.float32, numpy.float64])
-    def test_spmm_large_n(self, dtype):
+    def test_spmm_large_n(self):
         if not cusparse.check_availability('spmm'):
             pytest.skip('spmm is not available')
         n = 65535 * 16 + 1  # just above gridDim.y overflow threshold
         m, k = 5, 5
-        a = sparse.random(m, k, density=0.2, format='csr', dtype=dtype)
+        a = sparse.random(m, k, density=0.2, format='csr',
+                          dtype=self.dtype)
         a.sum_duplicates()
-        b = cupy.ones((k, n), dtype=dtype, order='F')
+        b = cupy.ones((k, n), dtype=self.dtype, order='F')
         c = cusparse.spmm(a, b, alpha=1.0)
         expected = a.toarray() @ b
         testing.assert_allclose(c, expected, rtol=1e-5)

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -798,6 +798,25 @@ class TestSpmm:
         testing.assert_array_almost_equal(y, expect)
 
 
+class TestSpmmLargeColumns:
+    """cuSPARSE SpMM gridDim.y overflow (#9850)."""
+
+    @testing.slow
+    @pytest.mark.parametrize('dtype',
+                             [numpy.float32, numpy.float64])
+    def test_spmm_large_n(self, dtype):
+        if not cusparse.check_availability('spmm'):
+            pytest.skip('spmm is not available')
+        n = 65535 * 16 + 1  # just above gridDim.y overflow threshold
+        m, k = 5, 5
+        a = sparse.random(m, k, density=0.2, format='csr', dtype=dtype)
+        a.sum_duplicates()
+        b = cupy.ones((k, n), dtype=dtype, order='F')
+        c = cusparse.spmm(a, b, alpha=1.0)
+        expected = a.toarray() @ b
+        testing.assert_allclose(c, expected, rtol=1e-5)
+
+
 @testing.with_requires('scipy')
 class TestErrorSpmm:
 


### PR DESCRIPTION
Fixes #9850.

cuSPARSE csrmm_alg1 sets gridDim.y = ceil(n/16) where n is the number of columns in the dense output. When n > 65535*16 the grid dimension exceeds the hardware limit and the kernel silently produces zeros. Chunk the dense matrix along columns on CUDA < 13.1 where the bug is present.

I've confirmed the cuSPARSE fix is present on a system with `_runtime.runtimeGetVersion()` of 13020, but I'm unsure in which exact version it became available.