### PR TITLE
Bump SciPy minimum to 1.14 and remove now-dead version handling

### DIFF
--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Type Check
       run: |
         # TODO: Test against various NumPy/SciPy versions.
-        pip install 'numpy==1.25.*' 'scipy==1.10.*'
+        pip install 'numpy==2.0.*' 'scipy==1.14.*'
         pip install 'mypy==1.5.*' 'types-setuptools==57.4.14' 'pytest>=7.2'
         sed -i s/error::cupy.exceptions./error::numpy./ pyproject.toml  # Because no cupy here. See cupy#8346
         pytest -v tests/typing_tests/test_typing.py

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -42,7 +42,7 @@ jobs:
         # TODO: Test against various NumPy/SciPy versions.
         pip install 'numpy==2.0.*' 'scipy==1.14.*'
         pip install 'mypy==1.5.*' 'types-setuptools==57.4.14' 'pytest>=7.2'
-        sed -i s/error::cupy.exceptions./error::numpy./ pyproject.toml  # Because no cupy here. See cupy#8346
+        sed -i s/error::cupy.exceptions./error::numpy.exceptions./ pyproject.toml  # Because no cupy here. See cupy#8346
         pytest -v tests/typing_tests/test_typing.py
 
   build-cuda:

--- a/cupyx/scipy/fft/__init__.py
+++ b/cupyx/scipy/fft/__init__.py
@@ -6,7 +6,6 @@ from cupyx.scipy.fft._fft import (
 )
 from cupyx.scipy.fft._fft import (
     __ua_domain__, __ua_convert__, __ua_function__)
-from cupyx.scipy.fft._fft import _scipy_150, _scipy_160
 from cupyx.scipy.fft._fftlog import fht, ifht
 from cupyx.scipy.fft._helper import next_fast_len  # NOQA
 from cupy.fft import fftshift, ifftshift, fftfreq, rfftfreq

--- a/cupyx/scipy/fft/_fft.py
+++ b/cupyx/scipy/fft/_fft.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from numbers import Number
-import warnings
 
 import numpy as np
 
@@ -9,10 +8,7 @@ import cupy
 
 from cupy.fft._fft import _fft, _default_fft_func, _swap_direction
 
-_scipy_150 = False
-_scipy_160 = False
 try:
-    import scipy
     import scipy.fft as _scipy_fft
 except ImportError:
     class _DummyModule:
@@ -20,12 +16,6 @@ except ImportError:
             return None
 
     _scipy_fft = _DummyModule()
-else:
-    from numpy.lib import NumpyVersion as Version
-    _scipy_150 = Version(scipy.__version__) >= Version('1.5.0')
-    _scipy_160 = Version(scipy.__version__) >= Version('1.6.0')
-    del Version
-    del scipy
 
 # Backend support for scipy.fft
 
@@ -55,8 +45,6 @@ def __ua_function__(method, args, kwargs):
     fn = _implemented.get(method, None)
     if fn is None:
         return NotImplemented
-    if 'plan' in kwargs and not _scipy_150:
-        warnings.warn('The \'plan\' argument is supported in SciPy v1.5.0+')
     return fn(*args, **kwargs)
 
 

--- a/cupyx/scipy/fft/_fftlog.py
+++ b/cupyx/scipy/fft/_fftlog.py
@@ -12,10 +12,8 @@ from cupyx.scipy.fft import _fft
 from cupyx.scipy.special import loggamma, poch
 
 try:
-    # fht only exists in SciPy >= 1.7
-    from scipy.fft import fht as _fht
+    import scipy.fft  # NOQA
     _scipy_fft = _fft._scipy_fft
-    del _fht
 except ImportError:
     class _DummyModule:
         def __getattr__(self, name):

--- a/cupyx/scipy/signal/_fir_filter_design.py
+++ b/cupyx/scipy/signal/_fir_filter_design.py
@@ -175,8 +175,6 @@ _firwin_kernel = cupy.ElementwiseKernel(
 )
 
 
-# Scipy <= 1.12 has a deprecated `nyq` argument (nyq = fs/2).
-# Remove it here, to be forward-looking.
 def firwin(
     numtaps,
     cutoff,
@@ -600,8 +598,6 @@ def firwin2(
     return out
 
 
-# Scipy <= 1.12 has a deprecated `nyq` argument (nyq = fs/2).
-# Remove it here, to be forward-looking.
 def firls(numtaps, bands, desired, weight=None, fs=2):
     """
     FIR filter design using least-squares error minimization.

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -353,14 +353,6 @@ class IndexMixin:
     """
 
     def __getitem__(self, key):
-
-        # For testing- Scipy >= 1.4.0 is needed to guarantee
-        # results match.
-        if scipy_available and numpy.lib.NumpyVersion(
-                scipy.__version__) < '1.4.0':
-            raise NotImplementedError(
-                "Sparse __getitem__() requires Scipy >= 1.4.0")
-
         row, col = self._parse_indices(key)
 
         # Dispatch to specialized methods.

--- a/cupyx/scipy/special/_erf.py
+++ b/cupyx/scipy/special/_erf.py
@@ -41,8 +41,7 @@ erfinv = _core.create_ufunc(
     .. seealso:: :meth:`scipy.special.erfinv`
 
     .. note::
-        The behavior close to (and outside) the domain follows that of
-        SciPy v1.4.0+.
+        The behavior close to (and outside) the domain follows that of SciPy.
 
     ''')
 
@@ -55,7 +54,6 @@ erfcinv = _core.create_ufunc(
     .. seealso:: :meth:`scipy.special.erfcinv`
 
     .. note::
-        The behavior close to (and outside) the domain follows that of
-        SciPy v1.4.0+.
+        The behavior close to (and outside) the domain follows that of SciPy.
 
     ''')

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -133,9 +133,16 @@ The following versions are no longer supported in CuPy v14.
 * CUDA 11.x or earlier (CUDA 12.0 or later is now required)
 * Python 3.9 or earlier (Python 3.10 or later is now required)
 * NumPy 1.x (NumPy 2.0 or later is now required)
+* SciPy 1.13 or earlier (SciPy 1.14 or later is now required)
 * ROCm 6.x or earlier (ROCm 7.0 or later is now required)
 * NCCL 2.17 or earlier (NCCL 2.18 or later is now required)
 * cuSPARSELt 0.8.0 or earlier (cuSPARSELt 0.8.1 is now required)
+
+NumPy/SciPy Baseline API Update
+-------------------------------
+
+Baseline API has been bumped from NumPy 1.26 and SciPy 1.11 to NumPy 2.3 and SciPy 1.16.
+CuPy v14 will follow the upstream products' specifications of these baseline versions.
 
 Other API Changes
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,6 @@ filterwarnings = [
   # pkg_resources
   "ignore::DeprecationWarning:pkg_resources",
   "ignore:pkg_resources is deprecated",
-  # importing old SciPy is warned because it tries to
-  # import nose via numpy.testing
-  'ignore::DeprecationWarning:scipy\._lib\._numpy_compat',
-  # importing stats from old SciPy is warned because it tries to
-  # import numpy.testing.decorators
-  'ignore::DeprecationWarning:scipy\.stats\.morestats',
   # Using `scipy.sparse` against NumPy 1.15+ raises warning
   # as it uses `np.matrix` which is pending deprecation.
   # Also exclude `numpy.matrixlib.defmatrix` as SciPy and our

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ dependencies = [
 ]
 optional_dependencies = {
     "all": [
-        "scipy>=1.10,<1.17",  # see #4773
+        "scipy>=1.14,<1.17",  # see #4773
         "Cython>=3",
         "optuna>=2.0",
     ],

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 try:
-    # scipy.fft is available since scipy v1.4.0+
+    import scipy
     import scipy.fft as scipy_fft
 except ImportError:
     scipy_fft = None
     scipy = None
-else:
-    import scipy
 import pytest
 
 import cupy as cp
@@ -43,16 +41,6 @@ def _correct_np_dtype(xp, dtype, out):
     return out
 
 
-def _skip_forward_backward(norm):
-    if norm in ('backward', 'forward'):
-        if (scipy_fft is not None
-                and not (np.lib.NumpyVersion(scipy.__version__) >= '1.6.0')):
-            pytest.skip('forward/backward is supported by SciPy 1.6.0+')
-        elif (scipy_fft is None
-                and not (np.lib.NumpyVersion(np.__version__) >= '1.20.0')):
-            pytest.skip('forward/backward is supported by NumPy 1.20+')
-
-
 @testing.parameterize(*testing.product({
     'n': [None, 0, 5, 10, 15],
     'shape': [(9,), (10,), (10, 9), (10, 10)],
@@ -60,10 +48,6 @@ def _skip_forward_backward(norm):
     'norm': [None, 'backward', 'ortho', 'forward', '']
 }))
 class TestFft:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -146,7 +130,7 @@ class TestFft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -159,7 +143,7 @@ class TestFft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -265,7 +249,7 @@ class TestFft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -278,7 +262,7 @@ class TestFft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -322,10 +306,6 @@ class TestFft:
     )
 ))
 class TestFft2:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -405,7 +385,7 @@ class TestFft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -418,7 +398,7 @@ class TestFft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -521,7 +501,7 @@ class TestFft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -534,7 +514,7 @@ class TestFft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -582,10 +562,6 @@ class TestFft2:
     )
 ))
 class TestFftn:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -666,7 +642,7 @@ class TestFftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -679,7 +655,7 @@ class TestFftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -782,7 +758,7 @@ class TestFftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -795,7 +771,7 @@ class TestFftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -827,10 +803,6 @@ class TestFftn:
     'norm': [None, 'backward', 'ortho', 'forward', '']
 }))
 class TestRfft:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-6, accept_error=ValueError,
@@ -868,7 +840,7 @@ class TestRfft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-6, accept_error=ValueError,
                                  contiguous_check=False)
@@ -915,8 +887,6 @@ class TestRfft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    # the irfft tests show a slightly different results in CUDA 11.0 when
-    # compared to SciPy 1.6.1
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, accept_error=ValueError,
                                  contiguous_check=False)
@@ -988,7 +958,7 @@ class TestRfft:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-5, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1032,10 +1002,6 @@ def _skip_hipFFT_PlanNd_bug(axes, shape):
     )
 ))
 class TestRfft2:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -1130,7 +1096,7 @@ class TestRfft2:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1254,7 +1220,7 @@ class TestRfft2:
 
     @pytest.mark.skipif(_irfft_skip_condition,
                         reason="Known to fail with Pascal or older")
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1289,10 +1255,6 @@ class TestRfft2:
     )
 ))
 class TestRfftn:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
@@ -1387,7 +1349,7 @@ class TestRfftn:
         testing.assert_array_equal(x, x_orig)
         return _correct_np_dtype(xp, dtype, out)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1511,7 +1473,7 @@ class TestRfftn:
 
     @pytest.mark.skipif(_irfft_skip_condition,
                         reason="Known to fail with Pascal or older")
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1532,10 +1494,6 @@ class TestRfftn:
     'norm': [None, 'backward', 'ortho', 'forward', ''],
 }))
 class TestHfft:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
@@ -1565,7 +1523,7 @@ class TestHfft:
             _fft_module(cp).hfft(x, n=self.n, axis=self.axis,
                                  norm=self.norm, plan='abc')
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=4e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1606,7 +1564,7 @@ class TestHfft:
             _fft_module(cp).ihfft(x, n=self.n, axis=self.axis,
                                   norm=self.norm, plan='abc')
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-7, accept_error=ValueError,
                                  contiguous_check=False)
@@ -1637,12 +1595,8 @@ class TestHfft:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestHfft2:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @pytest.mark.skipif(_irfft_skip_condition,
                         reason="Known to fail with Pascal or older")
@@ -1716,12 +1670,8 @@ class TestHfft2:
         testing.product({'norm': [None, 'backward', 'ortho', 'forward']})
     )
 ))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestHfftn:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        _skip_forward_backward(self.norm)
 
     @pytest.mark.skipif(_irfft_skip_condition,
                         reason="Known to fail with Pascal or older")

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_fftlog.py
@@ -7,15 +7,10 @@ import cupyx.scipy.fft as cp_fft
 from cupy import testing
 
 try:
-    # scipy.fft is available since scipy v1.4.0+
     import scipy.fft as scipy_fft  # noqa
-except ImportError:
-    scipy_fft = None
-
-try:
-    # fht, ifht, fhtoffset are available in scipy v1.7.0+
     from scipy.fft import fhtoffset
 except ImportError:
+    scipy_fft = None
     fhtoffset = None
 
 atol = {cupy.float64: 1e-10, 'default': 1e-5}
@@ -67,7 +62,7 @@ class TestFftlogScipyBackend:
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(rtol=1e-4, atol=1e-5, accept_error=ValueError,
                                  contiguous_check=False)
-    @testing.with_requires('scipy>=1.9.0')
+    @testing.with_requires('scipy')
     def test_dct_backend(self, xp, dtype):
         backend = 'scipy' if xp is np else cp_fft
         with scipy_fft.set_backend(backend):

--- a/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
+++ b/tests/cupyx_tests/scipy_tests/fft_tests/test_realtransforms.py
@@ -7,20 +7,11 @@ from cupyx.scipy import fft as cp_fft
 from cupy import testing
 
 try:
-    # scipy.fft is available since scipy v1.4.0+
     import scipy.fft as scipy_fft  # noqa
 except ImportError:
     scipy_fft = None
 
-# used to avoid SciPy bug in complex dtype cases with output_x=True
-# https://github.com/scipy/scipy/pull/11904
-scipy_cplx_bug = not cp_fft._scipy_150
-
-if cp_fft._scipy_160:
-    # additional normalization options available for SciPy>=1.6
-    all_dct_norms = [None, 'ortho', 'forward', 'backward']
-else:
-    all_dct_norms = [None, 'ortho']
+all_dct_norms = [None, 'ortho', 'forward', 'backward']
 
 
 @testing.parameterize(
@@ -48,14 +39,11 @@ else:
         }
     )
 )
-@testing.with_requires('scipy>=1.12.0rc1')
+@testing.with_requires('scipy')
 class TestDctDst:
 
     def _run_transform(self, dct_func, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if scipy_cplx_bug and x.dtype.kind == 'c':
-            # skip cases where SciPy has a bug
-            return x
         x_orig = x.copy()
         kwargs = dict(type=self.type,
                       n=self.n,
@@ -135,14 +123,11 @@ class TestDctDst:
         )
     )
 )
-@testing.with_requires('scipy>=1.12.0rc1')
+@testing.with_requires('scipy')
 class TestDctnDstn:
 
     def _run_transform(self, dct_func, xp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if scipy_cplx_bug and x.dtype.kind == 'c':
-            # skip cases where SciPy has a bug
-            return x
         x_orig = x.copy()
         out = dct_func(
             x,

--- a/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
+++ b/tests/cupyx_tests/scipy_tests/fftpack_tests/test_fftpack.py
@@ -19,7 +19,7 @@ if cupyx.scipy._scipy_available:
     'shape': [(9,), (10,), (10, 9), (10, 10)],
     'axis': [-1, 0],
 }))
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestFft(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -202,7 +202,7 @@ class TestFft(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1)},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None},
 )
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestFft2(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -377,7 +377,7 @@ class TestFft2(unittest.TestCase):
     {'shape': (2, 3, 4), 's': None, 'axes': (0, 1)},
     {'shape': (2, 3, 4, 5), 's': None, 'axes': None},
 )
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestFftn(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -557,7 +557,7 @@ class TestFftn(unittest.TestCase):
     'shape': [(9,), (10,), (10, 9), (10, 10)],
     'axis': [-1, 0],
 }))
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestRfft(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline.py
@@ -296,7 +296,7 @@ class TestBSpline:
 
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
-    @testing.with_requires('scipy>=1.8.0')
+    @testing.with_requires('scipy')
     def test_design_matrix(self, xp, scp, dtype):
         if xp.dtype(dtype).kind == 'u':
             pytest.skip()
@@ -448,7 +448,7 @@ class TestBSpline:
 
     @testing.numpy_cupy_allclose(
         scipy_name='scp', rtol=3e-5, atol=3e-5)
-    @testing.with_requires('scipy>=1.8.0')
+    @testing.with_requires('scipy')
     def test_design_matrix_same_as_BSpline_call(self, xp, scp):
         """Test that design_matrix(x) is equivalent to BSpline(..)(x)."""
         ret = []

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_bspline2.py
@@ -42,7 +42,7 @@ class TestInterp:
         return (scp.interpolate.make_interp_spline(x, y, k=1)(x),
                 scp.interpolate.make_interp_spline(x, y, k=1, axis=-1)(x))
 
-    @testing.with_requires("scipy >= 1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=ValueError)
     @pytest.mark.parametrize('k', [0, 1, 2, 3])
     def test_incompatible_x_y(self, xp, scp, k):
@@ -50,7 +50,7 @@ class TestInterp:
         y = [0, 1, 2, 3, 4, 5, 6, 7]
         scp.interpolate.make_interp_spline(x, y, k=k)
 
-    @testing.with_requires("scipy >= 1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=ValueError)
     @pytest.mark.parametrize('k', [0, 1, 2, 3])
     def test_broken_x(self, xp, scp, k):
@@ -58,7 +58,7 @@ class TestInterp:
         y = [0, 1, 2, 3, 4, 5]
         scp.interpolate.make_interp_spline(x, y, k=k)
 
-    @testing.with_requires("scipy >= 1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=ValueError)
     @pytest.mark.parametrize('k', [0, 1, 2, 3])
     def test_broken_x_2(self, xp, scp, k):
@@ -66,7 +66,7 @@ class TestInterp:
         y = [0, 1, 2, 3, 4, 5]
         scp.interpolate.make_interp_spline(x, y, k=k)
 
-    @testing.with_requires("scipy >= 1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', accept_error=ValueError)
     @pytest.mark.parametrize('k', [0, 1, 2, 3])
     def test_broken_x_3(self, xp, scp, k):
@@ -361,7 +361,7 @@ class TestInterp:
     # test periodic constructor #
 
 
-@testing.with_requires("scipy>=1.7")
+@testing.with_requires("scipy")
 @pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')
 class TestInterpPeriodic:
     #

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
@@ -16,7 +16,7 @@ import pytest
 import itertools
 
 
-@testing.with_requires('scipy>=1.12')
+@testing.with_requires('scipy')
 class TestNdBSpline:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_1D(self, xp, scp):
@@ -382,7 +382,7 @@ class TestNdBSpline:
         bspl3 = scp.interpolate.NdBSpline(t3, c3, k=3)
         return bspl3((1, 2, 3))
 
-    @testing.with_requires('scipy>=1.13')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_design_matrix(self, xp, scp):
         t3, c3, k = self.make_3d_case(xp, scp)
@@ -396,7 +396,7 @@ class TestNdBSpline:
 
         return dm.todense(), dm1.todense()
 
-    @testing.with_requires('scipy>=1.13')
+    @testing.with_requires('scipy')
     @pytest.mark.parametrize('k', [(3, 1), (1, 3), (1, 1), (3, 3)])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_design_matrix_2(self, xp, scp, k):
@@ -415,7 +415,7 @@ class TestNdBSpline:
 
 
 @pytest.mark.skipif(runtime.is_hip, reason='csrlsvqr not available')
-@testing.with_requires('scipy>=1.13')
+@testing.with_requires('scipy')
 class TestMakeND:
 
     def _make(self, xp):

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndgriddata.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndgriddata.py
@@ -37,7 +37,7 @@ class TestNearestNDInterpolator:
         return NI(xp.asarray([0.1, 0.9]),
                   xp.asarray([0.1, 0.9])).astype(xp.float64)
 
-    @testing.with_requires('scipy>=1.12')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_nearest_query_options(self, xp, scp):
         nd = xp.array([[0, 0.5, 0, 1],
@@ -63,7 +63,7 @@ class TestNearestNDInterpolator:
         r3 = NI(query_points, distance_upper_bound=distance_upper_bound)
         return r1, r2, r3
 
-    @testing.with_requires('scipy>=1.12')
+    @testing.with_requires('scipy')
     @pytest.mark.parametrize('xp,scp', [(np, scipy), (cupy, cupyx.scipy)])
     def test_nearest_query_valid_inputs(self, xp, scp):
         nd = xp.array([[0, 1, 0, 1],

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -131,7 +131,7 @@ class TestBarycentric:
         test_xs = xp.array(test_xs)
         return xp.shape(P(test_xs))
 
-    @testing.with_requires("scipy>=1.8.0")
+    @testing.with_requires("scipy")
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_large_chebyshev(self, xp, scp, dtype):
@@ -393,7 +393,7 @@ class TestKrogh:
         return D
 
 
-@testing.with_requires("scipy>=1.10.0")
+@testing.with_requires("scipy")
 class TestZeroSizeArrays:
     # regression tests for gh-17241 : CubicSpline et al must not segfault
     # when y.size == 0
@@ -692,7 +692,7 @@ class TestCubicSpline:
         S = scp.interpolate.CubicSpline(x, y, bc_type='periodic')
         return S.derivative(1)(x)
 
-    @testing.with_requires("scipy >= 1.13")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_periodic_three_points_multidim(self, xp, scp):
         # make sure one multidimensional interpolator does the same as multiple
@@ -856,7 +856,7 @@ class TestInterp1D:
         yp = scp.interpolate.interp1d(x, y, kind='linear')(x)
         return yp
 
-    @testing.with_requires("scipy>=1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_linear_dtypes_2(self, xp, scp):
         # regression test for gh-14531, where 1D linear interpolation has been
@@ -890,7 +890,7 @@ class TestInterp1D:
         f = scp.interpolate.interp1d(x10, y10, kind='cubic')
         return f(x10), f(xp.asarray([2.4, 5.6, 6.0]))
 
-    @testing.with_requires("scipy>=1.10")
+    @testing.with_requires("scipy")
     @pytest.mark.parametrize('kind',
                              ['nearest', 'nearest-up', 'previous', 'next']
                              )
@@ -907,7 +907,7 @@ class TestInterp1D:
         xe = xp.asarray([-1., 0, 9, 11])
         return f(1.2), f(1.5), f(xval), fe(xe)
 
-    @testing.with_requires("scipy>=1.10")
+    @testing.with_requires("scipy")
     @pytest.mark.parametrize('kind', ['previous', 'next'])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_previous_2(self, xp, scp, kind):
@@ -930,7 +930,7 @@ class TestInterp1D:
                 interpolator2D(xval),
                 interpolator2DAxis0(xval2))
 
-    @testing.with_requires("scipy>=1.10")
+    @testing.with_requires("scipy")
     @pytest.mark.parametrize('kind', ['previous', 'next'])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_previous_3(self, xp, scp, kind):
@@ -1315,7 +1315,7 @@ class TestInterp1D:
         with assert_raises(ValueError):
             cupyx.scipy.interpolate.interp1d(x, y, kind='cubic')
 
-    @testing.with_requires("scipy>=1.10")
+    @testing.with_requires("scipy")
     @pytest.mark.parametrize(
         "kind", ("linear", "nearest", "nearest-up", "previous", "next")
     )

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -14,13 +14,8 @@ import cupyx.scipy.interpolate  # NOQA
 
 try:
     from scipy import interpolate  # NOQA
-except ImportError:
-    pass
-
-try:
     from scipy.stats.qmc import Halton
 except ImportError:
-    # qmc.Halton is only available in SciPy >= 1.70
     pass
 
 
@@ -102,7 +97,7 @@ def _is_conditionally_positive_definite(kernel, m, xp, scp):
 
 # Sorting the parametrize arguments is necessary to avoid a parallelization
 # issue described here: https://github.com/pytest-dev/pytest-xdist/issues/432.
-@testing.with_requires("scipy>=1.7.0")
+@testing.with_requires("scipy")
 @pytest.mark.skip(reason='conditionally posdef: skip for now')
 @testing.numpy_cupy_allclose(scipy_name='scp')
 @pytest.mark.parametrize('kernel', sorted(_AVAILABLE))
@@ -114,7 +109,7 @@ def test_conditionally_positive_definite(xp, scp, kernel):
     assert _is_conditionally_positive_definite(kernel, m, xp, scp)
 
 
-@testing.with_requires("scipy>=1.7.0")
+@testing.with_requires("scipy")
 class _TestRBFInterpolator:
     rtol = 5e-5
     atol = 5e-5
@@ -444,7 +439,7 @@ class _TestRBFInterpolator:
         testing.assert_array_equal(yitp1, yitp2)
 
 
-@testing.with_requires("scipy>=1.7.0")
+@testing.with_requires("scipy")
 class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):
     def build(self, scp, *args, **kwargs):
         return scp.interpolate.RBFInterpolator(*args, **kwargs)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -71,7 +71,7 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
         'args': [((0,),), ((1,),), ((2,),), ((4,),), ((10,),), ((25,),)],
     })
 ))
-@testing.with_requires('scipy>=1.3.0')
+@testing.with_requires('scipy')
 class TestSpecialMatrices_1_3_0(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
@@ -96,7 +96,7 @@ class TestSpecialMatrices_1_3_0(TestSpecialMatricesBase):
                  ((4,), 6, 'full'), ((10,), 8, 'same'), ((25,), 25, 'valid')],
     })
 ))
-@testing.with_requires('scipy>=1.5.0')
+@testing.with_requires('scipy')
 class TestSpecialMatrices_1_5_0(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
@@ -4,7 +4,7 @@ from cupy import testing
 import cupyx.scipy.linalg._uarray
 
 
-@testing.with_requires('scipy>=1.5')
+@testing.with_requires('scipy')
 def test_implements_names():
     # With the newest SciPy, the decorator `@implements` must find the
     # matching scipy functions.

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -444,7 +444,7 @@ class TestFilterFast(FilterTestCaseBase):
         })
     )
 ))
-@testing.with_requires('scipy>=1.11')
+@testing.with_requires('scipy')
 class TestFilterFastAxes(FilterTestCaseBase):
 
     def _hip_skip_invalid_condition(self):
@@ -572,7 +572,7 @@ class TestFilterFastAxesSciPy15(FilterTestCaseBase):
 class TestFilterComplexFast(FilterTestCaseBase):
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_filter(self, xp, scp):
         return self._filter(xp, scp)
 
@@ -765,7 +765,6 @@ class TestGeneric1DFilter(FilterTestCaseBase):
         return self._filter(xp, scp)
 
 
-# Tests things requiring scipy >= 1.5.0
 @testing.parameterize(*(
     testing.product_dict(
         # Filter-function specific params
@@ -786,8 +785,7 @@ class TestGeneric1DFilter(FilterTestCaseBase):
         })
     )
 ))
-# SciPy behavior fixed in 1.5.0: https://github.com/scipy/scipy/issues/11661
-@testing.with_requires('scipy>=1.5.0')
+@testing.with_requires('scipy')
 class TestMirrorWithDim1(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_filter(self, xp, scp):
@@ -894,7 +892,7 @@ class TestWeightDtype(FilterTestCaseBase):
         })
     )
 ))
-@testing.with_requires('scipy>=1.5.9')
+@testing.with_requires('scipy')
 class TestWeightComplexDtype(FilterTestCaseBase):
 
     def _skip_noncomplex(self):
@@ -908,12 +906,12 @@ class TestWeightComplexDtype(FilterTestCaseBase):
         return arr, weights
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_filter_complex(self, xp, scp):
         self._skip_noncomplex()
         return self._filter(xp, scp)
 
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_filter_complex_output_dtype_error(self):
         # raises RuntimeError if provided a real-valued output array
         self._skip_noncomplex()
@@ -924,7 +922,7 @@ class TestWeightComplexDtype(FilterTestCaseBase):
             with pytest.raises(RuntimeError):
                 func(arr, weights, output=output)
 
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_filter_complex_output_dtype_warns(self):
         # warns if a real-valued dtype is specified for the output
         self._skip_noncomplex()
@@ -1043,8 +1041,7 @@ class TestInvalidMode(FilterTestCaseBase):
     'ksize': [3, 4],
     'shape': [(4, 5)], 'dtype': [numpy.float64],
 }))
-# SciPy behavior fixed in 1.2.0: https://github.com/scipy/scipy/issues/822
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestInvalidOrigin(FilterTestCaseBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_fourier.py
@@ -6,23 +6,15 @@ import pytest
 
 from cupy import testing
 from cupy.exceptions import AxisError
-# TODO (grlee77): use fft instead of fftpack once min. supported scipy >= 1.4
 import cupyx.scipy.fft  # NOQA
 import cupyx.scipy.fftpack  # NOQA
 import cupyx.scipy.ndimage  # NOQA
 
 try:
-    # scipy.fft only available since SciPy 1.4.0
-    import scipy.fft  # NOQA
-except ImportError:
-    pass
-
-try:
-    # These modules will be present in all supported SciPy versions
     import scipy
+    import scipy.fft  # NOQA
     import scipy.fftpack  # NOQA
     import scipy.ndimage  # NOQA
-    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
     pass
 
@@ -75,7 +67,7 @@ class TestFourierShift:
             a = a.real
         return xp.ascontiguousarray(a)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -84,7 +76,7 @@ class TestFourierShift:
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -162,7 +154,7 @@ class TestFourierGaussian:
             a = a.real
         return xp.ascontiguousarray(a)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -171,7 +163,7 @@ class TestFourierGaussian:
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -249,7 +241,7 @@ class TestFourierUniform:
             a = a.real
         return xp.ascontiguousarray(a)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis0(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -258,7 +250,7 @@ class TestFourierUniform:
             return x
         return self._test_real_nd(xp, scp, x, 0)
 
-    @testing.with_requires("scipy>=1.4.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name="scp")
     def test_real_fft_axis1(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.dtype)
@@ -313,9 +305,6 @@ class TestFourierUniform:
 @testing.with_requires('scipy')
 class TestFourierEllipsoid:
     def _test_real_nd(self, xp, scp, x, real_axis):
-        if x.ndim == 1 and scipy_version < '1.5.3':
-            # 1D case gives an incorrect result in SciPy < 1.5.3
-            pytest.skip('scipy version to old')
 
         a = scp.fft.rfft(x, axis=real_axis)
         # complex-valued FFTs on all other axes
@@ -334,14 +323,14 @@ class TestFourierEllipsoid:
             a = a.real
         return xp.ascontiguousarray(a)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_real_fft_axis0(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
         return self._test_real_nd(xp, scp, x, 0)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_real_fft_axis1(self, xp, scp, dtype):
@@ -355,9 +344,6 @@ class TestFourierEllipsoid:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_complex_fft(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if x.ndim == 1 and scipy_version < '1.5.3':
-            # 1D case gives an incorrect result in SciPy < 1.5.3
-            pytest.skip('scipy version to old')
         a = scp.fftpack.fftn(x)
         a = scp.ndimage.fourier_ellipsoid(a, self.size)
         a = scp.fftpack.ifftn(a)
@@ -369,9 +355,6 @@ class TestFourierEllipsoid:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_complex_fft_with_output(self, xp, scp, dtype):
         x = testing.shaped_random(self.shape, xp, dtype)
-        if x.ndim == 1 and scipy_version < '1.5.3':
-            # 1D case gives an incorrect result in SciPy < 1.5.3
-            pytest.skip('scipy version to old')
         a = scp.fftpack.fftn(x)
         scp.ndimage.fourier_ellipsoid(a.copy(), self.size, output=a)
         a = scp.fftpack.ifftn(a)
@@ -383,8 +366,7 @@ class TestFourierEllipsoid:
 @testing.with_requires('scipy')
 class TestFourierEllipsoidInvalid:
 
-    # SciPy < 1.5 raises ValueError instead of AxisError
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     def test_0d_input(self):
         for xp, scp in zip((numpy, cupy), (scipy, cupyx.scipy)):
             with pytest.raises(AxisError):
@@ -400,8 +382,7 @@ class TestFourierEllipsoidInvalid:
                 scp.ndimage.fourier_ellipsoid(xp.ones(shape), size=2)
         return
 
-    # SciPy < 1.5 raises ValueError instead of AxisError
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     def test_invalid_axis(self):
         # SciPy should raise here too because >3d isn't implemented, but
         # as of 1.5.4, it does not.

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -12,7 +12,6 @@ from cupyx.scipy.ndimage import _util
 try:
     import scipy
     import scipy.ndimage
-    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
     pass
 
@@ -21,18 +20,12 @@ try:
 except ImportError:
     pass
 
-# testing these modes can only be tested against SciPy >= 1.6.0+
+# Boundary modes split into two groups because some tests only exercise the
+# basic set.  Names are historical (scipy16_modes were added in SciPy 1.6) but
+# every supported SciPy has all of these now.
 scipy16_modes = ['wrap', 'grid-wrap', 'reflect', 'grid-mirror',
                  'grid-constant']
-# these modes are okay to test on older SciPy
 legacy_modes = ['constant', 'nearest', 'mirror']
-
-
-def _conditional_scipy_version_skip(mode, order):
-    if ((mode in scipy16_modes or (mode != 'mirror' and order > 1)) and
-            (scipy_version < '1.6.0')):
-        pytest.skip(
-            'SciPy >= 1.6.0 needed to test this mode/order combination.')
 
 
 def _random_affine_matrix(matrix_shape, xp, dtype=numpy.float64, seed=12345):
@@ -124,7 +117,6 @@ class TestMapCoordinates:
     _multiprocess_can_split = True
 
     def _map_coordinates(self, xp, scp, a, coordinates):
-        _conditional_scipy_version_skip(self.mode, self.order)
         map_coordinates = scp.ndimage.map_coordinates
         output = _maybe_promote_complex_output(self.output, a.dtype)
         if output == 'empty':
@@ -147,7 +139,7 @@ class TestMapCoordinates:
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_map_coordinates_complex_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, xp.float64)
@@ -173,12 +165,6 @@ class TestMapCoordinates:
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=1e-4, scipy_name='scp')
     def test_map_coordinates_int(self, xp, scp, dtype):
-        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
-            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
-                dtype = numpy.int64
-            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
-                dtype = numpy.uint64
-
         a = testing.shaped_random((100, 100), xp, dtype)
         coordinates = testing.shaped_random((a.ndim, 100), xp, dtype)
         out = self._map_coordinates(xp, scp, a, coordinates)
@@ -197,7 +183,6 @@ class TestMapCoordinates:
 class TestMapCoordinatesHalfInteger:
 
     def _map_coordinates(self, xp, scp, a, coordinates):
-        _conditional_scipy_version_skip(self.mode, self.order)
         map_coordinates = scp.ndimage.map_coordinates
         return map_coordinates(a, coordinates, None, self.order, self.mode)
 
@@ -241,11 +226,6 @@ class TestAffineTransform:
     _multiprocess_can_split = True
 
     def _affine_transform(self, xp, scp, a, matrix):
-        _conditional_scipy_version_skip(self.mode, self.order)
-        ver = numpy.lib.NumpyVersion(scipy.__version__)
-        if ver < '1.0.0' and matrix.ndim == 2 and matrix.shape[1] == 3:
-            return xp.empty(0)
-
         if matrix.shape == (3, 3):
             matrix[-1, 0:-1] = 0
             matrix[-1, -1] = 1
@@ -276,7 +256,7 @@ class TestAffineTransform:
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.complex64: 1e-4},
                                  atol=1e-4, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_affine_transform_complex_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = _random_affine_matrix(self.matrix_shape, xp, xp.float64)
@@ -305,12 +285,6 @@ class TestAffineTransform:
                                  atol=1e-4, scipy_name='scp')
     def test_affine_transform_int(self, xp, scp, dtype):
         self._hip_skip_invalid_condition()
-
-        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
-            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
-                dtype = numpy.int64
-            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
-                dtype = numpy.uint64
 
         a = testing.shaped_random((100, 100), xp, dtype)
         matrix = _random_affine_matrix(self.matrix_shape, xp)
@@ -347,7 +321,7 @@ class TestAffineExceptions:
             with pytest.raises(RuntimeError):
                 ndi.affine_transform(x, xp.eye(x.ndim)[:, :-1])
 
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_invalid_output_dtype(self):
         # real output array with complex input is not allowed
         ndimage_modules = (scipy.ndimage, cupyx.scipy.ndimage)
@@ -542,7 +516,6 @@ class TestRotate:
     _multiprocess_can_split = True
 
     def _rotate(self, xp, scp, a):
-        _conditional_scipy_version_skip(self.mode, self.order)
         rotate = scp.ndimage.rotate
         output = _maybe_promote_complex_output(self.output, a.dtype)
         if output == 'empty':
@@ -570,7 +543,7 @@ class TestRotate:
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.complex64: 1e-5},
                                  atol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_rotate_complex_float(self, xp, scp, dtype):
         a = testing.shaped_random((10, 10), xp, dtype)
         return self._rotate(xp, scp, a)
@@ -601,12 +574,6 @@ class TestRotate:
     def test_rotate_int(self, xp, scp, dtype):
         self._hip_skip_invalid_condition()
 
-        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
-            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
-                dtype = numpy.int64
-            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
-                dtype = numpy.uint64
-
         a = testing.shaped_random((10, 10), xp, dtype)
         out = self._rotate(xp, scp, a)
         float_out = self._rotate(xp, scp, a.astype(xp.float64)) % 1
@@ -615,8 +582,7 @@ class TestRotate:
         return out
 
 
-# Scipy older than 1.3.0 raises IndexError instead of ValueError
-@testing.with_requires('scipy>=1.3.0')
+@testing.with_requires('scipy')
 class TestRotateExceptions:
 
     def test_rotate_invalid_plane(self):
@@ -692,7 +658,6 @@ class TestShift:
 
     def _shift(self, xp, scp, a):
         shift = scp.ndimage.shift
-        _conditional_scipy_version_skip(self.mode, self.order)
         output = _maybe_promote_complex_output(self.output, a.dtype)
         if output == 'empty':
             output = xp.empty_like(a)
@@ -714,7 +679,7 @@ class TestShift:
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.complex64: 1e-4},
                                  atol=1e-4, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_shift_complex_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._shift(xp, scp, a)
@@ -746,12 +711,6 @@ class TestShift:
                 # Non-finite cval with integer output array is not supported
                 # CuPy exception is tested in TestInterpolationInvalidCval
                 return xp.asarray([])
-
-        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
-            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
-                dtype = numpy.int64
-            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
-                dtype = numpy.uint64
 
         a = testing.shaped_random((100, 100), xp, dtype)
         out = self._shift(xp, scp, a)
@@ -879,7 +838,6 @@ class TestZoom:
     _multiprocess_can_split = True
 
     def _zoom(self, xp, scp, a):
-        _conditional_scipy_version_skip(self.mode, self.order)
         zoom = scp.ndimage.zoom
         output = _maybe_promote_complex_output(self.output, a.dtype)
         if output == 'empty':
@@ -903,7 +861,7 @@ class TestZoom:
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.complex64: 1e-4},
                                  atol=1e-4, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_zoom_complex_float(self, xp, scp, dtype):
         a = testing.shaped_random((100, 100), xp, dtype)
         return self._zoom(xp, scp, a)
@@ -920,12 +878,6 @@ class TestZoom:
     @testing.numpy_cupy_allclose(rtol={"default": 1e-7, numpy.float32: 1e-4},
                                  atol=1e-4, scipy_name='scp')
     def test_zoom_int(self, xp, scp, dtype):
-        if numpy.lib.NumpyVersion(scipy.__version__) < '1.0.0':
-            if dtype in (numpy.dtype('l'), numpy.dtype('q')):
-                dtype = numpy.int64
-            elif dtype in (numpy.dtype('L'), numpy.dtype('Q')):
-                dtype = numpy.uint64
-
         a = testing.shaped_random((100, 100), xp, dtype)
         out = self._zoom(xp, scp, a)
         float_out = self._zoom(xp, scp, a.astype(xp.float64)) % 1
@@ -966,7 +918,7 @@ class TestZoomOutputSize1:
 
     @testing.for_float_dtypes(no_float16=True)
     @testing.numpy_cupy_allclose(atol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.6.0')
+    @testing.with_requires('scipy')
     def test_zoom_output_size1(self, xp, scp, dtype):
         x = xp.zeros(self.shape, dtype=dtype)
         x[1, 1, 1] = 1
@@ -1019,8 +971,6 @@ class TestZoomOpenCV:
 class TestSplineFilter1d:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d(self, xp, scp):
-        if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         return scp.ndimage.spline_filter1d(x, order=self.order, axis=self.axis,
                                            output=self.output, mode=self.mode)
@@ -1028,8 +978,6 @@ class TestSplineFilter1d:
     @testing.for_CF_orders(name='array_order')
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d_output(self, xp, scp, array_order):
-        if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
                                   order=array_order)
         output = xp.empty(x.shape, dtype=self.output, order=array_order)
@@ -1046,8 +994,6 @@ class TestSplineFilter1dLargeArray:
     @pytest.mark.parametrize('mode', ['mirror', 'grid-wrap', 'reflect'])
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_spline_filter1d_large_array(self, xp, scp, mode):
-        if mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         # Test input that cannot be indexed by int32 in bytes, i.e.
         # x.size * dtype.itemsize >= 2 ** 31
         x = xp.empty((2**20, 2**9), numpy.float32)
@@ -1069,8 +1015,6 @@ class TestSplineFilter1dLargeArray:
 class TestSplineFilter:
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter(self, xp, scp):
-        if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         if self.order < 2:
             with pytest.raises(RuntimeError):
@@ -1083,8 +1027,6 @@ class TestSplineFilter:
     @testing.for_CF_orders(name='array_order')
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter_with_output(self, xp, scp, array_order):
-        if self.mode == 'grid-wrap' and scipy_version < '1.6.0':
-            pytest.skip('testing mode grid-wrap requires scipy >= 1.6.0')
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp,
                                   order=array_order)
         output = xp.empty(x.shape, dtype=self.output, order=array_order)
@@ -1107,27 +1049,9 @@ class TestSplineFilter:
 @testing.with_requires('scipy')
 class TestSplineFilterComplex:
 
-    @testing.with_requires('scipy>=1.6')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(atol=1e-4, rtol=1e-4, scipy_name='scp')
     def test_spline_filter_complex(self, xp, scp):
         x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=xp)
         return scp.ndimage.spline_filter(x, order=self.order,
                                          output=self.output, mode=self.mode)
-
-    # the following test case is for SciPy versions lacking complex support
-    @testing.with_requires('scipy<1.6')
-    def test_spline_filter_complex2(self):
-        if self.mode == 'wrap':
-            pytest.skip('mode cannot be tested against SciPy < 1.6')
-        cpu_func = scipy.ndimage.spline_filter
-        gpu_func = cupyx.scipy.ndimage.spline_filter
-        x = testing.shaped_random((16, 12, 11), dtype=self.dtype, xp=numpy)
-        x_gpu = cupy.asarray(x)
-
-        kwargs_gpu = dict(order=self.order, output=self.output, mode=self.mode)
-        res_gpu = gpu_func(x_gpu, **kwargs_gpu)
-
-        output_real = numpy.empty((1,), dtype=self.output).real.dtype
-        kwargs = dict(order=self.order, output=output_real, mode=self.mode)
-        res_cpu = cpu_func(x.real, **kwargs) + 1j * cpu_func(x.imag, **kwargs)
-        testing.assert_allclose(res_cpu, res_gpu, atol=1e-4, rtol=1e-4)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -16,15 +16,11 @@ import cupyx.scipy.ndimage  # NOQA
 try:
     import scipy
     import scipy.ndimage  # NOQA
-    scipy_version = numpy.lib.NumpyVersion(scipy.__version__)
 except ImportError:
-    scipy_version = numpy.lib.NumpyVersion('0.0.0')
     pass
 
-stats_ops = ['sum', 'mean', 'variance', 'standard_deviation', 'center_of_mass']
-if scipy_version >= '1.6.0':
-    # 'scipy 1.6 added a copy of sum under the name sum_labels'
-    stats_ops += ['sum_labels']
+stats_ops = ['sum', 'mean', 'variance', 'standard_deviation', 'center_of_mass',
+             'sum_labels']
 
 
 def _generate_binary_structure(rank, connectivity):
@@ -460,7 +456,7 @@ class TestLabeledComprehension:
 @testing.parameterize(*testing.product({
     'shape': [(500,), (220, 240), (16, 24, 32), (4, 6, 8, 10)],
 }))
-@testing.with_requires('scipy>=1.10')
+@testing.with_requires('scipy')
 class TestValueIndices:
 
     def _make_image(self, shape, xp, dtype, scale):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -158,7 +158,7 @@ class TestBinaryErosionAndDilation1d:
         'output': [None, numpy.float32, numpy.int8]}
     )
 ))
-@testing.with_requires('scipy>=1.1.0')
+@testing.with_requires('scipy')
 class TestBinaryOpeningAndClosing:
     def _filter(self, xp, scp, x):
         filter = getattr(scp.ndimage, self.filter)
@@ -202,7 +202,7 @@ class TestBinaryOpeningAndClosing:
                    'binary_closing']}
     ))
 )
-@testing.with_requires('scipy>=1.1.0')
+@testing.with_requires('scipy')
 class TestBinaryMorphologyTupleFootprint:
     def _filter(self, x, structure):
         filter = getattr(cupyx.scipy.ndimage, self.filter)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_czt.py
@@ -69,7 +69,7 @@ def _gen_random_signal():
     yield from lengths
 
 
-@testing.with_requires("scipy >= 1.8.0")
+@testing.with_requires("scipy")
 class Test1D:
 
     @pytest.mark.parametrize('func', zf_checks)
@@ -155,7 +155,7 @@ class Test1D:
         return scp.signal.czt(x)
 
 
-@testing.with_requires("scipy >= 1.8.0")
+@testing.with_requires("scipy")
 class TestErrors:
 
     @pytest.mark.parametrize('size', [0, -5, 3.5, 4.0])
@@ -197,7 +197,7 @@ class TestErrors:
             signal.zoom_fft(5, 0.5)
 
 
-@testing.with_requires("scipy >= 1.8.0")
+@testing.with_requires("scipy")
 class TestCZTPoints:
 
     @pytest.mark.parametrize("N", [1, 2, 3, 8, 11, 100, 101, 10007])
@@ -221,7 +221,7 @@ class TestCZTPoints:
                 scp.signal.czt_points(11, w=2))
 
 
-@testing.with_requires("scipy >= 1.8.0")
+@testing.with_requires("scipy")
 @pytest.mark.slow
 def test_czt_vs_fft():
     cupy.random.seed(123)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_filter_design.py
@@ -550,7 +550,7 @@ class TestFreqz_zpk:
             assert_array_almost_equal(h, [1])
 
 
-@testing.with_requires("scipy>=1.8")
+@testing.with_requires("scipy")
 class TestSOSFreqz:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
@@ -796,7 +796,7 @@ class TestGroupDelay:
 
     @pytest.mark.parametrize('w', [8.0, 8.0+0j])
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
-    @testing.with_requires('scipy>=1.8')
+    @testing.with_requires('scipy')
     def test_w_types(self, w, xp, scp):
         # Measure at frequency 8 rad/sec
         w_out, gd = scp.signal.group_delay((1, 1), w)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_conversion.py
@@ -243,7 +243,7 @@ class TestLp2bs_zpk:
         return z_bs_s, p_bs_s, k_bs
 
 
-@testing.with_requires("scipy >= 1.8.0")
+@testing.with_requires("scipy")
 class TestZpk2Sos:
 
     @pytest.mark.parametrize('dt', 'fdFD')

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_iir_filter_design.py
@@ -19,7 +19,7 @@ nimpl = pytest.mark.xfail(reason="not implemented")
 prec_loss = pytest.mark.xfail(reason="zpk2tf loses precision")
 
 
-@testing.with_requires("scipy>=1.8")
+@testing.with_requires("scipy")
 class TestIIRFilter:
 
     # NB: test_symmetry with higher order ellip filters need low tolerance
@@ -167,7 +167,7 @@ class TestButter:
                               'sos',
                               pytest.param('ba', marks=prec_loss)])
     @testing.numpy_cupy_allclose(scipy_name="scp")
-    @testing.with_requires("scipy>=1.8")
+    @testing.with_requires("scipy")
     def test_ba_output(self, xp, scp, outp):
         outp = scp.signal.butter(
             4, [100, 300], 'bandpass', analog=True, output=outp)
@@ -393,7 +393,7 @@ class TestCheby2:
         # assert_allclose(a, a2, rtol=1e-14)
 
 
-@testing.with_requires("scipy>=1.8")
+@testing.with_requires("scipy")
 class TestEllip:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
@@ -773,7 +773,7 @@ class TestEllipord:
         return N, Wn
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_lowpass_1000dB(self, xp, scp):
         # failed when ellipkm1 wasn't used in ellipord and ellipap
         wp = 0.2
@@ -1071,7 +1071,7 @@ class TestIIRComb:
         return b, a
 
     # Verify pass_zero parameter
-    @testing.with_requires("scipy>=1.9.0")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name="scp")
     @pytest.mark.parametrize('ftype,pass_zero,peak,notch',
                              [('peak', True, 123.45, 61.725),
@@ -1104,7 +1104,7 @@ class TestIIRComb:
         return b, a
 
     # Verify that https://github.com/scipy/scipy/issues/14043 is fixed
-    @testing.with_requires('scipy>=1.9.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_nearest_divisor(self, xp, scp):
         # Create a notching comb filter

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_ltisys.py
@@ -612,7 +612,7 @@ class TestPlacePoles:
         fsf = scp.signal.place_poles(A, B, P)
         return fsf.computed_poles
 
-    @testing.with_requires("scipy >= 1.9")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-8)
     def test_complex_2(self, xp, scp):
         # Try to reach the specific case in _YT_complex where two singular

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_resample.py
@@ -363,7 +363,7 @@ class TestDecimate:
         x_out = scp.signal.decimate(x, 30, ftype='fir')
         return x_out
 
-    @testing.with_requires('scipy>=1.10')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=5e-5, rtol=5e-5)
     def test_long_float32(self, xp, scp):
         # regression: gh-15072.  With 32-bit float and either lfilter
@@ -371,7 +371,7 @@ class TestDecimate:
         x = scp.signal.decimate(xp.ones(10_000, dtype=np.float32), 10)
         return x
 
-    @testing.with_requires('scipy>=1.10')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_float16_upcast(self, xp, scp):
         # float16 must be upcast to float64

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -239,7 +239,7 @@ def test_correlation_lags(mode, xp, scp, behind, input_size):
 class TestConvolve2DEdgeCase:
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.10')
+    @testing.with_requires('scipy')
     def test_convolve2d_1(self, xp, scp):
         # Meant a gray-scale image
         data = testing.shaped_random(
@@ -362,20 +362,7 @@ class TestOrderFilter:
     'kernel_size': [3, 4, (3, 3, 5)],
 }))
 class TestMedFilt:
-    @testing.with_requires('scipy>=1.7.0', 'scipy<1.11.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
-                                 accept_error=ValueError)  # for even kernels
-    def test_medfilt_no_complex(self, xp, scp, dtype):
-        if sys.platform == 'win32':
-            pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
-        volume = testing.shaped_random(self.volume, xp, dtype)
-        kernel_size = self.kernel_size
-        if isinstance(kernel_size, tuple):
-            kernel_size = kernel_size[:volume.ndim]
-        return scp.signal.medfilt(volume, kernel_size)
-
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         atol=1e-8, rtol=1e-8, scipy_name='scp',
@@ -385,7 +372,7 @@ class TestMedFilt:
             # https://github.com/scipy/scipy/issues/22368
             return xp.array([])  # Skip
         if sys.platform == 'win32':
-            pytest.xfail('medfilt broken for Scipy 1.7.0 in windows')
+            pytest.xfail('medfilt broken for SciPy on windows')
         volume = testing.shaped_random(self.volume, xp, dtype)
         kernel_size = self.kernel_size
         if isinstance(kernel_size, tuple):
@@ -398,25 +385,14 @@ class TestMedFilt:
     'kernel_size': [3, 4, (3, 5)],
 }))
 class TestMedFilt2d:
-    @testing.with_requires('scipy>=1.7.0', 'scipy<1.11.0')
-    @testing.for_all_dtypes(no_complex=True)
-    @testing.numpy_cupy_allclose(atol=1e-8, rtol=1e-8, scipy_name='scp',
-                                 accept_error=ValueError)  # for even kernels
-    def test_medfilt2d_no_complex(self, xp, scp, dtype):
-        if sys.platform == 'win32':
-            pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')
-        input = testing.shaped_random(self.input, xp, dtype)
-        kernel_size = self.kernel_size
-        return scp.signal.medfilt2d(input, kernel_size)
-
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(
         atol=1e-8, rtol=1e-8, scipy_name='scp',
         accept_error=ValueError)  # for even kernels
     def test_medfilt2d(self, xp, scp, dtype):
         if sys.platform == 'win32':
-            pytest.xfail('medfilt2d broken for Scipy 1.7.0 in windows')
+            pytest.xfail('medfilt2d broken for SciPy on windows')
         input = testing.shaped_random(self.input, xp, dtype)
         kernel_size = self.kernel_size
         return scp.signal.medfilt2d(input, kernel_size)
@@ -1054,7 +1030,7 @@ class TestHilbert:
 
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
     @testing.numpy_cupy_allclose(scipy_name='scp')
-    @testing.with_requires("scipy>=1.9")
+    @testing.with_requires("scipy")
     def test_hilbert_types(self, dtype, xp, scp):
         in_typed = xp.zeros(8, dtype=dtype)
         return scp.signal.hilbert(in_typed)
@@ -1087,7 +1063,7 @@ class TestHilbert2:
 
     @testing.numpy_cupy_allclose(scipy_name='scp')
     @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-    @testing.with_requires("scipy>=1.9")
+    @testing.with_requires("scipy")
     def test_hilbert2_types(self, dtype, xp, scp):
         in_typed = xp.zeros((2, 32), dtype=dtype)
         return scp.signal.hilbert2(in_typed)

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -967,7 +967,7 @@ class TestCheckNOLACOLA:
         return result
 
 
-@testing.with_requires('scipy>=1.9.0')
+@testing.with_requires('scipy')
 class TestSTFT:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_average_all_segments(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-@testing.with_requires('scipy>=1.9')
+@testing.with_requires('scipy')
 class TestSymIIROrder:
     @pytest.mark.parametrize('size', [11, 20, 32, 51, 64, 120])
     @pytest.mark.parametrize(

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_windows.py
@@ -294,7 +294,7 @@ class TestKaiser:
                 scp.signal.windows.kaiser(6, 2.7, False),)
 
 
-@testing.with_requires('scipy>=1.10')
+@testing.with_requires('scipy')
 class TestKaiserBesselDerived:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -440,7 +440,7 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3)  # negative M
 
 
-@testing.with_requires("scipy>=1.10")
+@testing.with_requires("scipy")
 class TestLanczos:
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-13, atol=1e-13)
     def test_basic(self, xp, scp):
@@ -535,7 +535,7 @@ class TestGetWindow:
             scp.signal.get_window(('general_hamming', 0.7), 5),
             scp.signal.get_window(('general_hamming', 0.7), 5, fftbins=False),)
 
-    @testing.with_requires("scipy >= 1.10")
+    @testing.with_requires("scipy")
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=1e-15)
     def test_lanczos(self, xp, scp):
         return (scp.signal.get_window('lanczos', 6),
@@ -606,7 +606,7 @@ def test_needs_params(windows):
         assert_raises(ValueError, windows.get_window, winstr, 7)
 
 
-@testing.with_requires("scipy>=1.10")
+@testing.with_requires("scipy")
 @pytest.mark.parametrize('windows', [cu_windows, cpu_windows])
 def test_needs_params_2(windows):
     for winstr in ['kaiser_bessel_derived']:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
@@ -15,7 +15,7 @@ from cupy import testing
 from cupyx.scipy import sparse
 
 
-@testing.with_requires('scipy>=1.14')
+@testing.with_requires('scipy')
 class TestSpmatrix(unittest.TestCase):
 
     def dummy_class(self, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
@@ -323,7 +323,7 @@ class TestRandomInvalidArgument:
                 sp.random(3, 4, density=1.1)
 
     def test_invalid_dtype(self):
-        # Note: SciPy 1.12+ accepts integer.
+        # Note: SciPy accepts integer (cupy does not yet).
         with pytest.raises(NotImplementedError):
             sparse.random(3, 4, dtype='i')
 
@@ -420,7 +420,7 @@ def skip_HIP_0_size_matrix():
     'arrA': _arrs_kron,
     'arrB': _arrs_kron,
 }))
-@testing.with_requires('scipy>=1.6')
+@testing.with_requires('scipy')
 class TestKron:
 
     def _make_sp_mat(self, xp, sp, arr, dtype):
@@ -459,7 +459,7 @@ _arrs_kronsum = [
     'arrA': _arrs_kronsum,
     'arrB': _arrs_kronsum,
 }))
-@testing.with_requires('scipy>=1.6')
+@testing.with_requires('scipy')
 class TestKronsum:
 
     def _make_sp_mat(self, xp, sp, arr, dtype):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -207,7 +207,7 @@ class TestCooMatrix:
         ], dtype=self.dtype)
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy>=1.14')
+    @testing.with_requires('scipy')
     def test_str(self):
         # CuPy delegates ``__str__`` to ``str(self.get())`` so the output
         # always matches the installed scipy's format.  Sanity-check the
@@ -506,12 +506,6 @@ class TestCooMatrixScipyComparison:
         m = self.make(xp, sp, self.dtype)
         return m.toarray()
 
-    @testing.with_requires('scipy<1.14')
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_A(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return m.toarray()
-
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = _make(xp, sp, self.dtype)
@@ -557,13 +551,13 @@ class TestCooMatrixScipyComparison:
         return n
 
     # dot
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.dot(2.0)
 
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
@@ -872,11 +866,6 @@ class TestCooMatrixScipyComparison:
             with pytest.raises(ValueError):
                 x * m
 
-    @pytest.mark.xfail(
-        scipy_available and
-        numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
-        numpy.lib.NumpyVersion(scipy.__version__) <= '1.9.0rc1',
-        reason='See scipy/15210')
     def test_rmul_unsupported(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)
@@ -1041,7 +1030,7 @@ class TestCooMatrixSumDuplicates:
         assert m.nnz == 0
         return m
 
-    @testing.with_requires('scipy>=1.11.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sum_duplicates_compatibility(self, xp, sp):
         m = _make_sum_dup(xp, sp, self.dtype)
@@ -1053,29 +1042,6 @@ class TestCooMatrixSumDuplicates:
         testing.assert_array_equal(m.row, row)
         testing.assert_array_equal(m.col, col)
         assert m.has_canonical_format
-        return m
-
-    @testing.with_requires('scipy<1.11.0')
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_sum_duplicates_incompatibility(self, xp, sp):
-        # See #3620 and #3624. CuPy's and SciPy's COO indices could mismatch
-        # due to the order of lexsort, but the matrix is correct.
-        m = _make_sum_dup(xp, sp, self.dtype)
-        if xp is cupy:
-            sorted_first = m.row.copy()
-        else:
-            sorted_first = m.col.copy()
-        assert not m.has_canonical_format
-        m.sum_duplicates()
-        assert m.has_canonical_format
-        # Here we ensure this sorting order is not altered by future PRs...
-        sorted_first.sort()
-        if xp is cupy:
-            testing.assert_array_equal(m.row, sorted_first)
-        else:
-            testing.assert_array_equal(m.col, sorted_first)
-        assert m.has_canonical_format
-        # ...and now we make sure the dense matrix is the same
         return m
 
 
@@ -1126,7 +1092,7 @@ class TestIsspmatrixCoo:
 @testing.parameterize(*testing.product({
     'shape': [(8, 5), (5, 5), (5, 8)],
 }))
-@testing.with_requires('scipy>=1.5.0')
+@testing.with_requires('scipy')
 class TestCooMatrixDiagonal:
     density = 0.5
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -248,7 +248,7 @@ class TestCscMatrix:
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy>=1.14')
+    @testing.with_requires('scipy')
     def test_str(self):
         # CuPy delegates ``__str__`` to ``str(self.get())`` so the output
         # always matches the installed scipy version's format.  Sanity-
@@ -505,14 +505,6 @@ class TestCscMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.toarray(order='#')
 
-    @testing.with_requires('scipy<1.14')
-    @pytest.mark.filterwarnings(
-        r"ignore:`spmatrix\.A` is deprecated:DeprecationWarning")
-    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
-    def test_A(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return m.A
-
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
@@ -554,13 +546,13 @@ class TestCscMatrixScipyComparison:
         return n
 
     # dot
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.dot(2.0)
 
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
@@ -599,7 +591,7 @@ class TestCscMatrixScipyComparison:
         x = _make3(xp, sp, self.dtype).tocoo()
         return m.dot(x)
 
-    @testing.with_requires('scipy>=1.8.0rc1')
+    @testing.with_requires('scipy')
     def test_dot_zero_dim(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -905,10 +897,7 @@ class TestCscMatrixScipyComparison:
                 x * m
 
     def test_rmul_unsupported(self):
-        if (
-            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
-            self.make_method not in ['_make_empty', '_make_shape']
-        ):
+        if self.make_method not in ['_make_empty', '_make_shape']:
             pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -995,19 +984,11 @@ class TestCscMatrixScipyComparison:
         assert 2 == len(M.indices)  # unaffected content
         return M
 
-    @testing.with_requires('scipy>1.6.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_has_sorted_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.has_sorted_indices
-
-    # TODO(asi1024): Remove test after the fixed version is released.
-    # https://github.com/scipy/scipy/pull/13426
-    @testing.with_requires('scipy<=1.6.0')
-    @testing.numpy_cupy_equal(sp_name='sp')
-    def test_has_sorted_indices_for_old_scipy(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return bool(m.has_sorted_indices)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_has_sorted_indices2(self, xp, sp):
@@ -1186,7 +1167,7 @@ class TestCscMatrixScipyCompressed:
     'axis': [None, -2, -1, 0, 1],
     'dense': [False, True],  # means a sparse matrix but all elements filled
 }))
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestCscMatrixScipyCompressedMinMax:
 
     def _make_data_min(self, xp, sp, dense=False):
@@ -1431,7 +1412,7 @@ class TestIsspmatrixCsc:
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem:
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1492,8 +1473,6 @@ class TestCsrMatrixGetitem:
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, -2:-1]
 
-    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
-    # segfault occurs instead of returning an empty slice.
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         return _make(xp, sp, self.dtype)[:, 3:2]
@@ -1504,7 +1483,7 @@ class TestCsrMatrixGetitem:
         return _make(xp, sp, self.dtype)[slice(None, None, None)]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    @testing.with_requires('scipy>=1.9.3')
+    @testing.with_requires('scipy')
     def test_getitem_rowslice_negative_stop(self, xp, sp):
         # This test is adapted from Scipy's CSC tests
         return _make(xp, sp, self.dtype)[slice(1, -2, 2)]
@@ -1542,7 +1521,7 @@ class TestCsrMatrixGetitem:
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem2:
 
     @testing.numpy_cupy_allclose(sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -291,7 +291,7 @@ class TestCsrMatrix:
         ]
         numpy.testing.assert_allclose(m.toarray(), expect)
 
-    @testing.with_requires('scipy>=1.14')
+    @testing.with_requires('scipy')
     def test_str(self):
         # CuPy delegates ``__str__`` to ``str(self.get())`` so the output
         # always matches the installed scipy's format.  Sanity-check the
@@ -514,7 +514,7 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(TypeError):
                 len(m)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_iter(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
@@ -558,14 +558,6 @@ class TestCsrMatrixScipyComparison:
             with pytest.raises(ValueError):
                 m.toarray(order='#')
 
-    @testing.with_requires('scipy<1.14')
-    @pytest.mark.filterwarnings(
-        r"ignore:`spmatrix\.A` is deprecated:DeprecationWarning")
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_A(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return m.A
-
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_tocoo(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
@@ -607,13 +599,13 @@ class TestCsrMatrixScipyComparison:
         return n
 
     # dot
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
         return m.dot(2.0)
 
-    @testing.with_requires('scipy!=1.8.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', _check_sparse_format=False)
     def test_dot_numpy_scalar(self, xp, sp):
         m = _make(xp, sp, self.dtype)
@@ -646,7 +638,7 @@ class TestCsrMatrixScipyComparison:
         x = _make3(xp, sp, self.dtype).tocoo()
         return m.dot(x)
 
-    @testing.with_requires('scipy>=1.8.0rc1')
+    @testing.with_requires('scipy')
     def test_dot_zero_dim(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -946,10 +938,7 @@ class TestCsrMatrixScipyComparison:
                 x * m
 
     def test_rmul_unsupported(self):
-        if (
-            numpy.lib.NumpyVersion(scipy.__version__) >= '1.8.0rc1' and
-            self.make_method not in ['_make_empty', '_make_shape']
-        ):
+        if self.make_method not in ['_make_empty', '_make_shape']:
             pytest.xfail('See scipy/15210')
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = self.make(xp, sp, self.dtype)
@@ -1036,19 +1025,11 @@ class TestCsrMatrixScipyComparison:
         assert 2 == len(M.indices)  # unaffected content
         return M
 
-    @testing.with_requires('scipy>1.6.0')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_has_sorted_indices(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         return m.has_sorted_indices
-
-    # TODO(asi1024): Remove test after the fixed version is released.
-    # https://github.com/scipy/scipy/pull/13426
-    @testing.with_requires('scipy<=1.6.0')
-    @testing.numpy_cupy_equal(sp_name='sp')
-    def test_has_sorted_indices_for_old_scipy(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return bool(m.has_sorted_indices)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_has_sorted_indices2(self, xp, sp):
@@ -1236,21 +1217,21 @@ class TestCsrMatrixScipyComparison:
         y = m / xp.array(self._make_scalar(dtype))
         return y.toarray()
 
-    @testing.with_requires('scipy>=1.11')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_divide_dense_row(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(4, dtype=self.dtype)
         return m / x
 
-    @testing.with_requires('scipy>=1.11')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_divide_dense_col(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
         x = xp.arange(3, dtype=self.dtype).reshape(3, 1)
         return m / x
 
-    @testing.with_requires('scipy>=1.11')
+    @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp', rtol=2e-7)
     def test_divide_dense_matrix(self, xp, sp):
         m = self.make(xp, sp, self.dtype)
@@ -1316,7 +1297,7 @@ class TestCsrMatrixPowScipyComparison:
             with pytest.raises(ValueError):
                 m ** 1.5
 
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     def test_pow_list(self):
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make_square(xp, sp, self.dtype)
@@ -1405,7 +1386,7 @@ class TestCsrMatrixScipyCompressed:
     'axis': [None, -2, -1, 0, 1],
     'dense': [False, True],  # means a sparse matrix but all elements filled
 }))
-@testing.with_requires('scipy>=0.19.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixScipyCompressedMinMax:
     def _make_data_min(self, xp, sp, dense=False):
         dm_data = testing.shaped_random((10, 20), xp=xp, scale=1.0)
@@ -1641,7 +1622,7 @@ class TestIsspmatrixCsr:
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem:
 
     @testing.numpy_cupy_equal(sp_name='sp')
@@ -1720,8 +1701,6 @@ class TestCsrMatrixGetitem:
     def test_getitem_slice_negative(self, xp, sp):
         return _make(xp, sp, self.dtype)[-2:-1]
 
-    # SciPy prior to 1.4 has bugs where either an IndexError is raised or a
-    # segfault occurs instead of returning an empty slice.
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_getitem_slice_start_larger_than_stop(self, xp, sp):
         return _make(xp, sp, self.dtype)[3:2]
@@ -1740,7 +1719,7 @@ class TestCsrMatrixGetitem:
         return _make(xp, sp, self.dtype)[slice(None, None, None)]
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    @testing.with_requires('scipy>=1.9.3')
+    @testing.with_requires('scipy')
     def test_getitem_rowslice_negative_stop(self, xp, sp):
         # This test is adapted from Scipy
         return _make(xp, sp, self.dtype)[slice(1, -2, 2)]
@@ -1777,7 +1756,7 @@ class TestCsrMatrixGetitem:
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, cupy.complex64, cupy.complex128],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixGetitem2:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -1918,7 +1897,7 @@ class TestCsrMatrixMaximumMinimum:
     'shape': [(6, 15), (15, 6)],
     'opt': ['_eq_', '_ne_', '_lt_', '_gt_', '_le_', '_ge_'],
 }))
-@testing.with_requires('scipy>=1.2')
+@testing.with_requires('scipy')
 class TestCsrMatrixComparison:
     nz_rate = 0.3
 
@@ -2083,7 +2062,7 @@ class TestCsrMatrixComparison:
 @testing.parameterize(*testing.product({
     'shape': [(8, 5), (5, 5), (5, 8)],
 }))
-@testing.with_requires('scipy>=1.5.0')
+@testing.with_requires('scipy')
 class TestCsrMatrixDiagonal:
     density = 0.5
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -86,7 +86,7 @@ class TestDiaMatrix(unittest.TestCase):
         n = _make_complex(cupy, sparse, self.dtype)
         cupy.testing.assert_array_equal(n.conjugate().data, n.data.conj())
 
-    @testing.with_requires('scipy>=1.14')
+    @testing.with_requires('scipy')
     def test_str(self):
         # The exact DIA __str__ format differs across SciPy versions:
         # SciPy 1.14-1.16 use diagonal-major order; SciPy 1.17 switched
@@ -285,14 +285,6 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.toarray()
 
-    @testing.with_requires('scipy<1.14')
-    @pytest.mark.filterwarnings(
-        r"ignore:`spmatrix\.A` is deprecated:DeprecationWarning")
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_A(self, xp, sp):
-        m = self.make(xp, sp, self.dtype)
-        return m.A
-
     @testing.with_requires('scipy>=1.16')
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_sum_tuple_axis(self, xp, sp):
@@ -352,10 +344,8 @@ class TestDiaMatrixScipyComparison(unittest.TestCase):
         m = self.make(xp, sp, self.dtype)
         return m.transpose()
 
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     def test_diagonal_error(self):
-        # Before scipy 1.5.0 dia_matrix diagonal raised
-        # `ValueError`, now returns empty array.
         # Check #3469
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             m = _make(xp, sp, self.dtype)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py
@@ -16,12 +16,6 @@ from cupy import testing
 from cupy.cuda import runtime
 from cupyx.scipy import sparse
 
-try:
-    import scipy
-    scipy_113_or_later = scipy.__version__ >= "1.13"
-except ImportError:
-    scipy_113_or_later = False
-
 
 def _get_index_combos(idx):
     return [dict['arr_fn'](idx, dtype=dict['dtype'])
@@ -45,7 +39,7 @@ def _check_shares_memory(xp, sp, x, y):
     'n_rows': [25, 150],
     'n_cols': [25, 150]
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestSetitemIndexing:
 
     def _run(self, maj, min=None, data=5, density=None):
@@ -129,8 +123,8 @@ class TestSetitemIndexing:
         m[0, 0] = rhs
         assert m.toarray()[0, 0] == 7.0
 
-    @pytest.mark.xfail(scipy_113_or_later, reason="XXX: scipy1.13")
-    @testing.with_requires('scipy>=1.5.0')
+    @pytest.mark.xfail(reason="XXX: scipy1.13")
+    @testing.with_requires('scipy')
     def test_set_zero_dim_bool_mask(self):
 
         zero_dim_data = [numpy.array(5), cupy.array(5)]
@@ -298,14 +292,9 @@ class TestSetitemIndexing:
         self._run(slice(10, 2, 5), slice(None))
         self._run(slice(10, 0, 10), slice(None))
 
-    @pytest.mark.xfail(scipy_113_or_later,
-                       reason="XXX: scipy 1.13")
-    @testing.with_requires('scipy>=1.5.0')
+    @pytest.mark.xfail(reason="XXX: scipy 1.13")
+    @testing.with_requires('scipy')
     def test_fancy_setting_bool(self):
-        # Unfortunately, boolean setting is implemented slightly
-        # differently between Scipy 1.4 and 1.5. Using the most
-        # up-to-date version in CuPy.
-
         for maj in _get_index_combos(
                 [[True], [False], [False], [True], [True], [True]]):
             self._run(maj, data=5)
@@ -400,7 +389,7 @@ _int_array_index = [
         ]
     ),
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestSliceIndexing(IndexingTestBase):
 
     @testing.for_dtypes('fdFD')
@@ -525,15 +514,13 @@ class TestArrayIndexing(IndexingTestBase):
         ([True, False, True], [True, False, True]),
     ],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestBoolMaskIndexing(IndexingTestBase):
 
     n_rows = 3
     n_cols = 5
 
-    # In older environments (e.g., py35, scipy 1.4), scipy sparse arrays are
-    # crashing when indexed with native Python boolean list.
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
     def test_bool_mask(self, xp, sp, dtype):
@@ -585,7 +572,7 @@ class TestBoolMaskIndexing(IndexingTestBase):
         ([[0, 0], [1, 1]]),
     ],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestIndexingIndexError(IndexingTestBase):
 
     def test_indexing_index_error(self):
@@ -605,7 +592,7 @@ class TestIndexingIndexError(IndexingTestBase):
         ([1, 2, 3], [1, 2, 3, 4]),
     ],
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 class TestIndexingValueError(IndexingTestBase):
 
     def test_indexing_value_error(self):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import contextlib
 import functools
-import re
-import io
 import unittest
 import warnings
 
@@ -401,7 +398,7 @@ class TestCg:
                 M = sp.linalg.aslinearoperator(M)
         return self._test_cg(dtype, xp, sp, a, M)
 
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):
@@ -540,7 +537,7 @@ class TestBicgstab:
                 M = sp.linalg.aslinearoperator(M)
         return self._test_bicgstab(dtype, xp, sp, a, M)
 
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):
@@ -614,7 +611,7 @@ class TestBicgstab:
     'restart': [None, 10],
     'use_linear_operator': [False, True],
 }))
-@testing.with_requires('scipy>=1.4')
+@testing.with_requires('scipy')
 class TestGmres:
     n = 30
     density = 0.2
@@ -689,7 +686,7 @@ class TestGmres:
                 M = sp.linalg.aslinearoperator(M)
         return self._test_gmres(dtype, xp, sp, a, M)
 
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):
@@ -766,7 +763,7 @@ class TestGmres:
             sp.linalg.gmres(ng_a, b)
 
 
-@testing.with_requires('scipy>=1.4')
+@testing.with_requires('scipy')
 class TestGmresInfo:
 
     def test_nonconvergence_with_restart_maxiter_mismatch(self):
@@ -807,7 +804,7 @@ def skip_HIP_spMM_error(outer=()):
     'M': [1, 6],
     'N': [1, 7],
 }))
-@testing.with_requires('scipy>=1.4')
+@testing.with_requires('scipy')
 class TestLinearOperator:
 
     # modified from scipy
@@ -930,7 +927,7 @@ class TestLinearOperator:
     'nrhs': [None, 1, 4],
     'order': ['C', 'F']
 }))
-@testing.with_requires('scipy>=1.4.0')
+@testing.with_requires('scipy')
 @pytest.mark.skipif(not cusparse.check_availability('csrsm2'),
                     reason='no working implementation')
 class TestSpsolveTriangular:
@@ -1087,7 +1084,7 @@ def _eigen_vec_transform(block_vec, xp):
     return block_vec * direction
 
 
-@testing.with_requires('scipy>=1.4')
+@testing.with_requires('scipy')
 @pytest.mark.skipif(runtime.is_hip and driver.get_build_version() < 402,
                     reason='syevj not available')
 # tests adapted from scipy's tests of lobpcg
@@ -1149,32 +1146,6 @@ class TestLOBPCG:
         A, B = self._generate_input_for_mikota_pair(10, xp)
         n = A.shape[0]
         X = self._generate_random_initial_ortho_eigvec(n, 10, xp)
-        eigvals, eigvecs = sp.linalg.lobpcg(A,
-                                            X, B=B,
-                                            tol=1e-5, maxiter=30,
-                                            largest=False)
-        return eigvals, _eigen_vec_transform(eigvecs, xp)
-
-    @testing.with_requires('scipy<1.11')
-    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp',
-                                 contiguous_check=False)
-    def test_generate_input_for_elastic_rod(self, xp, sp):
-        A, B = self._generate_input_for_elastic_rod(100, xp)
-        n = A.shape[0]
-        X = self._generate_random_initial_ortho_eigvec(n, 20, xp)
-        eigvals, eigvecs = sp.linalg.lobpcg(A,
-                                            X, B=B,
-                                            tol=1e-5, maxiter=30,
-                                            largest=False)
-        return eigvals, _eigen_vec_transform(eigvecs, xp)
-
-    @testing.with_requires('scipy<1.11')
-    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp',
-                                 contiguous_check=False)
-    def test_generate_input_for_mikota_pair(self, xp, sp):
-        A, B = self._generate_input_for_mikota_pair(100, xp)
-        n = A.shape[0]
-        X = self._generate_random_initial_ortho_eigvec(n, 20, xp)
         eigvals, eigvecs = sp.linalg.lobpcg(A,
                                             X, B=B,
                                             tol=1e-5, maxiter=30,
@@ -1314,38 +1285,6 @@ class TestLOBPCG:
         lobpcg_w, lobpcg_V = sp.linalg.lobpcg(A, X, largest=False)
         return lobpcg_w, _eigen_vec_transform(lobpcg_V, xp)
 
-    def _verbosity_helper(self, xp, sp):
-        """Helper to capture the verbose output from stdout
-        """
-        A, B = self._generate_input_for_elastic_rod(100, xp)
-        n = A.shape[0]
-        m = 20
-        X = self._generate_random_initial_ortho_eigvec(n, m, xp)
-        saved_stdout = io.StringIO()
-        with contextlib.redirect_stdout(saved_stdout):
-            _, _ = sp.linalg.lobpcg(A, X, B=B, tol=1e-5,
-                                    maxiter=30, largest=False,
-                                    verbosityLevel=9)
-        output = saved_stdout.getvalue().strip()
-        return output
-
-    @testing.with_requires('scipy>=1.10', 'scipy<1.11')
-    def test_verbosity(self):
-        """Check that nonzero verbosity level code runs
-           and is identical to scipy's output format.
-        """
-        stdout_cupy = self._verbosity_helper(cupy, cupyx.scipy.sparse)
-        stdout_numpy = self._verbosity_helper(numpy, scipy.sparse)
-        # getting rid of the numbers and whitespaces, we care only about
-        # format of printed output.
-        # also, due to the fact that there are unpredictable (but minor)
-        # differences in decimal digits between scipy and cupy verbose output
-        stdout_cupy = re.sub(r'[-+]?\d+\.?\d*[ ]*', '{number}', stdout_cupy)
-        stdout_numpy = re.sub(r'[-+]?\d+\.?\d*[ ]*', '{number}', stdout_numpy)
-        assert stdout_numpy == stdout_cupy, '''numpy: %s
-                                               cupy: %s''' % (stdout_numpy,
-                                                              stdout_cupy)
-
     @testing.numpy_cupy_allclose(
         rtol=1e-5, atol=5e-3 if runtime.is_hip else 1e-3, sp_name='sp',
         contiguous_check=False)
@@ -1399,7 +1338,7 @@ class TestLOBPCG:
         assert len(l_h) == 22
 
 
-@testing.with_requires('scipy>=1.4')
+@testing.with_requires('scipy')
 @testing.parameterize(*testing.product({
     'A_sparsity': [True, False],
     'B_sparsity': [True, False],
@@ -1689,7 +1628,7 @@ class TestCgs:
                 M = sp.linalg.aslinearoperator(M)
         return self._test_cgs(dtype, xp, sp, a, M)
 
-    @testing.with_requires('scipy>=1.12.0rc1')
+    @testing.with_requires('scipy')
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_empty(self, dtype, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_kdtree.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_kdtree.py
@@ -208,7 +208,7 @@ class TestVectorization:
         d, _ = tree.query(x, k=kk)
         return d
 
-    @testing.with_requires('scipy>=1.9.0')
+    @testing.with_requires('scipy')
     def test_query_raises_for_k_none(self):
         for xp, scp in [(cupy, cupyx.scipy), (np, scipy)]:
             x, tree = create_small_kd_tree(xp, scp)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_digamma.py
@@ -7,7 +7,7 @@ import cupyx.scipy.special  # NOQA
 import numpy
 
 
-@testing.with_requires("scipy>=1.14")
+@testing.with_requires("scipy")
 class TestDigamma(unittest.TestCase):
 
     @testing.for_all_dtypes()
@@ -43,7 +43,7 @@ class TestDigamma(unittest.TestCase):
 
         return scp.special.digamma(dtype(1.5))
 
-    @testing.with_requires('scipy>=1.1.0')
+    @testing.with_requires('scipy')
     @testing.for_dtypes("efdFD")
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_inf_and_nan(self, xp, scp, dtype):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erf.py
@@ -71,7 +71,7 @@ class TestSpecial(unittest.TestCase, _TestBase):
         a = xp.array(a, dtype=dtype)
         return getattr(scp.special, name)(a)
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_dtypes(['f', 'd'])
     def test_erfinv_behavior(self, dtype):
         a = cupy.empty((1,), dtype=dtype)
@@ -89,7 +89,7 @@ class TestSpecial(unittest.TestCase, _TestBase):
         a = cupyx.scipy.special.erfinv(a)
         assert numpy.isneginf(cupy.asnumpy(a))
 
-    @testing.with_requires('scipy>=1.4.0')
+    @testing.with_requires('scipy')
     @testing.for_dtypes(['f', 'd'])
     def test_erfcinv_behavior(self, dtype):
         a = cupy.empty((1,), dtype=dtype)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_gamma.py
@@ -51,11 +51,10 @@ class TestGamma:
         func = getattr(scp.special, function)
         return func(val)
 
-    # skip on SciPy < 1.5 due to: https://github.com/scipy/scipy/issues/11315
     @pytest.mark.parametrize('function', ['gamma', 'loggamma', 'rgamma'])
     @testing.for_dtypes("efdFD")
     @testing.numpy_cupy_allclose(atol=1e-2, rtol=1e-3, scipy_name='scp')
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     def test_inf_and_nan(self, xp, scp, dtype, function):
         import scipy.special  # NOQA
 

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_logsumexp.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-import numpy
-
 import cupy
 from cupy import testing
 import cupyx.scipy.special  # NOQA
@@ -40,7 +38,7 @@ class TestLogsumexp:
         a = xp.array([[100, 1000], [1e10, 1e-10]])
         return scp.special.logsumexp(a, axis=-1, keepdims=True)
 
-    @testing.with_requires('scipy>=1.13')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-6)
     def test_array_inputs(self, xp, scp, dtype):
@@ -97,7 +95,7 @@ class TestLogsumexp:
         b = xp.array([1, 0], dtype=dtype)
         return scp.special.logsumexp(a, b=b)
 
-    @testing.with_requires('scipy>=1.13')
+    @testing.with_requires('scipy')
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_b_multi_dims(self, xp, scp, dtype):
@@ -111,12 +109,3 @@ class TestLogsumexp:
     def test_special_values(self, xp, scp):
         a = xp.array([cupy.inf, -cupy.inf, cupy.nan, -cupy.nan])
         return scp.special.logsumexp(a)
-
-    # TODO(asi1024): Fix after initial_value is supported in cupy.max
-    @testing.with_requires('scipy<1.14')
-    @testing.for_all_dtypes(no_bool=True)
-    def test_empty_array_inputs(self, dtype):
-        a = numpy.array([], dtype=dtype)
-        for xp in (scipy, cupyx.scipy):
-            with pytest.raises(ValueError):
-                xp.special.logsumexp(a)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_polygamma.py
@@ -11,7 +11,7 @@ import pytest
 import warnings
 
 
-@testing.with_requires("scipy>=1.14")
+@testing.with_requires("scipy")
 class TestPolygamma(unittest.TestCase):
 
     @testing.for_all_dtypes(no_complex=True)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_statistics.py
@@ -21,15 +21,15 @@ class _TestBase:
     def test_ndtri(self):
         self.check_unary_linspace0_1('ndtri')
 
-    @testing.with_requires("scipy>=1.14")
+    @testing.with_requires("scipy")
     def test_logit(self):
         self.check_unary_lower_precision('logit')
 
-    @testing.with_requires("scipy>=1.14")
+    @testing.with_requires("scipy")
     def test_expit(self):
         self.check_unary_lower_precision('expit')
 
-    @testing.with_requires("scipy>=1.14")
+    @testing.with_requires("scipy")
     def test_log_expit(self):
         self.check_unary_lower_precision('log_expit')
 
@@ -237,12 +237,11 @@ class TestThreeArgumentDistributions(_TestDistributionsBase):
         x = x[xp.newaxis, xp.newaxis, :]
         return func(a, b, x)
 
-    # omit test with scipy < 1.5 due to change in ufunc type signatures
     @pytest.mark.parametrize('function', ['bdtr', 'bdtrc', 'bdtri'])
     @testing.for_float_dtypes()
     @testing.for_signed_dtypes(name='int_dtype')
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    @testing.with_requires('scipy>=1.5.0')
+    @testing.with_requires('scipy')
     @pytest.mark.skipif(cupy.cuda.runtime.is_hip,
                         reason="avoid failures observed on HIP")
     def test_binomdist_linspace(self, xp, scp, function, dtype, int_dtype):

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_ufunc_dispatch.py
@@ -26,7 +26,7 @@ except ImportError:
     cupyx_scipy_ufuncs = set()
 
 
-@testing.with_requires("scipy>=1.12.0rc1")
+@testing.with_requires("scipy")
 @pytest.mark.parametrize("ufunc", sorted(cupyx_scipy_ufuncs & scipy_ufuncs))
 class TestUfunc:
     def _should_skip(self, f):

--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_stats.py
@@ -128,7 +128,7 @@ class TestZmap:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zmap_nan_policy_propagate(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         y = xp.array([xp.nan, -4.0, -1.0, -5.0], dtype=dtype)
@@ -137,7 +137,7 @@ class TestZmap:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zmap_nan_policy_omit(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         y = xp.array([xp.nan, -4.0, -1.0, -5.0], dtype=dtype)
@@ -145,14 +145,14 @@ class TestZmap:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zmap_nan_policy_omit_axis_ddof(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         y = xp.array([xp.nan, -4.0, -1.0, -5.0], dtype=dtype)
         return scp.stats.zmap(x, y, axis=0, ddof=1, nan_policy='omit')
 
     @testing.for_dtypes('fdFD')
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zmap_nan_policy_raise(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3], dtype=dtype)
@@ -223,7 +223,7 @@ class TestZscore:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zscore_nan_policy_propagate(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         with numpy.errstate(invalid='ignore'):  # numpy warns with complex
@@ -231,20 +231,20 @@ class TestZscore:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zscore_nan_policy_omit(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         return scp.stats.zscore(x, nan_policy='omit')
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zscore_nan_policy_omit_axis_ddof(self, xp, scp, dtype):
         x = xp.array([4.0, 1.0, 1.0, xp.nan], dtype=dtype)
         return scp.stats.zscore(x, axis=0, ddof=1, nan_policy='omit')
 
     @testing.for_dtypes('fdFD')
-    @testing.with_requires('scipy>=1.7')
+    @testing.with_requires('scipy')
     def test_zscore_nan_policy_raise(self, dtype):
         for xp, scp in [(numpy, scipy), (cupy, cupyx.scipy)]:
             x = xp.array([1, 2, 3, xp.nan], dtype=dtype)

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -144,7 +144,7 @@ class TestCsrmm2:
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(3, 4), (4, 3)]
 }))
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestCsrgeam:
 
     alpha = 0.5
@@ -277,7 +277,7 @@ class TestCsrgemm:
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(2, 3, 4), (4, 3, 2)]
 }))
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestCsrgemm2:
 
     alpha = 0.5
@@ -373,7 +373,7 @@ class TestCsrgemm2InvalidCases:
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
     'shape': [(2, 3, 4), (4, 3, 2), (100000, 100000, 50)]
 }))
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestSpgemm:
 
     alpha = 0.5
@@ -633,7 +633,7 @@ class TestCscsort:
     'shape': [(3, 2), (4, 3)],
     'format': ['csr', 'csc', 'coo'],
 }))
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestSpmv:
 
     alpha = 0.5
@@ -735,7 +735,7 @@ class TestErrorSpmv:
     'dims': [(2, 3, 4), (3, 4, 2)],
     'format': ['csr', 'csc', 'coo'],
 }))
-@testing.with_requires('scipy>=1.2.0')
+@testing.with_requires('scipy')
 class TestSpmm:
 
     alpha = 0.5


### PR DESCRIPTION
This ended up being a lot more involved than I was expecting, but it feels good to remove things and clean things up!

- setup.py: scipy>=1.10 -> scipy>=1.14
- pretest.yml: bump CI pins to numpy==2.0 / scipy==1.14 (match setup.py floor)
- pyproject.toml: drop two filterwarnings entries for scipy modules that no longer emit (or no longer exist) on supported scipy versions
- cupyx/scipy/fft: drop _scipy_150/_scipy_160 flags, the fht-as-version-probe in _fftlog.py, the deprecated `plan` warning, and the scipy<1.4 early raise in sparse/_index.py
- docs/source/upgrade.rst: add the SciPy 1.13-or-earlier bullet and the NumPy/SciPy Baseline API Update section
- tests: replace @testing.with_requires('scipy>=X.Y') with @testing.with_requires('scipy') wherever X.Y ≤ 1.14 (preserves the install-time gate); delete tests, branches, and stale comments that are unreachable under the new floor (_skip_forward_backward + 9 setUp fixtures, _conditional_scipy_version_skip, scipy_cplx_bug, scipy<1.0 int-dtype shims, scipy<1.11 LOBPCG helpers, scipy<1.14 .A tests, medfilt_no_complex methods, "SciPy 1.6.1 / CUDA 11.0" tolerance notes, etc.)