### PR TITLE
CI,TST: Improve xdist GPU distribution and try using for CI

### DIFF
--- a/.pfnci/linux/tests/actions/unittest.sh
+++ b/.pfnci/linux/tests/actions/unittest.sh
@@ -21,6 +21,8 @@ if [[ "${MARKER}" =~ "not slow" ]]; then
     # I we are not running slow tests (and not high memory)
     # running tests in parallel should be safe.
     pytest_opts+=("-n2")
+    # Use nvidia-cuda-mps-control -d to start MPS server and hopefully help execution speed on T4
+    nvidia-cuda-mps-control -d
 fi
 
 # TODO: support coverage reporting

--- a/.pfnci/linux/tests/actions/unittest.sh
+++ b/.pfnci/linux/tests/actions/unittest.sh
@@ -17,6 +17,12 @@ if [[ "${MARKER}" != "" ]]; then
     pytest_opts+=(-m "${MARKER}")
 fi
 
+if [[ "${MARKER}" =~ "not slow" ]]; then
+    # I we are not running slow tests (and not high memory)
+    # running tests in parallel should be safe.
+    pytest_opts+=("-n2")
+fi
+
 # TODO: support coverage reporting
 python3 -m pip install --user pytest-timeout pytest-xdist
 

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -18,7 +18,6 @@ from libc.stdlib cimport free as c_free
 from libcpp.atomic cimport atomic as std_atomic
 from libcpp.set cimport set as std_set
 from libcpp.pair cimport pair as std_pair
-from libcpp.mutex cimport mutex as cpp_mutex
 
 from cupy.cuda cimport device
 from cupy.cuda cimport memory_hook
@@ -1182,6 +1181,7 @@ cdef class _Arena:
         return chunk
 
     cdef _get_size(self):
+        self._commit_pending_free()
         return self.index.size()
 
     cdef _index_to_python(self):
@@ -1234,12 +1234,11 @@ cdef class SingleDeviceMemoryPool:
         # `_Chunk` attribute that keeps the arena alive.
         # NOTE: If you work with any arena you must hold the `_arena_mutex`.
         # The only safe operation is `add_pending_free_atomic` (note the
-        # atomic # in the name).
+        # atomic # in the name); `pool.free` always uses that path so it
+        # never acquires `_arena_mutex` itself, which keeps finalizer-driven
+        # frees from re-entering the lock from the owning thread.
         dict _arenas
-        # NOTE: Never use `.lock()` outside a `with nogil:` statement as it
-        # may deadlock (GIL may be unlocked and another thread also locks).
-        # We currently use a mutex for the ability to use `try_lock`.
-        cpp_mutex _arena_mutex
+        cython.pymutex _arena_mutex
 
         # Number of total bytes actually allocated on GPU.
         # NOTE: You MUST use _try_block_total_bytes to increase the value
@@ -1293,12 +1292,8 @@ cdef class SingleDeviceMemoryPool:
 
     def _debug_arena_get_index(self, intptr_t stream_ident):
         # Sets returned are not copies, mutating them will break things
-        with nogil:
-            self._arena_mutex.lock()
-        try:
+        with self._arena_mutex:
             return self._arena(stream_ident)._index_to_python()
-        finally:
-            self._arena_mutex.unlock()
 
     cdef MemoryPointer _alloc(self, Py_ssize_t rounded_size):
         if memory_hook._has_memory_hooks():
@@ -1361,15 +1356,10 @@ cdef class SingleDeviceMemoryPool:
         stream_ident = _get_stream_identifier(
             stream_module.get_current_stream_ptr())
 
-        if not self._arena_mutex.try_lock():
-            with nogil:
-                self._arena_mutex.lock()
-        try:
+        with self._arena_mutex:
             arena = self._arena(stream_ident)
             # find best-fit, or a smallest larger allocation
             chunk = arena.get_chunk(size)
-        finally:
-            self._arena_mutex.unlock()
 
         if chunk is None:
             # cudaMalloc if a cache chunk is not found
@@ -1388,14 +1378,8 @@ cdef class SingleDeviceMemoryPool:
     cdef free(self, _Chunk chunk):
         self._in_use_bytes -= chunk.size
 
-        # Make sure freeing is always safe, but if we can lock do it.
-        if self._arena_mutex.try_lock():
-            try:
-                chunk.arena.insert_chunk(chunk)
-            finally:
-                self._arena_mutex.unlock()
-        else:
-            chunk.arena.add_pending_free_atomic(chunk)
+        # Free must be atomic as we may already be holding the arena mutex.
+        chunk.arena.add_pending_free_atomic(chunk)
 
     cpdef free_all_blocks(self, stream=None):
         """Free all **non-split** blocks for one or all arenas.
@@ -1405,26 +1389,23 @@ cdef class SingleDeviceMemoryPool:
         cdef tuple idents
         cdef size_t bytes_freed = 0
 
-        if not self._arena_mutex.try_lock():
-            with nogil:
-                self._arena_mutex.lock()
         try:
-            if stream is None:
-                idents = tuple(self._arenas.keys())
-            else:
-                stream_ident = _get_stream_identifier(stream.ptr)
-                if stream_ident not in self._arenas:
-                    return  # stream doesn't exist, just return
-                idents = (stream_ident,)
-
-            for ident in idents:
-                arena = self._arenas[ident]()
-                if arena is None:
-                    del self._arenas[ident]
+            with self._arena_mutex:
+                if stream is None:
+                    idents = tuple(self._arenas.keys())
                 else:
-                    bytes_freed += arena.free_all()
+                    stream_ident = _get_stream_identifier(stream.ptr)
+                    if stream_ident not in self._arenas:
+                        return  # stream doesn't exist, just return
+                    idents = (stream_ident,)
+
+                for ident in idents:
+                    arena = self._arenas[ident]()
+                    if arena is None:
+                        del self._arenas[ident]
+                    else:
+                        bytes_freed += arena.free_all()
         finally:
-            self._arena_mutex.unlock()
             self._total_bytes -= bytes_freed
 
     cpdef free_all_free(self):
@@ -1437,17 +1418,12 @@ cdef class SingleDeviceMemoryPool:
         cdef size_t n = 0
         cdef _Arena arena
 
-        if not self._arena_mutex.try_lock():
-            with nogil:
-                self._arena_mutex.lock()
-        try:
+        with self._arena_mutex:
             for ref in self._arenas.itervalues():
                 arena = ref()
                 if arena is None:
                     continue
                 n += arena._get_size()
-        finally:
-            self._arena_mutex.unlock()
 
         return n
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ markers = [
   "slow", "multi_gpu",
   # If pytest-run-parallel is not available
   "parallel_threads", "iterations", "thread_unsafe",
+  # If pytest-xdist is not available
+  "xdist_group",
 ]
 filterwarnings = [
   "always",  # Make sure previous calls cannot hide future warnings.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ def _is_in_ci():
     return ci_name != ''
 
 
+def pytest_configure(config):
+    if config.pluginmanager.hasplugin("xdist"):
+        # Some (few) tests should run grouped by class, so just force that.
+        config.option.dist = "loadscope"
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
     # Print installed packages
@@ -89,34 +95,36 @@ def pytest_sessionstart(session):
                 mem_fraction = int(100 / workers_on_my_gpu)
                 os.environ['CUPY_GPU_MEMORY_LIMIT'] = f"{mem_fraction}%"
 
+    # After setting up xdist do potentially non-trivial `cupy` configuration.
+    # (A simple cupy import by itself is OK, as it doesn't initialize CUDA.)
 
-if int(os.environ.get('CUPY_ENABLE_UMP', 0)) != 0:
-    # Make sure malloc is used in a stream-ordered fashion
-    import cupy as cp
-    cp.cuda.set_allocator(cp.cuda.MemoryPool(
-        cp.cuda.memory.malloc_system).malloc)
+    if int(os.environ.get('CUPY_ENABLE_UMP', 0)) != 0:
+        # Make sure malloc is used in a stream-ordered fashion
+        import cupy as cp
+        cp.cuda.set_allocator(cp.cuda.MemoryPool(
+            cp.cuda.memory.malloc_system).malloc)
 
-    import cupy._core.numpy_allocator as ac
-    import numpy_allocator
-    import ctypes
-    lib = ctypes.CDLL(ac.__file__)
+        import cupy._core.numpy_allocator as ac
+        import numpy_allocator
+        import ctypes
+        lib = ctypes.CDLL(ac.__file__)
 
-    class my_allocator(metaclass=numpy_allocator.type):
-        _calloc_ = ctypes.addressof(lib._calloc)
-        _malloc_ = ctypes.addressof(lib._malloc)
-        _realloc_ = ctypes.addressof(lib._realloc)
-        _free_ = ctypes.addressof(lib._free)
-    my_allocator.__enter__()
+        class my_allocator(metaclass=numpy_allocator.type):
+            _calloc_ = ctypes.addressof(lib._calloc)
+            _malloc_ = ctypes.addressof(lib._malloc)
+            _realloc_ = ctypes.addressof(lib._realloc)
+            _free_ = ctypes.addressof(lib._free)
+        my_allocator.__enter__()
 
+    if int(os.environ.get('CUPY_CI_ENABLE_GCP_KERNEL_CACHE', 0)) != 0:
+        from cupy.cuda.compiler import _set_kernel_cache_backend
+        from cupy_tests._gcp_kernel_cache_backend import GCPStorageCacheBackend
 
-if int(os.environ.get('CUPY_CI_ENABLE_GCP_KERNEL_CACHE', 0)) != 0:
-    from cupy.cuda.compiler import _set_kernel_cache_backend
-    from cupy_tests._gcp_kernel_cache_backend import GCPStorageCacheBackend
-
-    backend = GCPStorageCacheBackend(
-        bucket_name='tmp-asia-pfn-public-ci',
-        prefix='cupy-ci/kernel_cache_objects/'
-    )
-    print("GCP kernel cache: initializing local cache from GCS...", flush=True)
-    backend.initialize_local_cache()
-    _set_kernel_cache_backend(backend)
+        backend = GCPStorageCacheBackend(
+            bucket_name='tmp-asia-pfn-public-ci',
+            prefix='cupy-ci/kernel_cache_objects/'
+        )
+        print("GCP kernel cache: initializing local cache from GCS...",
+              flush=True)
+        backend.initialize_local_cache()
+        _set_kernel_cache_backend(backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,8 @@ def pytest_sessionstart(session):
                 if w % n_gpu < remainder:
                     workers_on_my_gpu += 1
                 mem_fraction = int(100 / workers_on_my_gpu)
-                os.environ['CUPY_GPU_MEMORY_LIMIT'] = f"{mem_fraction}%"
+                if os.environ.get('CUPY_GPU_MEMORY_LIMIT') is None:
+                    os.environ['CUPY_GPU_MEMORY_LIMIT'] = f"{mem_fraction}%"
 
     # After setting up xdist do potentially non-trivial `cupy` configuration.
     # (A simple cupy import by itself is OK, as it doesn't initialize CUDA.)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 
+import pytest
 
 # enable NEP 50 weak promotion rules
 import numpy
@@ -30,18 +31,22 @@ def _is_in_ci():
     return ci_name != ''
 
 
-def pytest_configure(config):
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionstart(session):
     # Print installed packages
     if _is_in_ci() and _is_pip_installed():
         print("***** Installed packages *****", flush=True)
         subprocess.check_call([sys.executable, '-m', 'pip', 'freeze', '--all'])
 
-    if config.pluginmanager.hasplugin("xdist"):
+    if session.config.pluginmanager.hasplugin("xdist"):
+        plugin = session.config.pluginmanager.getplugin("xdist")
+        xdist_active = plugin.is_xdist_master(session)
+
         n_gpu = os.environ.get('CUPY_TEST_GPU_LIMIT')
         worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
 
         if n_gpu is None:
-            if worker_id == 'master':
+            if xdist_active and worker_id == 'master':
                 print('\nTIP: when using pytest-xdist, you can automatically '
                       'rotate CUDA_VISIBLE_DEVICES for each test worker by '
                       'setting CUPY_TEST_GPU_LIMIT environment variable.\n')
@@ -55,6 +60,10 @@ def pytest_configure(config):
                 devices = [str(k) for k in range(n_gpu)]
             else:
                 devices = devices.split(',')[:n_gpu]
+                if len(devices) < n_gpu:
+                    raise ValueError(
+                        f"Fewer CUDA_VISIBLE_DEVICES ({len(devices)}) "
+                        f"than CUPY_TEST_GPU_LIMIT ({n_gpu})")
 
             if worker_id == 'master':
                 print(f'\nNOTE: Setting workers to use a shifted version of:'
@@ -68,6 +77,17 @@ def pytest_configure(config):
                 devices.rotate(-w)
                 devices = ','.join(devices)
                 os.environ['CUDA_VISIBLE_DEVICES'] = devices
+
+                # Make sure workers don't starve each other if sharing GPUs
+                # by setting the memory limit to be split across workers
+                # (ignore potential distributed tests here).
+                # `PYTEST_XDIST_WORKER_COUNT` is alwasy set at this point.
+                n_workers = int(os.environ.get('PYTEST_XDIST_WORKER_COUNT'))
+                workers_on_my_gpu, remainder = divmod(n_workers, n_gpu)
+                if w % n_gpu < remainder:
+                    workers_on_my_gpu += 1
+                mem_fraction = int(100 / workers_on_my_gpu)
+                os.environ['CUPY_GPU_MEMORY_LIMIT'] = f"{mem_fraction}%"
 
 
 if int(os.environ.get('CUPY_ENABLE_UMP', 0)) != 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def _is_in_ci():
 def pytest_configure(config):
     if config.pluginmanager.hasplugin("xdist"):
         # Some (few) tests should run grouped by class, so just force that.
-        config.option.dist = "loadscope"
+        config.option.dist = "loadgroup"
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import gc
+import os
 import pickle
 import sys
 import threading
@@ -291,7 +292,11 @@ class TestMemoryPointerAsync(unittest.TestCase):
 class TestSingleDeviceMemoryPool(unittest.TestCase):
 
     def setUp(self):
+        # For these tests unset possible CUPY_GPU_MEMORY_LIMIT.
+        original_limit = os.environ.pop('CUPY_GPU_MEMORY_LIMIT', None)
         self.pool = memory.SingleDeviceMemoryPool(allocator=mock_alloc)
+        if original_limit is not None:
+            os.environ['CUPY_GPU_MEMORY_LIMIT'] = original_limit
         self.unit = memory._allocation_unit_size
         self.stream = stream_module.Stream()
         self.arena = self.pool._arena(self.stream.ptr)
@@ -1089,20 +1094,24 @@ free_bytes_watermark = 0
                     and cupy.cuda.driver.get_build_version() < 11020,
                     reason='malloc_async is supported since CUDA 11.2')
 @pytest.mark.thread_unsafe(reason="tests shared self.pool properties")
-class TestMemoryAsyncPool(unittest.TestCase):
+class TestMemoryAsyncPool:
 
-    def setUp(self):
+    def setup_method(self):
         if cupy.cuda.runtime.deviceGetAttribute(
                 cupy.cuda.runtime.cudaDevAttrMemoryPoolsSupported, 0) == 0:
             pytest.skip('malloc_async is not supported on device 0')
+        # For these tests unset possible CUPY_GPU_MEMORY_LIMIT.
+        original_limit = os.environ.pop('CUPY_GPU_MEMORY_LIMIT', None)
         self.pool = memory.MemoryAsyncPool()
+        if original_limit is not None:
+            os.environ['CUPY_GPU_MEMORY_LIMIT'] = original_limit
         self.unit = memory._allocation_unit_size
         self.stream = stream_module.Stream()
         self.stream_ident = self.stream.ptr
         cupy.get_default_memory_pool().free_all_blocks()
         cupy.cuda.Device().synchronize()
 
-    def tearDown(self):
+    def teardown_method(self):
         self.pool.set_limit(size=0)
         self.pool.free_all_blocks()
         global used_bytes_watermark, free_bytes_watermark
@@ -1317,7 +1326,7 @@ class TestMemoryAsyncPool(unittest.TestCase):
         self.pool.set_limit(size=0)
         assert 2**64-1 == self.pool.get_limit()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.pool.set_limit(size=-1)
 
     def test_set_limit_fraction(self):
@@ -1332,10 +1341,10 @@ class TestMemoryAsyncPool(unittest.TestCase):
         self.pool.set_limit(fraction=1.0)
         assert total == self.pool.get_limit()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.pool.set_limit(fraction=-1)
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.pool.set_limit(fraction=1.1)
 
 

--- a/tests/cupy_tests/cuda_tests/test_memory.py
+++ b/tests/cupy_tests/cuda_tests/test_memory.py
@@ -886,6 +886,9 @@ class TestAllocator(unittest.TestCase):
             self._ptr = arr.data.ptr
             del arr
             self._error = False
+            # Wait for job to finish, otherwise shutdown seems unsafe
+            # when using the PTDS and work is still in progress.
+            stream.synchronize()
 
         # Run in main thread.
         self._ptr = -1
@@ -1094,6 +1097,9 @@ free_bytes_watermark = 0
                     and cupy.cuda.driver.get_build_version() < 11020,
                     reason='malloc_async is supported since CUDA 11.2')
 @pytest.mark.thread_unsafe(reason="tests shared self.pool properties")
+@pytest.mark.xdist_group(
+    # use of free/used_bytes_watermark assumes single worker
+    "memory-async-pool-tests")
 class TestMemoryAsyncPool:
 
     def setup_method(self):

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -185,4 +185,4 @@ class TestAsnumpy:
         else:
             ctx = contextlib.nullcontext()
         with ctx:
-            assert cupy.allclose(a, c)
+            testing.assert_array_equal(a, c)

--- a/tests/cupy_tests/test_numpy_interop.py
+++ b/tests/cupy_tests/test_numpy_interop.py
@@ -179,10 +179,18 @@ class TestAsnumpy:
             c[c.size//2:] = -1.  # potential data race
         s.synchronize()
 
-        a[c.size//2:] = -1.
+        # Sanity check that the first part of `c` seems correct:
+        half = c.size//2
+        testing.assert_array_equal(a[half - 100:half], c[half - 100:half])
+
+        # only second half of `a` has potential for corruption
+        del a
+        expected = cupy.full(c.size - half, -1.0, dtype=cupy.float64)
+
         if not blocking:
             ctx = pytest.raises(AssertionError)
         else:
             ctx = contextlib.nullcontext()
         with ctx:
-            testing.assert_array_equal(a, c)
+            # compare the large array on GPU For speed
+            assert (expected == cupy.asarray(c[c.size//2:])).all()


### PR DESCRIPTION
This modifies the setup slightly, because I noticed that otherwise the note is printed even when xdist isn't used (which is a bit confusing).

Otherwise, it sets `CUPY_GPU_MEMORY_LIMIT` as I suspect this may have been part of the reason why pytest-xdist wasn't reliable in CI previously.

Then attempt using pytest-xdist in CI (this will have to be an experiment, it is very possible that the same old issues appear).

*Draft until it seems good, if it seems to work well, should probably also use it on windows.*