### PR TITLE
Drop stale xfail on TestRand{int,omIntegers}2.test_goodness_of_fit_2

### DIFF
--- a/tests/cupy_tests/random_tests/test_sample.py
+++ b/tests/cupy_tests/random_tests/test_sample.py
@@ -4,11 +4,9 @@ import unittest
 from unittest import mock
 
 import numpy
-import pytest
 
 import cupy
 from cupy import cuda
-from cupy.cuda import runtime
 from cupy import random
 from cupy import testing
 from cupy.testing import _condition
@@ -100,7 +98,6 @@ class TestRandint2(unittest.TestCase):
         assert _hypothesis.chi_square_test(counts, expected)
 
     @_condition.repeat(3, 10)
-    @pytest.mark.xfail(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_goodness_of_fit_2(self):
         mx = 5
         vals = random.randint(mx, size=(5, 20)).get()
@@ -194,7 +191,6 @@ class TestRandomIntegers2(unittest.TestCase):
         assert _hypothesis.chi_square_test(counts, expected)
 
     @_condition.repeat(3, 10)
-    @pytest.mark.xfail(runtime.is_hip, reason='ROCm/HIP may have a bug')
     def test_goodness_of_fit_2(self):
         mx = 5
         vals = random.randint(0, mx, (5, 20)).get()


### PR DESCRIPTION
Both tests were marked xfail on ROCm/HIP with 'may have a bug' and no investigation. Under xfail_strict=True they now report XPASS(strict) because they pass on HIP. Drop the markers and the now-unused pytest and runtime imports.