### PR TITLE
Narrow CODEOWNERS notifications to important metadata files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-* @cupy/code-owners
+# Require review approval from code owners group for important repo-wide metadata changes.
+/.github/ @cupy/code-owners
+/CODE_OF_CONDUCT.md @cupy/code-owners
+/LICENSE @cupy/code-owners


### PR DESCRIPTION
Currently code-owners are mentioned for every for PRs. This PR updates the CODEOWNERS to get notifications only when important meetadata files has been changed.