### PR TITLE
Skip TestUnivariateSpline on HIP (spsolve / csrlsvqr unavailable)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_fitpack2.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_fitpack2.py
@@ -12,6 +12,19 @@ except ImportError:
     pass
 
 
+@pytest.mark.skipif(
+    cupy.cuda.runtime.is_hip,
+    reason=(
+        'TestUnivariateSpline is skipped on ROCm/HIP because the '
+        'UnivariateSpline construction path goes through '
+        'cupyx.scipy.sparse.linalg.spsolve, which requires the '
+        'cuSOLVER csrlsvqr routine. hipSOLVER does not currently '
+        'expose an equivalent, so spsolve raises NotImplementedError '
+        'and every test that constructs a UnivariateSpline (i.e. '
+        'almost every test in this class) fails the '
+        'numpy_cupy_allclose harness with "Only cupy raises error". '
+        'Re-enable on HIP once cupyx.scipy.sparse.linalg.spsolve has '
+        'a hipSOLVER-backed path.'))
 @testing.with_requires("scipy")
 class TestUnivariateSpline:
 


### PR DESCRIPTION
Every test in TestUnivariateSpline constructs a UnivariateSpline, which triggers the construction path

    UnivariateSpline.__init__
      → set_smoothing_factor
        → make_splrep
          → make_interp_spline
            → cupyx.scipy.sparse.linalg.spsolve

cupyx.scipy.sparse.linalg.spsolve in turn requires the cuSOLVER csrlsvqr routine via cupyx.cusolver.check_availability('csrlsvqr'); hipSOLVER does not currently expose an equivalent, so on HIP every spsolve call raises NotImplementedError. Each affected test fails the numpy_cupy_allclose harness with

    AssertionError: Only cupy raises error
    ...
    File '.../cupyx/scipy/sparse/linalg/_solve.py', line 504, in spsolve
      raise NotImplementedError

reproduced for at least

    test_set_smoothing_factor
    test_integral_out_of_bounds[...]
    test_out_of_range_regression[...-UnivariateSpline]
    test_out_of_range_regression[...-InterpolatedUnivariateSpline]

and almost certainly the other test_* methods in the class as well.

Skip the whole class on HIP rather than per-test, because the failure mode is structural (the entire spsolve dependency is missing) and applying skipif to each affected method would be churn that we'd want to undo wholesale once spsolve has a hipSOLVER backing.

The skip should be removed once cupyx.scipy.sparse.linalg.spsolve grows a hipSOLVER-backed path or a CPU fallback for the small dense-RHS case used here.