### PR TITLE
core: bool.conj() promotes to int8 (match NumPy 2.x)

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -34,7 +34,9 @@ except ImportError:
 
 
 cdef _ndarray_base _ndarray_conj(_ndarray_base self):
-    if self.dtype.kind == 'c':
+    # NumPy 2.x promotes bool -> int8 on conj; keep the same-object
+    # fast path for other real dtypes.
+    if self.dtype.kind == 'c' or self.dtype.kind == 'b':
         return _conjugate(self)
     else:
         return self

--- a/cupy/_statistics/correlation.py
+++ b/cupy/_statistics/correlation.py
@@ -73,10 +73,18 @@ def correlate(a, v, mode='valid'):
     # choose_conv_method does not choose from the values in
     # the input array, so no need to apply conj.
     method = cupy._math.misc._choose_conv_method(a, v, mode)
+    # conj is mathematically a no-op for real-typed v (and would
+    # promote bool -> int8 via the matching _ndarray_conj fix
+    # elsewhere in this branch, leaking the dtype change into
+    # correlate's output and diverging from numpy.correlate, which
+    # preserves the input dtype for real types). Skip the conj entirely
+    # for non-complex v -- the [::-1] reversal alone is what
+    # correlate actually needs there.
+    v_for_conv = v.conj()[::-1] if v.dtype.kind == 'c' else v[::-1]
     if method == 'direct':
-        out = cupy._math.misc._dot_convolve(a, v.conj()[::-1], mode)
+        out = cupy._math.misc._dot_convolve(a, v_for_conv, mode)
     elif method == 'fft':
-        out = cupy._math.misc._fft_convolve(a, v.conj()[::-1], mode)
+        out = cupy._math.misc._fft_convolve(a, v_for_conv, mode)
     else:
         raise ValueError('Unsupported method')
     return out
@@ -209,6 +217,10 @@ def cov(a, y=None, rowvar=True, bias=False, ddof=None,
         X_T = X.T
     else:
         X_T = (X * w).T
-    out = X.dot(X_T.conj()) / fact
+    # See the matching comment in correlate() above: skip the conj
+    # for real-typed X so that the matching _ndarray_conj bool ->
+    # int8 promotion does not leak into cov()'s output dtype.
+    X_T_for_dot = X_T.conj() if X_T.dtype.kind == 'c' else X_T
+    out = X.dot(X_T_for_dot) / fact
 
     return out.squeeze()

--- a/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_complex_ops.py
@@ -9,6 +9,7 @@ from cupy import testing
 
 class TestConj:
 
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal()
     def test_conj(self, xp, dtype):
@@ -27,6 +28,7 @@ class TestConj:
         assert x is y
         return y
 
+    @testing.with_requires('numpy>=2.0')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_almost_equal()
     def test_conjugate(self, xp, dtype):


### PR DESCRIPTION
Symptom
-------
On NumPy >= 2.0:
  tests/cupy_tests/core_tests/test_ndarray_complex_ops.py::TestConj::*
fail with

  AssertionError: ndarrays of different dtypes are returned.
    cupy: bool
    numpy: int8

The four affected tests (test_conj, test_conjugate, and the _pass variants) exercise the bool parametrisation of @for_all_dtypes() and call x.conj() / x.conjugate() on a bool ndarray.

NumPy 2.x promotes bool to int8 on conj/conjugate (NEP 50 fallout -- bool no longer carries through arithmetic-shaped operations unchanged). CuPy short-circuited every non-complex dtype in _ndarray_conj and returned the input array as-is, including bool.

Fix
---
Extend the _ndarray_conj fast-path predicate to include bool.dtype .kind == 'b', so bool inputs go through the _conjugate ufunc the same way complex inputs do. The ufunc's type-loop table doesn't list '?->?', so dispatch naturally promotes bool -> int8 (the 'b->b' loop is the next-smallest match), matching NumPy 2.x.

Real-typed non-bool inputs (int*, float*, complex*) keep the existing same-object fast path -- numpy 2.x technically allocates a fresh array there too, but downstream code (and several self-identity-asserting tests) depend on the no-op contract, so the wider change is left for a separate pass.

Gate test_conj / test_conjugate with @testing.with_requires( 'numpy>=2.0'). The cupy-side change is only correct against numpy
>= 2.0; on numpy < 2 the test would now FAIL because cupy returns
int8 for bool while numpy 1.x still returns bool, inverting the original failure. (The _pass variants have a separate problem: their `assert x is y` line breaks for bool after this fix regardless of numpy version, since bool now dispatches through the ufunc and gets a fresh array; that is handled by the companion PR #109 which drops the identity assertion.)

The secondary changes in cupy/_statistics/correlation.py (skipping .conj() on real-typed inputs inside correlate() and cov()) prevent the new bool -> int8 promotion from leaking into correlate / cov output dtypes, where numpy preserves the input dtype for real types.

Requires a rebuild (Cython source). Tested locally on ROCm 7.2.0
+ NumPy 2.4.6: all 4 previously-failing TestConj tests now pass (test_conj and test_conjugate via the fix; test_conj_pass and test_conjugate_pass via the companion PR #109).