### PR TITLE
Clear runtime sticky error after any failed driver-API call

### DIFF
--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -33,6 +33,10 @@ cdef extern from '../../cupy_backend.h' nogil:
     # Note: CUDA_VERSION is defined either in CUDA Python or _driver_extern.pxi
     enum: HIP_VERSION
 
+# Used by check_status() to drain HIP 7's sticky runtime-error slot.
+cdef extern from '../../cupy_backend_runtime.h' nogil:
+    int cudaGetLastError()
+
 # Provide access to constants from Python.
 from cupy_backends.cuda.api._driver_enum import *
 
@@ -61,6 +65,10 @@ class CUDADriverError(RuntimeError):
 @cython.profile(False)
 cpdef inline check_status(int status):
     if status != 0:
+        # HIP 7 leaks failed driver-API status into the runtime sticky
+        # slot, poisoning subsequent kernel launches. Drain it. No-op
+        # on CUDA when no runtime error is pending.
+        cudaGetLastError()
         raise CUDADriverError(status)
 
 

--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -33,9 +33,10 @@ cdef extern from '../../cupy_backend.h' nogil:
     # Note: CUDA_VERSION is defined either in CUDA Python or _driver_extern.pxi
     enum: HIP_VERSION
 
-# Used by check_status() to drain HIP 7's sticky runtime-error slot.
-cdef extern from '../../cupy_backend_runtime.h' nogil:
-    int cudaGetLastError()
+IF CUPY_HIP_VERSION > 0:
+    # Used by check_status() to drain HIP 7's sticky runtime-error slot.
+    cdef extern from '../../cupy_backend_runtime.h' nogil:
+        int cudaGetLastError()
 
 # Provide access to constants from Python.
 from cupy_backends.cuda.api._driver_enum import *
@@ -65,10 +66,11 @@ class CUDADriverError(RuntimeError):
 @cython.profile(False)
 cpdef inline check_status(int status):
     if status != 0:
-        # HIP 7 leaks failed driver-API status into the runtime sticky
-        # slot, poisoning subsequent kernel launches. Drain it. No-op
-        # on CUDA when no runtime error is pending.
-        cudaGetLastError()
+        IF CUPY_HIP_VERSION > 0:
+            # HIP 7 leaks failed driver-API status into the runtime
+            # sticky slot, poisoning subsequent kernel launches. Drain
+            # it. Compiled out entirely on CUDA.
+            cudaGetLastError()
         raise CUDADriverError(status)
 
 

--- a/tests/cupy_tests/cuda_tests/test_driver.py
+++ b/tests/cupy_tests/cuda_tests/test_driver.py
@@ -65,3 +65,20 @@ class TestExceptionPicklable(unittest.TestCase):
         e2 = pickle.loads(pickle.dumps(e1))
         assert e1.args == e2.args
         assert str(e1) == str(e2)
+
+
+class TestCheckStatusClearsStickyError(unittest.TestCase):
+    """Regression test for the HIP 7+ driver-API sticky-error leak fixed
+    in cupy_backends/cuda/api/driver.pyx::check_status."""
+
+    def test_failed_get_function_does_not_poison_subsequent_launch(self):
+        mod = cupy.RawModule(
+            code='extern "C" __global__ void k(float *x) {}')
+        with self.assertRaises(cupy.cuda.driver.CUDADriverError):
+            mod.get_function('no_such_kernel')
+        # cupy.random.* would raise CURAND_STATUS_LAUNCH_FAILURE pre-fix.
+        result = cupy.random.uniform(-1, 1, 100).astype(cupy.float32)
+        self.assertEqual(result.shape, (100,))
+        self.assertEqual(result.dtype, cupy.float32)
+        # Same poisoning via the ufunc path.
+        _ = (result * 2.0).sum()


### PR DESCRIPTION
On HIP 7+ several driver-API calls leak their failure into the per-thread runtime sticky-error slot. The leak is observed for at least

  * cuModuleGetFunction() / cuModuleGetGlobal() against a missing symbol
  * cuModuleLoad{,Data,DataEx}() against a missing or corrupt image
  * (almost certainly other driver-API failures we have not yet bisected)

Each one returns its cuResult correctly (CUDA_ERROR_NOT_FOUND, CUDA_ERROR_FILE_NOT_FOUND, CUDA_ERROR_INVALID_IMAGE, ...), but ALSO leaves the runtime context in a sticky-error state. The next runtime kernel launch on the same thread, regardless of which library issues it, then fails with CUDA_ERROR_LAUNCH_FAILURE /
CURAND_STATUS_LAUNCH_FAILURE for no apparent reason. The cascade is particularly nasty in the cupy test suite. Two confirmed offenders so far, both bisected with an in-process probe:

  - test_raw.py::test_get_function_failure deliberately requests a missing kernel name to verify cupy raises CUDADriverError.
  - test_raw.py::test_module_load_failure deliberately loads a missing .cubin to verify the same.

Both then poison cuRAND for the rest of the pytest process, with the first downstream victim being test_userkernel.py::test_cached_code's

    cupy.random.uniform(-1, 1, 100).astype(cupy.float32)

which fails with CURANDError: CURAND_STATUS_LAUNCH_FAILURE. Other tests that exercise CUB or partition through paths that don't translate launch errors back to Python (e.g. test_meanvar test_median_nan) can later SIGABRT for the same root cause. Minimal four-line reproducer:

    mod = cupy.RawModule(code='extern "C" __global__ void k(float *x) {}')
    try: mod.get_function('no_such_kernel')
    except cupy.cuda.driver.CUDADriverError: pass
    cupy.random.uniform(-1, 1, 100)   # CURANDError on HIP 7

cudaGetLastError() / hipGetLastError() both retrieves and clears the sticky state, restoring the context to a usable state.

Fix
---
Rather than wrap each individual driver entry-point that is currently known to leak, plumb the cleanup through the universal driver.check_status(): every driver-API call already routes its status through this function, and we already have empirical evidence that more than one entry point exhibits the leak. Putting the cleanup in check_status() is the analogue of what runtime.check_status() has been doing on the runtime-API side for years, and means we do not have to track down every additional offender as users hit them.

The clear is a harmless no-op on CUDA when no runtime error is pending, so the fix is safe to apply unconditionally on both backends and does not need a #ifdef HIP guard. The user-visible behavior is unchanged: callers still see CUDADriverError raised with the same status code; the only difference is that the next kernel launch on the same thread no longer inherits the sticky state.

Regression test
---------------
tests/cupy_tests/cuda_tests/test_driver.py grows a new TestCheck StatusClearsStickyError class with one test:
test_failed_get_function_does_not_poison_subsequent_launch. It is the 4-line reproducer above lifted verbatim into a unittest, plus a second downstream operation through a different runtime path (a cupy.ndarray * scalar reduction) to guarantee the cleanup covers more than just the cuRAND consumer. The test was confirmed to fail prior to this commit on HIP 7+ (CURAND_STATUS_LAUNCH_FAILURE on the second call) and to pass after; on CUDA it always passes because the underlying leak does not occur.