### PR TITLE
Fix cupy.kron raising ValueError on empty arrays + refactor and performance improvement

### DIFF
--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -500,6 +500,15 @@ def kron(a, b):
             b_shape = (1,) * (a_ndim - b_ndim) + b_shape
             ndim = a_ndim
 
+    if a.size == 0 or b.size == 0:
+        # The concatenate-based path below iterates each intermediate's
+        # leading axis; once that axis has length 0 (the next iteration when
+        # `a` is empty, or the first one for some shape combinations) it
+        # raises. Bypass it for empty inputs.
+        out_shape = tuple(s_a * s_b for s_a, s_b in zip(a_shape, b_shape))
+        return cupy.empty(
+            out_shape, dtype=numpy.result_type(a.dtype, b.dtype))
+
     axis = ndim - 1
     out = _core.tensordot_core(
         a, b, None, a.size, b.size, 1, a_shape + b_shape)

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -490,32 +490,15 @@ def kron(a, b):
     if a_ndim == 0 or b_ndim == 0:
         return cupy.multiply(a, b)
 
-    ndim = b_ndim
-    a_shape = a.shape
-    b_shape = b.shape
-    if a_ndim != b_ndim:
-        if b_ndim > a_ndim:
-            a_shape = (1,) * (b_ndim - a_ndim) + a_shape
-        else:
-            b_shape = (1,) * (a_ndim - b_ndim) + b_shape
-            ndim = a_ndim
-
-    if a.size == 0 or b.size == 0:
-        # The concatenate-based path below iterates each intermediate's
-        # leading axis; once that axis has length 0 (the next iteration when
-        # `a` is empty, or the first one for some shape combinations) it
-        # raises. Bypass it for empty inputs.
-        out_shape = tuple(s_a * s_b for s_a, s_b in zip(a_shape, b_shape))
-        return cupy.empty(
-            out_shape, dtype=numpy.result_type(a.dtype, b.dtype))
-
-    axis = ndim - 1
-    out = _core.tensordot_core(
-        a, b, None, a.size, b.size, 1, a_shape + b_shape)
-    for _ in range(ndim):
-        out = _core.concatenate_method(out, axis=axis)
-
-    return out
+    ndim = max(a_ndim, b_ndim)
+    a_shape = (1,) * (ndim - a_ndim) + a.shape
+    b_shape = (1,) * (ndim - b_ndim) + b.shape
+    a_arr = cupy.expand_dims(
+        a.reshape(a_shape), axis=tuple(range(1, ndim * 2, 2)))
+    b_arr = cupy.expand_dims(
+        b.reshape(b_shape), axis=tuple(range(0, ndim * 2, 2)))
+    out_shape = tuple(s_a * s_b for s_a, s_b in zip(a_shape, b_shape))
+    return cupy.multiply(a_arr, b_arr).reshape(out_shape)
 
 
 def _move_axes_to_head(a, axes):

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -443,6 +443,63 @@ class TestProduct:
                 else arg for arg in [a, b]]
         return xp.kron(*args)
 
+    @pytest.mark.parametrize(
+        "shape_a, shape_b", [
+            # 2-D, empty in `a`
+            ((1, 0), (2, 2)),
+            ((3, 0), (2, 4)),
+            ((0, 3), (2, 4)),
+            ((0, 0), (2, 4)),
+            # 2-D, empty in `b`
+            ((2, 4), (3, 0)),
+            ((2, 4), (0, 0)),
+            # 1-D
+            ((0,), (4,)),
+            ((4,), (0,)),
+            ((0,), (0,)),
+            # >2-D with an empty dim
+            ((2, 0, 3), (1, 4, 2)),
+            ((1, 2, 0), (3, 4, 5)),
+            # mixed ndim, empty operand smaller-rank
+            ((0,), (3, 4)),
+            ((4,), (3, 0)),
+            ((3, 0), (2,)),
+        ]
+    )
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_kron_empty(self, xp, dtype, shape_a, shape_b):
+        a = xp.empty(shape_a, dtype=dtype)
+        b = xp.empty(shape_b, dtype=dtype)
+        return xp.kron(a, b)
+
+    @pytest.mark.parametrize(
+        "shape_b", [(0,), (0, 5), (3, 0), (2, 0, 4)],
+    )
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_kron_zerodim_with_empty(self, xp, dtype, shape_b):
+        # 0-D scalar array × empty array — exercises the early
+        # `cupy.multiply` branch rather than the empty-result short-circuit.
+        a = xp.array(2, dtype=dtype)
+        b = xp.empty(shape_b, dtype=dtype)
+        return xp.kron(a, b)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_kron_empty_fortran_order(self, xp, dtype):
+        a = xp.empty((3, 0), dtype=dtype, order='F')
+        b = xp.empty((2, 4), dtype=dtype, order='F')
+        return xp.kron(a, b)
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose()
+    def test_kron_empty_via_slice(self, xp, dtype):
+        # Empty array produced by zero-length slicing of a non-empty buffer.
+        a = xp.zeros((3, 4), dtype=dtype)[:0]
+        b = xp.zeros((1, 2), dtype=dtype)
+        return xp.kron(a, b)
+
 
 @testing.parameterize(*testing.product({
     'params': [


### PR DESCRIPTION
The concatenate-based path iterates each intermediate's leading axis; when either operand has size 0 that axis is empty and concatenate_method raises. Short-circuit on empty inputs and return cupy.empty with the shape/dtype numpy.kron would produce.

Fixes #9904

I may have gotten a little excessive with the tests. Also, note that sparse kron behaves properly.

_**edit:**_

After @seberg's feedback, I ended up refactoring `kron` to match numpy's implementation, which is faster and uses less peak memory