### PR TITLE
feat: implement __repr__ for sparse matrix classes

### DIFF
--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -33,6 +33,13 @@ class spmatrix:
     See :class:`scipy.sparse.spmatrix`
     """
 
+    _formats = {
+        'csc': 'Compressed Sparse Column',
+        'csr': 'Compressed Sparse Row',
+        'coo': 'COOrdinate',
+        'dia': 'DIAgonal',
+    }
+
     __array_priority__ = 101
     # ``_data_matrix.__init__`` (and therefore the format subclasses
     # built on it: csr/csc/coo/dia) does not chain through to
@@ -72,6 +79,24 @@ class spmatrix:
         # TODO(unno): Do not use get method which is only available when scipy
         # is installed.
         return str(self.get())
+
+    def __repr__(self):
+        # Subclasses that lack format/dtype/nnz/shape (e.g. test
+        # helpers) fall back to object.__repr__.
+        try:
+            format_name = self._formats[self.format]
+        except (AttributeError, KeyError):
+            return object.__repr__(self)
+        return (
+            f"<{format_name} sparse matrix of dtype '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements"
+            f"{self._repr_detail()} and shape {self.shape}>"
+        )
+
+    def _repr_detail(self):
+        """Hook for subclasses to append format-specific info to
+        ``__repr__``.  Non-empty values must start with a space."""
+        return ''
 
     def __iter__(self):
         for r in range(self.shape[0]):

--- a/cupyx/scipy/sparse/_dia.py
+++ b/cupyx/scipy/sparse/_dia.py
@@ -93,6 +93,10 @@ class dia_matrix(_data._data_matrix):
         else:
             return dia_matrix((data, self.offsets), shape=self.shape)
 
+    def _repr_detail(self):
+        d = self.data.shape[0]
+        return f' ({d} diagonals)'
+
     def get(self, stream=None):
         """Returns a copy of the array on host memory.
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -219,6 +219,14 @@ class TestCooMatrix:
         assert str(self.m.shape) in s
         assert s == str(self.m.get())
 
+    def test_repr(self):
+        r = repr(self.m)
+        assert 'COOrdinate' in r
+        assert 'sparse matrix' in r
+        assert str(self.m.dtype) in r
+        assert str(self.m.shape) in r
+        assert f'with {self.m.nnz} stored elements' in r
+
     def test_toarray(self):
         m = self.m.toarray()
         expect = numpy.array([

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -260,6 +260,14 @@ class TestCscMatrix:
         assert str(self.m.shape) in s
         assert s == str(self.m.get())
 
+    def test_repr(self):
+        r = repr(self.m)
+        assert 'Compressed Sparse Column' in r
+        assert 'sparse matrix' in r
+        assert str(self.m.dtype) in r
+        assert str(self.m.shape) in r
+        assert f'with {self.m.nnz} stored elements' in r
+
     def test_toarray(self):
         m = self.m.toarray()
         expect = [

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -303,6 +303,14 @@ class TestCsrMatrix:
         assert str(self.m.shape) in s
         assert s == str(self.m.get())
 
+    def test_repr(self):
+        r = repr(self.m)
+        assert 'Compressed Sparse Row' in r
+        assert 'sparse matrix' in r
+        assert str(self.m.dtype) in r
+        assert str(self.m.shape) in r
+        assert f'with {self.m.nnz} stored elements' in r
+
     def test_toarray(self):
         m = self.m.toarray()
         expect = [

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -106,6 +106,15 @@ class TestDiaMatrix(unittest.TestCase):
         # Delegation invariant.
         assert s == str(self.m.get())
 
+    def test_repr(self):
+        r = repr(self.m)
+        assert 'DIAgonal' in r
+        assert 'sparse matrix' in r
+        assert str(self.m.dtype) in r
+        assert str(self.m.shape) in r
+        assert f'with {self.m.nnz} stored elements' in r
+        assert f'({self.m.data.shape[0]} diagonals)' in r
+
     def test_toarray(self):
         m = self.m.toarray()
         expect = [


### PR DESCRIPTION
# Implement `__repr__` in sparse matrix classes

Closes #7848

## Solution

Add `__repr__` to `spmatrix` base class following the current SciPy format

```python
>>> cupyx.scipy.sparse.coo_matrix((10, 10))
<COOrdinate sparse matrix of dtype 'float64'
	with 0 stored elements and shape (10, 10)>

>>> cupyx.scipy.sparse.dia_matrix(...)
<DIAgonal sparse matrix of dtype 'float64'
	with 3 stored elements (2 diagonals) and shape (3, 3)>
```

### Design decisions

- **`_formats` as class attribute on `spmatrix`** — maps format codes (`'coo'`, `'csr'`, etc.) to display names. Placed on the class rather than a module-level dict so subclasses can access it via MRO without extra imports.

- **`_repr_detail()` hook** — base `__repr__` owns the full format template; `dia_matrix` overrides `_repr_detail()` to inject `({d} diagonals)` instead of duplicating the entire format string. This keeps the template in one place and makes it easy for future formats (e.g. `bsr_matrix`) to add their own detail.

- **Defensive fallback** — `__repr__` wraps `_formats[self.format]` in `try/except` so that `spmatrix` subclasses missing `format`/`dtype` (e.g. test helpers) gracefully fall back to `object.__repr__` instead of crashing.

- **`__str__` unchanged** — it still delegates to `str(self.get())` (SciPy), which is a separate concern.

- **No scipy dependency** — unlike `__str__`, `__repr__` is implemented natively in CuPy and works without scipy installed.

## Changes

| File | Change |
|------|--------|
| `cupyx/scipy/sparse/_base.py` | Add `_formats` class attribute, `__repr__`, and `_repr_detail()` hook to `spmatrix` |
| `cupyx/scipy/sparse/_dia.py` | Override `_repr_detail()` to include diagonal count |
| `tests/.../test_coo.py` | Add `test_repr` |
| `tests/.../test_csr.py` | Add `test_repr` |
| `tests/.../test_csc.py` | Add `test_repr` |
| `tests/.../test_dia.py` | Add `test_repr` (also checks diagonal count) |
