### PR TITLE
Resolve symlinks when deriving ROCm install path from hipcc

### DIFF
--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -217,10 +217,12 @@ def _get_rocm_path():
     if os.path.exists(rocm_path):
         return rocm_path
 
-    # Use hipcc path
+    # Resolve hipcc symlinks (distros expose /usr/bin/hipcc ->
+    # /opt/rocm-X.Y/bin/hipcc via update-alternatives).
     hipcc_path = shutil.which('hipcc')
     if hipcc_path is not None:
-        return os.path.dirname(os.path.dirname(hipcc_path))
+        return os.path.dirname(
+            os.path.dirname(os.path.realpath(hipcc_path)))
 
     # Use typical path
     if os.path.exists('/opt/rocm'):


### PR DESCRIPTION
cupy._environment._get_rocm_path() falls back to deriving the ROCm install root from the location of the hipcc binary on PATH:

    hipcc_path = shutil.which('hipcc')
    return os.path.dirname(os.path.dirname(hipcc_path))

That assumes 'hipcc' on PATH lives directly at <ROCM>/bin/hipcc. On distros that expose ROCm tooling via update-alternatives -- which includes Debian / Ubuntu, where ROCm packages drop entries in /etc/alternatives -- 'hipcc' on PATH is actually a symlink chain like

    /usr/bin/hipcc -> /etc/alternatives/hipcc -> /opt/rocm-7.2.0/bin/hipcc

shutil.which() returns the first match it finds (/usr/bin/hipcc), so without resolving the chain the function walks two parent directories up to '/usr' and reports that as the ROCm install root. Every downstream consumer that constructs paths under '<ROCM>/include' then misses the real layout: in particular _get_cub_path() looks for /usr/include/hipcub, doesn't find it, returns None, and the rest of cupy proceeds with the (silent) RuntimeWarning

    RuntimeWarning: CUB headers are not found.

This causes the block-CUB reduction path in cupy._core._cub_reduction to fall back instead of using hipCUB. Tests in TestCubReduction (e.g. test_cub_min, test_cub_max) that mock
_SimpleCubReductionKernel_get_cached_function then see call_count == 0 where they expect 1 or 2, fail their AssertFunctionIsCalled assertion, and the leaked accelerator state can cascade into surprising failures in tests that run later (test_meanvar.py::test_median_nan, test_userkernel.py).

Resolve the symlink with os.path.realpath() before walking up. Verified on this system that 'shutil.which(hipcc)' returns '/usr/bin/hipcc' and the corrected expression now yields '/opt/rocm-7.2.0', under which 'include/hipcub' exists. Distros that ship hipcc directly under <ROCM>/bin (no symlink) are unaffected because realpath() on a non-symlink is the identity.