### PR TITLE
sparse: respect copy=False for DIA offsets array

### DIFF
--- a/cupyx/scipy/sparse/_dia.py
+++ b/cupyx/scipy/sparse/_dia.py
@@ -54,10 +54,12 @@ class dia_matrix(_data._data_matrix):
             raise ValueError(
                 'unrecognized form for dia_matrix constructor')
 
-        data = cupy.array(data, dtype=dtype, copy=copy)
+        # copy=None means "copy only if needed"; copy=False might raise
+        data = cupy.array(data, dtype=dtype, copy=copy if copy else None)
         data = cupy.atleast_2d(data)
         off_dtype = _sputils.get_index_dtype(maxval=max(shape))
-        offsets = cupy.array(offsets, dtype=off_dtype, copy=copy)
+        offsets = cupy.array(
+            offsets, dtype=off_dtype, copy=copy if copy else None)
         offsets = cupy.atleast_1d(offsets)
 
         if offsets.ndim != 1:

--- a/cupyx/scipy/sparse/_dia.py
+++ b/cupyx/scipy/sparse/_dia.py
@@ -57,7 +57,7 @@ class dia_matrix(_data._data_matrix):
         data = cupy.array(data, dtype=dtype, copy=copy)
         data = cupy.atleast_2d(data)
         off_dtype = _sputils.get_index_dtype(maxval=max(shape))
-        offsets = cupy.array(offsets, dtype=off_dtype)
+        offsets = cupy.array(offsets, dtype=off_dtype, copy=copy)
         offsets = cupy.atleast_1d(offsets)
 
         if offsets.ndim != 1:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -242,6 +242,27 @@ class TestDiaMatrixInit(unittest.TestCase):
         n = _make_complex(xp, sp, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
+    def test_offsets_no_copy(self):
+        # copy=False must not copy the offsets array when its dtype
+        # already matches; mutating the input is reflected in the matrix.
+        for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
+            offsets = self.offsets(xp)
+            m = sp.dia_matrix(
+                (self.data(xp), offsets), shape=self.shape, copy=False)
+            offsets[0] += 1
+            assert int(m.offsets[0]) == int(offsets[0])
+
+    def test_offsets_copy(self):
+        # copy=True must copy the offsets array; mutating the input must
+        # not affect the matrix.
+        for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
+            offsets = self.offsets(xp)
+            original = int(offsets[0])
+            m = sp.dia_matrix(
+                (self.data(xp), offsets), shape=self.shape, copy=True)
+            offsets[0] += 1
+            assert int(m.offsets[0]) == original
+
 
 @testing.parameterize(*testing.product({
     'make_method': ['_make', '_make_empty'],

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -169,13 +169,14 @@ class TestDiaMatrix(unittest.TestCase):
             c.toarray(), cupy.eye(2, dtype=self.dtype))
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
-}))
-@unittest.skipUnless(scipy_available, 'requires scipy')
-class TestDiaMatrixInit(unittest.TestCase):
+@pytest.mark.parametrize(
+    'dtype', [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
+@pytest.mark.skipif(not scipy_available, reason='requires scipy')
+class TestDiaMatrixInit:
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def _setup(self, dtype):
+        self.dtype = dtype
         self.shape = (3, 4)
 
     def data(self, xp):
@@ -242,18 +243,39 @@ class TestDiaMatrixInit(unittest.TestCase):
         n = _make_complex(xp, sp, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
-    @pytest.mark.parametrize("copy", [True, False])
+    @pytest.mark.parametrize('copy', [True, False])
     def test_copy_kwarg(self, copy):
-        # If their dtypes are correct, data and offset should be copied
-        # only when copy=True.
+        # If their dtypes are correct, data and offsets are copied only when
+        # copy=True; copy=False must share memory.
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             offsets = self.offsets(xp)
             data = self.data(xp)
             m = sp.dia_matrix((data, offsets), shape=self.shape, copy=copy)
-
             shares_memory = not copy
             assert xp.may_share_memory(m.data, data) == shares_memory
             assert xp.may_share_memory(m.offsets, offsets) == shares_memory
+
+    def test_copy_false_dtype_mismatch(self):
+        # copy=False must not raise even when dtype conversion is needed.
+        # The arrays are copied (conversion requires it), but no error.
+        for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
+            # Pass int64 offsets for a small matrix (constructor needs int32).
+            offsets64 = xp.array([0, -1], dtype=xp.int64)
+            data = self.data(xp)
+            m = sp.dia_matrix((data, offsets64), shape=self.shape, copy=False)
+            assert m.offsets.dtype == xp.dtype('i')  # converted to int32
+            xp.testing.assert_array_equal(m.offsets, offsets64)
+
+            # Pass float32 data; constructor should convert to self.dtype
+            # without raising.  (float32 → any sparse dtype is always safe.)
+            if self.dtype != numpy.float32:
+                data_f32 = xp.array([[1, 2, 3], [4, 5, 6]], dtype=xp.float32)
+                m2 = sp.dia_matrix(
+                    (data_f32, self.offsets(xp)), shape=self.shape,
+                    dtype=self.dtype, copy=False)
+                assert m2.dtype == xp.dtype(self.dtype)
+                xp.testing.assert_array_almost_equal(
+                    m2.data, data_f32.astype(self.dtype))
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -175,7 +175,7 @@ class TestDiaMatrix(unittest.TestCase):
 class TestDiaMatrixInit:
 
     @pytest.fixture(autouse=True)
-    def _setup(self, dtype):
+    def _setup(self, dtype, scope='class'):
         self.dtype = dtype
         self.shape = (3, 4)
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -242,26 +242,18 @@ class TestDiaMatrixInit(unittest.TestCase):
         n = _make_complex(xp, sp, self.dtype)
         cupy.testing.assert_array_equal(n.conj().data, n.data.conj())
 
-    def test_offsets_no_copy(self):
-        # copy=False must not copy the offsets array when its dtype
-        # already matches; mutating the input is reflected in the matrix.
+    @pytest.mark.parametrize("copy", [True, False])
+    def test_copy_kwarg(self, copy):
+        # If their dtypes are correct, data and offset should be copied
+        # only when copy=True.
         for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
             offsets = self.offsets(xp)
-            m = sp.dia_matrix(
-                (self.data(xp), offsets), shape=self.shape, copy=False)
-            offsets[0] += 1
-            assert int(m.offsets[0]) == int(offsets[0])
+            data = self.data(xp)
+            m = sp.dia_matrix((data, offsets), shape=self.shape, copy=copy)
 
-    def test_offsets_copy(self):
-        # copy=True must copy the offsets array; mutating the input must
-        # not affect the matrix.
-        for xp, sp in ((numpy, scipy.sparse), (cupy, sparse)):
-            offsets = self.offsets(xp)
-            original = int(offsets[0])
-            m = sp.dia_matrix(
-                (self.data(xp), offsets), shape=self.shape, copy=True)
-            offsets[0] += 1
-            assert int(m.offsets[0]) == original
+            shares_memory = not copy
+            assert xp.may_share_memory(m.data, data) == shares_memory
+            assert xp.may_share_memory(m.offsets, offsets) == shares_memory
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
The dia_matrix constructor dropped copy=copy when building offsets (regression from gh-9825). Since cupy.array defaults to copy=True, offsets was always copied, breaking the copy=False contract and diverging from scipy. Restore copy=copy and add regression tests.

I looked for other places where copy=copy may have been dropped, but didn't find any other offenders.

Fixes bug https://github.com/cupy/cupy/pull/9825/changes#r3357665856