### PR TITLE
Fix HIP-incompatible warp shuffle in cupyx.scipy.sparse CSR row-counting kernel

### DIFF
--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -543,6 +543,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
     )
 
     _calc_Bp_kernel = r"""
+    // __shfl_*_sync requires the mask to equal the active-lane set
+    // (__ballot(true)); a hardcoded all-ones mask over-claims lanes and
+    // aborts with an HSA exception on the wrong wavefront width.
+    // HIP: use __activemask() (== __ballot(true), unsigned long long) so the
+    //      contract holds on both wave64 (CDNA) and wave32 (Navi/RDNA).
+    // NVRTC: CUDA uses a 32-bit mask.
+    #ifdef __HIP_DEVICE_COMPILE__
+      #define CUPY_FULL_WARP_MASK __activemask()
+    #else
+      #define CUPY_FULL_WARP_MASK 0xffffffffu
+    #endif
+
     template<typename I>
     __global__
     void row_kept_count(const int  n_row,
@@ -559,19 +571,26 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
     for (I p = Ap[row] + threadIdx.x; p < Ap[row + 1]; p += blockDim.x)
         local += col_cnt[Aj[p]];
 
+    // Reduce each warp/wavefront into lane 0 (warpSize: 32 on NVIDIA,
+    // 64 on AMD wave64).
     #pragma unroll
-    for (int offs = 16; offs; offs >>= 1)
-        local += __shfl_down_sync(0xffffffff, local, offs);
+    for (int offs = warpSize / 2; offs > 0; offs >>= 1)
+        local += __shfl_down_sync(CUPY_FULL_WARP_MASK, local, offs);
 
-    static __shared__ int s[32];              // one per warp
-    if ((threadIdx.x & 31) == 0) s[threadIdx.x>>5] = local;
+    // Stage each warp's partial sum (up to 32 warps).
+    static __shared__ int s[32];
+    if ((threadIdx.x & (warpSize - 1)) == 0)
+        s[threadIdx.x / warpSize] = local;
     __syncthreads();
 
-    if (threadIdx.x < 32) {
-        int val = (threadIdx.x < (blockDim.x>>5)) ? s[threadIdx.x] : int(0);
+    // First warp reduces the per-warp sums (mask must match EXEC; the
+    // <32 guard the old kernel used aborted with HSA exception on wave64).
+    if (threadIdx.x < warpSize) {
+        const int n_warps = blockDim.x / warpSize;
+        int val = (threadIdx.x < n_warps) ? s[threadIdx.x] : int(0);
         #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            val += __shfl_down_sync(0xffffffff, val, offset);
+        for (int offs = warpSize / 2; offs > 0; offs >>= 1)
+            val += __shfl_down_sync(CUPY_FULL_WARP_MASK, val, offs);
         if (threadIdx.x == 0) Bp[row + 1] = I(val);
     }
 }


### PR DESCRIPTION
The kernel _calc_Bp_kernel in cupyx/scipy/sparse/_compressed.py -- used by csc[indices] / _minor_index_fancy / _minor_slice etc. via the _calc_Bp_minor RawKernel -- was written assuming CUDA's 32-wide warps and broke on HIP's 64-wide wavefronts in two compounding ways:

1. ROCm 7+ requires a 64-bit mask type for the native __shfl_*_sync builtins (declared in /opt/rocm/include/hip/amd_detail/ amd_warp_sync_functions.h). The kernel passed 0xffffffff (a 32-bit unsigned literal), which triggered HIPRTC's static_assert at compile time:

       static assertion failed due to requirement
       'sizeof(unsigned int) == 8': The mask must be a 64-bit integer.

   manifesting as a CompileException in any test that pulls a fancy / sliced minor index out of a CSR / CSC matrix (tests/cupyx_tests/scipy_tests/sparse_tests/test_index.py, etc.).

2. After fixing the mask type, the kernel SIGABRT'd at runtime on AMD's 64-wide wavefronts with HSA_STATUS_ERROR_EXCEPTION (a hardware exception). Two related issues:

   (a) The first reduction loop was hardcoded to start at offset 16, which assumes a 32-wide warp. On a 64-wide wavefront with __shfl_down_sync's default width=warpSize=64, this only reduces 32 of the 64 lanes per wavefront -- the partial sums later written into s[] are off by half.

   (b) The second reduction was inside 'if (threadIdx.x < 32)'. On a 64-wide wavefront only 32 lanes are inside the if, but the 64-bit mask CUPY_FULL_WARP_MASK still claims all 64 lanes are participating in the shuffle. The 'mask' parameter is a synchronization contract, not a lane selector -- when the claimed-participating set doesn't match the EXEC mask, AMD's HSAIL layer treats it as a contract violation and raises a hardware exception. CUDA never sees this because warp_size=32 there and the entire warp is inside the if.

The earlier blanket fix from PR #9748 (commit 9034fca9a, 'fix(hip): use 64-bit mask for warp shuffle/vote intrinsics') consolidated the mask constants for kernels routed through cupy/_core/_kernel.pyx, but inline RawKernel sources defined as Python string literals in cupyx/scipy/sparse/ slipped through the sweep.

Two-part fix:

  * Define a CUPY_FULL_WARP_MASK macro at the top of the kernel string that picks the right active-lane mask per backend:
    - HIP: __activemask() (== __ballot(true), an unsigned long long, so it satisfies the ROCm 7+ sizeof(mask)==8 static_assert). The sync builtins require the mask to equal the active-lane set at the call site; a hardcoded 0xffffffffffffffffULL over-claims lanes on wave32 (Navi/RDNA) parts -- only 32 lanes exist there, so __ballot(true) is 0x00000000ffffffff and the 64-bit all-ones mask trips the same EXEC-mismatch HSA exception this patch removes on wave64. Using __activemask() is correct on both wave64 (CDNA) and wave32 (RDNA) and across ROCm versions regardless of header auto-trimming.
    - NVRTC: 0xffffffffu (matches CUDA's unsigned int mask parameter)

  * Use the compiler-provided per-arch compile-time constant warpSize everywhere instead of hardcoding 32 / 0x1f / 16:
      - reduction loop bound: warpSize / 2 (32 on AMD, 16 on NVIDIA)
      - per-warp partial-sum write: (threadIdx.x & (warpSize - 1)) == 0 - per-warp index: threadIdx.x / warpSize - second-reduction if-condition: threadIdx.x < warpSize The kernel adapts automatically to whatever wavefront / warp size the target arch reports. The s[] shared array stays sized at 32 entries since the host caller fixes blockDim.x = 256 (well under 32 * warpSize on either backend).