### PR TITLE
BUG: Avoid _symiirorder1_nd/NaN issues with type-casting

### DIFF
--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
+import math
 
 import cupy
 import cupyx.scipy.ndimage
@@ -251,12 +252,12 @@ def _quadratic_coeff(signal):
 
 
 def compute_root_from_lambda(lamb):
-    tmp = np.sqrt(3 + 144 * lamb)
+    tmp = math.sqrt(3 + 144 * lamb)
     xi = 1 - 96 * lamb + 24 * lamb * tmp
-    omega = np.arctan(np.sqrt((144 * lamb - 1.0) / xi))
-    tmp2 = np.sqrt(xi)
+    omega = np.arctan(math.sqrt((144 * lamb - 1.0) / xi))
+    tmp2 = math.sqrt(xi)
     r = ((24 * lamb - 1 - tmp2) / (24 * lamb) *
-         np.sqrt(48*lamb + 24 * lamb * tmp) / tmp2)
+         math.sqrt(48*lamb + 24 * lamb * tmp) / tmp2)
     return r, omega
 
 
@@ -469,7 +470,7 @@ def cspline2d(signal, lamb=0.0, precision=-1.0):
     """
     if lamb <= 1 / 144.0:
         # Normal cubic spline
-        r = -2 + np.sqrt(3.0)
+        r = -2 + math.sqrt(3.0)
         out = _symiirorder1_nd(signal, -r * 6.0, r, precision=precision,
                                axis=-1)
         out = _symiirorder1_nd(out, -r * 6.0, r, precision=precision,
@@ -509,7 +510,7 @@ def qspline2d(signal, lamb=0.0, precision=-1.0):
         raise ValueError('lambda must be negative or zero')
 
     # normal quadratic spline
-    r = -3 + 2 * np.sqrt(2.0)
+    r = -3 + 2 * math.sqrt(2.0)
 
     out = _symiirorder1_nd(signal, -r * 8.0, r, precision=precision, axis=-1)
     out = _symiirorder1_nd(out, -r * 8.0, r, precision=precision, axis=0)

--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -36,8 +36,6 @@ from cupyx.scipy.signal._iir_utils import apply_iir_sos
 from cupyx.scipy.signal._splines import _symiirorder1_nd, _symiirorder2_nd
 from cupyx.scipy.interpolate._bspline import BSpline
 
-import numpy as np
-
 
 def sepfir2d(input, hrow, hcol):
     """Convolve with a 2-D separable FIR filter.

--- a/cupyx/scipy/signal/_bsplines.py
+++ b/cupyx/scipy/signal/_bsplines.py
@@ -254,7 +254,7 @@ def _quadratic_coeff(signal):
 def compute_root_from_lambda(lamb):
     tmp = math.sqrt(3 + 144 * lamb)
     xi = 1 - 96 * lamb + 24 * lamb * tmp
-    omega = np.arctan(math.sqrt((144 * lamb - 1.0) / xi))
+    omega = math.atan(math.sqrt((144 * lamb - 1.0) / xi))
     tmp2 = math.sqrt(xi)
     r = ((24 * lamb - 1 - tmp2) / (24 * lamb) *
          math.sqrt(48*lamb + 24 * lamb * tmp) / tmp2)

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -191,7 +191,7 @@ def _symiirorder1_nd(input, c0, z1, precision=-1.0, axis=-1):
 
     # Compute backward symmetric condition and apply the system
     # c0 / (1 - z1 * z)
-    zi = -c0 / (z1 - 1.0) * axis_slice(y1, -1)
+    zi = (-c0 / (z1 - 1.0) * axis_slice(y1, -1)).astype(input.dtype)
     all_zi = axis_assign(all_zi, zi, 3, 4)
 
     coef = cupy.r_[c0, 0, 0, 1, -z1, 0]

--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -191,7 +191,7 @@ def _symiirorder1_nd(input, c0, z1, precision=-1.0, axis=-1):
 
     # Compute backward symmetric condition and apply the system
     # c0 / (1 - z1 * z)
-    zi = (-c0 / (z1 - 1.0) * axis_slice(y1, -1)).astype(input.dtype)
+    zi = -c0 / (z1 - 1.0) * axis_slice(y1, -1)
     all_zi = axis_assign(all_zi, zi, 3, 4)
 
     coef = cupy.r_[c0, 0, 0, 1, -z1, 0]

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_splines.py
@@ -69,3 +69,14 @@ class TestSymIIROrder:
         x = testing.shaped_random((size,), xp, dtype=dtype)
 
         return scp.signal.symiirorder2(x, r, omega, precision)
+
+    @testing.numpy_cupy_allclose(
+        atol=2e-5, rtol=2e-5, scipy_name='scp', accept_error=True)
+    def test_spline_filter_complex(self, xp, scp):
+        rng = numpy.random.RandomState(12457)
+        data_array_complex = rng.rand(7, 7) + rng.rand(7, 7)*1j
+        # make the magnitude exceed 1, and make some negative
+        data_array_complex = 10*(1+1j-2*data_array_complex)
+        data_array_complex = xp.asarray(data_array_complex)
+
+        return scp.signal.spline_filter(data_array_complex, 0)


### PR DESCRIPTION
Resolves #9758

In this [line](https://github.com/cupy/cupy/blob/main/cupyx/scipy/signal/_splines.py#L194), the resulting array's data type changes between 13.6 and 14.0. This is due to CuPy's [NEP 50 support](https://docs.cupy.dev/en/stable/upgrade.html#numpy-2-related-changes) that was added in 14.0.0:
```
# 13.6
(Pdb) -c0 / (z1 - 1.0)
np.float64(1.267949192431123)
(Pdb) axis_slice(y1, -1)
array([[ 8.392689 ],
       [ 6.2653627],
       [ 7.6676435],
       [ 8.546563 ],
       [-2.6850176],
       [ 2.795763 ],
       [ 9.093413 ]], dtype=float32)
(Pdb) -c0 / (z1 - 1.0) * axis_slice(y1, -1)
array([[10.641503 ],
       [ 7.944162 ],
       [ 9.722182 ],
       [10.836608 ],
       [-3.404466 ],
       [ 3.5448856],
       [11.529986 ]], dtype=float32)

# 14.0
(Pdb) -c0 / (z1 - 1.0)
np.float64(1.267949192431123)
(Pdb) axis_slice(y1, -1)
array([[ 8.392689 ],
       [ 6.2653627],
       [ 7.6676435],
       [ 8.546563 ],
       [-2.6850176],
       [ 2.795763 ],
       [ 9.093413 ]], dtype=float32)
(Pdb) -c0 / (z1 - 1.0) * axis_slice(y1, -1)
array([[10.64150292],
       [ 7.94416163],
       [ 9.72218244],
       [10.83660784],
       [-3.40446588],
       [ 3.54488546],
       [11.52998612]])
```

In the bottom of the proposal, they state the following:
> In other cases, increased precision may occur. For example:
> ```python
> np.multiple(float32_arr, 2.)
> float32_arr * np.float64(2.)
> ```
>   Will both return a float64 rather than float32. This improves precision but slightly changes results and uses double the memory.

Looking through the [PR](https://github.com/cupy/cupy/pull/8323) that merged the NEP-50 changes, I saw some casting being done in this [file](https://github.com/cupy/cupy/blob/main/cupyx/scipy/sparse/linalg/_solve.py#L905); perhaps we could do that too:
```diff
diff --git a/cupyx/scipy/signal/_splines.py b/cupyx/scipy/signal/_splines.py
index 4ac5ecf6f..1923fe357 100644
--- a/cupyx/scipy/signal/_splines.py
+++ b/cupyx/scipy/signal/_splines.py
@@ -191,7 +191,7 @@ def _symiirorder1_nd(input, c0, z1, precision=-1.0, axis=-1):
 
     # Compute backward symmetric condition and apply the system
     # c0 / (1 - z1 * z)
-    zi = -c0 / (z1 - 1.0) * axis_slice(y1, -1)
+    zi = (-c0 / (z1 - 1.0) * axis_slice(y1, -1)).astype(input.dtype)
     all_zi = axis_assign(all_zi, zi, 3, 4)
 
     coef = cupy.r_[c0, 0, 0, 1, -z1, 0]
```