### PR TITLE
TST: Migrate fusion_tests to using pytest

### DIFF
--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -261,7 +261,7 @@ def _wraps_partial(wrapped, *names):
     return decorator
 
 
-def _wraps_partial_xp(wrapped, name, sp_name, scipy_name):
+def _wraps_partial_xp(wrapped, name, sp_name=None, scipy_name=None):
     names = [name, sp_name, scipy_name]
     names = [n for n in names if n is not None]
     return _wraps_partial(wrapped, *names)

--- a/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import inspect
+
 import numpy
 
 import cupy
 from cupy import testing
-
+from cupy.testing._loops import _wraps_partial_xp
 
 scalar_types = (numpy.generic, int, float, complex)
 
@@ -92,11 +94,20 @@ def check_fusion(
                 raise err_e
 
     def deco(func):
-        def wrapper(self, **generate_inputs_kwargs):
+        @_wraps_partial_xp(func, 'xp')
+        def wrapper(self, **kwargs):
             generate_inputs = getattr(self, generate_inputs_name)
 
-            impl_np = func(self, numpy, **generate_inputs_kwargs)
-            impl_cp = func(self, cupy, **generate_inputs_kwargs)
+            generate_inputs_params = inspect.signature(
+                generate_inputs).parameters
+
+            impl_np = func(self, numpy, **kwargs)
+            impl_cp = func(self, cupy, **kwargs)
+
+            generate_inputs_kwargs = {
+                k: v for k, v in kwargs.items()
+                if k in generate_inputs_params
+            }
 
             # TODO(imanishi): Fix these workaround after `cupy.fuse`
             # supports lambda function.
@@ -133,7 +144,6 @@ def check_fusion(
                 check(cupy, args_cp, args_np)
                 check(numpy, args_fuse_np, args_np)
                 check(cupy, args_fuse_cp, args_np)
-
         return wrapper
     return deco
 

--- a/tests/cupy_tests/core_tests/fusion_tests/test_array.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_array.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import unittest
+import pytest
 
 import numpy
 
@@ -8,7 +8,7 @@ from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-class FusionArrayTestBase(unittest.TestCase):
+class FusionArrayTestBase:
 
     def _get_argument(self, xp, dtype, seed, value_type):
         dtype = numpy.dtype(dtype)
@@ -24,61 +24,69 @@ class FusionArrayTestBase(unittest.TestCase):
             return dtype.type(3).tolist()
         assert False
 
-    def generate_inputs(self, xp, dtype1, dtype2):
-        x = self._get_argument(xp, dtype1, 0, self.left_value)
-        y = self._get_argument(xp, dtype2, 1, self.right_value)
+    def generate_inputs(self, xp, dtype1, dtype2, left_value, right_value):
+        x = self._get_argument(xp, dtype1, 0, left_value)
+        y = self._get_argument(xp, dtype2, 1, right_value)
         return (x, y), {}
 
 
-@testing.parameterize(*testing._parameterized.product_dict(
+@pytest.mark.parametrize(
+    "func",
     [
-        {'name': 'neg', 'func': lambda x, y: -x},
-        {'name': 'add', 'func': lambda x, y: x + y},
-        {'name': 'sub', 'func': lambda x, y: x - y},
-        {'name': 'mul', 'func': lambda x, y: x * y},
-        {'name': 'div', 'func': lambda x, y: x / y},
-        {'name': 'pow', 'func': lambda x, y: x ** y},
-        {'name': 'eq', 'func': lambda x, y: x == y},
-        {'name': 'ne', 'func': lambda x, y: x != y},
-        {'name': 'lt', 'func': lambda x, y: x < y},
-        {'name': 'le', 'func': lambda x, y: x <= y},
-        {'name': 'gt', 'func': lambda x, y: x > y},
-        {'name': 'ge', 'func': lambda x, y: x >= y},
-    ],
-    [
-        {'left_value': 'array', 'right_value': 'array'},
-        {'left_value': 'array', 'right_value': 'scalar'},
-        {'left_value': 'array', 'right_value': 'primitive'},
-        {'left_value': 'scalar', 'right_value': 'array'},
-        {'left_value': 'primitive', 'right_value': 'array'},
+        pytest.param(lambda x, y: -x, id='neg'),
+        pytest.param(lambda x, y: x + y, id='add'),
+        pytest.param(lambda x, y: x - y, id='sub'),
+        pytest.param(lambda x, y: x * y, id='mul'),
+        pytest.param(lambda x, y: x / y, id='div'),
+        pytest.param(lambda x, y: x ** y, id='pow'),
+        pytest.param(lambda x, y: x == y, id='eq'),
+        pytest.param(lambda x, y: x != y, id='ne'),
+        pytest.param(lambda x, y: x < y, id='lt'),
+        pytest.param(lambda x, y: x <= y, id='le'),
+        pytest.param(lambda x, y: x > y, id='gt'),
+        pytest.param(lambda x, y: x >= y, id='ge'),
     ]
-))
+)
+@pytest.mark.parametrize(
+    "left_value,right_value",
+    [
+        ('array', 'array'),
+        ('array', 'scalar'),
+        ('array', 'primitive'),
+        ('scalar', 'array'),
+        ('primitive', 'array'),
+    ]
+)
 class TestFusionArrayOperator(FusionArrayTestBase):
 
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_bool=True)
     @fusion_utils.check_fusion()
-    def test_operator(self, xp, dtype1, dtype2):
-        return self.func
+    def test_operator(self, xp, dtype1, dtype2, func, left_value, right_value):
+        return func
 
 
-@testing.parameterize(*testing._parameterized.product_dict(
+@pytest.mark.parametrize(
+    "func",
     [
-        {'name': 'lshift', 'func': lambda x, y: x << y},
-        {'name': 'rshift', 'func': lambda x, y: x >> y},
-        {'name': 'and', 'func': lambda x, y: x & y},
-        {'name': 'or', 'func': lambda x, y: x | y},
-        {'name': 'xor', 'func': lambda x, y: x ^ y},
-        {'name': 'invert', 'func': lambda x, y: ~x},
-    ],
-    [
-        {'left_value': 'array', 'right_value': 'array'},
-        {'left_value': 'array', 'right_value': 'scalar'},
-        {'left_value': 'array', 'right_value': 'primitive'},
-        {'left_value': 'scalar', 'right_value': 'array'},
-        {'left_value': 'primitive', 'right_value': 'array'},
+        pytest.param(lambda x, y: x << y, id='lshift'),
+        pytest.param(lambda x, y: x >> y, id='rshift'),
+        pytest.param(lambda x, y: x & y, id='and'),
+        pytest.param(lambda x, y: x | y, id='or'),
+        pytest.param(lambda x, y: x ^ y, id='xor'),
+        pytest.param(lambda x, y: ~x, id='invert'),
     ]
-))
+)
+@pytest.mark.parametrize(
+    "left_value,right_value",
+    [
+        ('array', 'array'),
+        ('array', 'scalar'),
+        ('array', 'primitive'),
+        ('scalar', 'array'),
+        ('primitive', 'array'),
+    ]
+)
 class TestFusionArrayBitwiseOperator(FusionArrayTestBase):
 
     def _is_uint64(self, x):
@@ -90,51 +98,55 @@ class TestFusionArrayBitwiseOperator(FusionArrayTestBase):
     @testing.for_int_dtypes_combination(
         names=('dtype1', 'dtype2'), no_bool=True)
     @fusion_utils.check_fusion()
-    def test_operator(self, xp, dtype1, dtype2):
-        def func(x, y):
+    def test_operator(self, xp, dtype1, dtype2, func, left_value, right_value):
+        def impl(x, y):
             if ((self._is_uint64(x) and self._is_signed_int(y))
                     or (self._is_uint64(y) and self._is_signed_int(x))):
                 # Skip TypeError case.
                 return
-            return self.func(x, y)
+            return func(x, y)
 
-        return func
+        return impl
 
 
-@testing.parameterize(
-    {'left_value': 'array', 'right_value': 'array'},
-    {'left_value': 'array', 'right_value': 'scalar'},
-    {'left_value': 'array', 'right_value': 'primitive'},
-    {'left_value': 'scalar', 'right_value': 'array'},
-    {'left_value': 'primitive', 'right_value': 'array'},
+@pytest.mark.parametrize(
+    "left_value,right_value",
+    [
+        ('array', 'array'),
+        ('array', 'scalar'),
+        ('array', 'primitive'),
+        ('scalar', 'array'),
+        ('primitive', 'array'),
+    ]
 )
 class TestFusionArrayFloorDivide(FusionArrayTestBase):
 
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_bool=True, no_complex=True)
     @fusion_utils.check_fusion()
-    def test_floor_divide(self, xp, dtype1, dtype2):
+    def test_floor_divide(self, xp, dtype1, dtype2, left_value, right_value):
         return lambda x, y: x // y
 
 
 # TODO(imanishi): Fix TypeError in use of dtypes_combination test.
-@testing.parameterize(*testing._parameterized.product_dict(
+@pytest.mark.parametrize(
+    "left_value,right_value",
     [
-        {'left_value': 'array', 'right_value': 'array'},
-        {'left_value': 'array', 'right_value': 'scalar'},
-        {'left_value': 'array', 'right_value': 'primitive'},
+        ('array', 'array'),
+        ('array', 'scalar'),
+        ('array', 'primitive'),
     ]
-))
+)
 class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
-    def generate_inputs(self, xp, dtype):
-        x = self._get_argument(xp, dtype, 0, self.left_value)
-        y = self._get_argument(xp, dtype, 1, self.right_value)
+    def generate_inputs(self, xp, dtype, left_value, right_value):
+        x = self._get_argument(xp, dtype, 0, left_value)
+        y = self._get_argument(xp, dtype, 1, right_value)
         return (x, y), {}
 
     @testing.for_all_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_iadd(self, xp, dtype):
+    def test_iadd(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x += y
 
@@ -142,7 +154,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_all_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_isub(self, xp, dtype):
+    def test_isub(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x -= y
 
@@ -150,7 +162,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_all_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_imul(self, xp, dtype):
+    def test_imul(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x *= y
 
@@ -158,7 +170,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_float_dtypes()
     @fusion_utils.check_fusion()
-    def test_itruediv_py3(self, xp, dtype):
+    def test_itruediv_py3(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x /= y
 
@@ -166,7 +178,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion(accept_error=(TypeError,))
-    def test_int_itruediv_py3_raises(self, xp, dtype):
+    def test_int_itruediv_py3_raises(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x /= y
 
@@ -174,7 +186,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_imod(self, xp, dtype):
+    def test_imod(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x %= y
 
@@ -182,7 +194,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_all_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_ipow(self, xp, dtype):
+    def test_ipow(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x **= y
 
@@ -190,7 +202,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_ilshift(self, xp, dtype):
+    def test_ilshift(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x <<= y
 
@@ -198,7 +210,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_irshift(self, xp, dtype):
+    def test_irshift(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x >>= y
 
@@ -206,7 +218,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_iand(self, xp, dtype):
+    def test_iand(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x &= y
 
@@ -214,7 +226,7 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_ior(self, xp, dtype):
+    def test_ior(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x |= y
 
@@ -222,14 +234,14 @@ class TestFusionArrayInplaceOperator(FusionArrayTestBase):
 
     @testing.for_int_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_ixor(self, xp, dtype):
+    def test_ixor(self, xp, dtype, left_value, right_value):
         def func(x, y):
             x ^= y
 
         return func
 
 
-class TestFusionArraySetItem(unittest.TestCase):
+class TestFusionArraySetItem:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int32', scale=10, seed=0)
@@ -255,7 +267,7 @@ class TestFusionArraySetItem(unittest.TestCase):
         return func
 
 
-class TestFusionArrayMethods(unittest.TestCase):
+class TestFusionArrayMethods:
 
     def generate_inputs(self, xp, dtype):
         x = testing.shaped_random((3, 4), xp, dtype, scale=10, seed=0)
@@ -297,7 +309,7 @@ class TestFusionArrayMethods(unittest.TestCase):
         return lambda x: x.any()
 
 
-class TestFusionArrayAsType(unittest.TestCase):
+class TestFusionArrayAsType:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_example.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_example.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import unittest
 import pytest
 
 import cupy
@@ -11,7 +10,7 @@ from cupy_tests.core_tests.fusion_tests import fusion_utils
 @testing.slow
 @pytest.mark.skipif(
     cupy.cuda.runtime.is_hip, reason='HIP does not support this')
-class TestFusionExample(unittest.TestCase):
+class TestFusionExample:
     def generate_inputs(self, xp):
         shape = (8, 64, 112, 112)
         _, chan, _, _ = shape

--- a/tests/cupy_tests/core_tests/fusion_tests/test_indexing.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_indexing.py
@@ -1,71 +1,77 @@
 from __future__ import annotations
 
-import unittest
+import pytest
 
 from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-@testing.parameterize(
-    # Integer
-    {'shape': (2, 3, 4), 'indices': 1},
-    {'shape': (2, 3, 4), 'indices': -1},
-    {'shape': (2, 3, 4), 'indices': (1,)},
-    {'shape': (2, 3, 4), 'indices': (1, 0)},
-    {'shape': (2, 3, 4), 'indices': (1, 0, 2)},
-    {'shape': (2, 3, 4), 'indices': (-1, 0, -2)},
-    # Slice
-    {'shape': (2, 3, 4), 'indices': slice(None)},
-    {'shape': (2, 3, 4), 'indices': slice(None, None, 1)},
-    {'shape': (2, 3, 4), 'indices': slice(None, None, -1)},
-    {'shape': (2, 3, 4), 'indices': (slice(None), slice(None, None, -1))},
-    # Ellipsis
-    {'shape': (2, 3, 4), 'indices': Ellipsis},
-    {'shape': (2, 3, 4), 'indices': (Ellipsis,)},
-    # Newaxis
-    {'shape': (2, 3, 4), 'indices': None},
-    {'shape': (2, 3, 4), 'indices': (None,)},
-    {'shape': (2, 3, 4), 'indices': (None, None, None)},
-    # Tuple
-    {'shape': (2, 3, 4), 'indices': (slice(None), 0, slice(None, None, -1))},
-    {'shape': (2, 3, 4), 'indices': (1, None, slice(None, None, -1), None, 2)},
-    {'shape': (2,), 'indices': (slice(None), None)},
-    {'shape': (2, 3, 4), 'indices': (Ellipsis, 2)},
-    {'shape': (2, 3, 4), 'indices': (1, Ellipsis)},
-    {'shape': (2, 3, 4, 5), 'indices': (1, Ellipsis, 3)},
+@pytest.mark.parametrize(
+    "shape,indices",
+    [
+        # Integer
+        ((2, 3, 4), 1),
+        ((2, 3, 4), -1),
+        ((2, 3, 4), (1,)),
+        ((2, 3, 4), (1, 0)),
+        ((2, 3, 4), (1, 0, 2)),
+        ((2, 3, 4), (-1, 0, -2)),
+        # Slice
+        ((2, 3, 4), slice(None)),
+        ((2, 3, 4), slice(None, None, 1)),
+        ((2, 3, 4), slice(None, None, -1)),
+        ((2, 3, 4), (slice(None), slice(None, None, -1))),
+        # Ellipsis
+        ((2, 3, 4), Ellipsis),
+        ((2, 3, 4), (Ellipsis,)),
+        # Newaxis
+        ((2, 3, 4), None),
+        ((2, 3, 4), (None,)),
+        ((2, 3, 4), (None, None, None)),
+        # Tuple
+        ((2, 3, 4), (slice(None), 0, slice(None, None, -1))),
+        ((2, 3, 4), (1, None, slice(None, None, -1), None, 2)),
+        ((2,), (slice(None), None)),
+        ((2, 3, 4), (Ellipsis, 2)),
+        ((2, 3, 4), (1, Ellipsis)),
+        ((2, 3, 4, 5), (1, Ellipsis, 3)),
+    ]
 )
-class TestIndexing(unittest.TestCase):
+class TestIndexing:
 
-    def generate_inputs(self, xp, dtype):
-        x = testing.shaped_random(self.shape, xp, dtype, scale=10, seed=0)
+    def generate_inputs(self, xp, dtype, shape):
+        x = testing.shaped_random(shape, xp, dtype, scale=10, seed=0)
         return (x,), {}
 
     @testing.for_all_dtypes()
     @fusion_utils.check_fusion()
-    def test_getitem(self, xp, dtype):
-        return lambda x: x[self.indices]
+    def test_getitem(self, xp, dtype, shape, indices):
+        return lambda x: x[indices]
 
 
-@testing.parameterize(
-    {'shape': (), 'indices': 0},
-    {'shape': (2, 3), 'indices': (0, 0, 0)},
-    {'shape': (2, 3, 4), 'indices': -3},
-    {'shape': (2, 3, 4), 'indices': 3},
+@pytest.mark.parametrize(
+    "shape,indices",
+    [
+        ((), 0),
+        ((2, 3), (0, 0, 0)),
+        ((2, 3, 4), -3),
+        ((2, 3, 4), 3),
+    ]
 )
 @testing.with_requires('numpy>=1.12.0')
-class TestArrayInvalidIndex(unittest.TestCase):
+class TestArrayInvalidIndex:
 
-    def generate_inputs(self, xp, dtype):
-        x = testing.shaped_arange(self.shape, xp, dtype)
+    def generate_inputs(self, xp, dtype, shape):
+        x = testing.shaped_arange(shape, xp, dtype)
         return (x,), {}
 
     @testing.for_all_dtypes()
     @fusion_utils.check_fusion(accept_error=(IndexError,))
-    def test_invalid_getitem(self, xp, dtype):
-        return lambda x: x[self.indices]
+    def test_invalid_getitem(self, xp, dtype, shape, indices):
+        return lambda x: x[indices]
 
 
-class TestIndexingCombination(unittest.TestCase):
+class TestIndexingCombination:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -109,9 +115,9 @@ class TestIndexingCombination(unittest.TestCase):
     def test_indexing_twice_2(self, xp, dtype1, dtype2):
         return lambda x, y, z: x[0][1] + x[1][0]
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @testing.for_all_dtypes_combination(
         names=['dtype1', 'dtype2'], no_bool=True)
     @fusion_utils.check_fusion()

--- a/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_kernel_cache.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import numpy
-
 import cupy
+import pytest
+
 from cupy import testing
 
 
@@ -42,7 +42,7 @@ def mock_fusion_history():
     return wrapper
 
 
-class TestFusionCache(unittest.TestCase):
+class TestFusionCache:
 
     @mock_fusion_history()
     def test_same_array(self, xp, m):
@@ -140,7 +140,7 @@ class TestFusionCache(unittest.TestCase):
 
         x = testing.shaped_random((2, 5), xp, 'int32', scale=10, seed=10)
         y = testing.shaped_random((4, 5), xp, 'int32', scale=10, seed=11)
-        with self.assertRaises(ValueError, msg='could not be broadcast'):
+        with pytest.raises(ValueError, match='could not be broadcast'):
             f(x, y)
         m.check_call_count(xp, 4)
 

--- a/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_misc.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import threading
-import unittest
+
 from unittest import mock
 
+import cupy
 import pytest
 
-import cupy
 from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-class FusionTestBase(unittest.TestCase):
+class FusionTestBase:
     def generate_inputs(self, xp, nargs, dtype):
         inputs = [
             testing.shaped_random((3, 4), xp, dtype, scale=10, seed=seed)
@@ -96,9 +96,9 @@ class TestFusionTuple(FusionTestBase):
 
         return func
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @testing.for_all_dtypes(no_bool=True, no_complex=True)
     @fusion_utils.check_fusion(generate_inputs_args=(2,))
     def test_various_shape(self, xp, dtype):
@@ -137,7 +137,7 @@ class TestReturnNone(FusionTestBase):
         return impl
 
 
-class TestFusionNoneParams(unittest.TestCase):
+class TestFusionNoneParams:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
@@ -207,7 +207,7 @@ class TestSpecialValues(FusionTestBase):
         return func(points, mask)
 
 
-class TestFusionDecorator(unittest.TestCase):
+class TestFusionDecorator:
     def test_without_paren(self):
         @cupy.fuse
         def func_wo_paren(x):
@@ -228,7 +228,7 @@ class TestFusionDecorator(unittest.TestCase):
 
 
 @pytest.mark.thread_unsafe(reason="Uses mock.patch on global state")
-class TestFusionKernelName(unittest.TestCase):
+class TestFusionKernelName:
 
     def check(self, xp, func, expected_name, is_elementwise):
         a = xp.arange(0, 12, dtype='d').reshape(3, 4)
@@ -317,7 +317,7 @@ class TestFusionKernelName(unittest.TestCase):
         return self.check(xp, func, 'abc', False)
 
 
-class TestFusionComposition(unittest.TestCase):
+class TestFusionComposition:
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
@@ -342,7 +342,7 @@ class TestFusionComposition(unittest.TestCase):
         return h(x, y)
 
 
-class TestFusionCompile(unittest.TestCase):
+class TestFusionCompile:
 
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_array_equal()
@@ -369,7 +369,7 @@ class TestFusionGetArrayModule(FusionTestBase):
         return func
 
 
-class TestFusionThread(unittest.TestCase):
+class TestFusionThread:
 
     def test_thread(self):
         x = testing.shaped_arange((3, 3), cupy, cupy.int64)
@@ -430,7 +430,7 @@ class TestFusionThread(unittest.TestCase):
         return xp.concatenate(out)
 
 
-class TestFusionMultiDevice(unittest.TestCase):
+class TestFusionMultiDevice:
 
     @testing.multi_gpu(2)
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_optimization.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -59,7 +58,7 @@ def check_number_of_ops(
     return pytest.mark.thread_unsafe(reason="mocks TraceImpl.")(wrapper)
 
 
-class TestOptimizations(unittest.TestCase):
+class TestOptimizations:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_reduction.py
@@ -1,78 +1,89 @@
 from __future__ import annotations
 
-import unittest
-
 import cupy
-from cupy.exceptions import AxisError
+import pytest
+
 from cupy import testing
+from cupy.exceptions import AxisError
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(1,), (3, 4), (2, 1, 4), (2, 0, 3)],
-    'axis': [-4, -3, -2, -1, 0, 1, 2, 3, 4],
-}))
-class TestFusionReductionAxis(unittest.TestCase):
+@pytest.mark.parametrize(
+    "shape",
+    [(1,), (3, 4), (2, 1, 4), (2, 0, 3)]
+)
+@pytest.mark.parametrize(
+    "axis", [-4, -3, -2, -1, 0, 1, 2, 3, 4]
+)
+class TestFusionReductionAxis:
 
-    def generate_inputs(self, xp):
-        x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
+    def generate_inputs(self, xp, shape):
+        x = testing.shaped_random(shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
     @fusion_utils.check_fusion(accept_error=AxisError)
-    def test_sum_axis(self, xp):
-        return lambda x: cupy.sum(x, self.axis)
+    def test_sum_axis(self, xp, shape, axis):
+        return lambda x: cupy.sum(x, axis)
 
     @fusion_utils.check_fusion(accept_error=AxisError)
-    def test_sum_kwargs_axis(self, xp):
-        return lambda x: cupy.sum(x, axis=self.axis)
+    def test_sum_kwargs_axis(self, xp, shape, axis):
+        return lambda x: cupy.sum(x, axis=axis)
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(1,), (3, 4), (2, 1, 4), (2, 0, 3), (2, 3, 2, 2, 3)],
-    'axis': [
+@pytest.mark.parametrize(
+    "shape",
+    [(1,), (3, 4), (2, 1, 4), (2, 0, 3), (2, 3, 2, 2, 3)]
+)
+@pytest.mark.parametrize(
+    "axis",
+    [
         None, (0,), (1,), (0, 1), (1, 2), (0, 2), (1, 3)
         # TODO(asi1024): Fix core.simple_reduction_kernel to raise Error.
         # (0, 0), (-1, 1)
-    ],
-}))
-class TestFusionReductionMultiAxis(unittest.TestCase):
+    ]
+)
+class TestFusionReductionMultiAxis:
 
-    def generate_inputs(self, xp):
-        x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
+    def generate_inputs(self, xp, shape):
+        x = testing.shaped_random(shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
     @fusion_utils.check_fusion(accept_error=(ValueError, AxisError))
-    def test_sum_axis(self, xp):
-        return lambda x: cupy.sum(x, self.axis)
+    def test_sum_axis(self, xp, shape, axis):
+        return lambda x: cupy.sum(x, axis)
 
     @fusion_utils.check_fusion(accept_error=(ValueError, AxisError))
-    def test_sum_kwargs_axis(self, xp):
-        return lambda x: cupy.sum(x, axis=self.axis)
+    def test_sum_kwargs_axis(self, xp, shape, axis):
+        return lambda x: cupy.sum(x, axis=axis)
 
 
-@testing.parameterize(*testing.product({
-    'shape': [
+@pytest.mark.parametrize(
+    "shape",
+    [
         (120, 128, 144),
         (119, 127, 143),
         (128, 128, 128),
         (32, 1024, 1024)
-    ],
-    'axis': [None, 0, 1, 2, (0, 1), (0, 2), (1, 2)],
-}))
+    ]
+)
+@pytest.mark.parametrize(
+    "axis",
+    [None, 0, 1, 2, (0, 1), (0, 2), (1, 2)],
+)
 @testing.slow
-class TestFusionReductionLarge(unittest.TestCase):
+class TestFusionReductionLarge:
 
-    def generate_inputs(self, xp):
-        x = testing.shaped_random(self.shape, xp, 'int64', scale=10, seed=0)
+    def generate_inputs(self, xp, shape):
+        x = testing.shaped_random(shape, xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
     @fusion_utils.check_fusion()
-    def test_sum_kwargs_axis(self, xp):
-        return lambda x: cupy.sum(x, axis=self.axis)
+    def test_sum_kwargs_axis(self, xp, shape, axis):
+        return lambda x: cupy.sum(x, axis=axis)
 
 
 # TODO(asi1024): Support for bool and complex dtypes.
-class TestFusionReductionSpecifyDtype(unittest.TestCase):
+class TestFusionReductionSpecifyDtype:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -85,10 +96,8 @@ class TestFusionReductionSpecifyDtype(unittest.TestCase):
         return lambda x: x.sum(axis=0, dtype=dtype2)
 
 
-@testing.parameterize(*testing.product({
-    'axis': [None, 0, 1],
-}))
-class TestFusionReductionAndElementwise(unittest.TestCase):
+@pytest.mark.parametrize("axis", [None, 0, 1])
+class TestFusionReductionAndElementwise:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
@@ -96,30 +105,30 @@ class TestFusionReductionAndElementwise(unittest.TestCase):
         return (x, y), {}
 
     @fusion_utils.check_fusion()
-    def test_premap_one_array(self, xp):
-        return lambda x, y: xp.sum(x * 3, self.axis)
+    def test_premap_one_array(self, xp, axis):
+        return lambda x, y: xp.sum(x * 3, axis)
 
     @fusion_utils.check_fusion()
-    def test_premap_two_arrays(self, xp):
-        return lambda x, y: xp.sum(x + y, self.axis)
+    def test_premap_two_arrays(self, xp, axis):
+        return lambda x, y: xp.sum(x + y, axis)
 
     @fusion_utils.check_fusion()
-    def test_postmap_one_array(self, xp):
-        return lambda x, y: xp.sum(x, self.axis) + 3
+    def test_postmap_one_array(self, xp, axis):
+        return lambda x, y: xp.sum(x, axis) + 3
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_postmap_two_arrays(self, xp):
-        return lambda x, y: xp.sum(x, self.axis) + y
+    def test_postmap_two_arrays(self, xp, axis):
+        return lambda x, y: xp.sum(x, axis) + y
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_premap_postmap(self, xp):
-        return lambda x, y: xp.sum(xp.sqrt(x) + y, self.axis) * 2 + y
+    def test_premap_postmap(self, xp, axis):
+        return lambda x, y: xp.sum(xp.sqrt(x) + y, axis) * 2 + y
 
     # TODO(asi1024): Uncomment after replace fusion implementation.
     # @fusion_utils.check_fusion()
@@ -130,80 +139,78 @@ class TestFusionReductionAndElementwise(unittest.TestCase):
     #         return xp.sum(y, self.axis)
     #     return impl
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_postmap_inplace(self, xp):
+    def test_postmap_inplace(self, xp, axis):
         def impl(x, y):
             y += x
-            res = xp.sum(x, self.axis)
+            res = xp.sum(x, axis)
             y += res
         return impl
 
 
-@testing.parameterize(*testing.product({
-    'axis1': [None, 0, 1],
-    'axis2': [None, 0, 1],
-}))
-class TestFusionMultipleReductions(unittest.TestCase):
+@pytest.mark.parametrize("axis1", [None, 0, 1])
+@pytest.mark.parametrize("axis2", [None, 0, 1])
+class TestFusionMultipleReductions:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
         y = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=1)
         return (x, y), {}
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion()
-    def test_two_distinct_reductions(self, xp):
-        return lambda x, y: (x.sum(self.axis1), y.sum(self.axis2))
+    def test_two_distinct_reductions(self, xp, axis1, axis2):
+        return lambda x, y: (x.sum(axis1), y.sum(axis2))
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_two_reductions_and_elementwise(self, xp):
-        return lambda x, y: x.sum(self.axis1) + y.sum(self.axis2)
+    def test_two_reductions_and_elementwise(self, xp, axis1, axis2):
+        return lambda x, y: x.sum(axis1) + y.sum(axis2)
 
 
-class TestFusionMultistageReductions(unittest.TestCase):
+class TestFusionMultistageReductions:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4, 5), xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion()
     def test_multistage_reductions(self, xp):
         return lambda x: x.prod(axis=1).sum(axis=1)
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion()
     def test_multistage_reductions_and_elementwise(self, xp):
         return lambda x: (xp.sqrt(x).prod(axis=0) + x).sum(axis=1) * 2
 
 
-class TestFusionMultistageReductionsMultiAxis(unittest.TestCase):
+class TestFusionMultistageReductionsMultiAxis:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4, 5, 6), xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion()
     def test_multistage_reductions(self, xp):
         return lambda x: x.prod(axis=(-1, 1)).sum(axis=(0, 1))
 
 
-class TestFusionReductionRoutines(unittest.TestCase):
+class TestFusionReductionRoutines:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((30,), xp, 'int64', scale=10, seed=0)
@@ -226,15 +233,15 @@ class TestFusionReductionRoutines(unittest.TestCase):
         return lambda x: xp.nanprod(x)
 
 
-class TestFusionMisc(unittest.TestCase):
+class TestFusionMisc:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
         return (x,), {}
 
-    @unittest.skipUnless(
-        fusion_utils.can_use_grid_synchronization(),
-        'Requires CUDA grid synchronization')
+    @pytest.mark.skipif(
+        not fusion_utils.can_use_grid_synchronization(),
+        reason='Requires CUDA grid synchronization')
     @fusion_utils.check_fusion()
     def test_sum_div_clip(self, xp):
         def impl(x):

--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import unittest
-
 import numpy
 import pytest
 
@@ -9,14 +7,14 @@ from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
 
 
-class FusionUnaryUfuncTestBase(unittest.TestCase):
+class FusionUnaryUfuncTestBase:
 
     def generate_inputs(self, xp, dtype):
         x = testing.shaped_random((3, 4), xp, dtype, scale=10, seed=0)
         return (x,), {}
 
 
-class FusionBinaryUfuncTestBase(unittest.TestCase):
+class FusionBinaryUfuncTestBase:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -24,22 +22,23 @@ class FusionBinaryUfuncTestBase(unittest.TestCase):
         return (x, y), {}
 
 
-@testing.parameterize(*testing.product({
-    'func': [
+@pytest.mark.parametrize(
+    'func',
+    [
         'bitwise_and', 'bitwise_or', 'bitwise_xor', 'left_shift', 'right_shift'
     ]
-}))
+)
 class TestFusionBitwiseBinary(FusionBinaryUfuncTestBase):
 
     @testing.for_int_dtypes_combination(names=('dtype1', 'dtype2'))
     @fusion_utils.check_fusion()
-    def test_bitwise(self, xp, dtype1, dtype2):
+    def test_bitwise(self, xp, dtype1, dtype2, func):
         def impl(x, y):
             if ((x.dtype == 'uint64' and y.dtype.kind == 'i')
                     or (y.dtype == 'uint64' and x.dtype.kind == 'i')):
                 # Skip TypeError case.
                 return
-            return getattr(xp, self.func)(x, y)
+            return getattr(xp, func)(x, y)
         return impl
 
 
@@ -51,20 +50,21 @@ class TestFusionBitwiseUnary(FusionUnaryUfuncTestBase):
         return lambda x: xp.invert(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': [
+@pytest.mark.parametrize(
+    "func",
+    [
         'greater', 'greater_equal', 'less', 'less_equal', 'equal', 'not_equal',
         'logical_and', 'logical_or', 'logical_xor',
         'maximum', 'minimum', 'fmax', 'fmin',
     ]
-}))
+)
 class TestFusionComparisonBinary(FusionBinaryUfuncTestBase):
 
     @testing.for_all_dtypes_combination(
         no_complex=True, names=('dtype1', 'dtype2'))
     @fusion_utils.check_fusion()
-    def test_comparison(self, xp, dtype1, dtype2):
-        return lambda x, y: getattr(xp, self.func)(x, y)
+    def test_comparison(self, xp, dtype1, dtype2, func):
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
 class TestFusionComparisonUnary(FusionUnaryUfuncTestBase):
@@ -107,13 +107,14 @@ class TestFusionArrayContents(FusionUnaryUfuncTestBase):
         return lambda x: xp.isnan(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': [
+@pytest.mark.parametrize(
+    "func",
+    [
         'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
         'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh',
-    ],
-}))
-class TestFusionTrigonometricUnary(unittest.TestCase):
+    ]
+)
+class TestFusionTrigonometricUnary:
 
     def generate_inputs(self, xp, dtype):
         if numpy.dtype(dtype).kind not in ('f', 'c'):
@@ -124,52 +125,54 @@ class TestFusionTrigonometricUnary(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @fusion_utils.check_fusion()
-    def test_trigonometric(self, xp, dtype):
+    def test_trigonometric(self, xp, dtype, func):
         def impl(x):
             with numpy.errstate(divide='ignore', invalid='ignore'):
-                return getattr(xp, self.func)(x)
+                return getattr(xp, func)(x)
         return impl
 
 
-@testing.parameterize(*testing.product({
-    'func': ['arctan2', 'hypot']
-}))
+@pytest.mark.parametrize(
+    "func", ['arctan2', 'hypot']
+)
 class TestFusionTrigonometricBinary(FusionBinaryUfuncTestBase):
 
     @testing.for_all_dtypes_combination(
         no_complex=True, names=('dtype1', 'dtype2'))
     @fusion_utils.check_fusion()
-    def test_trigonometric(self, xp, dtype1, dtype2):
-        return lambda x, y: getattr(xp, self.func)(x, y)
+    def test_trigonometric(self, xp, dtype1, dtype2, func):
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['deg2rad', 'rad2deg', 'degrees', 'radians']
-}))
+@pytest.mark.parametrize(
+    "func", ['deg2rad', 'rad2deg', 'degrees', 'radians']
+)
 class TestFusionDegRad(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
     @fusion_utils.check_fusion()
-    def test_trigonometric(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_trigonometric(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['around', 'round', 'rint', 'floor', 'ceil', 'trunc',
-             'fix']
-}))
+@pytest.mark.parametrize(
+    "func",
+    [
+        'around', 'round', 'rint', 'floor', 'ceil', 'trunc', 'fix'
+    ]
+)
 class TestFusionRounding(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
     @fusion_utils.check_fusion()
-    def test_rounding(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_rounding(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['exp', 'expm1', 'exp2', 'log', 'log10', 'log2', 'log1p']
-}))
-class TestFusionExpLogUnary(unittest.TestCase):
+@pytest.mark.parametrize(
+    "func", ['exp', 'expm1', 'exp2', 'log', 'log10', 'log2', 'log1p']
+)
+class TestFusionExpLogUnary:
 
     def generate_inputs(self, xp, dtype):
         x = testing.shaped_random((3, 4), xp, dtype, scale=10, seed=0) + 1
@@ -177,20 +180,20 @@ class TestFusionExpLogUnary(unittest.TestCase):
 
     @testing.for_all_dtypes()
     @fusion_utils.check_fusion()
-    def test_explog(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_explog(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['logaddexp', 'logaddexp2']
-}))
+@pytest.mark.parametrize(
+    "func", ['logaddexp', 'logaddexp2']
+)
 class TestFusionExpLogBinary(FusionBinaryUfuncTestBase):
 
     @testing.for_all_dtypes_combination(
         no_complex=True, names=('dtype1', 'dtype2'))
     @fusion_utils.check_fusion()
-    def test_explog(self, xp, dtype1, dtype2):
-        return lambda x, y: getattr(xp, self.func)(x, y)
+    def test_explog(self, xp, dtype1, dtype2, func):
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
 class TestFusionLdexp(FusionBinaryUfuncTestBase):
@@ -202,32 +205,32 @@ class TestFusionLdexp(FusionBinaryUfuncTestBase):
         return lambda x, y: xp.ldexp(x, y)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['signbit', 'frexp']
-}))
+@pytest.mark.parametrize(
+    "func", ['signbit', 'frexp']
+)
 class TestFusionFloatingUnary(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
     @fusion_utils.check_fusion()
-    def test_floating_point_routine(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_floating_point_routine(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['copysign', 'nextafter']
-}))
+@pytest.mark.parametrize(
+    "func", ['copysign', 'nextafter']
+)
 class TestFusionFloatingBinary(FusionBinaryUfuncTestBase):
 
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True)
     @fusion_utils.check_fusion()
-    def test_floating_point_routine(self, xp, dtype1, dtype2):
-        return lambda x, y: getattr(xp, self.func)(x, y)
+    def test_floating_point_routine(self, xp, dtype1, dtype2, func):
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['reciprocal', 'negative', 'angle', 'conj', 'real', 'imag']
-}))
+@pytest.mark.parametrize(
+    "func", ['reciprocal', 'negative', 'angle', 'conj', 'real', 'imag']
+)
 class TestArithmeticUnary(FusionUnaryUfuncTestBase):
 
     def generate_inputs(self, xp, dtype):
@@ -237,8 +240,8 @@ class TestArithmeticUnary(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_bool=True)
     @fusion_utils.check_fusion()
-    def test_arithmetic(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_arithmetic(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
 class TestModf(FusionUnaryUfuncTestBase):
@@ -253,9 +256,9 @@ class TestModf(FusionUnaryUfuncTestBase):
         return lambda x: xp.modf(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['add', 'subtract', 'multiply', 'power']
-}))
+@pytest.mark.parametrize(
+    "func", ['add', 'subtract', 'multiply', 'power']
+)
 class TestArithmeticBinary(FusionBinaryUfuncTestBase):
 
     def generate_inputs(self, xp, dtype1, dtype2):
@@ -266,15 +269,15 @@ class TestArithmeticBinary(FusionBinaryUfuncTestBase):
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True, no_bool=True)
     @fusion_utils.check_fusion()
-    def test_arithmetic(self, xp, dtype1, dtype2):
+    def test_arithmetic(self, xp, dtype1, dtype2, func):
         # TODO(unno): boolean subtract causes DeprecationWarning in numpy>=1.13
-        return lambda x, y: getattr(xp, self.func)(x, y)
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['divide', 'true_divide', 'floor_divide', 'fmod', 'remainder']
-}))
-class TestDivide(unittest.TestCase):
+@pytest.mark.parametrize(
+    "func", ['divide', 'true_divide', 'floor_divide', 'fmod', 'remainder']
+)
+class TestDivide:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -285,11 +288,11 @@ class TestDivide(unittest.TestCase):
     @testing.for_all_dtypes_combination(
         names=('dtype1', 'dtype2'), no_complex=True)
     @fusion_utils.check_fusion()
-    def test_divide(self, xp, dtype1, dtype2):
-        return lambda x, y: getattr(xp, self.func)(x, y)
+    def test_divide(self, xp, dtype1, dtype2, func):
+        return lambda x, y: getattr(xp, func)(x, y)
 
 
-class TestDivmod(unittest.TestCase):
+class TestDivmod:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -345,19 +348,19 @@ class TestFusionMisc(FusionUnaryUfuncTestBase):
         return lambda x: xp.clip(x, dtype(2), dtype(4))
 
 
-@testing.parameterize(*testing.product({
-    'func': ['i0', 'sinc']
-}))
+@pytest.mark.parametrize(
+    "func", ['i0', 'sinc']
+)
 class TestFusionSpecialMath(FusionUnaryUfuncTestBase):
 
     # TODO(imanishi): Fix for integer tests
     @testing.for_float_dtypes()
     @fusion_utils.check_fusion()
-    def test_special_math(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_special_math(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-class TestFusionManipulation(unittest.TestCase):
+class TestFusionManipulation:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         cond = testing.shaped_random((3, 4), xp, 'bool_', seed=0)
@@ -393,23 +396,23 @@ class TestFusionManipulation(unittest.TestCase):
         return lambda cond, x, y: xp.where(x, y, where=cond)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['sum', 'prod', 'amax', 'amin', 'max', 'min']
-}))
+@pytest.mark.parametrize(
+    "func", ['sum', 'prod', 'amax', 'amin', 'max', 'min']
+)
 class TestFusionNumericalReduction(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes()
     @fusion_utils.check_fusion()
-    def test_reduction(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_reduction(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)
 
 
-@testing.parameterize(*testing.product({
-    'func': ['all', 'any']
-}))
+@pytest.mark.parametrize(
+    "func", ['all', 'any']
+)
 class TestFusionLogicalReduction(FusionUnaryUfuncTestBase):
 
     @testing.for_all_dtypes(no_complex=True)
     @fusion_utils.check_fusion()
-    def test_reduction(self, xp, dtype):
-        return lambda x: getattr(xp, self.func)(x)
+    def test_reduction(self, xp, dtype, func):
+        return lambda x: getattr(xp, func)(x)

--- a/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_ufunc.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import itertools
-import unittest
+
+import pytest
 
 from cupy import testing
 from cupy_tests.core_tests.fusion_tests import fusion_utils
@@ -16,8 +17,9 @@ def _permutate_shapes(shapes_list):
     return list(permutated_shapes_set)
 
 
-@testing.parameterize(*testing.product({
-    'shapes': _permutate_shapes([
+@pytest.mark.parametrize(
+    "shapes",
+    _permutate_shapes([
         # Same shapes
         ((1,), (1,)),
         ((3, 4), (3, 4)),
@@ -50,57 +52,58 @@ def _permutate_shapes(shapes_list):
         ((256, 256), (256,)),
         ((256, 256), (256, 1)),
     ])
-}))
-class TestFusionBroadcast(unittest.TestCase):
+)
+class TestFusionBroadcast:
 
-    def generate_inputs(self, xp):
-        shape1, shape2 = self.shapes
+    def generate_inputs(self, xp, shapes):
+        shape1, shape2 = shapes
         x = testing.shaped_random(shape1, xp, 'int64', scale=10, seed=0)
         y = testing.shaped_random(shape2, xp, 'int64', scale=10, seed=1)
         return (x, y), {}
 
     @fusion_utils.check_fusion()
-    def test_broadcast(self, xp):
+    def test_broadcast(self, xp, shapes):
         return lambda x, y: x + y
 
     # TODO(asi1024): Uncomment after replace fusion implementation.
 
     # @fusion_utils.check_fusion(accept_error=ValueError)
-    # def test_broadcast_inplace(self, xp):
+    # def test_broadcast_inplace(self, xp, shapes):
     #     def impl(x, y):
     #         x += y
     #     return impl
 
 
-@testing.parameterize(*testing.product({
-    'shapes': _permutate_shapes([
+@pytest.mark.parametrize(
+    "shapes",
+    _permutate_shapes([
         ((2,), (3,)),
         ((2,), (0,)),
         ((3, 2), (3, 3)),
         ((3, 2), (2, 2)),
         ((3,), (1, 2)),
     ])
-}))
-class TestFusionBroadcastInvalid(unittest.TestCase):
+)
+class TestFusionBroadcastInvalid:
 
-    def generate_inputs(self, xp):
-        shape1, shape2 = self.shapes
+    def generate_inputs(self, xp, shapes):
+        shape1, shape2 = shapes
         x = testing.shaped_random(shape1, xp, 'int64', scale=10, seed=0)
         y = testing.shaped_random(shape2, xp, 'int64', scale=10, seed=1)
         return (x, y), {}
 
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_broadcast(self, xp):
+    def test_broadcast(self, xp, shapes):
         return lambda x, y: x + y
 
     @fusion_utils.check_fusion(accept_error=ValueError)
-    def test_broadcast_inplace(self, xp):
+    def test_broadcast_inplace(self, xp, shapes):
         def impl(x, y):
             x += y
         return impl
 
 
-class TestFusionParseInput(unittest.TestCase):
+class TestFusionParseInput:
 
     def generate_inputs(self, xp):
         x = testing.shaped_random((3, 4), xp, 'int64', scale=10, seed=0)
@@ -168,7 +171,7 @@ class TestFusionParseInput(unittest.TestCase):
         return lambda x: xp.divmod(x, x)
 
 
-class TestFusionOutDtype(unittest.TestCase):
+class TestFusionOutDtype:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         x = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)
@@ -187,7 +190,7 @@ class TestFusionOutDtype(unittest.TestCase):
         return impl
 
 
-class TestFusionScalar(unittest.TestCase):
+class TestFusionScalar:
 
     def generate_inputs(self, xp, dtype1, dtype2):
         array = testing.shaped_random((3, 4), xp, dtype1, scale=10, seed=0)


### PR DESCRIPTION
In order to migrate the fusion tests to using pytest, a few things need to happen:
1. Remove `unittest.TestCase` inheritance
2. Incorporate `pytest.mark.parametrize` where appropriate
3. Refactor `fusion_utils.check_fusion` decorator so it can pick up parameters passed by `pytest.mark.parametrize`

It's actually not as easy as it looks at first glance. The `check_fusion` decorator was designed to return the implementation that is going to be called in the fusion tests, but using `pytest.mark.parametrize` will not work unless the parameters are in the test function signature (and do not exist outside of it, so `check_fusion` has no way of being passed these values). To get around this, `cupy.testing._loops._wraps_partial_xp` was used in the `check_fusion` decorator function.