### PR TITLE
BUG: Fix incomplete size guard for CUB segmented reduce and scan

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -390,10 +390,12 @@ cdef (bint, Py_ssize_t) can_use_device_segmented_reduce(  # noqa: E211
             return (False, 0)
     else:
         order = 'CF'  # for computing the contig size
-    # until we resolve cupy/cupy#3309
+    # CUB device segmented reduce uses int for num_items, segment_size,
+    # and the offset iterator (segment_size * segment_index). Check the
+    # total array size to ensure none of these overflow. (cupy/cupy#3309)
     cdef Py_ssize_t contiguous_size = _preprocess_array(
         x.shape, reduce_axis, out_axis, order)
-    return (contiguous_size <= 0x7fffffff, contiguous_size)
+    return (x.size <= 0x7fffffff, contiguous_size)
 
 
 cdef _cub_support_dtype(bint sum_mode, int dev_id):
@@ -518,6 +520,9 @@ cpdef cub_scan(_ndarray_base arr, op):
 
     cdef int dev_id = device.get_device_id()
     if x_dtype in _cub_support_dtype(False, dev_id):
+        # CUB device scan uses int for num_items (cupy/cupy#3309)
+        if arr.size > 0x7fffffff:
+            return None
         return device_scan(arr, op)
 
     return None

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -387,6 +387,110 @@ class TestCubReduction:
         return result
 
 
+INT32_MAX = numpy.iinfo(numpy.int32).max
+
+
+@pytest.mark.skipif(
+    not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
+@testing.slow
+class TestReductionSizeOverInt32Max:
+
+    @pytest.fixture(autouse=True)
+    def _cub_device_and_memory(self):
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+        old_routine = _acc.get_routine_accelerators()
+        old_red = _acc.get_reduction_accelerators()
+        _acc.set_routine_accelerators(['cub'])
+        _acc.set_reduction_accelerators([])
+        yield
+        _acc.set_routine_accelerators(old_routine)
+        _acc.set_reduction_accelerators(old_red)
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+
+    @pytest.mark.parametrize('shape,axis,dtype,part', [
+        ((INT32_MAX + 1024,), None, "int8", "first_part"),
+        ((4, 2**30 + 512), 1, "float32", "second_part"),
+        ((INT32_MAX + 1024, 2), 0, "int8", "first_part"),
+        ((INT32_MAX + 1024, 2), 1, "int32", "second_part"),
+    ])
+    def test_reduce(self, shape, axis, dtype, part):
+        try:
+            a = cupy.ones(shape, dtype=dtype)
+            # Make first and last element along each slice interesting
+            if axis is None:
+                a[[0, -1]] = [3, -1]
+            elif axis == 0:
+                a[[0, -1], :] = [[3], [-1]]
+            else:
+                a[:, [0, -1]] = [[3, -1]]
+
+            # Test only half of the reductions per test for better speed
+            # (it is still very slow.)
+            if part == "first_part":
+                if axis is None:
+                    # Full reduction: one segment, one 2 and (size-1) ones
+                    assert a.sum() == a.size
+                    assert a.max() == 3
+                    assert a.argmin() == a.size - 1
+                else:
+                    s = a.sum(axis=axis)
+                    expected_sum = shape[axis]
+                    testing.assert_array_equal(s, cupy.full(
+                        s.shape, expected_sum, dtype=s.dtype))
+                    testing.assert_array_equal(
+                        a.max(axis=axis), cupy.full(s.shape, 3, dtype=dtype))
+                    testing.assert_array_equal(
+                        a.argmin(axis), cupy.full(s.shape, a.shape[axis] - 1))
+            else:
+                if axis is None:
+                    # Full reduction: one segment, one 2 and (size-1) ones
+                    assert a.prod() == -3
+                    assert a.min() == -1
+                    assert a.argmax() == 0
+                else:
+                    p = a.prod(axis=axis)
+                    testing.assert_array_equal(p, cupy.full(
+                        p.shape, -3, dtype=p.dtype))
+                    testing.assert_array_equal(
+                        a.min(axis=axis), cupy.full(p.shape, -1, dtype=dtype))
+                    testing.assert_array_equal(
+                        a.argmax(axis), cupy.full(p.shape, 0))
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
+    def test_cumsum_size_over_int32_max(self, dtype):
+        """CUB device_scan with size > INT32_MAX."""
+        try:
+            n = INT32_MAX + 1024
+            a = cupy.ones(n, dtype=dtype)
+            a[0] = 3
+            a[-1] = -1
+            out = a.cumsum()
+            expected = n
+            if dtype in (numpy.float32, numpy.float64):
+                testing.assert_allclose(float(out[-1]), expected, rtol=2e-4)
+            else:
+                assert int(out[-1]) == expected
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.float32])
+    def test_cumprod_size_over_int32_max(self, dtype):
+        """CUB device_scan (cumprod) with size > INT32_MAX."""
+        try:
+            n = INT32_MAX + 1024
+            a = cupy.ones(n, dtype=dtype)
+            a[0] = 2
+            a[-1] = 3
+            out = a.cumprod()
+            assert out[-1] == 6  # product of array
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+
+
 # This class compares cuTENSOR results against NumPy's
 @testing.parameterize(*testing.product({
     'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],


### PR DESCRIPTION
## Summary

Minimal fix for #9780 — an alternative to the broader `int` → `size_t` rewrite in #9810.

The existing guard in `can_use_device_segmented_reduce` only checked `contiguous_size <= INT32_MAX` (per-segment size), but the C++ offset iterator in `cupy_cub.cu` computes `segment_size * segment_index` using `int`. When the **product** exceeds `INT32_MAX`, the `int` overflows and causes an illegal memory access.

For example, `cp.zeros((40000, 400, 200), dtype='f').sum(axis=2)`:
- `contiguous_size` = 200 → passes the old guard
- `n_segments` = 16,000,000 → fits in `int`
- But offset = 200 × 16,000,000 = 3,200,000,000 → **overflows `int`**

### Changes

1. **`can_use_device_segmented_reduce`**: Check `x.size <= 0x7fffffff` instead of `contiguous_size <= 0x7fffffff`. Since `x.size = contiguous_size × n_segments`, this covers the segment size, segment count, and their product in the offset iterator.

2. **`cub_scan`**: Add a missing size guard. `device_scan` casts `x.size` to `int` without checking, which silently truncates for arrays > `INT32_MAX`.

3. **Tests**: Large-array correctness tests adapted from #9810 (co-authored by @seberg), with a typo fix (`"first-part"` → `"first_part"` so the first_part test branch actually runs its assertions).

### Why not the `int` → `size_t` approach (#9810)?

CUB's tuning system has separate specializations for 32-bit vs 64-bit offset types (see `tuning_reduce.cuh` in CCCL). Passing `size_t` causes CUB to instantiate 64-bit offset kernels **for all problem sizes**, not just large ones. This means:
- Different vectorized load policies (e.g. `items_per_vec_load = 1` vs `2` on SM100)
- Higher register pressure (~25% more registers per thread, per CCCL profiling data)
- Potential perf regression across all reduction sizes, not just the large ones being fixed

This minimal fix instead falls back to CuPy's generic reduction kernel for oversized arrays, preserving the 32-bit CUB fast path for all sizes that fit.

### Test plan

- [ ] Existing CUB reduction tests pass (no behavior change for arrays ≤ `INT32_MAX`)
- [ ] Arrays with total size > `INT32_MAX` fall back gracefully (no crash, correct results via generic kernel)
- [x] Large-array correctness tests from #9810 included (marked `@testing.slow`, require 2+ GB GPU memory)
- [x] Fixed test typo from #9810: `"first-part"` → `"first_part"` so the first_part branch actually runs assertions

Closes #9780

-- Leo's bot