### PR TITLE
Remove NumericTraits specializations for complex types

### DIFF
--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -511,10 +511,6 @@ cpdef cub_scan(_ndarray_base arr, op):
         return None
 
     x_dtype = arr.dtype
-    if x_dtype == numpy.complex128:
-        # cub_device_scan seems buggy for complex128:
-        # https://github.com/cupy/cupy/pull/2919#issuecomment-574633590
-        return None
 
     cdef int dev_id = device.get_device_id()
     if x_dtype in _cub_support_dtype(False, dev_id):

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -84,8 +84,14 @@ inline constexpr bool is_floating_point_v<thrust::complex<double>> = true;
 
 }  // namespace cuda
 
-template <> struct NumericTraits<complex<float>>  : BaseTraits<FLOATING_POINT, true, unsigned int, thrust::complex<float>> {};
-template <> struct NumericTraits<complex<double>> : BaseTraits<FLOATING_POINT, true, unsigned long long, thrust::complex<double>> {};
+// NumericTraits specializations for complex types were removed because
+// marking them as primitive (is_primitive=true) caused UB in CUB's
+// decoupled lookback scan (torn reads/writes for sizeof(T) >= 16).
+// CUB reduce/scan still works for complex types without these traits
+// because CuPy provides custom operator specializations (Max, Min,
+// ArgMax, ArgMin) below, and the dtype_dispatcher handles the type
+// dispatch at the C++ level.
+// See: https://github.com/NVIDIA/cccl/issues/8207
 
 // need specializations for initial values
 namespace std {

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -323,7 +323,7 @@ class TestCubReduction:
     # TODO(leofang): test axis after support is added
     # don't test float16 as it's not as accurate?
     @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
-    @testing.for_dtypes('bhilBHILfdF')
+    @testing.for_dtypes('bhilBHILfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-4)
     def test_cub_cumsum(self, xp, dtype):
         if self.backend == 'block':
@@ -349,7 +349,7 @@ class TestCubReduction:
     # TODO(leofang): test axis after support is added
     # don't test float16 as it's not as accurate?
     @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
-    @testing.for_dtypes('bhilBHILfdF')
+    @testing.for_dtypes('bhilBHILfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-4)
     def test_cub_cumprod(self, xp, dtype):
         if self.backend == 'block':


### PR DESCRIPTION
## Summary

Remove `NumericTraits` specializations for `complex<float>` and `complex<double>` in `cupy_cub.cu`, and enable CUB scan for complex128.

### NumericTraits removal

These specializations marked complex types as primitive (`is_primitive=true`) via `BaseTraits<FLOATING_POINT, true, ...>`, which caused undefined behavior in CUB's decoupled lookback scan: the `UnsignedBits` storage type (`unsigned int` for complex64, `unsigned long long` for complex128) cannot fit the full complex value, leading to torn reads/writes.

The CUB scan path for complex128 was already disabled at the Python level (`cub.pyx:514`) since 2020 as a workaround for this issue. The specializations were originally added in #2538 (2019) to enable CUB reductions on complex numbers.

CUB device reductions (sum, min, max, argmin, argmax) and scans continue to work correctly for complex types without these traits, because CuPy provides:
- Custom operator specializations (`Max`, `Min`, `ArgMax`, `ArgMin`) for complex types
- `cuda::std::numeric_limits` specializations
- `cuda::is_floating_point_v` specializations

### CUB scan for complex128

With `NumericTraits` removed, CUB scan now produces correct results for complex128 (verified: 0 mismatches on 10K elements, `allclose=True` on 100K elements). The complex128 early-return bypass in `cub_scan` is removed, enabling the CUB fast path.

This also unblocks upgrading the CCCL submodule to versions where `ScanTileState` (after NVIDIA/cccl#7575) adds a `static_assert` that fails for `is_primitive` types with `sizeof >= 16`.

### Performance

CUB scan is 1.2–1.7x faster than the generic kernel for complex128:

<details>
<summary>Benchmark: complex128 cumsum (cupyx.profiler.benchmark, 20 repeats)</summary>

| n | CUB (ms) | Generic (ms) | Speedup | CUB (GB/s) | Generic (GB/s) |
|---:|---:|---:|---:|---:|---:|
| 10 | 0.0323 | 0.0316 | 1.0x | 0.00 | 0.01 |
| 100 | 0.0307 | 0.0311 | 1.0x | 0.05 | 0.05 |
| 1,000 | 0.0306 | 0.0480 | 1.6x | 0.52 | 0.33 |
| 10,000 | 0.0307 | 0.0482 | 1.6x | 5.22 | 3.32 |
| 100,000 | 0.0352 | 0.0518 | 1.5x | 45.45 | 30.89 |
| 1,000,000 | 0.0586 | 0.1011 | 1.7x | 273.04 | 158.33 |
| 10,000,000 | 0.8525 | 1.0985 | 1.3x | 187.69 | 145.66 |
| 100,000,000 | 8.5235 | 10.6189 | 1.2x | 187.72 | 150.67 |
| 1,000,000,000 | 84.5640 | 105.7326 | 1.3x | 189.21 | 151.33 |

GPU: NVIDIA RTX A5000, CUDA 13.1, CuPy 15.0.0a1

Benchmark script:
```python
import cupy as cp
from cupyx.profiler import benchmark

print(\"n, gpu_mean_ms, gpu_std_ms, throughput_GB/s\")
n = 10
while True:
    try:
        a = cp.ones(n, dtype=cp.complex128) * (1+1j)
        result = benchmark(cp.cumsum, (a,), n_repeat=20, n_warmup=5)
        gpu_mean = result.gpu_times.mean() * 1000
        gpu_std = result.gpu_times.std() * 1000
        bw = (n * 16) / (result.gpu_times.mean()) / 1e9
        print(f\"{n:>12d}, {gpu_mean:>10.4f}, {gpu_std:>10.4f}, {bw:>10.2f}\")
        n *= 10
    except cp.cuda.memory.OutOfMemoryError:
        print(f\"{n:>12d}, OOM\")
        break
```
</details>

## Test plan

- [x] CUB reduction tests pass for complex types (80/80 in `test_sumprod.py -k cub`)
- [x] CUB cumsum correct for complex128 (0 mismatches, allclose=True)
- [x] CUB cumprod correct for complex128 (allclose=True)
- [x] 1.2–1.7x speedup over generic kernel
- [ ] Full CI pass

See also: NVIDIA/cccl#8207

-- Leo's bot