### PR TITLE
Avoid extra host copy when uploading a non-contiguous NumPy array

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -3043,7 +3043,7 @@ cdef _ndarray_base _array_default(
             elif order == 'F':
                 a_cpu = numpy.asfortranarray(a_cpu)
             else:
-                assert False # order must be 'C' or 'F' here
+                assert False  # order must be 'C' or 'F' here
             ptr_h = <intptr_t>(a_cpu.ctypes.data)
             a.data.copy_from_host_async(ptr_h, nbytes, stream)
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2986,9 +2986,21 @@ cdef _ndarray_base _array_default(
         else:
             order = 'C'
 
-    copy = False if NUMPY_1x else None
-    a_cpu = numpy.array(obj, dtype=dtype, copy=copy, order=order,
-                        ndmin=ndmin)
+    # Avoid copy when the passed object is a compatible numpy array
+    # A non-contiguous array can be let through without copy,
+    # as it will be copied to a pinned vector below
+    if (
+        isinstance(obj, numpy.ndarray)
+        and obj.dtype == numpy.dtype(dtype)
+        and obj.ndim >= ndmin
+        and not pinned_memory.is_memory_pinned(obj.ctypes.data)
+        and not _is_ump_enabled
+    ):
+        a_cpu = obj
+    else:
+        copy = False if NUMPY_1x else None
+        a_cpu = numpy.array(obj, dtype=dtype, copy=copy, order=order,
+                            ndmin=ndmin)
 
     a_cpu = a_cpu.astype(_dtype.normalize_dtype(a_cpu.dtype), copy=False)
     a_dtype = a_cpu.dtype
@@ -3021,7 +3033,8 @@ cdef _ndarray_base _array_default(
         mem = _alloc_async_transfer_buffer(nbytes)
         if mem is not None:
             src_cpu = numpy.frombuffer(mem, a_dtype, a_cpu.size)
-            src_cpu[:] = a_cpu.ravel(order)
+            src_cpu = src_cpu.reshape(a_cpu.shape, order=order)
+            src_cpu[:] = a_cpu
             a.data.copy_from_host_async(mem.ptr, nbytes, stream)
             pinned_memory._add_to_watch_list(stream.record(), mem)
         else:

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -3034,10 +3034,17 @@ cdef _ndarray_base _array_default(
         if mem is not None:
             src_cpu = numpy.frombuffer(mem, a_dtype, a_cpu.size)
             src_cpu = src_cpu.reshape(a_cpu.shape, order=order)
-            src_cpu[:] = a_cpu
+            src_cpu[...] = a_cpu
             a.data.copy_from_host_async(mem.ptr, nbytes, stream)
             pinned_memory._add_to_watch_list(stream.record(), mem)
         else:
+            if order == 'C':
+                a_cpu = numpy.ascontiguousarray(a_cpu)
+            elif order == 'F':
+                a_cpu = numpy.asfortranarray(a_cpu)
+            else:
+                assert False # order must be 'C' or 'F' here
+            ptr_h = <intptr_t>(a_cpu.ctypes.data)
             a.data.copy_from_host_async(ptr_h, nbytes, stream)
 
     if blocking:

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2989,18 +2989,15 @@ cdef _ndarray_base _array_default(
     # Avoid copy when the passed object is a compatible numpy array
     # A non-contiguous array can be let through without copy,
     # as it will be copied to a pinned vector below
+    numpy_order = order
     if (
         isinstance(obj, numpy.ndarray)
-        and (dtype is None or obj.dtype == numpy.dtype(dtype))
-        and obj.ndim >= ndmin
         and not pinned_memory.is_memory_pinned(obj.ctypes.data)
         and not _is_ump_enabled
     ):
-        a_cpu = obj
-    else:
-        copy = False if NUMPY_1x else None
-        a_cpu = numpy.array(obj, dtype=dtype, copy=copy, order=order,
-                            ndmin=ndmin)
+        numpy_order = 'K'
+    a_cpu = numpy.array(obj, dtype=dtype, copy=None, order=numpy_order,
+                        ndmin=ndmin)
 
     a_cpu = a_cpu.astype(_dtype.normalize_dtype(a_cpu.dtype), copy=False)
     a_dtype = a_cpu.dtype

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2991,7 +2991,7 @@ cdef _ndarray_base _array_default(
     # as it will be copied to a pinned vector below
     if (
         isinstance(obj, numpy.ndarray)
-        and obj.dtype == numpy.dtype(dtype)
+        and (dtype is None or obj.dtype == numpy.dtype(dtype))
         and obj.ndim >= ndmin
         and not pinned_memory.is_memory_pinned(obj.ctypes.data)
         and not _is_ump_enabled

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -115,6 +115,44 @@ class TestNdarrayInit(unittest.TestCase):
         b = UserNdarray((2, 3))
         b.custom_attr = 100
 
+@testing.parameterize(
+    *testing.product({
+        'np_order': ['C', 'F'],
+        'np_pinned': [False, True],
+        'pinned_alloc_fails': [False, True],
+        'cp_setup': [
+            ('C', False, (48, 16, 4)),
+            ('C', True, (16, 4)),
+            ('F', False, (4, 8, 24)),
+            ('F', True, (4, 8)),
+        ]
+    })
+)
+class TestAsarray(unittest.TestCase):
+    def test_asarray(self):
+        cp_order, view, strides = self.cp_setup
+        shape = (2, 3, 4)
+        if self.np_pinned:
+            count = numpy.prod(shape)
+            dtype = numpy.float32()
+            pinned_ptr = cupy.cuda.alloc_pinned_memory(count * dtype.itemsize)
+            a_cpu = numpy.frombuffer(pinned_ptr, dtype=dtype, count=count).reshape(shape)
+        else:
+            a_cpu = numpy.ndarray(shape, dtype=numpy.float32, order=self.np_order)
+        a_cpu[...] = numpy.arange(a_cpu.size).reshape(a_cpu.shape)
+        if view:
+            a_cpu = a_cpu[:,1,:]
+        try:
+            if self.pinned_alloc_fails:
+                cupy.cuda.set_pinned_memory_allocator(lambda _: None)
+            a = cupy.asarray(a_cpu, order=cp_order)
+        finally:
+            cupy.cuda.set_pinned_memory_allocator(None)
+        assert a.flags.c_contiguous == (cp_order == 'C')
+        assert a.flags.f_contiguous == (cp_order == 'F')
+        assert a.strides == strides
+        testing.assert_array_equal(a_cpu, a)
+
 
 @testing.parameterize(
     *testing.product({

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -115,6 +115,7 @@ class TestNdarrayInit(unittest.TestCase):
         b = UserNdarray((2, 3))
         b.custom_attr = 100
 
+
 @testing.parameterize(
     *testing.product({
         'np_order': ['C', 'F'],
@@ -136,12 +137,14 @@ class TestAsarray(unittest.TestCase):
             count = numpy.prod(shape)
             dtype = numpy.float32()
             pinned_ptr = cupy.cuda.alloc_pinned_memory(count * dtype.itemsize)
-            a_cpu = numpy.frombuffer(pinned_ptr, dtype=dtype, count=count).reshape(shape)
+            a_cpu = numpy.frombuffer(
+                pinned_ptr, dtype=dtype, count=count).reshape(shape)
         else:
-            a_cpu = numpy.ndarray(shape, dtype=numpy.float32, order=self.np_order)
+            a_cpu = numpy.ndarray(
+                shape, dtype=numpy.float32, order=self.np_order)
         a_cpu[...] = numpy.arange(a_cpu.size).reshape(a_cpu.shape)
         if view:
-            a_cpu = a_cpu[:,1,:]
+            a_cpu = a_cpu[:, 1, :]
         try:
             if self.pinned_alloc_fails:
                 cupy.cuda.set_pinned_memory_allocator(lambda _: None)


### PR DESCRIPTION
Fixes #9813

In the original, the first copy occurs at line 2968 (`a_cpu = numpy.array(...)`), because of the `order=C` or `F` requirement on the non-contiguous array. The second copy occurs when copying to the pinned array at line 3002 (`src_cpu[:] = a_cpu.ravel(order)`).

This patch avoids the first copy by letting the input object pass without a copy, if its properties (except contiguity) are identical to the requested output array. The special case, when `_is_ump_enabled` is also excluded.

The second copy site must be modified too to avoid the extra copy, i.e. `ravel` also makes a copy. Instead, the destination 1D array is reshaped into the source shape (no-copy operation), specifying the order. Then the source array is copied into it. Therefore the source can be non-contiguous, and in any order, and the destination is contiguous and in the specified order. NumPy takes care of the indexing in any case.