### PR TITLE
Clean up two cupy-owned compiler warnings (rocsolver typedef + dead CAI helper)

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2790,13 +2790,6 @@ cdef _ndarray_base _array_from_cupy_ndarray(
     return a
 
 
-cdef _ndarray_base _array_from_cuda_array_interface(
-        obj, dtype, copy, order, bint subok, Py_ssize_t ndmin):
-    return array(
-        _convert_object_with_cuda_array_interface(obj),
-        dtype, copy, order, subok, ndmin)
-
-
 cdef _ndarray_base _array_from_nested_sequence(
         obj, dtype, order, Py_ssize_t ndmin, concat_shape, concat_type,
         concat_dtype, bint blocking):

--- a/cupy_backends/hip/cupy_rocsolver.h
+++ b/cupy_backends/hip/cupy_rocsolver.h
@@ -69,7 +69,10 @@ cusolverStatus_t cusolverGetProperty(libraryPropertyType type, int* val) {
 }
 
 
-typedef enum cusolverDnParams_t {};
+// Placeholder for cuSOLVER's opaque cusolverDnParams_t (HIP shims
+// ignore it). Anonymous enum named via typedef avoids the
+// "typedef ignored" warning the named-enum form produced.
+typedef enum {} cusolverDnParams_t;
 
 cusolverStatus_t cusolverDnCreateParams(...) {
     return rocblas_status_not_implemented;


### PR DESCRIPTION
Two unrelated benign warnings show up consistently in HIP host builds. Both are in code cupy itself owns, so they get real fixes rather than suppressions.

(1) cupy_backends/hip/cupy_rocsolver.h:72 -- 'typedef enum NAME {};' is
    malformed. The typedef keyword is silently dropped when the enum is
    named on the LEFT (after 'enum') and the right-hand side is empty,
    so the line declares an empty enum tag 'cusolverDnParams_t' but does
    not introduce 'cusolverDnParams_t' as a typedef name. g++ flags this
    as

        warning: 'typedef' was ignored in this declaration

    Worked downstream by accident because the same name is exposed via
    the enum-tag namespace in C, but is otherwise wrong on the C++ side
    where Cython's generated cusolver wrapper uses 'cusolverDnParams_t'
    as a typedef name. Fix by switching to 'typedef enum {} NAME;'
    (anonymous enum named via typedef), matching the existing spelling
    in cupy_backends/stub/cupy_cusolver.h:14 for the same type. The
    HIP-side functions below the typedef ignore the parameter anyway --
    rocSOLVER has no equivalent of CUDA's opaque cusolverDnParams_t --
    so type identity is what matters here, not the underlying enumerator
    set.

(2) cupy/_core/core.pyx:2811 -- '_array_from_cuda_array_interface' is
    defined but never called. g++ flags it as

        warning: '...' defined but not used [-Wunused-function]

    Confirmed dead code. Commit c259a8821 ('ENH,MAINT: Allow cupy-like
    protocols in setitem and consolidate') removed the only call site
    when the __cuda_array_interface__ / __cupy_get_ndarray__ /
    isinstance(ndarray) dispatch in array() was consolidated into a
    single _convert_from_cupy_like() call. The body was left behind --
    its two-line work (call _convert_object_with_cuda_array_interface()
    then dispatch through array()) is now subsumed by the consolidated
    helper, and grep confirms no other reference anywhere in the repo.
    Delete the orphaned definition.