### PR TITLE
Skip/xfail interpolate tests on HIP (no spsolve)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_fitpack2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_fitpack2.py
@@ -12,6 +12,9 @@ except ImportError:
     pass
 
 
+@pytest.mark.skipif(
+    cupy.cuda.runtime.is_hip,
+    reason='UnivariateSpline needs spsolve (no HIP backend)')
 @testing.with_requires("scipy")
 class TestUnivariateSpline:
 

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
@@ -17,6 +17,10 @@ import itertools
 
 
 @testing.with_requires('scipy')
+@pytest.mark.xfail(
+    runtime.is_hip, strict=False,
+    raises=(AssertionError, NotImplementedError),
+    reason='make_interp_spline needs spsolve (no HIP backend)')
 class TestNdBSpline:
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_1D(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
@@ -621,6 +621,9 @@ class TestAkima1D:
 
 
 @testing.with_requires("scipy")
+@pytest.mark.xfail(
+    runtime.is_hip, strict=False, raises=AssertionError,
+    reason='CubicSpline n>3 needs spsolve (no HIP backend)')
 class TestCubicSpline:
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=2e-14)
     @pytest.mark.parametrize('n', [2, 3, 8])    # 8 is x.size
@@ -751,6 +754,10 @@ class TestCubicSpline:
         return S(q)
 
 
+@pytest.mark.xfail(
+    runtime.is_hip, strict=False,
+    raises=(AssertionError, NotImplementedError),
+    reason='quadratic/cubic interp1d needs spsolve (no HIP backend)')
 class TestInterp1D:
 
     def setup_method(self):

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
@@ -490,6 +490,9 @@ class TestRegularGridInterpolator:
         v2 = cp.expand_dims(vs, axis=0)
         assert_allclose(v, v2, atol=1e-14, err_msg=method)
 
+    @pytest.mark.xfail(
+        runtime.is_hip, strict=True, raises=NotImplementedError,
+        reason='make_ndbspl needs spsolve (no HIP backend)')
     def test_derivatives(self):
         points, values = self._get_sample_4d()
         sample = cp.array([[0.1, 0.1, 1., 0.9],


### PR DESCRIPTION
Symptom
-------
On ROCm 7.x:
  tests/cupyx_tests/scipy_tests/interpolate_tests/test_polyint.py
  ::TestCubicSpline::*
  ::TestInterp1D::*
  tests/cupyx_tests/scipy_tests/interpolate_tests/test_ndbspline.py
  ::TestNdBSpline::*
  tests/cupyx_tests/scipy_tests/interpolate_tests/test_rgi.py
  ::TestRegularGridInterpolator::test_derivatives
  tests/cupyx_tests/scipy_tests/interpolate_tests/test_fitpack2.py
  ::TestUnivariateSpline::*
fail with

  AssertionError: Only cupy raises error
  NotImplementedError
    File '.../cupyx/scipy/sparse/linalg/_solve.py', line 504, in spsolve
      raise NotImplementedError

The call chain in every case ultimately reaches spsolve:

  {CubicSpline,interp1d(kind={quadratic,cubic}),NdBSpline,
   UnivariateSpline}(...)
    -> make_interp_spline / make_splrep / set_smoothing_factor
    -> _bspline2.py  coef = spsolve(matr, rhs)

  RegularGridInterpolator(method='slinear').__call__(..., method=...,
                                                    return_derivatives=True)
    -> make_ndbspl(...)
    -> _bspline2.py  coef = spsolve(matr, rhs)

  -> _solve.py:503  if not cupyx.cusolver.check_availability('csrlsvqr'):
                        raise NotImplementedError

(scipy succeeds via SuperLU; cupy raises because csrlsvqr is the only HIP-side spsolve path and rocSOLVER ships no csrlsvqr equivalent.)

Why no HIP equivalent exists
----------------------------
Probed ROCm 7.2.0 (/opt/rocm-7.2.0/include/rocsolver/, rocsparse/):

  * rocSOLVER ships no csrlsvqr / sparse exact factor-and-solve.
  * rocSPARSE ships sparse triangular solvers (rocsparse_?csrsv_solve, rocsparse_?csrsm_solve, rocsparse_spsv, rocsparse_spsm) and incomplete LU (rocsparse_?csrilu0), but no exact direct sparse factorization. cupy_backends/hip/ cupy_rocsolver.h consequently stubs cusolverSp?csrlsvqr to rocblas_status_not_implemented (lines 2124-2136), and CuPy's spsolve raises NotImplementedError before any GPU work runs.

Fix
---
Mark the affected tests xfail on HIP. strict=False where the test class has parametrisations that don't lower through make_interp_spline / make_ndbspl, so they don't XPASS-fail under pyproject.toml's xfail_strict=true. strict=True where the test is a single method that always hits spsolve.

  * TestCubicSpline:                raises=AssertionError
                                    strict=False
  * TestInterp1D:                   raises=(AssertionError, NotImplementedError)
                                    strict=False (linear/slinear/zero/
                                    nearest/previous/next pass; quadratic
                                    and cubic xfail)
  * TestNdBSpline:                  raises=(AssertionError, NotImplementedError)
                                    strict=False (analytic paths pass)
  * TestRegularGridInterpolator
    ::test_derivatives:             raises=NotImplementedError
                                    strict=True (always hits make_ndbspl)

For TestUnivariateSpline use skipif rather than xfail: every test in the class constructs a UnivariateSpline (set_smoothing_factor -> make_splrep -> make_interp_spline -> spsolve), so the failure mode is structural and per-test xfail would be churn to undo once spsolve has a hipSOLVER-backed path.

Supersedes #102, #103, #122 (TestInterp1D, TestNdBSpline and TestUnivariateSpline as standalone PRs) and absorbs the test_rgi half of #104 (test_delaunay's SIGABRT skip stays on #104 because it has a different root cause). The rocSOLVER-spsolve gap is documented in this single commit so the follow-up (write sparse QR ourselves or wire csrilu0 + csrsv for an iterative spsolve) has one tracking point.