### PR TITLE
FeistelBijection RawKernel: select <stdint.h> on HIP, keep <cuda/std/cstdint> on CUDA

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -1165,7 +1165,11 @@ cdef class FeistelBijection:
         global _feistel_bijection_with_cutoff_kernel
         if _feistel_bijection_with_cutoff_kernel is None:
             _feistel_bijection_with_cutoff_kernel = cupy.RawKernel(rf'''
+            #if defined(__HIPCC_RTC__) || defined(__HIPCC__)
+            #include <stdint.h>
+            #else
             #include <cuda/std/cstdint>
+            #endif
 
             struct FeistelParams {{
                 uint64_t __R_bits_;


### PR DESCRIPTION
The Feistel bijection kernel backing cupy.random.choice with replace=False on very large domains is JIT-compiled via cupy.RawKernel and previously hard-coded `#include <cuda/std/cstdint>`. CCCL's <cuda/std/cstdint> ships with NVRTC; HIPRTC does not ship the cuda/std/* headers at all, so the kernel failed to compile on HIP with

    fatal error: 'cuda/std/cstdint' file not found

reproduced by tests/cupy_tests/random_tests/test_generator.py:: TestChoiceReplaceFalseVeryLargeDomain::test_near_32bit_limit (and any other choice() call that needs a Feistel bijection on HIP).

Approach
--------
The kernel only needs uint32_t / uint64_t in the global namespace. The simplest fix would be to switch unconditionally to <stdint.h>:

    NVRTC : bundles its own <stdint.h>                -> uint{32,64}_t available
    HIPRTC: bundles clang's <stdint.h>                -> uint{32,64}_t available

i.e. both runtimes already ship <stdint.h> and the kernel would compile identically on both with a single-line change. We could just do that, and an earlier revision of this PR did.

However, the kernel was originally written with libcu++ specifically (<cuda/std/cstdint>, not <cstdint> or <stdint.h>), which signals an intentional preference for CCCL on the CUDA side -- consistent with the rest of CCCL usage in cupy. To preserve that signal while still unblocking HIP, gate per backend with the same preprocessor pattern already used in cupy/_core/include/cupy/carray.cuh:81 and bfloat16.cuh:5:

    #if defined(__HIPCC_RTC__) || defined(__HIPCC__)
    #include <stdint.h>
    #else
    #include <cuda/std/cstdint>
    #endif

If a future cleanup wants to standardise on <stdint.h> for both backends -- which would be technically equivalent for this kernel's needs -- the gate can be collapsed at that time.