### PR TITLE
Fix silent corruption in thrust sort/argsort/lexsort under OOM

### DIFF
--- a/cupy/cuda/cupy_thrust.cu
+++ b/cupy/cuda/cupy_thrust.cu
@@ -8,6 +8,7 @@
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
 #include <thrust/execution_policy.h>
+#include <new>
 #include <type_traits>
 
 
@@ -37,7 +38,15 @@ public:
     cupy_allocator(void* memory) : memory(memory) {}
 
     char *allocate(size_t num_bytes) {
-        return cupy_malloc(memory, num_bytes);
+        if (num_bytes == 0) return nullptr;
+        // cupy_malloc returns NULL on out-of-memory (see thrust.pyx).
+        // Without this check thrust would sort into a NULL workspace
+        // and produce corrupt results (cupy/cupy#9894).
+        char *ptr = cupy_malloc(memory, num_bytes);
+        if (ptr == nullptr) {
+            throw std::bad_alloc();
+        }
+        return ptr;
     }
 
     void deallocate(char *ptr, size_t n) {

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -24,13 +24,21 @@ cdef class _MemoryManager:
         self.memory = dict()
 
 
-# NOTE(seberg): On failure, thrust may expect a C++ exception, `noexcept`
-# prints it out and returns NULL (not great, but maybe OK).
+# MemoryError is caught explicitly so `noexcept` does not print an
+# "Exception ignored in: cupy_malloc" trace to stderr.  The C++ allocator
+# (cupy_thrust.cu) checks for NULL and throws std::bad_alloc so thrust
+# unwinds cleanly; the externs below use `except +` to convert that into
+# a Python MemoryError visible to the caller.  Any other (unexpected)
+# Python exception is left to noexcept to surface for diagnosis.
+# See cupy/cupy#9894.
 cdef public char* cupy_malloc(void *m, size_t size) noexcept with gil:
     if size == 0:
         return <char *>0
     cdef _MemoryManager mm = <_MemoryManager>m
-    mem = memory.alloc(size)
+    try:
+        mem = memory.alloc(size)
+    except MemoryError:
+        return <char *>0
     mm.memory[mem.ptr] = mem
     return <char *>mem.ptr
 
@@ -48,12 +56,16 @@ cdef public int cupy_free(void *m, char* ptr) except -1 with gil:
 ###############################################################################
 
 cdef extern from 'cupy_thrust.h' nogil:
+    # `except +` propagates std::bad_alloc thrown by the C++ allocator
+    # (when cupy_malloc returns NULL) as a Python MemoryError instead of
+    # letting thrust silently operate on garbage memory.  See cupy/cupy#9894.
     void thrust_sort(int, void *, size_t *, const vector.vector[ptrdiff_t]&,
-                     intptr_t, void *)
+                     intptr_t, void *) except +
     void thrust_lexsort(
-        int, size_t *, void *, size_t, size_t, intptr_t, void *)
-    void thrust_argsort(int, size_t *, void *, void *,
-                        const vector.vector[ptrdiff_t]&, intptr_t, void *)
+        int, size_t *, void *, size_t, size_t, intptr_t, void *) except +
+    void thrust_argsort(
+        int, size_t *, void *, void *,
+        const vector.vector[ptrdiff_t]&, intptr_t, void *) except +
 
     # Build-time version
     int THRUST_VERSION

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -433,6 +433,84 @@ class TestSort_complex(unittest.TestCase):
         return a, xp.sort_complex(a)
 
 
+class TestThrustWorkspaceOOM:
+    """Regression tests for cupy/cupy#9894.
+
+    When thrust's workspace allocation fails, sort/argsort/lexsort must
+    raise ``MemoryError`` instead of silently producing corrupt results.
+
+    Each op may make several pre-thrust allocations (e.g. ``data.copy()``
+    and ``idx_array``) before reaching thrust.  Failing the *first*
+    allocation only exercises pre-existing OOM behavior, not this fix.
+    To target thrust's workspace specifically, we count allocations during
+    a successful run, then re-run with the *last* allocation forced to
+    fail.  Since thrust is called last in each routine, the final
+    allocation is always inside thrust's workspace request.
+    """
+
+    @staticmethod
+    def _verify_workspace_oom_raises(op):
+        pool = cupy.get_default_memory_pool()
+        n = [0]
+
+        def counting(size):
+            n[0] += 1
+            return pool.malloc(size)
+
+        with cupy.cuda.using_allocator(counting):
+            op()
+        assert n[0] >= 1, "expected at least one allocation"
+        total = n[0]
+
+        seen = [0]
+
+        def fail_on_last(size):
+            seen[0] += 1
+            if seen[0] >= total:
+                raise cupy.cuda.memory.OutOfMemoryError(size, 0, 0)
+            return pool.malloc(size)
+
+        with cupy.cuda.using_allocator(fail_on_last):
+            with pytest.raises(MemoryError):
+                op()
+
+    def test_sort_workspace_oom(self):
+        self._verify_workspace_oom_raises(
+            lambda: cupy.arange(100_000, dtype=cupy.float32).sort()
+        )
+
+    def test_argsort_workspace_oom(self):
+        self._verify_workspace_oom_raises(
+            lambda: cupy.arange(100_000, dtype=cupy.float32).argsort()
+        )
+
+    def test_lexsort_workspace_oom(self):
+        self._verify_workspace_oom_raises(
+            lambda: cupy.lexsort(
+                cupy.arange(100_000, dtype=cupy.float32).reshape(2, 50_000)
+            )
+        )
+
+    @pytest.mark.thread_unsafe(
+        reason="contextlib.redirect_stderr replaces sys.stderr globally")
+    def test_no_stderr_noise_on_workspace_oom(self):
+        # The thrust allocator's `noexcept`-driven stderr trace was
+        # confusing to users (cupy/cupy#9894).  After the fix, OOM produces a
+        # clean MemoryError with no "Exception ignored" trace and no
+        # OutOfMemoryError print on stderr.
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            self._verify_workspace_oom_raises(
+                lambda: cupy.arange(100_000, dtype=cupy.float32).sort()
+            )
+        stderr = buf.getvalue()
+        assert "Exception ignored" not in stderr, stderr
+        assert "OutOfMemoryError" not in stderr, stderr
+
+
 @testing.parameterize(*testing.product({
     'external': [False, True],
     'length': [10, 20000],


### PR DESCRIPTION
Thrust's allocator callback `cupy_malloc` is declared `noexcept` on the Cython side: when `memory.alloc` raises `OutOfMemoryError`, the exception is swallowed (printed to stderr) and NULL is returned.  The C++ `cupy_allocator` did not check for NULL, so thrust silently operated on a NULL workspace and produced corrupt results.

- `cupy_thrust.cu`: throw `std::bad_alloc` when `cupy_malloc` returns NULL.
- `thrust.pyx`: add `except +` to the thrust externs so `std::bad_alloc` surfaces as `MemoryError`; catch `MemoryError` in `cupy_malloc` to suppress the noisy "Exception ignored" stderr trace.
- Add regression tests using `cupy.cuda.using_allocator` that fail the last allocation of each routine (always inside thrust's workspace request).

I measured virtually no performance impact.

Fixes cupy/cupy#9894.