### PR TITLE
Addition of cupy.polyint with NumPy-compatible polynomial integration

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -556,6 +556,7 @@ from cupy.lib._routines_poly import polyadd  # NOQA
 from cupy.lib._routines_poly import polysub  # NOQA
 from cupy.lib._routines_poly import polymul  # NOQA
 from cupy.lib._routines_poly import polyfit  # NOQA
+from cupy.lib._routines_poly import polyint  # NOQA
 from cupy.lib._routines_poly import polyval  # NOQA
 from cupy.lib._routines_poly import roots  # NOQA
 

--- a/cupy/lib/_routines_poly.py
+++ b/cupy/lib/_routines_poly.py
@@ -307,6 +307,61 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     return c
 
 
+def polyint(p, m=1, k=None):
+    """Returns an antiderivative (indefinite integral) of a polynomial.
+
+    Args:
+        p (cupy.ndarray or cupy.poly1d): Polynomial coefficients from highest
+            to lowest degree.
+        m (int): Order of the antiderivative.
+        k (scalar or array_like, optional): Integration constants.
+
+    Returns:
+        cupy.ndarray or cupy.poly1d: Coefficients of the integrated polynomial.
+
+    .. seealso:: :func:`numpy.polyint`
+    """
+    truepoly = isinstance(p, cupy.poly1d)
+    if truepoly:
+        p = p._coeffs
+    if not isinstance(p, cupy.ndarray):
+        p = cupy.asarray(p)
+    if p.ndim != 1:
+        raise ValueError('p must be 1-d array')
+
+    m = int(m)
+    if m < 0:
+        raise ValueError('Order of integral must be positive (see polyder)')
+    if m == 0:
+        return cupy.poly1d(p) if truepoly else p
+
+    if k is None:
+        k = cupy.zeros(m, float)
+    else:
+        k = cupy.asarray(k)
+        if k.ndim > 1:
+            k = k.ravel()
+        if k.ndim == 0:
+            k = k[None]
+        if len(k) == 1 and m > 1:
+            k = k[0] * \
+                cupy.ones(m, dtype=numpy.result_type(k.dtype, numpy.float64))
+        if len(k) < m:
+            raise ValueError(
+                'k must be a scalar or a rank-1 array of length 1 or >m.')
+
+    dtype = numpy.result_type(p.dtype, numpy.float64(1))
+    p = p.astype(dtype, copy=False)
+    k = k.astype(dtype, copy=False)
+
+    y = cupy.concatenate((
+        p / cupy.arange(len(p), 0, -1, dtype=dtype),
+        cupy.atleast_1d(k[0]).astype(dtype, copy=False)
+    ))
+    val = polyint(y, m - 1, k=k[1:])
+    return cupy.poly1d(val) if truepoly else val
+
+
 def polyval(p, x):
     """Evaluates a polynomial at specific values.
 

--- a/docs/source/reference/polynomials.rst
+++ b/docs/source/reference/polynomials.rst
@@ -53,6 +53,7 @@ Basics
 
    poly1d
    cupy.poly
+   polyint
    polyval
    roots
 

--- a/tests/cupy_tests/lib_tests/test_polynomial.py
+++ b/tests/cupy_tests/lib_tests/test_polynomial.py
@@ -301,6 +301,30 @@ class TestPoly:
         a = xp.zeros((0), dtype)
         return xp.poly(a)
 
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4)
+    def test_polyint(self, xp, dtype):
+        a = testing.shaped_arange((3,), xp, dtype)
+        return xp.polyint(a)
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4)
+    def test_polyint_poly1d(self, xp, dtype):
+        a = testing.shaped_arange((3,), xp, dtype)
+        return xp.polyint(xp.poly1d(a)).coeffs
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_allclose(rtol=1e-4)
+    def test_polyint_k(self, xp, dtype):
+        a = testing.shaped_arange((3,), xp, dtype)
+        return xp.polyint(a, 2, [1, 2])
+
+    @testing.for_all_dtypes(no_bool=True)
+    def test_polyint_negative_m(self, dtype):
+        for xp in (numpy, cupy):
+            with pytest.raises(ValueError):
+                xp.polyint(testing.shaped_arange((3,), xp, dtype), -1)
+
 
 @testing.parameterize(*testing.product({
     'shape': [(), (0,), (5,)],


### PR DESCRIPTION
Implemented `cupy.polyint` in `_routines_poly.py`
Exported `polyint` from `__init__.py`
Added regression tests for array input, `poly1d` input, constant `k`, and negative `m`
Updated polynomial docs reference in `polynomials.rst`

Matches NumPy `polyint` semantics for integration order and constants.
Supports both `cupy.ndarray` and `cupy.poly1d` inputs.

Closes cupy.poly from #6078