### PR TITLE
Fix arguments to `get_current_callback_manager` for HIP

### DIFF
--- a/cupy/fft/_config.py
+++ b/cupy/fft/_config.py
@@ -19,7 +19,7 @@ if not runtime.is_hip:
     from cupy.fft._callback import (
         get_current_callback_manager, set_cufft_callbacks)
 else:
-    def get_current_callback_manager():
+    def get_current_callback_manager(*args, **kwargs):
         return None
 
     def set_cufft_callbacks(*args, **kwargs):


### PR DESCRIPTION
Follows up #9853. This fixes the issue with ROCm build:

```
  >           mgr = config.get_current_callback_manager()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E           TypeError: get_current_callback_manager() takes 0 positional arguments but 1 was given
```