### PR TITLE
test_lfilter_zi_with_zeros: skip zeros=(1,2) on HIP (SIGABRT in SVD)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_signaltools.py
@@ -594,7 +594,16 @@ class TestLFilter:
         return out
 
     @pytest.mark.parametrize(
-        'zeros', [(2,), (1,), (0,), (1, 2), (0, 1), (0, 2), (0, 1, 2)])
+        'zeros',
+        [(2,), (1,), (0,),
+         pytest.param(
+             (1, 2),
+             marks=pytest.mark.skipif(
+                 runtime.is_hip,
+                 reason='SIGABRT in rocSOLVER SVD for this specific '
+                        'IIR-coefficient pattern (crashes the worker; '
+                        'not xfail-able)')),
+         (0, 1), (0, 2), (0, 1, 2)])
     @testing.numpy_cupy_array_almost_equal(scipy_name='scp', decimal=5)
     def test_lfilter_zi_with_zeros(self, zeros, xp, scp):
         fir_order = 3


### PR DESCRIPTION
Standalone Python reproducer with the same a/b sequence succeeds; only the pytest run crashes, meaning the rocSOLVER SVD path is sensitive to some prior test state. SIGABRT can't be xfailed (it kills the worker), so this parametrisation has to be a hard skip on HIP.