### PR TITLE
TST: Work around NumPy 2.4.5 regression in conj().

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -13,6 +13,8 @@ class TestConj:
     @testing.numpy_cupy_array_almost_equal()
     def test_conj(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
+        if xp is numpy and numpy.__version__ == "2.4.5" and x.dtype == bool:
+            return x  # NumPy 2.4.5 had a regression for bool_arr.conj()
         return x.conj()
 
     @testing.for_all_dtypes(no_complex=True)
@@ -20,6 +22,8 @@ class TestConj:
     def test_conj_pass(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         y = x.conj()
+        if xp is numpy and numpy.__version__ == "2.4.5":
+            return x  # NumPy 2.4.5 had a regression for bool_arr.conj()
         assert x is y
         return y
 
@@ -27,6 +31,8 @@ class TestConj:
     @testing.numpy_cupy_array_almost_equal()
     def test_conjugate(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
+        if xp is numpy and numpy.__version__ == "2.4.5" and x.dtype == bool:
+            return x  # NumPy 2.4.5 had a regression for bool_arr.conj()
         return x.conjugate()
 
     @testing.for_all_dtypes(no_complex=True)
@@ -34,6 +40,8 @@ class TestConj:
     def test_conjugate_pass(self, xp, dtype):
         x = testing.shaped_arange((2, 3), xp, dtype)
         y = x.conjugate()
+        if xp is numpy and numpy.__version__ == "2.4.5":
+            return x  # NumPy 2.4.5 had a regression for bool_arr.conj()
         assert x is y
         return y
 

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -192,6 +192,11 @@ class TestConvolveCorrelate2D:
             pytest.skip('fillvalue overflow')
         in1 = testing.shaped_random(self.size1, xp, dtype)
         in2 = testing.shaped_random(self.size2, xp, dtype)
+
+        if xp is np and np.__version__ == "2.4.5" and in1.dtype == bool:
+            # A NumPy regression causes SciPy to promote bool to int8:
+            raise ValueError("unsupported type in SciPy")
+
         return getattr(scp.signal, func)(in1, in2, self.mode, self.boundary,
                                          self.fillvalue)
 


### PR DESCRIPTION
NumPy has a pretty bad regression in `arr.conj()` causing it to use the ufunc path almost always.
The ufunc path has two problems (a) it creates copies, and (b) it has no bool version leading to knock on effects in SciPy.