### PR TITLE
BUG: Avoid hard `pytest` dependency in `cupy.testing` (and test)

### DIFF
--- a/cupy/testing/_condition.py
+++ b/cupy/testing/_condition.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import os
 
-import pytest
 import unittest
 
 
@@ -29,6 +28,7 @@ def repeat_with_success_at_least(times, min_success):
             case is regarded as passed.
 
     """
+    import pytest
 
     assert times >= min_success
 

--- a/cupy/testing/_random.py
+++ b/cupy/testing/_random.py
@@ -8,8 +8,6 @@ import random
 import types
 import unittest
 
-import pytest
-
 import cupy
 
 
@@ -108,6 +106,7 @@ def fix_random():
     It should not be applied within ``condition.retry`` or
     ``condition.repeat``.
     """
+    import pytest
 
     # TODO(niboshi): Prevent this decorator from being applied within
     #    condition.repeat or condition.retry decorators. That would repeat

--- a/tests/cupy_tests/test_init.py
+++ b/tests/cupy_tests/test_init.py
@@ -57,6 +57,27 @@ except Exception as e:
         assert stdoutdata in (b'', b'RuntimeError\n')
 
 
+def test_testing_import_does_not_require_pytest():
+    # cupy.testing import is lazy, but some environments tend to inspect
+    # it anyway.  Check that even an * import doesn't require pytest.
+    returncode, stdoutdata, stderrdata = _run_script('''
+import sys
+
+class BlockPytest:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'pytest' or fullname.startswith('_pytest'):
+            raise ModuleNotFoundError(fullname)
+        return None
+import sys
+sys.meta_path.insert(0, BlockPytest())
+
+# non-lazy import should succeed even if pytest is not available
+from cupy.testing import *
+''')
+    assert returncode == 0, 'stderr: {!r}'.format(stderrdata)
+    assert stdoutdata == b''
+
+
 if not cupy.cuda.runtime.is_hip:
     visible = 'CUDA_VISIBLE_DEVICES'
 else:


### PR DESCRIPTION
`cupy.testing` is imported lazily.  But in some environments the lazy module is inspected and thus imported fully.

Ensure we don't have a hard dependency on pytest even if testing is explicitly imported and add a test for this.

Closes gh-9963