### PR TITLE
Hip/fix rocsolver potrs

### DIFF
--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -1725,37 +1725,135 @@ cusolverStatus_t cusolverSpSetStream(...) {
 }
 
 
-/* ---------- potrs ---------- */
-cusolverStatus_t cusolverDnSpotrs(...) {
-    return rocblas_status_not_implemented;
+/* ---------- potrs ----------
+ * rocSOLVER potrs has no devInfo out-param; cusolver callers expect
+ * one (and uninitialised cupy.empty() devInfo would trip their post-
+ * synchronization check), so each shim zeros it via hipMemsetAsync.
+ */
+
+static cusolverStatus_t _cupy_zero_dev_info(rocblas_handle handle, int *devInfo) {
+    hipStream_t stream = 0;
+    rocblas_status s = rocblas_get_stream(handle, &stream);
+    if (s != rocblas_status_success) return s;
+    if (hipMemsetAsync(devInfo, 0, sizeof(int), stream) != hipSuccess) {
+        return rocblas_status_internal_error;
+    }
+    return rocblas_status_success;
 }
 
-cusolverStatus_t cusolverDnDpotrs(...) {
-    return rocblas_status_not_implemented;
+// A is `const T*` (matches cusolver); rocSOLVER takes T*, but never
+// mutates A for potrs, so const_cast is safe.
+
+cusolverStatus_t cusolverDnSpotrs(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n, int nrhs,
+                                  const float *A, int lda,
+                                  float *B, int ldb,
+                                  int *devInfo) {
+    rocblas_status status = rocsolver_spotrs(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        const_cast<float*>(A), lda, B, ldb);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnCpotrs(...) {
-    return rocblas_status_not_implemented;
+cusolverStatus_t cusolverDnDpotrs(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n, int nrhs,
+                                  const double *A, int lda,
+                                  double *B, int ldb,
+                                  int *devInfo) {
+    rocblas_status status = rocsolver_dpotrs(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        const_cast<double*>(A), lda, B, ldb);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnZpotrs(...) {
-    return rocblas_status_not_implemented;
+cusolverStatus_t cusolverDnCpotrs(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n, int nrhs,
+                                  const cuComplex *A, int lda,
+                                  cuComplex *B, int ldb,
+                                  int *devInfo) {
+    rocblas_status status = rocsolver_cpotrs(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        reinterpret_cast<rocblas_float_complex*>(const_cast<cuComplex*>(A)), lda,
+        reinterpret_cast<rocblas_float_complex*>(B), ldb);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnSpotrsBatched(...) {
-    return rocblas_status_not_implemented;
+cusolverStatus_t cusolverDnZpotrs(cusolverDnHandle_t handle,
+                                  cublasFillMode_t uplo,
+                                  int n, int nrhs,
+                                  const cuDoubleComplex *A, int lda,
+                                  cuDoubleComplex *B, int ldb,
+                                  int *devInfo) {
+    rocblas_status status = rocsolver_zpotrs(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        reinterpret_cast<rocblas_double_complex*>(const_cast<cuDoubleComplex*>(A)), lda,
+        reinterpret_cast<rocblas_double_complex*>(B), ldb);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnDpotrsBatched(...) {
-    return rocblas_status_not_implemented;
+// Batched: match cython's plain T** signatures (no const).
+
+cusolverStatus_t cusolverDnSpotrsBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n, int nrhs,
+                                         float **Aarray, int lda,
+                                         float **Barray, int ldb,
+                                         int *devInfo, int batchSize) {
+    rocblas_status status = rocsolver_spotrs_batched(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        Aarray, lda, Barray, ldb, batchSize);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnCpotrsBatched(...) {
-    return rocblas_status_not_implemented;
+cusolverStatus_t cusolverDnDpotrsBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n, int nrhs,
+                                         double **Aarray, int lda,
+                                         double **Barray, int ldb,
+                                         int *devInfo, int batchSize) {
+    rocblas_status status = rocsolver_dpotrs_batched(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        Aarray, lda, Barray, ldb, batchSize);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
-cusolverStatus_t cusolverDnZpotrsBatched(...) {
-    return rocblas_status_not_implemented;
+cusolverStatus_t cusolverDnCpotrsBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n, int nrhs,
+                                         cuComplex **Aarray, int lda,
+                                         cuComplex **Barray, int ldb,
+                                         int *devInfo, int batchSize) {
+    rocblas_status status = rocsolver_cpotrs_batched(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        reinterpret_cast<rocblas_float_complex* const*>(Aarray), lda,
+        reinterpret_cast<rocblas_float_complex* const*>(Barray), ldb,
+        batchSize);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
+}
+
+cusolverStatus_t cusolverDnZpotrsBatched(cusolverDnHandle_t handle,
+                                         cublasFillMode_t uplo,
+                                         int n, int nrhs,
+                                         cuDoubleComplex **Aarray, int lda,
+                                         cuDoubleComplex **Barray, int ldb,
+                                         int *devInfo, int batchSize) {
+    rocblas_status status = rocsolver_zpotrs_batched(
+        handle, convert_rocblas_fill(uplo), n, nrhs,
+        reinterpret_cast<rocblas_double_complex* const*>(Aarray), lda,
+        reinterpret_cast<rocblas_double_complex* const*>(Barray), ldb,
+        batchSize);
+    if (status != rocblas_status_success) return status;
+    return _cupy_zero_dev_info(handle, devInfo);
 }
 
 

--- a/cupyx/cusolver.pyx
+++ b/cupyx/cusolver.pyx
@@ -86,7 +86,8 @@ _available_hip_version = {
     'gesvdjBatched': (309, None),  # = rocsolver_<t>gesvd_batched
     'gesvda': (_numpy.inf, None),
     'potrfBatched': (306, None),
-    'potrsBatched': (_numpy.inf, None),
+    # Same HIP_VERSION gate as potrfBatched (shared pointer-array bridge).
+    'potrsBatched': (306, None),
     'syevj': (402, None),
     'gesv': (_numpy.inf, None),
     'gels': (_numpy.inf, None),

--- a/cupyx/lapack.py
+++ b/cupyx/lapack.py
@@ -256,18 +256,34 @@ def _batched_posv(a, b):
 
     b_shape = b.shape
     b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
-    bp = _cupy._core._mat_ptrs(b)
     ldb, nrhs = b.shape[-2:]
     dev_info = _cupy.empty(1, dtype=_numpy.int32)
 
-    # NOTE: potrsBatched does not currently support nrhs > 1 (CUDA v10.2)
-    # Solve: A[i] * X[i] = B[i]
-    potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
-                 dev_info.data.ptr, batch_size)
-    _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        potrsBatched, dev_info)
+    # potrsBatched expects each per-batch right-hand side block in
+    # column-major layout. When nrhs == 1 a single column is trivially
+    # column-major and we can issue one batched call. When nrhs > 1 the
+    # C-order (batch, n, nrhs) layout doesn't match cuSOLVER's F-order
+    # expectation; loop one column at a time (mirroring _batched_potrs).
+    # This also sidesteps cuSOLVER's documented restriction that
+    # cusolverDn?potrsBatched only supports nrhs == 1.
+    if nrhs == 1:
+        bp = _cupy._core._mat_ptrs(b)
+        potrsBatched(handle, uplo, n, 1, ap.data.ptr, lda, bp.data.ptr,
+                     ldb, dev_info.data.ptr, batch_size)
+        _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+            potrsBatched, dev_info)
+    else:
+        b_tmp = _cupy.empty(b.shape[:-1], dtype=b.dtype, order='C')
+        bp_tmp = _cupy._core._mat_ptrs(b_tmp[..., None])
+        for i in range(nrhs):
+            b_tmp[...] = b[..., i]
+            potrsBatched(handle, uplo, n, 1, ap.data.ptr, lda,
+                         bp_tmp.data.ptr, b_tmp.shape[-1],
+                         dev_info.data.ptr, batch_size)
+            _cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(  # noqa: E501
+                potrsBatched, dev_info)
+            b[..., i] = b_tmp
 
-    # TODO: check if conj() is necessary when nrhs > 1
     return b.conj().reshape(b_shape)
 
 

--- a/tests/cupyx_tests/linalg_tests/test_solve.py
+++ b/tests/cupyx_tests/linalg_tests/test_solve.py
@@ -6,7 +6,6 @@ import numpy
 import pytest
 
 import cupy
-from cupy.cuda import runtime
 from cupyx import cusolver
 from cupy import testing
 import cupyx
@@ -16,8 +15,6 @@ import cupyx
     'size': [5, 9, 17, 33],
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
-@pytest.mark.xfail(runtime.is_hip,
-                   reason='rocSOLVER does not implement potrs yet.')
 class TestInvh(unittest.TestCase):
 
     @testing.numpy_cupy_allclose(atol=1e-5)

--- a/tests/cupyx_tests/test_lapack.py
+++ b/tests/cupyx_tests/test_lapack.py
@@ -7,7 +7,6 @@ import pytest
 
 import cupy
 from cupy import testing
-import cupyx
 from cupyx import cusolver, lapack
 
 
@@ -156,12 +155,13 @@ class TestPosv(unittest.TestCase):
         return a
 
 
-# TODO: cusolver does not support nrhs > 1 for potrsBatched
 @testing.parameterize(*testing.product({
     'shape': [(2, 3, 3)],
-    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+    'dtype': [numpy.float32, numpy.float64,
+              numpy.complex64, numpy.complex128],
 }))
-class TestXFailBatchedPosv(unittest.TestCase):
+class TestBatchedPosvNrhsGt1(unittest.TestCase):
+    """Batched cupyx.lapack.posv with nrhs > 1."""
 
     def test_posv(self):
         if not cusolver.check_availability('potrsBatched'):
@@ -171,9 +171,16 @@ class TestXFailBatchedPosv(unittest.TestCase):
         identity_matrix = cupy.eye(n, dtype=a.dtype)
         b = cupy.empty(a.shape, a.dtype)
         b[...] = identity_matrix
-        with cupyx.errstate(linalg='ignore'):
-            with pytest.raises(cupy.cuda.cusolver.CUSOLVERError):
-                lapack.posv(a, b)
+        # Solve A @ X = I per batch element; X should be A^-1.
+        x = lapack.posv(a, b)
+        # Verify A @ X == I within tolerance. Use a moderately loose
+        # tolerance because the matrices are small (3x3) and the
+        # condition number, while bounded by the diagonal-shift in
+        # _create_posdef_matrix, is not specifically controlled.
+        reconstructed = a @ x
+        atol = 1e-4 if self.dtype in (numpy.float32,
+                                      numpy.complex64) else 1e-10
+        testing.assert_allclose(reconstructed, b, atol=atol)
 
     def _create_posdef_matrix(self, xp, shape, dtype):
         n = shape[-1]


### PR DESCRIPTION
## Wire `cusolverDn?potrs` to rocSOLVER on HIP, and fix `nrhs > 1` batched `posv`

### Summary
Two related changes to Cholesky solves:

1. **HIP:** implement the eight `cusolverDn{S,D,C,Z}potrs[Batched]` bridges that were previously hard-coded stubs returning `rocblas_status_not_implemented`, wiring them to the real `rocsolver_<t>potrs[_batched]` family.
2. **All backends:** fix incorrect results from `cupyx.lapack.posv` (and `_batched_posv`) when the batched right-hand side has `nrhs > 1`.

### Motivation

**Stubbed `potrs` on HIP.** On ROCm, every call into `cupyx.lapack.potrs` / `cupyx.linalg.cho_solve` reached `cusolver.{s,d,c,z}potrs`, whose HIP bridge in `cupy_backends/hip/cupy_rocsolver.h` returned `rocblas_status_not_implemented` unconditionally — surfacing as `CUSOLVERError: rocblas_status_not_implemented` before any GPU work ran. The corresponding tests were skipped via xfail. rocSOLVER has shipped `rocsolver_<t>potrs[_batched]` for many releases (present in ROCm 7.2.0 at `rocsolver-functions.h:11675+` / `:11802+`); the cuSOLVER and rocSOLVER signatures line up directly, with the sole difference that cuSOLVER's `potrs` takes a trailing `int *devInfo` and rocSOLVER signals errors via the `rocblas_status` return value.

**`nrhs > 1` correctness bug.** `_batched_posv` reshapes `b` to `(batch, n, nrhs)` in C-order and hands per-batch pointers to `potrsBatched` with `ldb == n`, but cuSOLVER/rocSOLVER expect each RHS block in **column-major** layout. C-order `B[i,j]` lives at `i*nrhs + j`, while the solver reads `i + j*n`; these coincide only when `nrhs == 1`. For `nrhs > 1` the solver reads scrambled positions and returns garbage. On CUDA this was masked by cuSOLVER's documented `nrhs == 1` restriction (it raised before computing); on HIP it was masked by the stubs. Once the HIP bridge lands, the bug becomes reachable.

### Changes

**`cupy_backends/hip/cupy_rocsolver.h`**
- Replace the 8 `potrs[Batched]` stubs with real bridges to `rocsolver_<t>potrs[_batched]`.
- Complex variants `reinterpret_cast` `cuComplex*`/`cuDoubleComplex*` to the rocBLAS complex types (matching the existing `potrf` bridges); batched variants use the `… * const*` pointer-array casts rocSOLVER expects.
- Add a small `_cupy_zero_dev_info` helper: on a successful return, zero the caller's `*devInfo` via `hipMemsetAsync` sequenced on the handle's rocBLAS stream, so the write is ordered before any later kernel that reads `devInfo`. This honors CuPy's `devInfo` convention (`cupyx.lapack.potrs` allocates uninitialized `devInfo` and asserts it's `0`) in one documented place.

**`cupyx/cusolver.pyx`**
- `_available_hip_version['potrsBatched']`: `(inf, None)` → `(306, None)`, the same `HIP_VERSION` gate as `potrfBatched` (they share the pointer-array bridge added in that ROCm release).

**`cupyx/lapack.py`**
- `_batched_posv`: when `nrhs == 1`, issue a single batched call as before; when `nrhs > 1`, loop one column at a time into a contiguous staging buffer and call `potrsBatched` with `nrhs=1` (mirroring the existing `_batched_potrs` pattern). A single column is layout-invariant, so the F-order interpretation matches storage. This also lifts the `nrhs > 1` restriction for `cupyx.lapack.posv`.

**Tests**
- `test_solve.py::TestInvh`: drop the `xfail(runtime.is_hip, reason='rocSOLVER does not implement potrs yet.')`.
- `test_lapack.py`: convert `TestXFailBatchedPosv` (which asserted the `CUSOLVERError` raise path) into `TestBatchedPosvNrhsGt1`, which now solves `A @ X = I` per batch element and verifies `A @ X ≈ I` for all real/complex dtypes.

### Testing
On ROCm 7.2.0 / gfx90a: `tests/cupyx_tests/test_lapack.py::TestPotrs`, `::TestBatchedPosvNrhsGt1`, and `tests/cupyx_tests/linalg_tests/test_solve.py::TestChosolve` / `::TestInvh` pass across the exercised shape/order/lower/nrhs/dtype combinations, including complex. CUDA path unchanged except for the `nrhs > 1` fix, which makes multi-RHS batched `posv` correct (and supported) where it previously raised.
