### PR TITLE
Define NULL in cupyx.scipy.spatial Delaunay kernel string

### DIFF
--- a/cupyx/scipy/spatial/delaunay_2d/_kernels.py
+++ b/cupyx/scipy/spatial/delaunay_2d/_kernels.py
@@ -7,6 +7,11 @@ from cupyx.scipy.spatial.delaunay_2d._schewchuk import SCHEWCHUK_DEF
 
 KERNEL_DIVISION = SCHEWCHUK_DEF + r"""
 
+// HIPRTC doesn't define NULL; kernel uses it as a sentinel pointer.
+#ifndef NULL
+#define NULL nullptr
+#endif
+
 #define INLINE_H_D __forceinline__ __device__
 #define DIM     2
 #define DEG     ( DIM + 1 )


### PR DESCRIPTION
The 3000-line Delaunay 2D kernel built from KERNEL_DIVISION in cupyx/scipy/spatial/delaunay_2d/_kernels.py uses NULL as a sentinel pointer in ~20 places (typically as out-arguments to nested device helpers, e.g. orgPointIdx != NULL, dbgCircleCountArr = NULL, ...).

NVRTC kernels happen to compile because cuda_runtime.h transitively pulls in <cstddef> which exposes NULL. HIPRTC does not -- its hiprtc_runtime.h does not provide NULL or include <cstddef> -- and the kernel fails to compile with

    error: use of undeclared identifier 'NULL'

reproduced ~20 times (once per call site), surfaced by any test that exercises the Delaunay 2D triangulation path through cupyx.scipy.spatial (test_qhull etc.).

Add a small '#ifndef NULL / #define NULL nullptr' header at the top of the kernel string, after the SCHEWCHUK_DEF prefix and before any code that references NULL. nullptr is recognised by both nvrtc and hiprtc as C++11, the macro guard avoids redefinition if a future nvrtc/hiprtc release does start providing NULL implicitly, and pointer comparisons of the form 'p != NULL' continue to work because nullptr is implicitly convertible to any pointer type.