### PR TITLE
Find static libs under conda's targets/<target>/lib path

### DIFF
--- a/install/cupy_builder/cupy_setup_build.py
+++ b/install/cupy_builder/cupy_setup_build.py
@@ -275,7 +275,11 @@ def _find_static_library(name: str) -> str:
             cuda_path = (f'{build.get_cuda_path()}/targets/'
                          f'{build.conda_get_target_name()}/')
         else:
-            libdirs = ['lib64', 'lib']
+            # On conda CUDA 12+, shared libs are symlinked into lib/ but
+            # static libs (e.g. libcufilt.a) live only under
+            # targets/<target>/lib/.
+            libdirs = ['lib64', 'lib',
+                       f'targets/{build.conda_get_target_name()}/lib']
             cuda_path = build.get_cuda_path()
     elif PLATFORM_WIN32:
         filename = f'{name}.lib'


### PR DESCRIPTION
I started having issues building locally in conda environments after #9801 was merged.

In conda CUDA 12+ envs, static libs (e.g. libcufilt.a) live only under targets/<target>/lib/. After PR #9801 began linking libcufilt.a, source builds in conda CUDA 12+ envs fail at setup time with "Could not find libcufilt.a".

Append targets/<target>/lib to the libdir search list. System-CUDA (lib64/) and conda-build (CUDA_PATH=$PREFIX/targets/<target>) layouts resolve via earlier libdirs and are unaffected.