### PR TITLE
install: infer ROCM_HOME from hipcc on PATH

### DIFF
--- a/install/cupy_builder/install_build.py
+++ b/install/cupy_builder/install_build.py
@@ -51,7 +51,21 @@ def get_rocm_path():
     if _rocm_path != 'NOT_INITIALIZED':
         return _rocm_path
 
-    _rocm_path = os.environ.get('ROCM_HOME', '')
+    # Prefer ROCM_HOME, else infer from hipcc on PATH (mirrors
+    # get_cuda_path()'s nvcc-based discovery).
+    rocm_home = os.environ.get('ROCM_HOME', '')
+    if rocm_home:
+        _rocm_path = rocm_home
+        return _rocm_path
+
+    hipcc_path = utils.search_on_path(('hipcc', 'hipcc.exe'))
+    if hipcc_path is not None:
+        hipcc_real = os.path.realpath(hipcc_path)
+        _rocm_path = os.path.normpath(
+            os.path.join(os.path.dirname(hipcc_real), '..'))
+        return _rocm_path
+
+    _rocm_path = ''
     return _rocm_path
 
 


### PR DESCRIPTION
Symptom
-------
On a perfectly functional ROCm 7.x install where:
    /usr/bin/hipcc  ->  /etc/alternatives/hipcc  ->  /opt/rocm-7.2.0/bin/hipcc
and ROCM_HOME is unset (the default on every distro that ships hipcc through the standard alternatives mechanism, including Ubuntu's rocm-* packages and the RHEL/SLES rocm-runtime packages),

  tests/install_tests/test_build.py
  ::TestCheckVersion::test_check_hip_version
fails with

  AssertionError: assert False
   +  where False = check_hip_version(<distutils...Compiler>, {settings...})

and any cupy install/build helper that asks for the ROCm root (get_rocm_path() / get_compiler_setting() / check_hip_version() / check_hipblas_version() / ...) silently degrades to "ROCm not detected", because every code path that needs <hip/hip_version.h> ends up compiling a stub file with no -I/opt/rocm-X.Y/include in the include search path:

  fatal error: hip/hip_version.h: No such file or directory
      2 |         #include <hip/hip_version.h>
        |                  ^~~~~~~~~~~~~~~~~~~

Root cause
----------
get_rocm_path() in install_build.py only consults the ROCM_HOME environment variable:

    def get_rocm_path():
        global _rocm_path
        if _rocm_path != 'NOT_INITIALIZED':
            return _rocm_path
        _rocm_path = os.environ.get('ROCM_HOME', '')
        return _rocm_path

There is no fallback to discover the ROCm root from a hipcc on PATH, even though the parallel function get_cuda_path() right below it does exactly that for nvcc:

    nvcc_path = utils.search_on_path(('nvcc', 'nvcc.exe'))
    cuda_path_default = None
    if nvcc_path is not None:
        cuda_path_default = os.path.normpath(
            os.path.join(os.path.dirname(nvcc_path), '..'))

So when ROCM_HOME is empty, get_rocm_path() returns the empty string and every downstream consumer treats ROCm as absent.

Fix
---
Make get_rocm_path() symmetric with get_cuda_path():

  1. Honour ROCM_HOME when explicitly set (unchanged).
  2. Otherwise, locate `hipcc` on PATH and infer the ROCm root by resolving the realpath (so an alternatives chain /usr/bin/hipcc -> /etc/alternatives/hipcc -> /opt/rocm-X.Y/bin/hipcc collapses to /opt/rocm-X.Y) and stripping the trailing /bin component.
  3. Fall back to the empty string only when neither ROCM_HOME nor hipcc is discoverable -- preserves the previous "ROCm not installed" semantics for true CPU-only / pure-CUDA builds.

Verified by re-running the check_hip_version probe manually on this host:
  get_rocm_path():           /opt/rocm-7.2.0
  include_dirs (rocm subset): /opt/rocm-7.2.0/include[hipcub|hip|hipblas|...]
  check_hip_version result:  True
  cached _hip_version:       70226015     # ROCm 7.2.26015

The change is purely a discovery improvement; CUDA-only builds and ROCM_HOME-pinned builds are unaffected.