### PR TITLE
BUG: Make `cutensor` bindings threadsafe (and some small fixes)

### DIFF
--- a/cupy/_core/_fusion_interface.py
+++ b/cupy/_core/_fusion_interface.py
@@ -23,7 +23,7 @@ def _set_dtype_to_astype_dict():
     This function is called at most once.
     """
     global _dtype_to_astype_dict
-    _dtype_to_astype_dict = {}
+    dtype_to_astype_dict = {}
 
     dtype_list = [numpy.dtype(type_char) for type_char in '?bhilqBHILQefdFD']
 
@@ -31,7 +31,10 @@ def _set_dtype_to_astype_dict():
         name = 'astype_{}'.format(t)
         rules = tuple(['{}->{}'.format(s.char, t.char) for s in dtype_list])
         command = 'out0 = static_cast< {} >(in0)'.format(get_typename(t))
-        _dtype_to_astype_dict[t] = core.create_ufunc(name, rules, command)
+        dtype_to_astype_dict[t] = core.create_ufunc(name, rules, command)
+
+    # Update the global variable after dict is fully populated:
+    _dtype_to_astype_dict = dtype_to_astype_dict
 
 
 class _VariableProxy:

--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -6,6 +6,7 @@ cpdef intptr_t get_cublas_handle() except? 0
 cpdef intptr_t get_cusolver_handle() except? 0
 cpdef intptr_t get_cusolver_sp_handle() except? 0
 cpdef intptr_t get_cusparse_handle() except? 0
+cpdef intptr_t get_cutensor_handle() except? 0
 cpdef str get_compute_capability()
 cdef bint _enable_peer_access(int device, int peer) except -1
 

--- a/cupy/cuda/device.pxd
+++ b/cupy/cuda/device.pxd
@@ -6,7 +6,7 @@ cpdef intptr_t get_cublas_handle() except? 0
 cpdef intptr_t get_cusolver_handle() except? 0
 cpdef intptr_t get_cusolver_sp_handle() except? 0
 cpdef intptr_t get_cusparse_handle() except? 0
-cpdef intptr_t get_cutensor_handle() except? 0
+cpdef get_cutensor_handle()
 cpdef str get_compute_capability()
 cdef bint _enable_peer_access(int device, int peer) except -1
 

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -55,7 +55,8 @@ cdef class Handle:
         self._destroy_func = destroy_func
 
     def __dealloc__(self):
-        self._destroy_func(self.handle)
+        if self._destroy_func is not None:
+            self._destroy_func(self.handle)
 
 
 cpdef intptr_t get_cublas_handle() except? 0:
@@ -74,7 +75,7 @@ cpdef intptr_t get_cusparse_handle() except? 0:
     return _get_device().cusparse_handle
 
 
-cpdef intptr_t get_cutensor_handle() except? 0:
+cpdef get_cutensor_handle():
     return _get_device().cutensor_handle
 
 
@@ -234,14 +235,17 @@ cdef class Device:
         if handles is None:
             handles = {}
             setattr(_thread_local, name, handles)
-        handle = handles.get(self.id, None)
-        if handle is not None:
-            return handle.handle
+        entry = handles.get(self.id, None)
+        if entry is not None:
+            return entry if destroy_func is None else entry.handle
         prev_device = runtime.getDevice()
         try:
             runtime.setDevice(self.id)
             handle = create_func()
-            handles[self.id] = Handle(handle, destroy_func)
+            if destroy_func is None:
+                handles[self.id] = handle
+            else:
+                handles[self.id] = Handle(handle, destroy_func)
             return handle
         finally:
             runtime.setDevice(prev_device)
@@ -299,11 +303,11 @@ cdef class Device:
         """The cuTENSOR handle for this device.
 
         The same handle is used for the same device even if the Device instance
-        itself is different.
+        itself is different. Returns a CutensorHandle object that owns the
+        raw library handle and all associated per-device caches.
         """
-        from cupy_backends.cuda.libs import cutensor
-        return self._get_handle(
-            'cutensor_handles', cutensor.create, cutensor.destroy)
+        from cupyx.cutensor import CutensorHandle
+        return self._get_handle('cutensor_handles', CutensorHandle, None)
 
     @property
     def mem_info(self):

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -241,10 +241,7 @@ cdef class Device:
         try:
             runtime.setDevice(self.id)
             handle = create_func()
-            if destroy_func is not None:
-                handles[self.id] = Handle(handle, destroy_func)
-            else:
-                handles[self.id] = handle
+            handles[self.id] = Handle(handle, destroy_func)
             return handle
         finally:
             runtime.setDevice(prev_device)
@@ -305,7 +302,8 @@ cdef class Device:
         itself is different.
         """
         from cupy_backends.cuda.libs import cutensor
-        return self._get_handle('cutensor_handles', cutensor.Handle(), None)
+        return self._get_handle(
+            'cutensor_handles', cutensor.create, cutensor.destroy)
 
     @property
     def mem_info(self):

--- a/cupy/cuda/device.pyx
+++ b/cupy/cuda/device.pyx
@@ -74,6 +74,10 @@ cpdef intptr_t get_cusparse_handle() except? 0:
     return _get_device().cusparse_handle
 
 
+cpdef intptr_t get_cutensor_handle() except? 0:
+    return _get_device().cutensor_handle
+
+
 cpdef str get_compute_capability():
     dev_id = get_device_id()
     ret = _compute_capabilities.get(dev_id, None)
@@ -237,7 +241,10 @@ cdef class Device:
         try:
             runtime.setDevice(self.id)
             handle = create_func()
-            handles[self.id] = Handle(handle, destroy_func)
+            if destroy_func is not None:
+                handles[self.id] = Handle(handle, destroy_func)
+            else:
+                handles[self.id] = handle
             return handle
         finally:
             runtime.setDevice(prev_device)
@@ -289,6 +296,16 @@ cdef class Device:
         from cupy_backends.cuda.libs import cusparse
         return self._get_handle(
             'cusparse_sp_handles', cusparse.create, cusparse.destroy)
+
+    @property
+    def cutensor_handle(self):
+        """The cuTENSOR handle for this device.
+
+        The same handle is used for the same device even if the Device instance
+        itself is different.
+        """
+        from cupy_backends.cuda.libs import cutensor
+        return self._get_handle('cutensor_handles', cutensor.Handle(), None)
 
     @property
     def mem_info(self):

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -2,7 +2,6 @@ import numpy as _numpy
 
 import cupy as _cupy
 from cupy import _util
-from cupy.cuda import device as _device
 
 cimport cython
 from libcpp cimport vector
@@ -51,7 +50,7 @@ cdef dict _available_compute_capability = {
 @_util.memoize(for_each_device=True)
 def check_availability(name):
     if name in _available_compute_capability:
-        compute_capability = int(_device.get_compute_capability())
+        compute_capability = int(device.get_compute_capability())
         if compute_capability < _available_compute_capability[name]:
             return False
     return True
@@ -216,10 +215,7 @@ cdef class Plan:
 
 
 cpdef Handle _get_handle():
-    cdef int dev = device.get_device_id()
-    if dev not in _handles:
-        _handles[dev] = Handle()
-    return _handles[dev]
+    return device.get_cutensor_handle()
 
 
 cpdef int _get_cutensor_dtype(dtype) except -1:

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -57,27 +57,6 @@ def check_availability(name):
 
 
 ###############################################################################
-# Handle: This class encapsulates the opaque structure `cutensorHandle_t`
-# holding cuTENSOR's library context.
-###############################################################################
-
-cdef class Handle:
-    cdef intptr_t _ptr
-
-    def __init__(self):
-        self._ptr = cutensor.create()
-
-    def __dealloc__(self):
-        if self._ptr is not 0:
-            cutensor.destroy(self._ptr)
-        self._ptr = <intptr_t>NULL
-
-    @property
-    def ptr(self):
-        return self._ptr
-
-
-###############################################################################
 # TensorDescriptor: This class encapsulates the opaque structure
 # `cutensorTensorDescriptor_t` representing a tensor descriptor.
 ###############################################################################
@@ -214,7 +193,7 @@ cdef class Plan:
         return self._ptr
 
 
-cpdef Handle _get_handle():
+cpdef intptr_t _get_handle():
     return device.get_cutensor_handle()
 
 
@@ -253,7 +232,7 @@ cpdef TensorDescriptor create_tensor_descriptor(_ndarray_base a):
     """
     handle = _get_handle()
     alignment_req = a.itemsize
-    key = (handle.ptr, a.dtype, tuple(a.shape),
+    key = (handle, a.dtype, tuple(a.shape),
            tuple(a.strides), alignment_req)
     if a.data.ptr & (alignment_req - 1) != 0:
         raise ValueError("Missaligned array")
@@ -263,7 +242,7 @@ cpdef TensorDescriptor create_tensor_descriptor(_ndarray_base a):
         stride = _numpy.array(a.strides, dtype=_numpy.int64) // a.itemsize
         cutensor_dtype = _get_cutensor_dtype(a.dtype)
         _tensor_descriptors[key] = TensorDescriptor(
-            handle.ptr, num_modes, extent.ctypes.data, stride.ctypes.data,
+            handle, num_modes, extent.ctypes.data, stride.ctypes.data,
             cutensor_dtype, alignment_req=alignment_req)
     return _tensor_descriptors[key]
 
@@ -282,9 +261,9 @@ cpdef PlanPreference create_plan_preference(
         (PlanPreference): A instance of class PlanPreference.
     """
     handle = _get_handle()
-    key = (handle.ptr, algo, jit_mode)
+    key = (handle, algo, jit_mode)
     if key not in _plan_preferences:
-        _plan_preferences[key] = PlanPreference(handle.ptr, algo, jit_mode)
+        _plan_preferences[key] = PlanPreference(handle, algo, jit_mode)
     return _plan_preferences[key]
 
 
@@ -301,9 +280,9 @@ cpdef Plan create_plan(
         (Plan): A instance of class Plan.
     """
     handle = _get_handle()
-    key = (handle.ptr, desc.ptr, pref.ptr, ws_limit)
+    key = (handle, desc.ptr, pref.ptr, ws_limit)
     if key not in _plans:
-        _plans[key] = Plan(handle.ptr, desc.ptr, pref.ptr, ws_limit)
+        _plans[key] = Plan(handle, desc.ptr, pref.ptr, ws_limit)
     return _plans[key]
 
 
@@ -445,14 +424,14 @@ cpdef OperationDescriptor create_elementwise_binary(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
     handle = _get_handle()
-    key = (handle.ptr,
+    key = (handle,
            desc_A.ptr, mode_A.data, op_A,
            desc_C.ptr, mode_C.data, op_C,
            desc_D.ptr, mode_D.data, op_AC, compute_desc)
     if key not in _elementwise_binary_operators:
         _elementwise_binary_operators[key] = OperationDescriptor()
         _elementwise_binary_operators[key].create_elementwise_binary(
-            handle.ptr,
+            handle,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_D.ptr, mode_D.data, op_AC, compute_desc)
@@ -510,7 +489,7 @@ def elementwise_binary(
     plan_pref = create_plan_preference()
     plan = create_plan(operator, plan_pref)
     cutensor.elementwiseBinaryExecute(
-        _get_handle().ptr, plan.ptr,
+        _get_handle(), plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(gamma, out.dtype).ptr, C.data.ptr,
         out.data.ptr)
@@ -577,7 +556,7 @@ cpdef OperationDescriptor create_elementwise_trinary(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
     handle = _get_handle()
-    key = (handle.ptr,
+    key = (handle,
            desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
@@ -585,7 +564,7 @@ cpdef OperationDescriptor create_elementwise_trinary(
     if key not in _elementwise_trinary_operators:
         _elementwise_trinary_operators[key] = OperationDescriptor()
         _elementwise_trinary_operators[key].create_elementwise_trinary(
-            handle.ptr,
+            handle,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
@@ -654,7 +633,7 @@ def elementwise_trinary(
     plan_pref = create_plan_preference()
     plan = create_plan(operator, plan_pref)
     cutensor.elementwiseTrinaryExecute(
-        _get_handle().ptr, plan.ptr,
+        _get_handle(), plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(beta, out.dtype).ptr, B.data.ptr,
         _create_scalar(gamma, out.dtype).ptr, C.data.ptr,
@@ -722,7 +701,7 @@ cpdef OperationDescriptor create_contraction(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
     handle = _get_handle()
-    key = (handle.ptr,
+    key = (handle,
            desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
@@ -730,7 +709,7 @@ cpdef OperationDescriptor create_contraction(
     if key not in _contraction_operators:
         _contraction_operators[key] = OperationDescriptor()
         _contraction_operators[key].create_contraction(
-            handle.ptr,
+            handle,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
@@ -796,11 +775,11 @@ def contraction(
     plan_pref = create_plan_preference(algo=algo, jit_mode=jit_mode)
     # Query the estimated workspace size
     estimated_ws_size = cutensor.estimateWorkspaceSize(
-        _get_handle().ptr, operator.ptr, plan_pref.ptr, ws_pref)
+        _get_handle(), operator.ptr, plan_pref.ptr, ws_pref)
     plan = create_plan(operator, plan_pref, ws_limit=estimated_ws_size)
     actual_ws_size = _numpy.empty(1, dtype=_numpy.uint64)
     cutensor.planGetAttribute(
-        _get_handle().ptr, plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
+        _get_handle(), plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
         actual_ws_size.ctypes.data, actual_ws_size.itemsize)
     ws_size = actual_ws_size.item()
     assert ws_size <= estimated_ws_size, "Workspace size is larger than the estimated workspace size"  # NOQA
@@ -809,7 +788,7 @@ def contraction(
     scalar_dtype = _get_scalar_dtype(C.dtype)
     out = C
     cutensor.contract(
-        _get_handle().ptr, plan.ptr,
+        _get_handle(), plan.ptr,
         _create_scalar(alpha, scalar_dtype).ptr, A.data.ptr, B.data.ptr,
         _create_scalar(beta, scalar_dtype).ptr, C.data.ptr, out.data.ptr,
         ws.data.ptr, ws_size)
@@ -857,14 +836,14 @@ cpdef OperationDescriptor create_reduction(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
     handle = _get_handle()
-    key = (handle.ptr,
+    key = (handle,
            desc_A.ptr, mode_A.data, op_A,
            desc_C.ptr, mode_C.data, op_C,
            op_reduce, compute_desc)
     if key not in _reduction_operators:
         _reduction_operators[key] = OperationDescriptor()
         _reduction_operators[key].create_reduction(
-            handle.ptr,
+            handle,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_C.ptr, mode_C.data,
@@ -911,13 +890,13 @@ def reduction(
         desc_A, mode_A, op_A, desc_C, mode_C, op_C, op_reduce, compute_desc)
     plan_pref = create_plan_preference()
     ws_size = cutensor.estimateWorkspaceSize(
-        _get_handle().ptr, operator.ptr, plan_pref.ptr,
+        _get_handle(), operator.ptr, plan_pref.ptr,
         cutensor.WORKSPACE_RECOMMENDED)
     plan = create_plan(operator, plan_pref, ws_limit=ws_size)
     ws = core._ndarray_init(
         _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     cutensor.reduce(
-        _get_handle().ptr, plan.ptr,
+        _get_handle(), plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(beta, out.dtype).ptr, C.data.ptr, out.data.ptr,
         ws.data.ptr, ws_size)
@@ -1440,13 +1419,13 @@ cpdef MgTensorDescriptor create_mg_tensor_descriptor(a, devices=None):
         (MgTensorDescriptor): A instance of class MgTensorDescriptor.
     """
     handle = _get_mg_handle(devices)
-    key = (handle.ptr, *a.key)
+    key = (handle, *a.key)
     if key not in _mg_tensor_descriptors:
         # It seems that cuda_type is the same as cutensor_type,
         # so just reuse the cutensor_type here
         cutensor_dtype = _get_cutensor_dtype(a.dtype)
         _mg_tensor_descriptors[key] = MgTensorDescriptor(
-            handle.ptr, a.ndim, a.extent,
+            handle, a.ndim, a.extent,
             a.element_stride, a.block_size,
             a.block_stride, a.device_count,
             a.num_devices, a.devices, cutensor_dtype)
@@ -1469,10 +1448,10 @@ cpdef MgCopyDescriptor create_mg_copy_descriptor(
         (MgCopyDescriptor): A instance of class MgCopyDescriptor.
     """
     handle = _get_mg_handle(devices)
-    key = (handle.ptr, descDst.ptr, modeDst.data, descSrc.ptr, modeSrc.data)
+    key = (handle, descDst.ptr, modeDst.data, descSrc.ptr, modeSrc.data)
     if key not in _mg_copy_descriptors:
         _mg_copy_descriptors[key] = MgCopyDescriptor(
-            handle.ptr, descDst.ptr, modeDst.data,
+            handle, descDst.ptr, modeDst.data,
             descSrc.ptr, modeSrc.data)
     return _mg_copy_descriptors[key]
 
@@ -1491,10 +1470,10 @@ cpdef MgCopyPlan create_mg_copy_plan(
         (MgCopyPlan): A instance of class MgCopyPlan.
     """
     handle = _get_mg_handle(devices)
-    key = (handle.ptr, desc.ptr, tuple(workspaceDeviceSize), workspaceHostSize)
+    key = (handle, desc.ptr, tuple(workspaceDeviceSize), workspaceHostSize)
     if key not in _mg_copy_plans:
         _mg_copy_plans[key] = MgCopyPlan(
-            handle.ptr, desc.ptr, workspaceDeviceSize.ctypes.data,
+            handle, desc.ptr, workspaceDeviceSize.ctypes.data,
             workspaceHostSize)
     return _mg_copy_plans[key]
 
@@ -1531,7 +1510,7 @@ def copyMg(dst, mode_Dst, src, mode_Src, deviceBuf=None, hostBuf=None,
     deviceBufSize = _numpy.empty(num_devices, dtype=_numpy.int64)
     if deviceBuf is None or hostBuf is None:
         hostBufSize = cutensor.getMgCopyWorkspace(
-            handle.ptr, desc.ptr, deviceBufSize.ctypes.data
+            handle, desc.ptr, deviceBufSize.ctypes.data
         )
     if hostBuf is None:
         mem = alloc_pinned_memory(hostBufSize)
@@ -1568,7 +1547,7 @@ def copyMg(dst, mode_Dst, src, mode_Src, deviceBuf=None, hostBuf=None,
     else:
         for i in range(num_devices):
             streamPtrs[i] = streams[i].ptr
-    cutensor._copyMg(handle.ptr, plan.ptr, dst.ptr, src.ptr,
+    cutensor._copyMg(handle, plan.ptr, dst.ptr, src.ptr,
                      deviceBufptr.ctypes.data, hostBufptr,
                      streamPtrs.ctypes.data)
 
@@ -1600,7 +1579,7 @@ def copyMgWorkspace(dst, mode_Dst, src, mode_Src, devices=None):
 
     deviceBufSize = _numpy.empty(num_devices, dtype=_numpy.int64)
     hostBufSize = cutensor.getMgCopyWorkspace(
-        handle.ptr, desc.ptr, deviceBufSize.ctypes.data
+        handle, desc.ptr, deviceBufSize.ctypes.data
     )
     return hostBufSize, deviceBufSize
 
@@ -1650,7 +1629,7 @@ cpdef MgContractionDescriptor create_mg_contraction_descriptor(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
     handle = _get_mg_handle(devices)
-    key = (handle.ptr,
+    key = (handle,
            descA.ptr, modeA.data,
            descB.ptr, modeB.data,
            descC.ptr, modeC.data,
@@ -1658,7 +1637,7 @@ cpdef MgContractionDescriptor create_mg_contraction_descriptor(
            compute_desc)
     if key not in _mg_contraction_descriptors:
         _mg_contraction_descriptors[key]=MgContractionDescriptor(
-            handle.ptr,
+            handle,
             descA.ptr, modeA.data,
             descB.ptr, modeB.data,
             descC.ptr, modeC.data,
@@ -1678,10 +1657,10 @@ cpdef MgContractionFind create_mg_contraction_find(
         (MgContractionFind): A instance of class MgContractionFind.
     """
     handle = _get_mg_handle(devices)
-    key = (handle.ptr, algo)
+    key = (handle, algo)
     if key not in _mg_contraction_finds:
         _mg_contraction_finds[key]=MgContractionFind(
-            handle.ptr, algo)
+            handle, algo)
     return _mg_contraction_finds[key]
 
 cpdef MgContractionPlan create_mg_contraction_plan(
@@ -1700,11 +1679,11 @@ cpdef MgContractionPlan create_mg_contraction_plan(
         (MgContractionPlan): A instance of class MgContractionPlan.
     """
     handle = _get_mg_handle(devices)
-    key = (handle.ptr, desc.ptr, find.ptr, tuple(workspaceDeviceSize),
+    key = (handle, desc.ptr, find.ptr, tuple(workspaceDeviceSize),
            workspaceHostSize)
     if key not in _mg_contraction_plans:
         _mg_contraction_plans[key]=MgContractionPlan(
-            handle.ptr, desc.ptr, find.ptr, workspaceDeviceSize.ctypes.data,
+            handle, desc.ptr, find.ptr, workspaceDeviceSize.ctypes.data,
             workspaceHostSize)
     return _mg_contraction_plans[key]
 
@@ -1778,7 +1757,7 @@ def contractionMg(alpha, A, modeA, B, modeB, beta, C, modeC,
     deviceBufSize = _numpy.zeros((num_devices,), dtype=_numpy.int64)
     if deviceBuf is None or hostBuf is None:
         hostBufSize = cutensor.getMgContractionWorkspace(
-            handle.ptr, desc.ptr, find.ptr, ws_pref,
+            handle, desc.ptr, find.ptr, ws_pref,
             deviceBufSize.ctypes.data)
     if hostBuf is None:
         mem = alloc_pinned_memory(hostBufSize)
@@ -1815,7 +1794,7 @@ def contractionMg(alpha, A, modeA, B, modeB, beta, C, modeC,
             streamPtrs[i] = streams[i].ptr
     scalar_dtype = _get_scalar_dtype(C.dtype)
     cutensor._contractMg(
-        handle.ptr, plan.ptr, _create_scalar(alpha, scalar_dtype).ptr, A.ptr,
+        handle, plan.ptr, _create_scalar(alpha, scalar_dtype).ptr, A.ptr,
         B.ptr, _create_scalar(beta, scalar_dtype).ptr, C.ptr, D.ptr,
         deviceBufptr.ctypes.data, hostBufptr, streamPtrs.ctypes.data)
 
@@ -1882,6 +1861,6 @@ def contractionMgWorkspace(
     num_devices = handle.num_devices
     deviceBufSize = _numpy.zeros((num_devices,), dtype=_numpy.int64)
     hostBufSize = cutensor.getMgContractionWorkspace(
-        handle.ptr, desc.ptr, find.ptr, ws_pref,
+        handle, desc.ptr, find.ptr, ws_pref,
         deviceBufSize.ctypes.data)
     return hostBufSize, deviceBufSize

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -20,23 +20,8 @@ from cupy.cuda.pinned_memory cimport alloc_pinned_memory, is_memory_pinned
 from cupy_backends.cuda.libs cimport cutensor
 from cupy.cuda import Device
 
-cdef dict _handles = {}
-cdef dict _tensor_descriptors = {}
-cdef dict _plan_preferences = {}
-cdef dict _plans = {}
 cdef dict _modes = {}
 cdef dict _scalars = {}
-cdef dict _elementwise_binary_operators = {}
-cdef dict _elementwise_trinary_operators = {}
-cdef dict _reduction_operators = {}
-cdef dict _contraction_operators = {}
-cdef dict _mg_handles = {}
-cdef dict _mg_tensor_descriptors = {}
-cdef dict _mg_copy_descriptors = {}
-cdef dict _mg_copy_plans = {}
-cdef dict _mg_contraction_descriptors = {}
-cdef dict _mg_contraction_finds = {}
-cdef dict _mg_contraction_plans = {}
 
 cdef dict _available_compute_capability = {
     'contraction': 60,
@@ -45,6 +30,45 @@ cdef dict _available_compute_capability = {
     'copyMg': 60,
     'contractMg': 60,
 }
+
+
+cdef class CutensorHandle:
+    """Per-device, per-thread cuTENSOR handle with co-located caches.
+
+    All cached descriptors, plans, and operators created from this handle
+    live here, so their lifetime is tied to the handle's lifetime. This
+    avoids the global-dict problems (unbounded growth from thread churn,
+    dangling pointers after handle destruction, handle-in-key bloat).
+    """
+    cdef intptr_t _ptr
+    cdef dict _tensor_descriptors
+    cdef dict _plan_preferences
+    cdef dict _plans
+    cdef dict _elementwise_binary_operators
+    cdef dict _elementwise_trinary_operators
+    cdef dict _reduction_operators
+    cdef dict _contraction_operators
+    cdef dict _mg_handles
+
+    def __init__(self):
+        self._ptr = cutensor.create()
+        self._tensor_descriptors = {}
+        self._plan_preferences = {}
+        self._plans = {}
+        self._elementwise_binary_operators = {}
+        self._elementwise_trinary_operators = {}
+        self._reduction_operators = {}
+        self._contraction_operators = {}
+        self._mg_handles = {}
+
+    def __dealloc__(self):
+        if self._ptr is not 0:
+            cutensor.destroy(self._ptr)
+        self._ptr = <intptr_t>NULL
+
+    @property
+    def ptr(self):
+        return self._ptr
 
 
 @_util.memoize(for_each_device=True)
@@ -193,7 +217,7 @@ cdef class Plan:
         return self._ptr
 
 
-cpdef intptr_t _get_handle():
+cpdef CutensorHandle _get_handle():
     return device.get_cutensor_handle()
 
 
@@ -230,21 +254,20 @@ cpdef TensorDescriptor create_tensor_descriptor(_ndarray_base a):
     Returns:
         (TensorDescriptor): A instance of class TensorDescriptor.
     """
-    handle = _get_handle()
+    cdef CutensorHandle handle = _get_handle()
     alignment_req = a.itemsize
-    key = (handle, a.dtype, tuple(a.shape),
-           tuple(a.strides), alignment_req)
+    key = (a.dtype, tuple(a.shape), tuple(a.strides), alignment_req)
     if a.data.ptr & (alignment_req - 1) != 0:
         raise ValueError("Missaligned array")
-    if key not in _tensor_descriptors:
+    if key not in handle._tensor_descriptors:
         num_modes = a.ndim
         extent = _numpy.array(a.shape, dtype=_numpy.int64)
         stride = _numpy.array(a.strides, dtype=_numpy.int64) // a.itemsize
         cutensor_dtype = _get_cutensor_dtype(a.dtype)
-        _tensor_descriptors[key] = TensorDescriptor(
-            handle, num_modes, extent.ctypes.data, stride.ctypes.data,
+        handle._tensor_descriptors[key] = TensorDescriptor(
+            handle.ptr, num_modes, extent.ctypes.data, stride.ctypes.data,
             cutensor_dtype, alignment_req=alignment_req)
-    return _tensor_descriptors[key]
+    return handle._tensor_descriptors[key]
 
 
 cpdef PlanPreference create_plan_preference(
@@ -260,11 +283,12 @@ cpdef PlanPreference create_plan_preference(
     Returns:
         (PlanPreference): A instance of class PlanPreference.
     """
-    handle = _get_handle()
-    key = (handle, algo, jit_mode)
-    if key not in _plan_preferences:
-        _plan_preferences[key] = PlanPreference(handle, algo, jit_mode)
-    return _plan_preferences[key]
+    cdef CutensorHandle handle = _get_handle()
+    key = (algo, jit_mode)
+    if key not in handle._plan_preferences:
+        handle._plan_preferences[key] = PlanPreference(handle.ptr, algo,
+                                                       jit_mode)
+    return handle._plan_preferences[key]
 
 
 cpdef Plan create_plan(
@@ -279,11 +303,11 @@ cpdef Plan create_plan(
     Returns:
         (Plan): A instance of class Plan.
     """
-    handle = _get_handle()
-    key = (handle, desc.ptr, pref.ptr, ws_limit)
-    if key not in _plans:
-        _plans[key] = Plan(handle, desc.ptr, pref.ptr, ws_limit)
-    return _plans[key]
+    cdef CutensorHandle handle = _get_handle()
+    key = (desc.ptr, pref.ptr, ws_limit)
+    if key not in handle._plans:
+        handle._plans[key] = Plan(handle.ptr, desc.ptr, pref.ptr, ws_limit)
+    return handle._plans[key]
 
 
 cdef class Mode:
@@ -423,19 +447,18 @@ cpdef OperationDescriptor create_elementwise_binary(
             'elementwise_binary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
-    handle = _get_handle()
-    key = (handle,
-           desc_A.ptr, mode_A.data, op_A,
+    cdef CutensorHandle handle = _get_handle()
+    key = (desc_A.ptr, mode_A.data, op_A,
            desc_C.ptr, mode_C.data, op_C,
            desc_D.ptr, mode_D.data, op_AC, compute_desc)
-    if key not in _elementwise_binary_operators:
-        _elementwise_binary_operators[key] = OperationDescriptor()
-        _elementwise_binary_operators[key].create_elementwise_binary(
-            handle,
+    if key not in handle._elementwise_binary_operators:
+        handle._elementwise_binary_operators[key] = OperationDescriptor()
+        handle._elementwise_binary_operators[key].create_elementwise_binary(
+            handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_D.ptr, mode_D.data, op_AC, compute_desc)
-    return _elementwise_binary_operators[key]
+    return handle._elementwise_binary_operators[key]
 
 
 def elementwise_binary(
@@ -489,7 +512,7 @@ def elementwise_binary(
     plan_pref = create_plan_preference()
     plan = create_plan(operator, plan_pref)
     cutensor.elementwiseBinaryExecute(
-        _get_handle(), plan.ptr,
+        _get_handle().ptr, plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(gamma, out.dtype).ptr, C.data.ptr,
         out.data.ptr)
@@ -555,21 +578,20 @@ cpdef OperationDescriptor create_elementwise_trinary(
             'elementwise_trinary ({}, {})'.format(ct_dtype_A, ct_dtype_C))
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
-    handle = _get_handle()
-    key = (handle,
-           desc_A.ptr, mode_A.data, op_A,
+    cdef CutensorHandle handle = _get_handle()
+    key = (desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
            desc_D.ptr, mode_D.data, op_AB, op_ABC, compute_desc)
-    if key not in _elementwise_trinary_operators:
-        _elementwise_trinary_operators[key] = OperationDescriptor()
-        _elementwise_trinary_operators[key].create_elementwise_trinary(
-            handle,
+    if key not in handle._elementwise_trinary_operators:
+        handle._elementwise_trinary_operators[key] = OperationDescriptor()
+        handle._elementwise_trinary_operators[key].create_elementwise_trinary(
+            handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
             desc_D.ptr, mode_D.data, op_AB, op_ABC, compute_desc)
-    return _elementwise_trinary_operators[key]
+    return handle._elementwise_trinary_operators[key]
 
 
 def elementwise_trinary(
@@ -633,7 +655,7 @@ def elementwise_trinary(
     plan_pref = create_plan_preference()
     plan = create_plan(operator, plan_pref)
     cutensor.elementwiseTrinaryExecute(
-        _get_handle(), plan.ptr,
+        _get_handle().ptr, plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(beta, out.dtype).ptr, B.data.ptr,
         _create_scalar(gamma, out.dtype).ptr, C.data.ptr,
@@ -700,21 +722,20 @@ cpdef OperationDescriptor create_contraction(
             ' ({}, {}, {})'.format(ct_dtype_A, ct_dtype_B, ct_dtype_C))
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
-    handle = _get_handle()
-    key = (handle,
-           desc_A.ptr, mode_A.data, op_A,
+    cdef CutensorHandle handle = _get_handle()
+    key = (desc_A.ptr, mode_A.data, op_A,
            desc_B.ptr, mode_B.data, op_B,
            desc_C.ptr, mode_C.data, op_C,
            compute_desc)
-    if key not in _contraction_operators:
-        _contraction_operators[key] = OperationDescriptor()
-        _contraction_operators[key].create_contraction(
-            handle,
+    if key not in handle._contraction_operators:
+        handle._contraction_operators[key] = OperationDescriptor()
+        handle._contraction_operators[key].create_contraction(
+            handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_B.ptr, mode_B.data, op_B,
             desc_C.ptr, mode_C.data, op_C,
             desc_C.ptr, mode_C.data, compute_desc)
-    return _contraction_operators[key]
+    return handle._contraction_operators[key]
 
 
 cdef _get_scalar_dtype(out_dtype):
@@ -775,11 +796,11 @@ def contraction(
     plan_pref = create_plan_preference(algo=algo, jit_mode=jit_mode)
     # Query the estimated workspace size
     estimated_ws_size = cutensor.estimateWorkspaceSize(
-        _get_handle(), operator.ptr, plan_pref.ptr, ws_pref)
+        _get_handle().ptr, operator.ptr, plan_pref.ptr, ws_pref)
     plan = create_plan(operator, plan_pref, ws_limit=estimated_ws_size)
     actual_ws_size = _numpy.empty(1, dtype=_numpy.uint64)
     cutensor.planGetAttribute(
-        _get_handle(), plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
+        _get_handle().ptr, plan.ptr, cutensor.PLAN_REQUIRED_WORKSPACE,
         actual_ws_size.ctypes.data, actual_ws_size.itemsize)
     ws_size = actual_ws_size.item()
     assert ws_size <= estimated_ws_size, "Workspace size is larger than the estimated workspace size"  # NOQA
@@ -788,7 +809,7 @@ def contraction(
     scalar_dtype = _get_scalar_dtype(C.dtype)
     out = C
     cutensor.contract(
-        _get_handle(), plan.ptr,
+        _get_handle().ptr, plan.ptr,
         _create_scalar(alpha, scalar_dtype).ptr, A.data.ptr, B.data.ptr,
         _create_scalar(beta, scalar_dtype).ptr, C.data.ptr, out.data.ptr,
         ws.data.ptr, ws_size)
@@ -835,20 +856,19 @@ cpdef OperationDescriptor create_reduction(
             '({}, {})'.format(ct_dtype_A, ct_dtype_C))
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_C]
-    handle = _get_handle()
-    key = (handle,
-           desc_A.ptr, mode_A.data, op_A,
+    cdef CutensorHandle handle = _get_handle()
+    key = (desc_A.ptr, mode_A.data, op_A,
            desc_C.ptr, mode_C.data, op_C,
            op_reduce, compute_desc)
-    if key not in _reduction_operators:
-        _reduction_operators[key] = OperationDescriptor()
-        _reduction_operators[key].create_reduction(
-            handle,
+    if key not in handle._reduction_operators:
+        handle._reduction_operators[key] = OperationDescriptor()
+        handle._reduction_operators[key].create_reduction(
+            handle.ptr,
             desc_A.ptr, mode_A.data, op_A,
             desc_C.ptr, mode_C.data, op_C,
             desc_C.ptr, mode_C.data,
             op_reduce, compute_desc)
-    return _reduction_operators[key]
+    return handle._reduction_operators[key]
 
 
 def reduction(
@@ -890,13 +910,13 @@ def reduction(
         desc_A, mode_A, op_A, desc_C, mode_C, op_C, op_reduce, compute_desc)
     plan_pref = create_plan_preference()
     ws_size = cutensor.estimateWorkspaceSize(
-        _get_handle(), operator.ptr, plan_pref.ptr,
+        _get_handle().ptr, operator.ptr, plan_pref.ptr,
         cutensor.WORKSPACE_RECOMMENDED)
     plan = create_plan(operator, plan_pref, ws_limit=ws_size)
     ws = core._ndarray_init(
         _cupy.ndarray, shape_t(1, ws_size), dtype=_numpy.int8, obj=None)
     cutensor.reduce(
-        _get_handle(), plan.ptr,
+        _get_handle().ptr, plan.ptr,
         _create_scalar(alpha, out.dtype).ptr, A.data.ptr,
         _create_scalar(beta, out.dtype).ptr, C.data.ptr, out.data.ptr,
         ws.data.ptr, ws_size)
@@ -1072,11 +1092,23 @@ def _try_elementwise_binary_routine(
 cdef class MgHandle:
     cdef intptr_t _ptr
     cdef object _devices
+    cdef public dict _tensor_descriptors
+    cdef public dict _copy_descriptors
+    cdef public dict _copy_plans
+    cdef public dict _contraction_descriptors
+    cdef public dict _contraction_finds
+    cdef public dict _contraction_plans
 
     def __init__(self, devices):
         num_devices = len(devices)
         self._ptr = cutensor.createMg(num_devices, devices.ctypes.data)
         self._devices = devices
+        self._tensor_descriptors = {}
+        self._copy_descriptors = {}
+        self._copy_plans = {}
+        self._contraction_descriptors = {}
+        self._contraction_finds = {}
+        self._contraction_plans = {}
 
     def __dealloc__(self):
         if self._ptr is not 0:
@@ -1252,15 +1284,24 @@ cdef class MgContractionPlan:
     def ptr(self):
         return self._ptr
 
-cpdef MgHandle _get_mg_handle(devices=None):
+cpdef _get_mg_handle(devices=None):
+    """Get or create a multi-GPU handle, cached on the first device's
+    CutensorHandle for thread-local scoping.
+
+    cutensorMgHandle_t is a distinct opaque type from cutensorHandle_t
+    and cannot be substituted — it carries multi-device state that the
+    single-GPU handle does not have.
+    """
     if devices is None:
         devices = _numpy.arange(getDeviceCount(), dtype=_numpy.int32)
     else:
         devices = _numpy.asarray(devices, dtype=_numpy.int32)
+    cdef CutensorHandle ch = <CutensorHandle>(
+        device.Device(int(devices[0])).cutensor_handle)
     key = tuple(devices)
-    if key not in _mg_handles:
-        _mg_handles[key] = MgHandle(devices)
-    return _mg_handles[key]
+    if key not in ch._mg_handles:
+        ch._mg_handles[key] = MgHandle(devices)
+    return ch._mg_handles[key]
 
 
 class ndarray_mg:
@@ -1419,17 +1460,15 @@ cpdef MgTensorDescriptor create_mg_tensor_descriptor(a, devices=None):
         (MgTensorDescriptor): A instance of class MgTensorDescriptor.
     """
     handle = _get_mg_handle(devices)
-    key = (handle, *a.key)
-    if key not in _mg_tensor_descriptors:
-        # It seems that cuda_type is the same as cutensor_type,
-        # so just reuse the cutensor_type here
+    key = tuple(a.key)
+    if key not in handle._tensor_descriptors:
         cutensor_dtype = _get_cutensor_dtype(a.dtype)
-        _mg_tensor_descriptors[key] = MgTensorDescriptor(
-            handle, a.ndim, a.extent,
+        handle._tensor_descriptors[key] = MgTensorDescriptor(
+            handle.ptr, a.ndim, a.extent,
             a.element_stride, a.block_size,
             a.block_stride, a.device_count,
             a.num_devices, a.devices, cutensor_dtype)
-    return _mg_tensor_descriptors[key]
+    return handle._tensor_descriptors[key]
 
 
 cpdef MgCopyDescriptor create_mg_copy_descriptor(
@@ -1448,12 +1487,12 @@ cpdef MgCopyDescriptor create_mg_copy_descriptor(
         (MgCopyDescriptor): A instance of class MgCopyDescriptor.
     """
     handle = _get_mg_handle(devices)
-    key = (handle, descDst.ptr, modeDst.data, descSrc.ptr, modeSrc.data)
-    if key not in _mg_copy_descriptors:
-        _mg_copy_descriptors[key] = MgCopyDescriptor(
-            handle, descDst.ptr, modeDst.data,
+    key = (descDst.ptr, modeDst.data, descSrc.ptr, modeSrc.data)
+    if key not in handle._copy_descriptors:
+        handle._copy_descriptors[key] = MgCopyDescriptor(
+            handle.ptr, descDst.ptr, modeDst.data,
             descSrc.ptr, modeSrc.data)
-    return _mg_copy_descriptors[key]
+    return handle._copy_descriptors[key]
 
 
 cpdef MgCopyPlan create_mg_copy_plan(
@@ -1470,12 +1509,12 @@ cpdef MgCopyPlan create_mg_copy_plan(
         (MgCopyPlan): A instance of class MgCopyPlan.
     """
     handle = _get_mg_handle(devices)
-    key = (handle, desc.ptr, tuple(workspaceDeviceSize), workspaceHostSize)
-    if key not in _mg_copy_plans:
-        _mg_copy_plans[key] = MgCopyPlan(
-            handle, desc.ptr, workspaceDeviceSize.ctypes.data,
+    key = (desc.ptr, tuple(workspaceDeviceSize), workspaceHostSize)
+    if key not in handle._copy_plans:
+        handle._copy_plans[key] = MgCopyPlan(
+            handle.ptr, desc.ptr, workspaceDeviceSize.ctypes.data,
             workspaceHostSize)
-    return _mg_copy_plans[key]
+    return handle._copy_plans[key]
 
 
 def copyMg(dst, mode_Dst, src, mode_Src, deviceBuf=None, hostBuf=None,
@@ -1510,7 +1549,7 @@ def copyMg(dst, mode_Dst, src, mode_Src, deviceBuf=None, hostBuf=None,
     deviceBufSize = _numpy.empty(num_devices, dtype=_numpy.int64)
     if deviceBuf is None or hostBuf is None:
         hostBufSize = cutensor.getMgCopyWorkspace(
-            handle, desc.ptr, deviceBufSize.ctypes.data
+            handle.ptr, desc.ptr, deviceBufSize.ctypes.data
         )
     if hostBuf is None:
         mem = alloc_pinned_memory(hostBufSize)
@@ -1547,7 +1586,7 @@ def copyMg(dst, mode_Dst, src, mode_Src, deviceBuf=None, hostBuf=None,
     else:
         for i in range(num_devices):
             streamPtrs[i] = streams[i].ptr
-    cutensor._copyMg(handle, plan.ptr, dst.ptr, src.ptr,
+    cutensor._copyMg(handle.ptr, plan.ptr, dst.ptr, src.ptr,
                      deviceBufptr.ctypes.data, hostBufptr,
                      streamPtrs.ctypes.data)
 
@@ -1579,7 +1618,7 @@ def copyMgWorkspace(dst, mode_Dst, src, mode_Src, devices=None):
 
     deviceBufSize = _numpy.empty(num_devices, dtype=_numpy.int64)
     hostBufSize = cutensor.getMgCopyWorkspace(
-        handle, desc.ptr, deviceBufSize.ctypes.data
+        handle.ptr, desc.ptr, deviceBufSize.ctypes.data
     )
     return hostBufSize, deviceBufSize
 
@@ -1629,20 +1668,19 @@ cpdef MgContractionDescriptor create_mg_contraction_descriptor(
     if compute_desc == 0:
         compute_desc = compute_descs[ct_dtype_A][ct_dtype_B][ct_dtype_C]
     handle = _get_mg_handle(devices)
-    key = (handle,
-           descA.ptr, modeA.data,
+    key = (descA.ptr, modeA.data,
            descB.ptr, modeB.data,
            descC.ptr, modeC.data,
            descD.ptr, modeD.data,
            compute_desc)
-    if key not in _mg_contraction_descriptors:
-        _mg_contraction_descriptors[key]=MgContractionDescriptor(
-            handle,
+    if key not in handle._contraction_descriptors:
+        handle._contraction_descriptors[key] = MgContractionDescriptor(
+            handle.ptr,
             descA.ptr, modeA.data,
             descB.ptr, modeB.data,
             descC.ptr, modeC.data,
             descD.ptr, modeD.data, compute_desc)
-    return _mg_contraction_descriptors[key]
+    return handle._contraction_descriptors[key]
 
 cpdef MgContractionFind create_mg_contraction_find(
         int algo=cutensor.CUTENSORMG_ALGO_DEFAULT, devices=None):
@@ -1657,11 +1695,10 @@ cpdef MgContractionFind create_mg_contraction_find(
         (MgContractionFind): A instance of class MgContractionFind.
     """
     handle = _get_mg_handle(devices)
-    key = (handle, algo)
-    if key not in _mg_contraction_finds:
-        _mg_contraction_finds[key]=MgContractionFind(
-            handle, algo)
-    return _mg_contraction_finds[key]
+    key = (algo,)
+    if key not in handle._contraction_finds:
+        handle._contraction_finds[key] = MgContractionFind(handle.ptr, algo)
+    return handle._contraction_finds[key]
 
 cpdef MgContractionPlan create_mg_contraction_plan(
         MgContractionDescriptor desc, MgContractionFind find,
@@ -1679,13 +1716,12 @@ cpdef MgContractionPlan create_mg_contraction_plan(
         (MgContractionPlan): A instance of class MgContractionPlan.
     """
     handle = _get_mg_handle(devices)
-    key = (handle, desc.ptr, find.ptr, tuple(workspaceDeviceSize),
-           workspaceHostSize)
-    if key not in _mg_contraction_plans:
-        _mg_contraction_plans[key]=MgContractionPlan(
-            handle, desc.ptr, find.ptr, workspaceDeviceSize.ctypes.data,
-            workspaceHostSize)
-    return _mg_contraction_plans[key]
+    key = (desc.ptr, find.ptr, tuple(workspaceDeviceSize), workspaceHostSize)
+    if key not in handle._contraction_plans:
+        handle._contraction_plans[key] = MgContractionPlan(
+            handle.ptr, desc.ptr, find.ptr,
+            workspaceDeviceSize.ctypes.data, workspaceHostSize)
+    return handle._contraction_plans[key]
 
 
 def contractionMg(alpha, A, modeA, B, modeB, beta, C, modeC,
@@ -1757,7 +1793,7 @@ def contractionMg(alpha, A, modeA, B, modeB, beta, C, modeC,
     deviceBufSize = _numpy.zeros((num_devices,), dtype=_numpy.int64)
     if deviceBuf is None or hostBuf is None:
         hostBufSize = cutensor.getMgContractionWorkspace(
-            handle, desc.ptr, find.ptr, ws_pref,
+            handle.ptr, desc.ptr, find.ptr, ws_pref,
             deviceBufSize.ctypes.data)
     if hostBuf is None:
         mem = alloc_pinned_memory(hostBufSize)
@@ -1794,7 +1830,7 @@ def contractionMg(alpha, A, modeA, B, modeB, beta, C, modeC,
             streamPtrs[i] = streams[i].ptr
     scalar_dtype = _get_scalar_dtype(C.dtype)
     cutensor._contractMg(
-        handle, plan.ptr, _create_scalar(alpha, scalar_dtype).ptr, A.ptr,
+        handle.ptr, plan.ptr, _create_scalar(alpha, scalar_dtype).ptr, A.ptr,
         B.ptr, _create_scalar(beta, scalar_dtype).ptr, C.ptr, D.ptr,
         deviceBufptr.ctypes.data, hostBufptr, streamPtrs.ctypes.data)
 
@@ -1861,6 +1897,6 @@ def contractionMgWorkspace(
     num_devices = handle.num_devices
     deviceBufSize = _numpy.zeros((num_devices,), dtype=_numpy.int64)
     hostBufSize = cutensor.getMgContractionWorkspace(
-        handle, desc.ptr, find.ptr, ws_pref,
+        handle.ptr, desc.ptr, find.ptr, ws_pref,
         deviceBufSize.ctypes.data)
     return hostBufSize, deviceBufSize

--- a/cupyx/cutensor.pyx
+++ b/cupyx/cutensor.pyx
@@ -350,16 +350,14 @@ def create_mode(*mode):
 
 
 cdef inline Mode _create_mode_with_cache(axis_or_ndim):
-    cdef Mode mode
-    if axis_or_ndim in _modes:
-        mode = _modes[axis_or_ndim]
+    cdef Mode mode = <Mode>_modes.get(axis_or_ndim)
+    if mode is not None:
+        return mode
+    if type(axis_or_ndim) is int:
+        mode = Mode(tuple(range(axis_or_ndim)))
     else:
-        if type(axis_or_ndim) is int:
-            mode = Mode(tuple(range(axis_or_ndim)))
-        else:
-            mode = Mode(axis_or_ndim)
-        _modes[axis_or_ndim] = mode
-    return mode
+        mode = Mode(axis_or_ndim)
+    return <Mode>_modes.setdefault(axis_or_ndim, mode)
 
 
 cdef inline Mode _auto_create_mode(_ndarray_base array, mode):
@@ -389,12 +387,11 @@ cdef class _Scalar:
 cdef inline _Scalar _create_scalar(scale, dtype):
     cdef _Scalar scalar
     key = (scale, dtype)
-    if key in _scalars:
-        scalar = _scalars[key]
-    else:
-        scalar = _Scalar(scale, dtype)
-        _scalars[key] = scalar
-    return scalar
+    scalar = <_Scalar>_scalars.get(key)
+    if scalar is not None:
+        return scalar
+    scalar = _Scalar(scale, dtype)
+    return <_Scalar>_scalars.setdefault(key, scalar)
 
 
 cdef dict _elementwise_binary_compute_descs = {

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -445,12 +445,8 @@ class _TestRawBase:
             # kernel uses nvcc, with which I/O cannot be avoided
             files = os.listdir(self.cache_dir)
             for f in files:
-                if f == 'test_load_cubin.cu':
-                    count = 1
-                    break
-            else:
-                count = 0
-            assert len(files) == count
+                # only test_load_cubin_*.cu files should be present
+                assert re.match(r'test_load_cubin_(\d+)\.cu', f)
 
         self.in_memory_context.__exit__(*sys.exc_info())
         self.temporary_cache_dir_context.__exit__(*sys.exc_info())

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -404,6 +404,7 @@ class TestCuTensorReduction:
         yield
         cupy._core.set_routine_accelerators(old_accelerators)
 
+    @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
     @testing.for_contiguous_axes()
     # sum supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')

--- a/tests/cupyx_tests/test_cutensor.py
+++ b/tests/cupyx_tests/test_cutensor.py
@@ -118,13 +118,14 @@ class TestCuTensor:
         if compute_capability < 70 and self.dtype == numpy.float16:
             pytest.skip('Not supported.')
 
+        c = self.c.copy("K")
         d = cutensor.contraction(
             self.alpha, self.a, self.mode_a,
             self.b, self.mode_b,
-            self.beta, self.c, self.mode_c
+            self.beta, c, self.mode_c
         )
 
-        assert self.c is d
+        assert c is d
         testing.assert_allclose(
             self.alpha * self.a_transposed * self.b_transposed +
             self.beta * self.c_transposed,
@@ -319,12 +320,13 @@ class TestCuTensorContraction:
         mode_a = cutensor.create_mode('m', 'k')
         mode_b = cutensor.create_mode('k', 'n')
         mode_c = cutensor.create_mode('m', 'n')
+        c = self.c.copy()
         cutensor.contraction(self.alpha,
                              self.a, mode_a,
                              self.b, mode_b,
                              self.beta,
-                             self.c, mode_c)
-        cupy.testing.assert_allclose(self.c, self.c_ref,
+                             c, mode_c)
+        cupy.testing.assert_allclose(c, self.c_ref,
                                      rtol=self.tol, atol=self.tol)
 
         # test the contraction descriptor cache (issues #7318, #7812)
@@ -366,27 +368,27 @@ class TestCuTensorIncontiguous:
         mode_b = cutensor.create_mode('c', 'd', 'b')
         mode_c = cutensor.create_mode('d', 'a')
         a, b, c, d = self.shape
-        self.a = testing.shaped_random(
+        x = testing.shaped_random(
             (a, b, c), cupy, dtype=self.dtype, order=self.order)
-        self.b = testing.shaped_random(
+        y = testing.shaped_random(
             (c, d, b), cupy, dtype=self.dtype, order=self.order)
-        self.c = testing.shaped_random(
+        z = testing.shaped_random(
             (d, a), cupy, dtype=self.dtype, order=self.order)
         delta = 7
-        c_ref = self.c.copy()
+        c_ref = z.copy()
         c_ref = cutensor.contraction(self.alpha,
-                                     self.a, mode_a,
-                                     self.b, mode_b,
+                                     x, mode_a,
+                                     y, mode_b,
                                      self.beta,
                                      c_ref, mode_c)
         for a0 in range(0, a, delta):
             for d0 in range(0, d, delta):
                 cutensor.contraction(self.alpha,
-                                     self.a[a0:a0+delta], mode_a,
-                                     self.b[:, d0:d0+delta], mode_b,
+                                     x[a0:a0+delta], mode_a,
+                                     y[:, d0:d0+delta], mode_b,
                                      self.beta,
-                                     self.c[d0:d0+delta, a0:a0+delta], mode_c)
-                cupy.testing.assert_allclose(self.c[d0:d0+delta, a0:a0+delta],
+                                     z[d0:d0+delta, a0:a0+delta], mode_c)
+                cupy.testing.assert_allclose(z[d0:d0+delta, a0:a0+delta],
                                              c_ref[d0:d0+delta, a0:a0+delta],
                                              rtol=self.tol, atol=self.tol)
 
@@ -394,23 +396,23 @@ class TestCuTensorIncontiguous:
         mode_a = cutensor.create_mode('a', 'b', 'c')
         mode_c = cutensor.create_mode('b')
         a, b, c, _ = self.shape
-        self.a = testing.shaped_random(
+        x = testing.shaped_random(
             (a, b, c), cupy, dtype=self.dtype, order=self.order)
-        self.c = testing.shaped_random(
+        z = testing.shaped_random(
             (b,), cupy, dtype=self.dtype, order=self.order)
 
-        c_ref = self.c.copy()
+        c_ref = z.copy()
         c_ref = cutensor.reduction(self.alpha,
-                                   self.a, mode_a,
+                                   x, mode_a,
                                    self.beta,
                                    c_ref, mode_c)
         delta = 7
         for b0 in range(0, b, delta):
             cutensor.reduction(self.alpha,
-                               self.a[:, b0:b0+delta, :], mode_a,
+                               x[:, b0:b0+delta, :], mode_a,
                                self.beta,
-                               self.c[b0:b0+delta], mode_c)
-            cupy.testing.assert_allclose(self.c[b0:b0+delta],
+                               z[b0:b0+delta], mode_c)
+            cupy.testing.assert_allclose(z[b0:b0+delta],
                                          c_ref[b0:b0+delta],
                                          rtol=self.tol, atol=self.tol)
 
@@ -418,24 +420,24 @@ class TestCuTensorIncontiguous:
         mode_a = cutensor.create_mode('a', 'b', 'c')
         mode_c = cutensor.create_mode('c', 'a', 'b')
         a, b, c, _ = self.shape
-        self.a = testing.shaped_random(
+        x = testing.shaped_random(
             (a, b, c), cupy, dtype=self.dtype, order=self.order)
-        self.c = testing.shaped_random(
+        z = testing.shaped_random(
             (c, a, b), cupy, dtype=self.dtype, order=self.order)
 
-        c_ref = self.c.copy()
+        c_ref = z.copy()
         c_ref = cutensor.elementwise_binary(self.alpha,
-                                            self.a, mode_a,
+                                            x, mode_a,
                                             self.beta,
                                             c_ref, mode_c)
         delta = 7
         for b0 in range(0, b, delta):
             cutensor.elementwise_binary(self.alpha,
-                                        self.a[:, b0:b0+delta], mode_a,
+                                        x[:, b0:b0+delta], mode_a,
                                         self.beta,
-                                        self.c[:, :, b0:b0+delta], mode_c,
-                                        out=self.c[:, :, b0:b0+delta])
-            cupy.testing.assert_allclose(self.c[:, :, b0:b0+delta],
+                                        z[:, :, b0:b0+delta], mode_c,
+                                        out=z[:, :, b0:b0+delta])
+            cupy.testing.assert_allclose(z[:, :, b0:b0+delta],
                                          c_ref[:, :, b0:b0+delta],
                                          rtol=self.tol, atol=self.tol)
 
@@ -444,29 +446,29 @@ class TestCuTensorIncontiguous:
         mode_b = cutensor.create_mode('b', 'c', 'a')
         mode_c = cutensor.create_mode('c', 'a', 'b')
         a, b, c, _ = self.shape
-        self.a = testing.shaped_random(
+        x = testing.shaped_random(
             (a, b, c), cupy, dtype=self.dtype, order=self.order)
-        self.b = testing.shaped_random(
+        y = testing.shaped_random(
             (b, c, a), cupy, dtype=self.dtype, order=self.order)
-        self.c = testing.shaped_random(
+        z = testing.shaped_random(
             (c, a, b), cupy, dtype=self.dtype, order=self.order)
 
         for gamma in [0.0, 1.0]:
-            c_ref = self.c.copy()
-            c_ref = cutensor.elementwise_trinary(self.alpha, self.a, mode_a,
-                                                 self.beta, self.b, mode_b,
+            c_ref = z.copy()
+            c_ref = cutensor.elementwise_trinary(self.alpha, x, mode_a,
+                                                 self.beta, y, mode_b,
                                                  gamma, c_ref, mode_c,
                                                  out=c_ref)
             delta = 7
             for a0 in range(0, a, delta):
                 cutensor.elementwise_trinary(self.alpha,
-                                             self.a[a0:a0+delta],
+                                             x[a0:a0+delta],
                                              mode_a, self.beta,
-                                             self.b[:, :, a0:a0+delta],
+                                             y[:, :, a0:a0+delta],
                                              mode_b, gamma,
-                                             self.c[:, a0:a0+delta], mode_c,
-                                             out=self.c[:, a0:a0+delta])
-                cupy.testing.assert_allclose(self.c[:, a0:a0+delta],
+                                             z[:, a0:a0+delta], mode_c,
+                                             out=z[:, a0:a0+delta])
+                cupy.testing.assert_allclose(z[:, a0:a0+delta],
                                              c_ref[:, a0:a0+delta],
                                              rtol=self.tol, atol=self.tol)
 
@@ -490,21 +492,19 @@ class TestCuTensorMg:
     def test_contraction(self):
         n = self.shape
         if self.dtype == 'e':
-            # 16-bit result host pageable tensors are not supported in the
-            # contraction routines.
-            self.a = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
+            a = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
         else:
-            self.a = testing.shaped_random(
+            a = testing.shaped_random(
                 (n, n, n, n), numpy, dtype=self.dtype)
-        self.b = testing.shaped_random(
+        b = testing.shaped_random(
             (n, n, n, n), cupy, dtype=self.dtype)
-        self.c = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
-        c_ref = numpy.einsum('kijl,kadl->iajd', self.a, self.b.get())
-        mga = cutensor.ndarray_mg(self.a, block_size=[8, 8, 8, 8])
-        cutensor.contractionMg(1, mga, 'kijl', self.b,
-                               'kadl', 0, self.c, 'iajd')
+        c = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
+        c_ref = numpy.einsum('kijl,kadl->iajd', a, b.get())
+        mga = cutensor.ndarray_mg(a, block_size=[8, 8, 8, 8])
+        cutensor.contractionMg(1, mga, 'kijl', b,
+                               'kadl', 0, c, 'iajd')
         cupy.cuda.Device(0).synchronize()
-        cupy.testing.assert_allclose(self.c, c_ref, rtol=self.tol,
+        cupy.testing.assert_allclose(c, c_ref, rtol=self.tol,
                                      atol=self.tol)
 
     def test_copy(self):
@@ -512,13 +512,13 @@ class TestCuTensorMg:
         if self.dtype == 'e':
             # 16-bit result host pageable tensors are not supported in the
             # contraction routines.
-            self.a = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
+            a = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
         else:
-            self.a = testing.shaped_random(
+            a = testing.shaped_random(
                 (n, n, n, n), numpy, dtype=self.dtype)
-        self.b = testing.shaped_random(
+        b = testing.shaped_random(
             (n, n, n, n), cupy, dtype=self.dtype)
-        cutensor.copyMg(self.b, 'cabd', self.a, 'abcd')
+        cutensor.copyMg(b, 'cabd', a, 'abcd')
         cupy.cuda.Device(0).synchronize()
-        cupy.testing.assert_allclose(self.b.get(), self.a.transpose(
+        cupy.testing.assert_allclose(b.get(), a.transpose(
             (2, 0, 1, 3)), rtol=self.tol, atol=self.tol)

--- a/tests/cupyx_tests/test_cutensor.py
+++ b/tests/cupyx_tests/test_cutensor.py
@@ -479,7 +479,7 @@ class TestCuTensorIncontiguous:
 }))
 @pytest.mark.skipif(not ct.available, reason='cuTensor is unavailable')
 class TestCuTensorMg:
-    _tol = {'e': 1e-3, 'f': 2e-6, 'd': 1e-12}
+    _tol = {'e': 4e-3, 'f': 2e-6, 'd': 1e-12}
 
     @pytest.fixture(autouse=True)
     def setUp(self):
@@ -493,6 +493,8 @@ class TestCuTensorMg:
         n = self.shape
         if self.dtype == 'e':
             a = cupyx.empty_pinned((n, n, n, n), dtype=self.dtype)
+            a[...] = testing.shaped_random(
+                (n, n, n, n), numpy, dtype="float32")
         else:
             a = testing.shaped_random(
                 (n, n, n, n), numpy, dtype=self.dtype)


### PR DESCRIPTION
Trying to run free-threading tests on CI, I noticed that I never ran the tests with `cutensor` locally...
And, `cutensor` was never thread-safe at all, this fixes that.

I did use claude for some of the fixes, it is mostly churn, but roughly:
* Move the `handle` on to the device thread-local storage.
  * This is slightly awkard, because we change the `Handle` definition and because for the others the handle is an `intptr_t` only, while here it is a Python object.
* Most other caches are moved to the handle itself so that they are thread-local
* (Some caches are just updated to use `setdefault()` for nicer threading.)

The tests were also problematic... I had to have claude pull all `self.<var>` into the local namespace.  This just makes sense but is churn.
The `empty()` behavior for pinned memory was unreliable/odd but initializing the array fixes it.

(This should be all good, but I'll make a pass myself to check claude before merging.)