### PR TITLE
Fix ZeroDivisionError when sorting along zero-length axis (#9816)

### DIFF
--- a/cupy/_core/_routines_sorting.pyx
+++ b/cupy/_core/_routines_sorting.pyx
@@ -36,6 +36,9 @@ cdef _ndarray_sort(_ndarray_base self, int axis):
 
     axis = internal._normalize_axis_index(axis, ndim)
 
+    if self._shape[axis] <= 1:
+        return  # already sorted (#9816)
+
     if axis == ndim - 1:
         data = self
     else:

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -27,6 +27,11 @@ class TestSort(unittest.TestCase):
                 xp.sort(a)
 
     @testing.numpy_cupy_array_equal()
+    def test_sort_zero_length_axis(self, xp):
+        """Sorting along a zero-length axis is a no-op (#9816)."""
+        return xp.sort(xp.empty((2, 0)), axis=-1)
+
+    @testing.numpy_cupy_array_equal()
     def test_sort_two_or_more_dim(self, xp):
         a = testing.shaped_random((2, 3, 3), xp)
         a.sort()


### PR DESCRIPTION
Fixes #9816.

Also, optimize to not sort when axis is length 1; this avoids a kernel launch