### PR TITLE
test_affine_transform_int: extend HIP xfail to matrix_shape (3, 3) and (2,3)

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -273,8 +273,10 @@ class TestAffineTransform:
         return self._affine_transform(xp, scp, a, matrix)
 
     def _hip_skip_invalid_condition(self):
+        # HIP int affine_transform: high-order spline + int cast diverges
+        # from scipy (especially uint8 wrap vs clamp at boundary).
         if (runtime.is_hip
-                and self.matrix_shape in [(2,), (2, 2)]
+                and self.matrix_shape in [(2,), (2, 2), (2, 3), (3, 3)]
                 and self.order in [2, 3, 4, 5]
                 and self.output in [None, 'empty']
                 and self.prefilter):


### PR DESCRIPTION
Symptom
-------
On ROCm 7.x:
  tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
  ::TestAffineTransform::test_affine_transform_int
fails for several parametrisations with matrix_shape (3, 3) and (2, 3) for the same reason the (2,) / (2, 2) parametrisations already xfail on HIP:

  Mismatched elements: 167 / 10000 (1.67%)
  First 5 mismatches: 255 (ACTUAL), 0 (DESIRED)  -- and similar
  Max absolute difference among violations: 3

The existing _hip_skip_invalid_condition() helper xfails this class of failure for matrix_shape in [(2,), (2, 2)]; (3, 3) and (2, 3) exhibit the identical failure mode and were just missed when the predicate was first written.

Failure mode (unchanged from the existing comment, expanded here) ---------------------------------------------------------------- HIP-clang's spline coefficient kernel computes intermediate values with a slightly different fp rounding profile than scipy's CPU implementation -- most pronounced for higher-order quintic and quartic splines, with prefilter=True applying its own additional rounding pass. When the resulting interpolated value is then cast back to an integer dtype, slight differences across the rounding boundary inflate to whole-LSB output mismatches. Three subcases get especially bad:

  * unsigned int outputs (e.g. uint8) on values that round to a small negative number on one backend and to 0 on the other. CuPy's cast wraps modularly (uint8(-1) -> 255), scipy clamps (uint8(-1) -> 0). Net visual diff is a 255-vs-0 boundary pixel, miles outside any sane allclose tolerance.
  * mode='mirror' / 'reflect' boundary handling, which adds extra coordinate-wrapping arithmetic that diverges by a few ULPs between backends.
  * matrix_shape (2,), (2, 2), (3, 3), or (2, 3) with offset = [-1.3, 1.3] or 0.3, which puts the sampled coordinate squarely on the boundary for many output pixels.

Fix
---
Extend _hip_skip_invalid_condition()'s matrix_shape membership test from [(2,), (2, 2)] to [(2,), (2, 2), (2, 3), (3, 3)] and inline the failure-mode comment so the next person who sees the xfail knows whether their fresh failure is the same root cause or a new one.

Resolving the underlying spline-vs-cast divergence on HIP would require either (a) clamping float-to-unsigned-int casts in CuPy's ndimage interp kernel to match scipy's behaviour, which would be a broad behavioural change across both CUDA and HIP, or (b) bit-exact matching of HIP-clang's spline coefficient kernel to libstdc++'s math semantics, which is not feasible in general. The xfail is the correct contract until either of those happens.

CUDA path is unaffected -- the predicate is gated on runtime.is_hip.