### PR TITLE
Implemention of numpy.ndarray.getfield method

### DIFF
--- a/cupy/_core/core.pxd
+++ b/cupy/_core/core.pxd
@@ -39,6 +39,7 @@ cdef class _ndarray_base:
     cpdef _ndarray_base byteswap(self, inplace=*)
     cpdef _ndarray_base copy(self, order=*)
     cpdef _ndarray_base view(self, dtype=*, array_class=*)
+    cpdef _ndarray_base getfield(self, dtype, Py_ssize_t offset=*)
     cpdef fill(self, value)
     cpdef _ndarray_base swapaxes(self, Py_ssize_t axis1, Py_ssize_t axis2)
     cpdef _ndarray_base flatten(self, order=*)

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -977,7 +977,42 @@ cdef class _ndarray_base:
             v._update_f_contiguity()
         return v
 
-    # TODO(okuta): Implement getfield
+    cpdef _ndarray_base getfield(self, dtype, Py_ssize_t offset=0):
+        """Returns a view of the array data as a different dtype.
+
+        Args:
+            dtype: Data type for the returned view.
+            offset (int): Number of bytes to skip before beginning the
+                element view within each original element.
+
+        Returns:
+            cupy.ndarray: A view of the array with the requested dtype.
+
+        .. seealso:: :meth:`numpy.ndarray.getfield`
+        """
+        cdef _ndarray_base v
+        cdef int self_is, v_is
+
+        if offset < 0:
+            raise ValueError('offset must be non-negative')
+
+        v = self._view(type(self), self._shape, self._strides,
+                       False, False, self)
+        v.dtype, v_is = _dtype.get_dtype_with_itemsize(
+            dtype, check_support=False)
+        self_is = self.dtype.itemsize
+        if v_is > self_is:
+            raise ValueError(
+                'dtype size must not be larger than the array element size')
+        if offset + v_is > self_is:
+            raise ValueError(
+                'offset must be such that the requested dtype fits in the '
+                'array element')
+        if offset != 0:
+            v.data = self.data + offset
+        v._update_contiguity()
+        return v
+
     # TODO(okuta): Implement setflags
 
     cpdef fill(self, value):

--- a/docs/source/reference/ndarray.rst
+++ b/docs/source/reference/ndarray.rst
@@ -27,11 +27,6 @@ That means, NumPy functions cannot take :class:`cupy.ndarray`\s as inputs, and v
 Note that converting between :class:`cupy.ndarray` and :class:`numpy.ndarray` incurs data transfer between
 the host (CPU) device and the GPU device, which is costly in terms of performance.
 
-.. note::
-
-   :meth:`cupy.ndarray.getfield` is supported and follows the same dtype/offset semantics as
-   :meth:`numpy.ndarray.getfield`.
-
 
 .. TODO(kmaehashi): use currentmodule:: cupy
 .. autosummary::

--- a/docs/source/reference/ndarray.rst
+++ b/docs/source/reference/ndarray.rst
@@ -27,6 +27,11 @@ That means, NumPy functions cannot take :class:`cupy.ndarray`\s as inputs, and v
 Note that converting between :class:`cupy.ndarray` and :class:`numpy.ndarray` incurs data transfer between
 the host (CPU) device and the GPU device, which is costly in terms of performance.
 
+.. note::
+
+   :meth:`cupy.ndarray.getfield` is supported and follows the same dtype/offset semantics as
+   :meth:`numpy.ndarray.getfield`.
+
 
 .. TODO(kmaehashi): use currentmodule:: cupy
 .. autosummary::

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -162,12 +162,14 @@ class TestView:
 
     @testing.numpy_cupy_array_equal()
     def test_getfield_basic(self, xp):
-        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]], dtype=numpy.complex128)
+        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]],
+                     dtype=numpy.complex128)
         return x.getfield(numpy.float64)
 
     @testing.numpy_cupy_array_equal()
     def test_getfield_offset(self, xp):
-        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]], dtype=numpy.complex128)
+        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]],
+                     dtype=numpy.complex128)
         return x.getfield(numpy.float64, offset=8)
 
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -182,23 +182,16 @@ class TestView:
         x = xp.arange(12, dtype=numpy.int32).reshape(3, 4).T
         return x.getfield(numpy.int16, offset=2)
 
-    def test_getfield_invalid_offset(self):
+    @pytest.mark.parametrize(('offset', 'dtype'), [
+        (4, numpy.float64),
+        (-1, numpy.float64),
+        (0, numpy.complex128),
+    ])
+    def test_getfield_invalid_cases(self, offset, dtype):
         for xp in (numpy, cupy):
             x = xp.array([1 + 1j], dtype=numpy.complex64)
             with pytest.raises(ValueError):
-                x.getfield(numpy.float64, offset=4)
-
-    def test_getfield_negative_offset(self):
-        for xp in (numpy, cupy):
-            x = xp.array([1 + 1j], dtype=numpy.complex64)
-            with pytest.raises(ValueError):
-                x.getfield(numpy.float64, offset=-1)
-
-    def test_getfield_invalid_dtype_size(self):
-        for xp in (numpy, cupy):
-            x = xp.array([1 + 1j], dtype=numpy.complex64)
-            with pytest.raises(ValueError):
-                x.getfield(numpy.complex128)
+                x.getfield(dtype, offset=offset)
 
 
 class TestArrayCopy:

--- a/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_copy_and_view.py
@@ -160,6 +160,44 @@ class TestView:
         x = xp.ones((3, 20), xp.int16)[:0, ::2]
         return x.view(xp.int32)
 
+    @testing.numpy_cupy_array_equal()
+    def test_getfield_basic(self, xp):
+        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]], dtype=numpy.complex128)
+        return x.getfield(numpy.float64)
+
+    @testing.numpy_cupy_array_equal()
+    def test_getfield_offset(self, xp):
+        x = xp.array([[1 + 1j, 0 + 0j], [0 + 0j, 2 + 4j]], dtype=numpy.complex128)
+        return x.getfield(numpy.float64, offset=8)
+
+    @testing.numpy_cupy_array_equal()
+    def test_getfield_0d(self, xp):
+        x = xp.array(1, dtype=numpy.int32)
+        return x.getfield(numpy.int16)
+
+    @testing.numpy_cupy_array_equal()
+    def test_getfield_non_contiguous(self, xp):
+        x = xp.arange(12, dtype=numpy.int32).reshape(3, 4).T
+        return x.getfield(numpy.int16, offset=2)
+
+    def test_getfield_invalid_offset(self):
+        for xp in (numpy, cupy):
+            x = xp.array([1 + 1j], dtype=numpy.complex64)
+            with pytest.raises(ValueError):
+                x.getfield(numpy.float64, offset=4)
+
+    def test_getfield_negative_offset(self):
+        for xp in (numpy, cupy):
+            x = xp.array([1 + 1j], dtype=numpy.complex64)
+            with pytest.raises(ValueError):
+                x.getfield(numpy.float64, offset=-1)
+
+    def test_getfield_invalid_dtype_size(self):
+        for xp in (numpy, cupy):
+            x = xp.array([1 + 1j], dtype=numpy.complex64)
+            with pytest.raises(ValueError):
+                x.getfield(numpy.complex128)
+
 
 class TestArrayCopy:
 


### PR DESCRIPTION
`cupy.ndarray.getfield()` to return a view of the array data 
reinterpreted as a different dtype with optional offset, matching NumPy 
semantics (closes `numpy.ndarray.getfield` in #6078).

Changes:
- Added cpdef getfield(dtype, offset=0) in _ndarray_base
- Validates offset range and dtype size constraints
- Adjusts device pointer for non-zero offset
- Tests cover basic, offset, 0d, non-contiguous arrays, and error cases
- Documented in ndarray.rst with cross-reference to NumPy method

Closes: #6078