### PR TITLE
HIP: implement cuFuncSetAttribute (was an unimplemented stub returning hipErrorUnknown)

### DIFF
--- a/cupy_backends/hip/cupy_hip.h
+++ b/cupy_backends/hip/cupy_hip.h
@@ -113,8 +113,9 @@ CUresult cuFuncGetAttribute(int* pi, CUfunction_attribute attrib, CUfunction hfu
     return hipFuncGetAttribute(pi, attrib, hfunc);
 }
 
-CUresult cuFuncSetAttribute(...) {
-    return hipErrorUnknown;
+CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int value) {
+    return hipFuncSetAttribute(reinterpret_cast<const void*>(hfunc),
+                               static_cast<hipFuncAttribute>(attrib), value);
 }
 
 // Occupancy


### PR DESCRIPTION

[`cuFuncSetAttribute` in `cupy_backends/hip/cupy_hip.h`](https://github.com/cupy/cupy/blob/main/cupy_backends/hip/cupy_hip.h#L116-L118) is a variadic stub returning `hipErrorUnknown` for every input (since #6604, 2022-03-30). All Python-level uses of `RawKernel.max_dynamic_shared_size_bytes` (and other attribute setters) fail identically on HIP — even `0`. This breaks `torchpq.clustering.KMeans` and anything downstream of it (e.g. `gsplat`'s PNG-checkpoint compression).

```diff
-CUresult cuFuncSetAttribute(...) {
-    return hipErrorUnknown;
+CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int value) {
+    return hipFuncSetAttribute(reinterpret_cast<const void*>(hfunc),
+                               static_cast<hipFuncAttribute>(attrib), value);
 }
```

HIP only ships the runtime-style `hipFuncSetAttribute(const void*, …)`; we `reinterpret_cast` the `CUfunction = hipFunction_t` handle to `const void*` — accepted on ROCm 7.13, same cast used by AMD's own code at `hip/hip_runtime_api.h:10077`. `hipFuncAttribute` enum values match `cudaFuncAttribute` (no remapping needed). CUDA backend untouched.

**Verified on AMD RX 9070 XT (gfx1201), ROCm 7.13.0, cupy-rocm-7-0 14.1.0.** Pre-patch, `RawKernel.max_dynamic_shared_size_bytes = n` raises for every `n ∈ {0, 1024, 49152}`; post-patch, all succeed. `torchpq.clustering.KMeans(n_clusters=4)` no longer raises on construction; `gsplat`'s `tests/test_compression.py::test_png_compression` clears the K-means step.

The sibling stubs `cuOccupancyMaxActiveBlocksPerMultiprocessor` and `cuOccupancyMaxPotentialBlockSize` (lines 124, 128) have the same shape and HIP equivalents — happy to fold in or follow up.
