### PR TITLE
Fix bincount with empty input array

### DIFF
--- a/cupy/_statistics/histogram.py
+++ b/cupy/_statistics/histogram.py
@@ -552,6 +552,11 @@ def bincount(x, weights=None, minlength=None):
         if minlength < 0:
             raise ValueError('minlength must be non-negative')
 
+    if x.size == 0:
+        size = minlength if minlength is not None else 0
+        # NumPy returns intp dtype for empty input even when weights is given
+        return cupy.zeros((size,), dtype=numpy.intp)
+
     size = int(cupy.max(x)) + 1  # synchronize!
     if minlength is not None:
         size = max(size, minlength)

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -329,6 +329,25 @@ class TestHistogram(unittest.TestCase):
             with pytest.raises((ValueError, TypeError)):
                 xp.bincount(x, minlength=-1)
 
+    @for_all_dtypes_bincount()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty(self, xp, dtype):
+        x = xp.array([], dtype)
+        return xp.bincount(x)
+
+    @for_all_dtypes_bincount()
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty_with_minlength(self, xp, dtype):
+        x = xp.array([], dtype)
+        return xp.bincount(x, minlength=2)
+
+    @for_all_dtypes_combination_bincount(names=['x_type', 'w_type'])
+    @testing.numpy_cupy_allclose(accept_error=TypeError)
+    def test_bincount_empty_with_weight(self, xp, x_type, w_type):
+        x = xp.array([], x_type)
+        w = xp.array([], w_type)
+        return xp.bincount(x, weights=w, minlength=2)
+
 
 # This class compares CUB results against NumPy's
 @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')


### PR DESCRIPTION
cupy.max() has no identity for empty arrays, so bincount raised ValueError on empty x (regardless of minlength). Short-circuit before the max call to return zeros of the appropriate size, matching NumPy (including its quirk of returning intp dtype even with weights).

Fixes #8116