### PR TITLE
Replace deprecated HIP API calls with their non-deprecated equivalents

### DIFF
--- a/cupy_backends/hip/cupy_hip.h
+++ b/cupy_backends/hip/cupy_hip.h
@@ -19,7 +19,10 @@ CUresult cuGetErrorString(CUresult hipError, const char** pStr) {
 
 // Primary context management
 CUresult cuDevicePrimaryCtxRelease(CUdevice dev) {
-    return hipDevicePrimaryCtxRelease(dev);
+    // HIP documents this as a no-op that always returns hipSuccess;
+    // marked [[deprecated]] in recent ROCm. Replicate inline.
+    (void)dev;
+    return CUDA_SUCCESS;
 }
 
 // Context management

--- a/cupy_backends/hip/cupy_hipsparse.h
+++ b/cupy_backends/hip/cupy_hipsparse.h
@@ -3034,7 +3034,8 @@ typedef enum {} cusparseFormat_t;
 typedef enum {} cusparseOrder_t;
 static hipsparseOrder_t convert_hipsparseOrder_t(cusparseOrder_t type) {
     switch(static_cast<int>(type)) {
-        case 1 /* CUSPARSE_ORDER_COL */: return HIPSPARSE_ORDER_COLUMN;
+        // hipSPARSE renamed HIPSPARSE_ORDER_COLUMN -> _COL (same value).
+        case 1 /* CUSPARSE_ORDER_COL */: return HIPSPARSE_ORDER_COL;
         case 2 /* CUSPARSE_ORDER_ROW */: return HIPSPARSE_ORDER_ROW;
         default: throw std::runtime_error("unrecognized type");
     }

--- a/cupy_backends/hip/cupy_profiler.h
+++ b/cupy_backends/hip/cupy_profiler.h
@@ -2,15 +2,21 @@
 #define INCLUDE_GUARD_HIP_CUPY_PROFILER_H
 
 #include "cupy_hip_common.h"
+// roctracer_start / _stop replace deprecated hipProfilerStart / _Stop
+// (libroctracer64 added to the HIP_cuda_nvtx_cusolver link
+// group in install/cupy_builder/_features.py.
+#include <roctracer/roctracer_ext.h>
 
 extern "C" {
 
 cudaError_t cudaProfilerStart() {
-  return hipProfilerStart();
+  roctracer_start();
+  return hipSuccess;
 }
 
 cudaError_t cudaProfilerStop() {
-  return hipProfilerStop();
+  roctracer_stop();
+  return hipSuccess;
 }
 
 } // extern "C"

--- a/install/cupy_builder/_features.py
+++ b/install/cupy_builder/_features.py
@@ -185,6 +185,7 @@ def get_features(ctx: Context) -> dict[str, Feature]:
             'hiprand',
             'hipsparse',
             'rocfft',
+            'roctracer64',  # cudaProfilerStart/Stop -> roctracer_start/stop
             'roctx64',
             'rocblas',
             'rocsolver',


### PR DESCRIPTION
Three host-side deprecation warnings surface when cupy is built against ROCm 7.x:

  1. cupy_backends/hip/cupy_hip.h: 'hipDevicePrimaryCtxRelease' is marked [[deprecated]]. AMD's own header documents this function as a no-op on the HIP/HIP-CLANG path:

         @warning This function returns #hipSuccess though doesn't release
                  the primaryCtx by design on HIP/HIP-CLANG path.

         @warning This API is deprecated on the AMD platform, only for
                  equivalent driver API on the NVIDIA platform.

     Replicate the documented no-op behavior locally and return CUDA_SUCCESS directly. No functional change relative to the previous wrapper, but the deprecation warning is gone and we no longer depend on a symbol AMD has flagged for removal.

  2. cupy_backends/hip/cupy_profiler.h: 'hipProfilerStart' / 'hipProfilerStop' are marked [[deprecated]] (pointing to 'roctracer/rocTX'). The documented direct replacement that matches CUDA's cudaProfilerStart/Stop semantics (a global tracing on/off switch, not a range-based mark) is roctracer_start / roctracer_stop, declared in <roctracer/roctracer_ext.h>. Switch the wrappers to call those, include the header, and add 'roctracer64' to the HIP_cuda_nvtx_cusolver link group in install/cupy_builder/_features.py so libroctracer64 is linked into the modules that need it.

  3. cupy_backends/hip/cupy_hipsparse.h: hipSPARSE renamed HIPSPARSE_ORDER_COLUMN to HIPSPARSE_ORDER_COL and marked the old spelling [[deprecated]]; both refer to the same enumerator (= 1) in any release that exposes the new name, so a verbatim rename is safe.

These are real updates rather than '#pragma GCC diagnostic ignored "-Wdeprecated-declarations"' suppressions: the call sites stop using deprecated APIs entirely.