### PR TITLE
BUG: ndimage: binary_erosion vs. broadcasted input

### DIFF
--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -290,24 +290,14 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
         {boundary}
             ''')
 
-        # Unconditionally handle strides and out-of-bound issues
         loops.append(f'''
-        // Offset remains unchanged for zero-strided arrays
-        {int_type} offset_{j} = 0;
-        bool ix_out_of_range = false;
-        if (xstride_{j} != 0) {{
-            offset_{j} = ix_{j} * xstride_{j};
-            ix_out_of_range = offset_{j} < 0
-                ? offset_{j} <= maxsize_{j}
-                : offset_{j} >= maxsize_{j};
-        }}
+        {int_type} offset_{j} = ix_{j} * xstride_{j};
         ''')
 
     # CArray: string becomes 'x[inds]', no format call needed
     value = f'(*(X*)&data[{expr}])'
     if constant_mode:
-        cond = ' || '.join(
-            [f'(ix_{j} < 0 || ix_out_of_range)' for j in range(ndim)])
+        cond = ' || '.join([f'(ix_{j} < 0)' for j in range(ndim)])
 
     if cval is numpy.nan:
         cval = 'CUDART_NAN'

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -290,7 +290,7 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
         {boundary}
         ''')
 
-        # Unconditionally handle strides and handle out-of-bound issues
+        # Unconditionally handle strides and out-of-bound issues
         loops.append(f'''
         // Offset remains unchanged for zero-strided arrays
         {int_type} offset_{j} = 0;

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -255,8 +255,9 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     constant_mode = (num_unique_modes == 1 and modes[0] == 'constant')
 
     # CArray: remove xstride_{j}=... from string
-    size = ('%s xsize_{j}=x.shape()[{j}], ysize_{j} = _raw_y.shape()[{j}]'
-            ', xstride_{j}=x.strides()[{j}];' % int_type)
+    size = ('%s xsize_{j} = x.shape()[{j}], ysize_{j} = _raw_y.shape()[{j}]'
+            ', xstride_{j} = x.strides()[{j}]'
+            ', maxsize_{j} = xsize_{j} * xstride_{j};' % int_type)
     sizes = [size.format(j=j) for j in range(ndim)]
     inds = _util._generate_indices_ops(ndim, int_type, offsets)
     # CArray: remove expr entirely
@@ -277,10 +278,7 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     for j in range(ndim):
         if w_shape[j] == 1:
             # CArray: string becomes 'inds[{j}] = ind_{j};', remove (int_)type
-            loops.append(f'''
-            {{
-                {int_type} ix_{j} = ind_{j};
-                {int_type} offset_{j} = ix_{j} * xstride_{j};''')
+            loops.append(f'{{ {int_type} ix_{j} = ind_{j};')
         else:
             boundary = _util._generate_boundary_condition_ops(
                 modes[j], f'ix_{j}', f'xsize_{j}', int_type)
@@ -289,16 +287,27 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     for (int iw_{j} = 0; iw_{j} < {w_shape[j]}; iw_{j}++)
     {{
         {int_type} ix_{j} = ind_{j} + iw_{j};
+        {boundary}
+        ''')
+
+        # Unconditionally handle strides and handle out-of-bound issues
+        loops.append(f'''
+        // Offset remains unchanged for zero-strided arrays
         {int_type} offset_{j} = 0;
-        {boundary} else {{
+        bool ix_out_of_range = false;
+        if (xstride_{j} != 0) {{
             offset_{j} = ix_{j} * xstride_{j};
+            ix_out_of_range = offset_{j} < 0
+                ? offset_{j} <= maxsize_{j}
+                : offset_{j} >= maxsize_{j};
         }}
         ''')
 
     # CArray: string becomes 'x[inds]', no format call needed
     value = f'(*(X*)&data[{expr}])'
     if constant_mode:
-        cond = ' || '.join([f'(ix_{j} < 0)' for j in range(ndim)])
+        cond = ' || '.join(
+            [f'(ix_{j} < 0 || ix_out_of_range)' for j in range(ndim)])
 
     if cval is numpy.nan:
         cval = 'CUDART_NAN'

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -288,7 +288,7 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     {{
         {int_type} ix_{j} = ind_{j} + iw_{j};
         {boundary}
-        ''')
+            ''')
 
         # Unconditionally handle strides and out-of-bound issues
         loops.append(f'''

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -286,8 +286,9 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     for (int iw_{j} = 0; iw_{j} < {w_shape[j]}; iw_{j}++)
     {{
         {int_type} ix_{j} = ind_{j} + iw_{j};
-        {boundary}
-        ix_{j} *= xstride_{j};
+        {boundary} else {{
+            ix_{j} *= xstride_{j};
+        }};
         ''')
 
     # CArray: string becomes 'x[inds]', no format call needed

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -256,8 +256,7 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
 
     # CArray: remove xstride_{j}=... from string
     size = ('%s xsize_{j} = x.shape()[{j}], ysize_{j} = _raw_y.shape()[{j}]'
-            ', xstride_{j} = x.strides()[{j}]'
-            ', maxsize_{j} = xsize_{j} * xstride_{j};' % int_type)
+            ', xstride_{j} = x.strides()[{j}];' % int_type)
     sizes = [size.format(j=j) for j in range(ndim)]
     inds = _util._generate_indices_ops(ndim, int_type, offsets)
     # CArray: remove expr entirely

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -260,7 +260,7 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     sizes = [size.format(j=j) for j in range(ndim)]
     inds = _util._generate_indices_ops(ndim, int_type, offsets)
     # CArray: remove expr entirely
-    expr = ' + '.join([f'ix_{j}' for j in range(ndim)])
+    expr = ' + '.join([f'offset_{j}' for j in range(ndim)])
 
     ws_init = ws_pre = ws_post = ''
     if has_weights or has_structure:
@@ -277,7 +277,10 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     for j in range(ndim):
         if w_shape[j] == 1:
             # CArray: string becomes 'inds[{j}] = ind_{j};', remove (int_)type
-            loops.append(f'{{ {int_type} ix_{j} = ind_{j} * xstride_{j};')
+            loops.append(f'''
+            {{
+                {int_type} ix_{j} = ind_{j};
+                {int_type} offset_{j} = ix_{j} * xstride_{j};''')
         else:
             boundary = _util._generate_boundary_condition_ops(
                 modes[j], f'ix_{j}', f'xsize_{j}', int_type)
@@ -286,9 +289,10 @@ def _generate_nd_kernel(name, pre, found, post, modes, w_shape, int_type,
     for (int iw_{j} = 0; iw_{j} < {w_shape[j]}; iw_{j}++)
     {{
         {int_type} ix_{j} = ind_{j} + iw_{j};
+        {int_type} offset_{j} = 0;
         {boundary} else {{
-            ix_{j} *= xstride_{j};
-        }};
+            offset_{j} = ix_{j} * xstride_{j};
+        }}
         ''')
 
     # CArray: string becomes 'x[inds]', no format call needed

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -164,9 +164,6 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
 
-    if any(stride < 0 for stride in input.strides):
-        input = cupy.ascontiguousarray(input)
-
     ndim = input.ndim
     axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -164,9 +164,6 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
 
-    # The Cython code can't cope with broadcasted inputs
-    if not input.flags.c_contiguous and not input.flags.f_contiguous:
-        input = cupy.ascontiguousarray(input)
     ndim = input.ndim
     axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -163,7 +163,6 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
 
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
-
     ndim = input.ndim
     axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -164,6 +164,9 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
 
+    if any(stride < 0 for stride in input.strides):
+        input = cupy.ascontiguousarray(input)
+
     ndim = input.ndim
     axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)

--- a/cupyx/scipy/ndimage/_morphology.py
+++ b/cupyx/scipy/ndimage/_morphology.py
@@ -163,6 +163,10 @@ def _binary_erosion(input, structure, iterations, mask, output, border_value,
 
     if input.dtype.kind == 'c':
         raise TypeError('Complex type not supported')
+
+    # The Cython code can't cope with broadcasted inputs
+    if not input.flags.c_contiguous and not input.flags.f_contiguous:
+        input = cupy.ascontiguousarray(input)
     ndim = input.ndim
     axes = _util._check_axes(axes, ndim)
     num_axes = len(axes)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -459,7 +459,6 @@ class TestBinaryPropagation:
         'density': [0.1, 0.5, 0.9],
         'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1],
-        'contiguity': ['C', 'F', 'none'],
         'output': [None]}
     ) + testing.product({
         'x_dtype': [numpy.int8, numpy.float32],
@@ -470,7 +469,6 @@ class TestBinaryPropagation:
         'density': [0.2],
         'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1, 2, 0],
-        'contiguity': ['C', 'F', 'none'],
         'output': [None, numpy.float32, 'array']}
     )
 ))
@@ -491,17 +489,29 @@ class TestBinaryErosionAndDilation:
                       output=self.output, border_value=self.border_value,
                       origin=self.origin, brute_force=True)
 
+    @pytest.mark.parametrize(
+        "contiguity",
+        ['C', 'F', 'none'],
+    )
     @testing.numpy_cupy_array_equal(scipy_name='scp')
-    def test_binary_erosion_and_dilation(self, xp, scp):
+    def test_contiguity(self, xp, scp, contiguity):
         if self.x_dtype == self.output:
             pytest.skip('redundant')
         rstate = numpy.random.RandomState(5)
         x = rstate.randn(*self.shape) > self.density
         x = xp.asarray(x, dtype=self.x_dtype)
-        if self.contiguity == 'F':
+        if contiguity == 'F':
             x = xp.asfortranarray(x)
-        elif self.contiguity == 'none':
+        elif contiguity == 'none':
             x = x[::-1]
+        return self._filter(xp, scp, x)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_zero_strides(self, xp, scp):
+        if self.x_dtype == self.output:
+            pytest.skip('redundant')
+        x = xp.ones((1, ), dtype=self.x_dtype)
+        x = xp.broadcast_to(x, self.shape)
         return self._filter(xp, scp, x)
 
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -506,6 +506,7 @@ class TestBinaryErosionAndDilation:
             x = x[::-1]
         return self._filter(xp, scp, x)
 
+    # TODO: remove scipy constraint when cuda120 mini jobs don't rely on 1.14
     @testing.with_requires('scipy>1.14')
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_zero_strides(self, xp, scp):

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -506,6 +506,7 @@ class TestBinaryErosionAndDilation:
             x = x[::-1]
         return self._filter(xp, scp, x)
 
+    @testing.with_requires('scipy>1.14')
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_zero_strides(self, xp, scp):
         if self.x_dtype == self.output:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -459,6 +459,7 @@ class TestBinaryPropagation:
         'density': [0.1, 0.5, 0.9],
         'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1],
+        'contiguity': ['C', 'F', 'none'],
         'output': [None]}
     ) + testing.product({
         'x_dtype': [numpy.int8, numpy.float32],
@@ -469,6 +470,7 @@ class TestBinaryPropagation:
         'density': [0.2],
         'filter': ['binary_erosion', 'binary_dilation'],
         'iterations': [1, 2, 0],
+        'contiguity': ['C', 'F', 'none'],
         'output': [None, numpy.float32, 'array']}
     )
 ))
@@ -496,6 +498,10 @@ class TestBinaryErosionAndDilation:
         rstate = numpy.random.RandomState(5)
         x = rstate.randn(*self.shape) > self.density
         x = xp.asarray(x, dtype=self.x_dtype)
+        if self.contiguity == 'F':
+            x = xp.asfortranarray(x)
+        elif self.contiguity == 'none':
+            x = x[::-1]
         return self._filter(xp, scp, x)
 
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -506,8 +506,8 @@ class TestBinaryErosionAndDilation:
             x = x[::-1]
         return self._filter(xp, scp, x)
 
-    # TODO: remove scipy constraint when cuda120 mini jobs don't rely on 1.14
-    @testing.with_requires('scipy>1.14')
+    # SciPy bug prior to 1.16: https://github.com/scipy/scipy/pull/22421
+    @testing.with_requires('scipy>=1.16.0')
     @testing.numpy_cupy_array_equal(scipy_name='scp')
     def test_zero_strides(self, xp, scp):
         if self.x_dtype == self.output:


### PR DESCRIPTION
Resolves #8912 

This has been fixed for a while on scipy side, but I believe it probably hasn't made its way to cupy since the tests in this codebase differ quite a bit from scipy, so some investigation is involved.

Since the issue at hand is how `binary_erosion` is unable to process non-contiguous arrays as expected, I added a `contiguous` parameter to the `TestBinaryErosionAndDilation` test to catch the issue and assert that the problem is now gone.

Now, this could be a situation where we don't want to convert non-contiguous arrays to a contiguous one, but rather add stride support. In either case, I'd be happy to investigate further if needed.