### PR TITLE
Provide HIPRTC fallback for cupy.ndarray.byteswap

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2606,9 +2606,38 @@ cdef fill_kernel = ElementwiseKernel('T x', 'T y', 'y = x', 'cupy_fill')
 
 cdef _byteswap_kernel = ElementwiseKernel(
     'T x', 'T y',
-    'y = cuda::std::byteswap(x)',
+    'y = cupy_byteswap(x)',
     'cupy_byteswap',
-    preamble='#include <cuda/std/bit>')
+    preamble='''
+#ifdef __HIPCC_RTC__
+// HIPRTC lacks <cuda/std/bit> and <bit>; use clang builtins.
+template <typename T>
+__device__ inline T cupy_byteswap(T x) {
+    if constexpr (sizeof(T) == 2) {
+        return static_cast<T>(
+            __builtin_bswap16(static_cast<unsigned short>(x)));
+    } else if constexpr (sizeof(T) == 4) {
+        return static_cast<T>(
+            __builtin_bswap32(static_cast<unsigned int>(x)));
+    } else if constexpr (sizeof(T) == 8) {
+        return static_cast<T>(
+            __builtin_bswap64(static_cast<unsigned long long>(x)));
+    } else {
+        static_assert(
+            false,
+            "cupy_byteswap: only 16, 32, and 64 bit integer types "
+            "are supported under HIPRTC");
+    }
+}
+#else
+#include <cuda/std/bit>
+#include <cuda/std/utility>
+template <typename T>
+__device__ inline auto cupy_byteswap(T&& x) {
+    return cuda::std::byteswap(cuda::std::forward<T>(x));
+}
+#endif
+''')
 
 
 cdef _byteswap_dispatch(_ndarray_base a):


### PR DESCRIPTION
The _byteswap_kernel ElementwiseKernel in cupy/_core/core.pyx is implemented as 'y = cuda::std::byteswap(x)' with '#include <cuda/std/bit>' in the preamble. Both the CCCL <cuda/std/bit> header and the C++23 <bit> header are unavailable under HIPRTC, so on a HIP build any call to cupy.ndarray.byteswap fails compilation with:

    fatal error: 'cuda/std/bit' file not found

Refactor the kernel to call a local cupy_byteswap helper and select its implementation in the preamble:

  - Under __HIPCC_RTC__ implement cupy_byteswap with the clang __builtin_bswap{16,32,64} intrinsics, dispatched on sizeof(T) via if constexpr. _byteswap_dispatch only invokes the kernel with unsigned-integer types of width 16, 32 or 64 bits, so this fully covers the supported call sites. An else branch with a plain static_assert(false, ...) rejects any other instantiation at compile time so a future caller that happens to wire in e.g. an 8- or 128-bit type fails loudly here instead of silently producing garbage.

  - Under NVRTC keep using cuda::std::byteswap from <cuda/std/bit>, but forward through a thin wrapper that takes a forwarding reference and perfect-forwards via cuda::std::forward (from <cuda/std/utility>). For the integral types byteswap is defined on this is mostly a cosmetic / consistency change with the standard wrapper pattern, but it preserves value category and avoids any extra copy if a caller ever passes an rvalue.