### PR TITLE
Make bspline QR helpers __device__ instead of __global__

### DIFF
--- a/cupyx/scipy/interpolate/_bspline2.py
+++ b/cupyx/scipy/interpolate/_bspline2.py
@@ -551,7 +551,7 @@ typedef long long ssize_t ;
  *
  */
 template<typename T>
-__global__ void
+__device__ void
 dlartg(T *f, T *g, T *cs, T *sn, T *r) {
 
     if (*g == 0) {
@@ -585,7 +585,7 @@ dlartg(T *f, T *g, T *cs, T *sn, T *r) {
  * Givens-rotate a pair [f, g] -> [f_out, g_out]
  */
 template<typename T>
-__global__ void
+__device__ void
 fprota(T c, T s, T f, T g, T *f_out, T *g_out) {
     *f_out =  c*f + s*g;
     *g_out = -s*f + c*g;
@@ -714,8 +714,7 @@ TYPES = ['double']
 
 QR_MODULE = cupy.RawModule(
     code=QR_KERNEL, options=('-std=c++17',),
-    name_expressions=[
-        f'dlartg<{type_name}>' for type_name in TYPES] + ['qr_reduce'],
+    name_expressions=['qr_reduce'],
 )
 
 


### PR DESCRIPTION
The QR triangularization RawKernel module used by
cupyx.scipy.interpolate's spline-fit machinery defines two helper functions, dlartg and fprota, with the __global__ qualifier:

    template<typename T>
    __global__ void
    dlartg(T *f, T *g, T *cs, T *sn, T *r) { ... }

    template<typename T>
    __global__ void
    fprota(T c, T s, T f, T g, T *f_out, T *g_out) { ... }

Both are called as plain function calls from inside the qr_reduce kernel:

    dlartg(&a[IDX(j, 0, nz)], ... );
    fprota(c, s, ... );

NVRTC tolerates this -- nvcc treats the call as if dlartg / fprota were __device__ in this context. HIP-clang (HIPRTC) does not: it interprets a __global__ function called from another __global__ function as a device-side launch and rejects the call:

    error: no matching function for call to 'dlartg'
    note: candidate function not viable: call to __global__ function
          from __global__ function

reproduced in any test that exercises the spline solver, e.g.

    test_fitpack2.py::TestUnivariateSpline::test_set_smoothing_factor
    test_fitpack2.py::TestUnivariateSpline::test_integral_out_of_bounds[*]
    test_fitpack2.py::TestUnivariateSpline::test_out_of_range_regression[*]
    test_interpnd.py::TestLinearNDInterpolator::test_interpolate

Both helpers are only used as inline implementation details of qr_reduce; neither is ever launched from host. Change both to __device__ so HIP-clang accepts them. Drop the now-stale 'dlartg<{T}>' entries from the QR_MODULE name_expressions list -- those existed only to expose host-callable mangled names that we no longer need.