### PR TITLE
test_delaunay::test_pathological[dataset0]: skip on HIP (SIGABRT)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
+++ b/tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
@@ -75,7 +75,15 @@ class TestDelaunay:
         return xp.sort(xp.sort(tri.simplices, axis=-1), axis=0)
 
     @pytest.mark.parametrize(
-        'dataset', [pathological_data_1, pathological_data_2])
+        'dataset',
+        [pytest.param(
+            pathological_data_1,
+            marks=pytest.mark.skipif(
+                cupy.cuda.runtime.is_hip,
+                reason='SIGABRT in cupyx.scipy.spatial.delaunay_2d '
+                '_do_flipping for this dataset (crashes the '
+                'worker; not xfail-able)')),
+         pathological_data_2])
     @testing.numpy_cupy_allclose(scipy_name='scp')
     def test_pathological(self, dataset, xp, scp):
         points = xp.asarray(dataset, dtype=xp.float64)


### PR DESCRIPTION
Symptom
-------
On ROCm 7.x:
  tests/cupyx_tests/scipy_tests/spatial_tests/test_delaunay.py
  ::TestDelaunay::test_pathological[dataset0]
takes SIGABRT inside cupyx.scipy.spatial.delaunay_2d._do_flipping and crashes the pytest worker. dataset0 is pathological_data_1, an 81-point regular 9x9 lattice on [-3.14, 3.14]^2 -- a textbook degenerate Delaunay configuration (entire rows and columns are exactly collinear, every grid square has 4 co-circular corners), which forces the algorithm onto the exact-arithmetic Schewchuk predicate / Symbolic-of-Simulation (SoS) path
(CheckDelaunayMode.CircleExactOrientSoS).

pathological_data_2 (a different grid) does not SIGABRT and is left running.

Root cause (hypothesis, not confirmed by attaching a debugger) -------------------------------------------------------------- The Delaunay 2D kernel module
(cupyx/scipy/spatial/delaunay_2d/_kernels.py) has no explicit assert(), abort(), or __trap() calls, and uses no warp-shuffle / __ballot intrinsics, so the SIGABRT is almost certainly a HIP runtime catching an out-of-bounds device memory access (HIP tends to surface these as host-side SIGABRT, where CUDA more often surfaces them as a returned CUDA error or silent corruption). Most likely suspect is the exact-arithmetic path in _schewchuk.py, whose buffer-resize logic for big-integer "growing expansion" arithmetic could exceed an assumed bound on this particular pathological input. A real RCA would require attaching rocgdb / running with AMD_LOG_LEVEL=3 to pin down the kernel that aborts.

Fix
---
SIGABRT cannot be wrapped in pytest.mark.xfail (the worker dies before pytest sees a raise), so use a per-parametrisation skipif on this one dataset only. pathological_data_2 still runs.

Note
----
The test_rgi half of this PR (TestRegularGridInterpolator ::test_derivatives xfail) has been folded into #101 because it has the same root cause as the existing #101 xfails (rocSOLVER has no csrlsvqr / sparse exact factor-and-solve). This PR keeps only the delaunay skip, which is independently caused by a SIGABRT in the Schewchuk SoS path.