### PR TITLE
cuda_workaround.h: enable std::is_signed et al. on HIPRTC

### DIFF
--- a/cupy/_core/include/cupy/hip_workaround.cuh
+++ b/cupy/_core/include/cupy/hip_workaround.cuh
@@ -1,6 +1,15 @@
 #ifndef INCLUDE_GUARD_CUPY_HIP_WORKAROUND_H
 #define INCLUDE_GUARD_CUPY_HIP_WORKAROUND_H
 
+#ifdef __HIPCC_RTC__
+
+// Pull in libstdc++ headers so kernel code can use std::is_signed,
+// std::declval, etc. under HIPRTC just like on NVRTC.
+#include <type_traits>
+#include <utility>
+
+#endif  // __HIPCC_RTC__
+
 #ifdef __HIP_DEVICE_COMPILE__
 
 // Determine whether native __shfl_*_sync functions are available.


### PR DESCRIPTION
NVRTC and HIPRTC both ship minimal STL: standard type-trait templates (std::is_signed, std::enable_if, std::declval, ...) that CuPy kernels routinely need aren't in scope by default. Each runtime needs a different shim:

  * NVRTC -- already handled. cuda_workaround.h pulls libcu++ in via <cuda/std/type_traits> et al. and re-exports each trait into namespace std via using-declarations, so kernel code can spell `std::is_signed<T>` and have it resolve to cuda::std::is_signed.

  * HIPRTC -- new. Clang's HIP mode picks up libstdc++'s host headers via the system gcc include search paths, but only if something explicitly includes them. Pull <type_traits> and <utility> in from this header so the same `std::is_signed<T>` spelling works on HIPRTC without any cupy-specific namespace at the call site.

Net result: kernel code that includes cuda_workaround.h can use `std::is_signed<T>`, `std::declval<T>()`, etc. uniformly on both backends.