### PR TITLE
Add SciPy-compatible sparse array classes (sparray) [split 1/3]

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -887,7 +887,7 @@ def get_array_module(*args):
     """
     import cupyx
     for arg in args:
-        if isinstance(arg, (ndarray, cupyx.scipy.sparse.spmatrix,
+        if isinstance(arg, (ndarray, cupyx.scipy.sparse._spbase,
                             _core.fusion._FusionVarArray,
                             _core.new_fusion._ArrayProxy)):
             return _cupy

--- a/cupyx/cusolver.pyx
+++ b/cupyx/cusolver.pyx
@@ -828,7 +828,7 @@ def csrlsvqr(A, b, tol=0, reorder=1):
     if not check_availability('csrlsvqr'):
         raise RuntimeError('csrlsvqr is not available.')
 
-    if not _cupyx.scipy.sparse.isspmatrix_csr(A):
+    if not (_cupyx.scipy.sparse.issparse(A) and A.format == 'csr'):
         raise ValueError('A must be CSR sparse matrix')
     if not isinstance(b, _cupy.ndarray):
         raise ValueError('b must be cupy.ndarray')

--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -16,6 +16,21 @@ from cupy import _util
 import cupyx.scipy.sparse
 
 
+def _is_csr_type(x):
+    """True if x is any CSR sparse (array or matrix)."""
+    return cupyx.scipy.sparse.issparse(x) and x.format == 'csr'
+
+
+def _is_csc_type(x):
+    """True if x is any CSC sparse (array or matrix)."""
+    return cupyx.scipy.sparse.issparse(x) and x.format == 'csc'
+
+
+def _is_csr_or_coo_type(x):
+    """True if x is any CSR or COO sparse (array or matrix)."""
+    return cupyx.scipy.sparse.issparse(x) and x.format in ('csr', 'coo')
+
+
 class MatDescriptor:
 
     def __init__(self, descriptor):
@@ -57,38 +72,56 @@ def _cast_common_type(*xs):
 
 
 def _check_int32_indices(a, func_name):
-    """Raise ValueError if *a* has int64 indices."""
+    """Raise ValueError if CSR/CSC ``a`` has int64 indices.
+
+    Used by legacy cuSPARSE entry points whose backends accept only
+    int32 (csrgeam, csrgemm, csrsm2, csrlsvqr).  ``a`` must already be
+    CSR/CSC; COO has no ``indices`` attribute.  ``func_name`` appears
+    in the error message so it points at the user-facing operation
+    rather than the internal cuSPARSE name.
+    """
     if a.indices.dtype == _cupy.int64:
         raise ValueError(
-            '{} does not support int64 indices '
-            '(cuSPARSE {} is int32-only)'.format(
-                func_name, func_name))
+            f'{func_name} does not support int64 indices '
+            f'(cuSPARSE {func_name} is int32-only)')
 
 
-def _indptr_to_coo(indptr, dtype=None):
+def _indptr_to_coo(indptr, dtype=None, *, nnz=None):
     """Expand compressed ``indptr`` to per-nnz major-axis indices.
 
     Inverse of :func:`_build_indptr`.  ``dtype`` defaults to ``indptr.dtype``.
 
-    For most matrices the ``cupy.repeat(arange(major), diff)`` formula
-    is the right call: O(major + nnz) memory, no host sync.  But when
-    the major axis dwarfs ``nnz`` (e.g. the (2, 2**31+5) CSC produced
-    by transposing a wide CSR with a single stored entry), the
-    ``arange(major)`` allocation dominates -- 17 GB of intermediate
-    state for one nnz.  In that regime fall back to a searchsorted
-    formula that uses O(nnz log major) memory at the cost of one D2H
-    sync to read ``int(indptr[-1])``.
+    Uses ``cupy.repeat(arange(major), diff)`` by default
+    (O(major + nnz) memory, no host sync).  When the major axis
+    dwarfs ``nnz`` the ``arange(major)`` allocation would dominate
+    memory, so the function falls back to a searchsorted-based
+    formula that is O(nnz log major).
+
+    Args:
+        indptr: Compressed major-axis offsets.
+        dtype: Desired output dtype.  Defaults to ``indptr.dtype``.
+        nnz: Optional pre-computed ``int(indptr[-1])``.  When supplied,
+            avoids the otherwise-mandatory D2H sync on the searchsorted
+            path.  Caller must guarantee ``nnz == int(indptr[-1])``.
     """
     if dtype is None:
         dtype = indptr.dtype
     nrows = indptr.shape[0] - 1
-    # Below 16K rows the ``arange`` is cheap (<= 128 KB at int64) and
-    # the log factor of searchsorted is a wash, so prefer ``repeat``.
-    # Above the threshold, sync once to read nnz; only switch to
-    # searchsorted if the major axis is much larger than nnz (4x gives
-    # a safety margin against marginal cases).
+    # Path selection.  These thresholds are conservative heuristics, not
+    # benchmark-derived constants:
+    #   * 16K (1 << 14) rows: below this the ``arange(major)`` allocation
+    #     is small and searchsorted's extra log factor + host sync isn't
+    #     worth saving.
+    #   * 4x ratio: above 16K, only switch to searchsorted when
+    #     ``major > 4 * nnz``.  The headroom prevents flip-flopping on
+    #     borderline inputs; the asymptotic memory win only matters when
+    #     major is orders of magnitude larger than nnz (motivating case:
+    #     wide CSC produced by transposing a wide CSR with few entries).
+    # Both paths are exercised by ``TestIndptrToCooMemoryOptimization``
+    # in ``test_sparse_int64_indices.py``.
     if nrows > (1 << 14):
-        nnz = int(indptr[-1])  # synchronize!
+        if nnz is None:
+            nnz = int(indptr[-1])  # synchronize!
         if nrows > 4 * max(nnz, 1):
             arange = _cupy.arange(nnz, dtype=dtype)
             # ``searchsorted`` returns intp; cast back to ``dtype``.
@@ -581,10 +614,10 @@ def csrgeam(a, b, alpha=1, beta=1):
     if not check_availability('csrgeam'):
         raise RuntimeError('csrgeam is not available.')
 
-    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
-    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    if not _is_csr_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
+    if not _is_csr_type(b):
+        raise TypeError(f'unsupported type (actual: {type(b)})')
     _check_int32_indices(a, 'csrgeam')
     _check_int32_indices(b, 'csrgeam')
     if not a.has_canonical_format:
@@ -673,14 +706,13 @@ def csrgeam2(a, b, alpha=1, beta=1):
         cupyx.scipy.sparse.csr_matrix: Result matrix.
 
     """
-    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
-    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    if not _is_csr_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
+    if not _is_csr_type(b):
+        raise TypeError(f'unsupported type (actual: {type(b)})')
 
-    # TODO(eriknw): cuSPARSE--when SpGEAM ships, route ALL addition through
-    # spgeam() (not just int64)--benchmarks show SpGEAM Generic API
-    # is ~2x faster than csrgeam2 Legacy for int32 at large sizes.
+    # TODO(eriknw): cuSPARSE--route int32 through spgeam() too when it
+    # ships in a public release (see 'spgeam' in _available_cusparse_version).
     if a.indices.dtype == _cupy.int64 or b.indices.dtype == _cupy.int64:
         if check_availability('spgeam'):
             return spgeam(a, b, alpha, beta)
@@ -758,18 +790,15 @@ def spgeam(a, b, alpha=1, beta=1):
 
     """
     if not check_availability('spgeam'):
-        # spgeam (Generic API) not available on this CUDA version.
-        # For int64: use the pure-CuPy fallback directly (no cuSPARSE needed).
-        # For int32: delegate to csrgeam2 (the legacy int32-only API).
         if a.indices.dtype == _cupy.int64 or b.indices.dtype == _cupy.int64:
             a, b = _cast_common_type(a, b)
             return _cupy_csrgeam_int64(a, b, alpha, beta)
         return csrgeam2(a, b, alpha, beta)
 
-    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
-    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    if not _is_csr_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
+    if not _is_csr_type(b):
+        raise TypeError(f'unsupported type (actual: {type(b)})')
     if not a.has_canonical_format:
         raise ValueError('expected canonical format for a')
     if not b.has_canonical_format:
@@ -945,10 +974,10 @@ def csrgemm2(a, b, d=None, alpha=1, beta=1):
 
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError('expected 2-D matrices')
-    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
-    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    if not _is_csr_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
+    if not _is_csr_type(b):
+        raise TypeError(f'unsupported type (actual: {type(b)})')
     _check_int32_indices(a, 'csrgemm2')
     _check_int32_indices(b, 'csrgemm2')
     if not a.has_canonical_format:
@@ -960,8 +989,8 @@ def csrgemm2(a, b, d=None, alpha=1, beta=1):
     if d is not None:
         if d.ndim != 2:
             raise ValueError('expected 2-D matrix for d')
-        if not isinstance(d, cupyx.scipy.sparse.csr_matrix):
-            raise TypeError('unsupported type (actual: {})'.format(type(d)))
+        if not _is_csr_type(d):
+            raise TypeError(f'unsupported type (actual: {type(d)})')
         _check_int32_indices(d, 'csrgemm2')
         if not d.has_canonical_format:
             raise ValueError('expected canonical format for d')
@@ -1804,16 +1833,15 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
     if not check_availability('spmv'):
         raise RuntimeError('spmv is not available.')
 
-    if isinstance(a, cupyx.scipy.sparse.csc_matrix):
+    if _is_csc_type(a):
         aT = a.T
-        if not isinstance(aT, cupyx.scipy.sparse.csr_matrix):
+        if not _is_csr_type(aT):
             msg = 'aT must be csr_matrix (actual: {})'.format(type(aT))
             raise TypeError(msg)
         a = aT
         transa = not transa
-    if not isinstance(a, (cupyx.scipy.sparse.csr_matrix,
-                          cupyx.scipy.sparse.coo_matrix)):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
+    if not _is_csr_or_coo_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
     a_shape = a.shape if not transa else a.shape[::-1]
     if a_shape[1] != len(x):
         raise ValueError('dimension mismatch')
@@ -1886,16 +1914,15 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
     if c is not None and not c.flags.f_contiguous:
         raise ValueError('expected F-contiguous array for c')
 
-    if isinstance(a, cupyx.scipy.sparse.csc_matrix):
+    if _is_csc_type(a):
         aT = a.T
-        if not isinstance(aT, cupyx.scipy.sparse.csr_matrix):
+        if not _is_csr_type(aT):
             msg = 'aT must be csr_matrix (actual: {})'.format(type(aT))
             raise TypeError(msg)
         a = aT
         transa = not transa
-    if not isinstance(a, (cupyx.scipy.sparse.csr_matrix,
-                          cupyx.scipy.sparse.coo_matrix)):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
+    if not _is_csr_or_coo_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
     a_shape = a.shape if not transa else a.shape[::-1]
     b_shape = b.shape if not transb else b.shape[::-1]
     if a_shape[1] != b_shape[0]:
@@ -1983,8 +2010,8 @@ def csrsm2(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False,
     if not check_availability('csrsm2'):
         raise RuntimeError('csrsm2 is not available.')
 
-    if not (cupyx.scipy.sparse.isspmatrix_csr(a) or
-            cupyx.scipy.sparse.isspmatrix_csc(a)):
+    if not (cupyx.scipy.sparse.issparse(a)
+            and a.format in ('csr', 'csc')):
         raise ValueError('a must be CSR or CSC sparse matrix')
     if not isinstance(b, _cupy.ndarray):
         raise ValueError('b must be cupy.ndarray')
@@ -2051,12 +2078,12 @@ def csrsm2(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False,
     else:
         raise ValueError('Unknown transa (actual: {})'.format(transa))
 
-    if cupyx.scipy.sparse.isspmatrix_csc(a):
+    if _is_csc_type(a):
         if transa == _cusparse.CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE:
             raise ValueError('If matrix is CSC format and complex dtype,'
                              'transa must not be \'H\'')
         a = a.T
-        if not cupyx.scipy.sparse.isspmatrix_csr(a):
+        if not _is_csr_type(a):
             raise TypeError('expected CSR matrix after transpose')
         transa = 1 - transa
         fill_mode = 1 - fill_mode
@@ -2115,7 +2142,7 @@ def csrilu02(a, level_info=False):
     if not check_availability('csrilu02'):
         raise RuntimeError('csrilu02 is not available.')
 
-    if not cupyx.scipy.sparse.isspmatrix_csr(a):
+    if not _is_csr_type(a):
         raise TypeError('a must be CSR sparse matrix')
     if a.shape[0] != a.shape[1]:
         raise ValueError('invalid shape (a.shape: {})'.format(a.shape))
@@ -2322,9 +2349,9 @@ def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
         raise ValueError(f'Unknown transa (actual: {transa})')
 
     # Check A's type and sparse format
-    if cupyx.scipy.sparse.isspmatrix_csr(a):
+    if _is_csr_type(a):
         pass
-    elif cupyx.scipy.sparse.isspmatrix_csc(a):
+    elif _is_csc_type(a):
         if transa == 'N':
             a = a.T
             transa = 'T'
@@ -2335,7 +2362,7 @@ def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
             a = a.conj().T
             transa = 'N'
         lower = not lower
-    elif cupyx.scipy.sparse.isspmatrix_coo(a):
+    elif cupyx.scipy.sparse.issparse(a) and a.format == 'coo':
         pass
     else:
         raise ValueError('a must be CSR, CSC or COO sparse matrix')
@@ -2533,10 +2560,10 @@ def spgemm(a, b, alpha=1):
     """
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError('expected 2-D matrices')
-    if not isinstance(a, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(a)))
-    if not isinstance(b, cupyx.scipy.sparse.csr_matrix):
-        raise TypeError('unsupported type (actual: {})'.format(type(b)))
+    if not _is_csr_type(a):
+        raise TypeError(f'unsupported type (actual: {type(a)})')
+    if not _is_csr_type(b):
+        raise TypeError(f'unsupported type (actual: {type(b)})')
 
     # TODO(eriknw): cuSPARSE--remove pure-CuPy fallback when all supported CUDA
     # versions have native int64 SpGEMM.  Native int64 SpGEMM is ~14x

--- a/cupyx/distributed/_nccl_comm.py
+++ b/cupyx/distributed/_nccl_comm.py
@@ -456,41 +456,55 @@ class _DenseNCCLCommunicator:
         nccl.groupEnd()
 
 
-def _make_sparse_empty(dtype, sparse_type):
+def _make_sparse_empty(dtype, sparse_type, *, sparray=False):
     data = cupy.empty(1, dtype)
     a = cupy.empty(1, 'i')
     b = cupy.empty(1, 'i')
     if sparse_type == 'csr':
-        return sparse.csr_matrix((data, a, b), shape=(0, 0))
+        cls = sparse.csr_array if sparray else sparse.csr_matrix
+        return cls((data, a, b), shape=(0, 0))
     elif sparse_type == 'csc':
-        return sparse.csc_matrix((data, a, b), shape=(0, 0))
+        cls = sparse.csc_array if sparray else sparse.csc_matrix
+        return cls((data, a, b), shape=(0, 0))
     elif sparse_type == 'coo':
-        return sparse.coo_matrix((data, (a, b)), shape=(0, 0))
+        cls = sparse.coo_array if sparray else sparse.coo_matrix
+        return cls((data, (a, b)), shape=(0, 0))
     else:
         raise TypeError(
             'NCCL is not supported for this type of sparse matrix')
+
+
+def _empty_like(model):
+    """Return an empty sparse object that matches the type of ``model``.
+
+    Preserves the array-vs-matrix distinction so operator semantics
+    (``*`` is matmul on matrices, element-wise on arrays) stay
+    consistent when reductions combine ``model`` with the placeholder.
+    """
+    return _make_sparse_empty(
+        model.dtype, _get_sparse_type(model),
+        sparray=isinstance(model, sparse.sparray))
 
 
 def _get_sparse_type(matrix):
-    if sparse.isspmatrix_coo(matrix):
-        return 'coo'
-    elif sparse.isspmatrix_csr(matrix):
-        return 'csr'
-    elif sparse.isspmatrix_csc(matrix):
-        return 'csc'
-    else:
+    if not sparse.issparse(matrix):
         raise TypeError(
             'NCCL is not supported for this type of sparse matrix')
+    if matrix.format in ('coo', 'csr', 'csc'):
+        return matrix.format
+    raise TypeError(
+        'NCCL is not supported for this type of sparse matrix')
 
 
 class _SparseNCCLCommunicator:
 
     @classmethod
     def _get_internal_arrays(cls, array):
-        if sparse.isspmatrix_coo(array):
+        if sparse.issparse(array) and array.format == 'coo':
             array.sum_duplicates()  # set it to canonical form
             return (array.data, array.row, array.col)
-        elif sparse.isspmatrix_csr(array) or sparse.isspmatrix_csc(array):
+        elif (sparse.issparse(array)
+              and array.format in ('csr', 'csc')):
             return (array.data, array.indptr, array.indices)
         raise TypeError('NCCL is not supported for this type of sparse matrix')
 
@@ -579,12 +593,13 @@ class _SparseNCCLCommunicator:
                 raise RuntimeError('Unsupported method')
 
     def _assign_arrays(matrix, arrays, shape):
-        if sparse.isspmatrix_coo(matrix):
+        if sparse.issparse(matrix) and matrix.format == 'coo':
             matrix.data = arrays[0]
             matrix.row = arrays[1]
             matrix.col = arrays[2]
             matrix._shape = tuple(shape)
-        elif sparse.isspmatrix_csr(matrix) or sparse.isspmatrix_csc(matrix):
+        elif (sparse.issparse(matrix)
+              and matrix.format in ('csr', 'csc')):
             matrix.data = arrays[0]
             matrix.indptr = arrays[1]
             matrix.indices = arrays[2]
@@ -613,8 +628,7 @@ class _SparseNCCLCommunicator:
                 raise ValueError(
                     'in_array and out_array must be the same format')
             result = in_array
-            partial = _make_sparse_empty(
-                in_array.dtype, _get_sparse_type(in_array))
+            partial = _empty_like(in_array)
             # each device will send and array with a different size
             for peer, ss in enumerate(shape_and_sizes):
                 shape = tuple(ss[0:2])
@@ -683,8 +697,7 @@ class _SparseNCCLCommunicator:
             raise ValueError(
                 'in_array must be a list or a tuple of sparse matrices')
         for s_m in in_array:
-            partial_out_array = _make_sparse_empty(
-                s_m.dtype, _get_sparse_type(s_m))
+            partial_out_array = _empty_like(s_m)
             cls.reduce(comm, s_m, partial_out_array, root, op, stream)
             reduce_out_arrays.append(partial_out_array)
         cls.scatter(comm, reduce_out_arrays, out_array, root, stream)
@@ -702,7 +715,7 @@ class _SparseNCCLCommunicator:
         cls.gather(comm, in_array, gather_out_arrays, root, stream)
         if comm.rank != root:
             gather_out_arrays = [
-                _make_sparse_empty(in_array.dtype, _get_sparse_type(in_array))
+                _empty_like(in_array)
                 for _ in range(comm._n_devices)
             ]
         for arr in gather_out_arrays:
@@ -787,8 +800,7 @@ class _SparseNCCLCommunicator:
         # out_array is a list of sparse matrices
         if comm.rank == root:
             for peer in range(comm._n_devices):
-                res = _make_sparse_empty(
-                    in_array.dtype, _get_sparse_type(in_array))
+                res = _empty_like(in_array)
                 if peer != root:
                     cls.recv(comm, res, peer, stream)
                 else:
@@ -832,7 +844,5 @@ class _SparseNCCLCommunicator:
             for a in r_arrays:
                 cls._recv(comm, a, i, a.dtype, a.size, stream)
             nccl.groupEnd()
-            out_array.append(_make_sparse_empty(
-                in_array[i].dtype,
-                _get_sparse_type(in_array[i])))
+            out_array.append(_empty_like(in_array[i]))
             cls._assign_arrays(out_array[i], r_arrays, shape)

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -27,7 +27,7 @@ def lschol(A, b):
     """
     from cupy_backends.cuda.libs import cusolver
 
-    if not sparse.isspmatrix_csr(A):
+    if not (sparse.issparse(A) and A.format == 'csr'):
         A = sparse.csr_matrix(A)
     # csr_matrix is 2d
     _util._assert_stacked_square(A)

--- a/cupyx/scipy/__init__.py
+++ b/cupyx/scipy/__init__.py
@@ -31,10 +31,10 @@ def get_array_module(*args):
         types of the arguments.
 
     """
-    from cupyx.scipy.sparse._base import spmatrix as _spmatrix
+    from cupyx.scipy.sparse._base import _spbase
 
     for arg in args:
-        if isinstance(arg, (_ndarray, _spmatrix)):
+        if isinstance(arg, (_ndarray, _spbase)):
             return _cupyx_scipy
     return _scipy
 

--- a/cupyx/scipy/sparse/__init__.py
+++ b/cupyx/scipy/sparse/__init__.py
@@ -1,44 +1,69 @@
+from __future__ import annotations
+
+# Base classes / type predicates
+from cupyx.scipy.sparse._base import _spbase  # NOQA
 from cupyx.scipy.sparse._base import issparse  # NOQA
 from cupyx.scipy.sparse._base import isspmatrix  # NOQA
+from cupyx.scipy.sparse._base import sparray  # NOQA
 from cupyx.scipy.sparse._base import spmatrix  # NOQA
 from cupyx.scipy.sparse._base import SparseWarning  # NOQA
 from cupyx.scipy.sparse._base import SparseEfficiencyWarning  # NOQA
+
+# Format classes (array + matrix variants)
+from cupyx.scipy.sparse._coo import coo_array  # NOQA
 from cupyx.scipy.sparse._coo import coo_matrix  # NOQA
 from cupyx.scipy.sparse._coo import isspmatrix_coo  # NOQA
+from cupyx.scipy.sparse._csc import csc_array  # NOQA
 from cupyx.scipy.sparse._csc import csc_matrix  # NOQA
 from cupyx.scipy.sparse._csc import isspmatrix_csc  # NOQA
+from cupyx.scipy.sparse._csr import csr_array  # NOQA
 from cupyx.scipy.sparse._csr import csr_matrix  # NOQA
 from cupyx.scipy.sparse._csr import isspmatrix_csr  # NOQA
+from cupyx.scipy.sparse._dia import dia_array  # NOQA
 from cupyx.scipy.sparse._dia import dia_matrix  # NOQA
 from cupyx.scipy.sparse._dia import isspmatrix_dia  # NOQA
 
+# Construction (matrix-style: kept for back-compat)
 from cupyx.scipy.sparse._construct import eye  # NOQA
 from cupyx.scipy.sparse._construct import identity  # NOQA
 from cupyx.scipy.sparse._construct import rand  # NOQA
 from cupyx.scipy.sparse._construct import random  # NOQA
 from cupyx.scipy.sparse._construct import spdiags  # NOQA
 from cupyx.scipy.sparse._construct import diags  # NOQA
-
 from cupyx.scipy.sparse._construct import bmat  # NOQA
+
+# Construction (array-style; preferred going forward)
+from cupyx.scipy.sparse._construct import block_array  # NOQA
+from cupyx.scipy.sparse._construct import block_diag  # NOQA
+from cupyx.scipy.sparse._construct import diags_array  # NOQA
+from cupyx.scipy.sparse._construct import eye_array  # NOQA
+from cupyx.scipy.sparse._construct import random_array  # NOQA
+
+# Combining (type-aware: returns array when any input is an array)
 from cupyx.scipy.sparse._construct import hstack  # NOQA
 from cupyx.scipy.sparse._construct import vstack  # NOQA
-
-# TODO(unno): implement bsr_matrix
-# TODO(unno): implement dok_matrix
-# TODO(unno): implement lil_matrix
-
 from cupyx.scipy.sparse._construct import kron  # NOQA
 from cupyx.scipy.sparse._construct import kronsum  # NOQA
-# TODO(unno): implement diags
-# TODO(unno): implement block_diag
 
+# Axis manipulation (2-D only in CuPy; SciPy supports nD).
+# ``expand_dims`` is omitted because it would require nD sparse arrays.
+from cupyx.scipy.sparse._construct import matrix_transpose  # NOQA
+from cupyx.scipy.sparse._construct import permute_dims  # NOQA
+from cupyx.scipy.sparse._construct import swapaxes  # NOQA
+
+# Extraction
 from cupyx.scipy.sparse._extract import find  # NOQA
 from cupyx.scipy.sparse._extract import tril  # NOQA
 from cupyx.scipy.sparse._extract import triu  # NOQA
 
-# TODO(unno): implement save_npz
-# TODO(unno): implement load_npz
+# Index-dtype utilities (re-exported to match scipy.sparse)
+from cupyx.scipy.sparse._sputils import get_index_dtype  # NOQA
+from cupyx.scipy.sparse._sputils import safely_cast_index_arrays  # NOQA
 
-# TODO(unno): implement isspmatrix_bsr(x)
-# TODO(unno): implement isspmatrix_lil(x)
-# TODO(unno): implement isspmatrix_dok(x)
+# Not-yet-implemented in CuPy:
+# - bsr_array / bsr_matrix (Block Sparse Row)
+# - dok_array / dok_matrix (Dictionary of Keys)
+# - lil_array / lil_matrix (List of Lists)
+# - isspmatrix_bsr / isspmatrix_lil / isspmatrix_dok
+# - save_npz / load_npz
+# - expand_dims (would require nD sparse-array support)

--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -23,55 +23,74 @@ except ImportError:
         pass
 
 
-# TODO(asi1024): Implement _spbase
+# Format -> human-readable name (mirrors scipy.sparse._base._formats).
+_format_names = {
+    'csr': 'Compressed Sparse Row',
+    'csc': 'Compressed Sparse Column',
+    'coo': 'COOrdinate',
+    'dia': 'DIAgonal',
+    'dok': 'Dictionary Of Keys',
+    'lil': 'List of Lists',
+    'bsr': 'Block Sparse Row',
+}
 
 
-class spmatrix:
+class _spbase:
+    """Common base class for all sparse arrays and matrices.
 
-    """Base class of all sparse matrixes.
-
-    See :class:`scipy.sparse.spmatrix`
+    .. seealso:: :class:`scipy.sparse._base._spbase`
     """
 
     __array_priority__ = 101
-    # ``_data_matrix.__init__`` (and therefore the format subclasses
-    # built on it: csr/csc/coo/dia) does not chain through to
-    # ``spmatrix.__init__``, so instances never get ``self.maxprint``
-    # set as an instance attribute.  This class default is the fallback.
+    # Class default since ``__init__`` chains across format subclasses
+    # don't always reach ``spmatrix.__init__``.
     maxprint = 50
 
-    def __init__(self, maxprint=50):
-        if self.__class__ == spmatrix:
-            raise ValueError(
-                'This class is not intended to be instantiated directly.')
-        self.maxprint = maxprint
+    def __class_getitem__(cls, args):
+        # ``coo_array[int]``-style typing aliases (scipy 1.16+).
+        import types
+        return types.GenericAlias(cls, args)
 
     @property
     def device(self):
-        """CUDA device on which this array resides."""
+        """CUDA device on which this object resides."""
         raise NotImplementedError
 
     def get(self, stream=None):
-        """Return a copy of the array on host memory.
+        """Return a copy of this object on host memory.
 
         Args:
-            stream (cupy.cuda.Stream): CUDA stream object. If it is given, the
-                copy runs asynchronously. Otherwise, the copy is synchronous.
+            stream (cupy.cuda.Stream): CUDA stream object. If it is given,
+                the copy runs asynchronously. Otherwise, the copy is
+                synchronous.
 
         Returns:
-            scipy.sparse.spmatrix: An array on host memory.
+            scipy.sparse: A SciPy sparse object on host memory of the
+            matching format and array/matrix type.
 
         """
         raise NotImplementedError
 
     def __len__(self):
-        raise TypeError('sparse matrix length is ambiguous; '
+        raise TypeError('sparse array length is ambiguous; '
                         'use shape[0] or .nnz')
 
+    def __repr__(self):
+        format_name = _format_names.get(self.format, self.format)
+        sparse_cls = 'array' if isinstance(self, sparray) else 'matrix'
+        return (
+            f"<{format_name} sparse {sparse_cls} of dtype '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements and shape {self.shape}>")
+
     def __str__(self):
-        # TODO(unno): Do not use get method which is only available when scipy
-        # is installed.
-        return str(self.get())
+        # Delegate to scipy via ``self.get()`` so the output (including
+        # version-specific quirks like DIA's "(N diagonals)" annotation)
+        # tracks the installed scipy.  Fall back to ``repr`` only when
+        # ``get()`` is unavailable.
+        try:
+            return str(self.get())
+        except (RuntimeError, NotImplementedError):
+            return repr(self)
 
     def __iter__(self):
         for r in range(self.shape[0]):
@@ -107,6 +126,9 @@ class spmatrix:
     def __abs__(self):
         return self.tocsr().__abs__()
 
+    def __neg__(self):
+        return -self.tocsr()
+
     def __add__(self, other):
         return self.tocsr().__add__(other)
 
@@ -119,31 +141,12 @@ class spmatrix:
     def __rsub__(self, other):
         return self.tocsr().__rsub__(other)
 
+    # Array semantics: * is element-wise (spmatrix overrides to matmul)
     def __mul__(self, other):
-        return self.tocsr().__mul__(other)
+        return self.multiply(other)
 
     def __rmul__(self, other):
-        if cupy.isscalar(other) or isdense(other) and other.ndim == 0:
-            return self * other
-        else:
-            try:
-                tr = other.T
-            except AttributeError:
-                return NotImplemented
-            return (self.T * tr).T
-
-    # matmul (@) operator
-    def __matmul__(self, other):
-        if _util.isscalarlike(other):
-            raise ValueError('Scalar operands are not allowed, '
-                             'use \'*\' instead')
-        return self.__mul__(other)
-
-    def __rmatmul__(self, other):
-        if _util.isscalarlike(other):
-            raise ValueError('Scalar operands are not allowed, '
-                             'use \'*\' instead')
-        return self.__rmul__(other)
+        return self.multiply(other)
 
     def __div__(self, other):
         return self.tocsr().__div__(other)
@@ -156,9 +159,6 @@ class spmatrix:
 
     def __rtruediv__(self, other):
         return self.tocsr().__rtruediv__(other)
-
-    def __neg__(self):
-        return -self.tocsr()
 
     def __iadd__(self, other):
         return NotImplemented
@@ -175,97 +175,106 @@ class spmatrix:
     def __itruediv__(self, other):
         return NotImplemented
 
+    # Array semantics: ** is element-wise (spmatrix overrides to matrix power)
     def __pow__(self, other):
-        """Calculates n-th power of the matrix.
+        return self.power(other)
 
-        This method calculates n-th power of a given matrix. The matrix must
-        be a squared matrix, and a given exponent must be an integer.
+    # matmul (@) operator
+    def __matmul__(self, other):
+        if _util.isscalarlike(other):
+            raise ValueError('Scalar operands are not allowed, '
+                             'use \'*\' instead')
+        return self._matmul_dispatch(other)
 
-        Args:
-            other (int): Exponent.
+    def __rmatmul__(self, other):
+        if _util.isscalarlike(other):
+            raise ValueError('Scalar operands are not allowed, '
+                             'use \'*\' instead')
+        return self._rmatmul_dispatch(other)
 
-        Returns:
-            cupyx.scipy.sparse.spmatrix: A sparse matrix representing n-th
-            power of this matrix.
+    def _matmul_dispatch(self, other):
+        """Default: convert to CSR.  Format subclasses override."""
+        return self.tocsr()._matmul_dispatch(other)
 
-        """
-        m, n = self.shape
-        if m != n:
-            raise TypeError('matrix is not square')
-        if not isinstance(other, numbers.Integral):
-            raise ValueError("exponent must be an integer")
-
-        if _util.isintlike(other):
-            other = int(other)
-            if other < 0:
-                raise ValueError('exponent must be >= 0')
-
-            if other == 0:
-                import cupyx.scipy.sparse
-                return cupyx.scipy.sparse.identity(
-                    m, dtype=self.dtype, format='csr')
-            elif other == 1:
-                return self.copy()
-            else:
-                tmp = self.__pow__(other // 2)
-                if other % 2:
-                    return self * tmp * tmp
-                else:
-                    return tmp * tmp
-        elif _util.isscalarlike(other):
-            raise ValueError('exponent must be an integer')
+    def _rmatmul_dispatch(self, other):
+        if cupy.isscalar(other) or (isdense(other) and other.ndim == 0):
+            return self._matmul_dispatch(other)
         else:
-            return NotImplemented
-
-    @property
-    def A(self):
-        """Dense ndarray representation of this matrix.
-
-        .. deprecated:: 15.0
-           Use :meth:`~cupyx.scipy.sparse.spmatrix.toarray` instead.
-
-        """
-        warnings.warn(
-            "`spmatrix.A` is deprecated; use `.toarray()` instead.",
-            DeprecationWarning, stacklevel=2)
-        return self.toarray()
+            try:
+                tr = other.T
+            except AttributeError:
+                return NotImplemented
+            return (self.T._matmul_dispatch(tr)).T
 
     @property
     def T(self):
         return self.transpose()
 
     @property
-    def H(self):
-        """Hermitian (conjugate) transpose of this matrix.
+    def mT(self):
+        """Matrix transpose.
 
-        .. deprecated:: 15.0
-           Use ``.T.conj()`` instead.
-
+        Equivalent to :func:`cupyx.scipy.sparse.matrix_transpose`.
+        CuPy sparse types are 2-D only.
         """
-        warnings.warn(
-            "`spmatrix.H` is deprecated; use `.T.conj()` instead.",
-            DeprecationWarning, stacklevel=2)
-        return self.transpose().conj()
+        n = self.ndim
+        if n < 2:
+            raise ValueError(
+                'Array must be at least 2-dimensional, '
+                f'but it is {n}-D')
+        return self.transpose()
 
     @property
     def ndim(self):
-        return 2
+        return len(self._shape)
 
     @property
     def size(self):
-        return self.getnnz()
+        return self._getnnz()
 
     @property
     def nnz(self):
-        return self.getnnz()
+        return self._getnnz()
 
     @property
     def shape(self):
-        return self.get_shape()
+        return self._shape
 
-    @shape.setter
-    def shape(self, value):
-        self.set_shape(value)
+    @property
+    def _shape_as_2d(self):
+        s = self._shape
+        return (1, s[-1]) if len(s) == 1 else s
+
+    # Container properties: default to array types.
+    # spmatrix overrides these to return matrix types.
+
+    @property
+    def _csr_container(self):
+        from cupyx.scipy.sparse._csr import csr_array
+        return csr_array
+
+    @property
+    def _csc_container(self):
+        from cupyx.scipy.sparse._csc import csc_array
+        return csc_array
+
+    @property
+    def _coo_container(self):
+        from cupyx.scipy.sparse._coo import coo_array
+        return coo_array
+
+    @property
+    def _dia_container(self):
+        from cupyx.scipy.sparse._dia import dia_array
+        return dia_array
+
+    def _get_index_dtype(self, arrays=(), maxval=None, check_contents=False):
+        """Wraps get_index_dtype: arrays never downcast (check_contents
+        is disabled for sparray instances).
+        """
+        return _sputils.get_index_dtype(
+            arrays, maxval,
+            check_contents and not isinstance(self, sparray))
 
     def asformat(self, format):
         """Return this matrix in a given sparse format.
@@ -278,34 +287,26 @@ class spmatrix:
         else:
             return getattr(self, 'to' + format)()
 
-    def asfptype(self):
-        """Upcasts matrix to a floating point format.
-
-        When the matrix has floating point type, the method returns itself.
-        Otherwise it makes a copy with floating point type and the same format.
-
-        Returns:
-            cupyx.scipy.sparse.spmatrix: A matrix with float type.
-
-        """
-        if self.dtype.kind == 'f':
-            return self
-        else:
-            typ = numpy.promote_types(self.dtype, 'f')
-            return self.astype(typ)
-
-    def astype(self, t):
-        """Casts the array to given data type.
+    def astype(self, dtype, copy=True):
+        """Cast the array elements to a specified type.
 
         Args:
-            t: Type specifier.
+            dtype: Target dtype.
+            copy (bool): If ``True`` (default), the returned array does
+                not share memory with ``self``.  If ``False``, ``self``
+                is returned unchanged when the dtype already matches.
 
         Returns:
-            cupyx.scipy.sparse.spmatrix:
-                A copy of the array with the given type and the same format.
-
+            cupyx.scipy.sparse: Sparse object with the requested dtype
+            and the same format as ``self``.
         """
-        return self.tocsr().astype(t).asformat(self.format)
+        dtype = numpy.dtype(dtype)
+        if self.dtype != dtype:
+            return self.tocsr().astype(
+                dtype, copy=copy).asformat(self.format)
+        if copy:
+            return self.copy()
+        return self
 
     def conj(self, copy=True):
         """Element-wise complex conjugation.
@@ -341,8 +342,12 @@ class spmatrix:
         """
         return self.__class__(self, copy=True)
 
-    def count_nonzero(self):
-        """Number of non-zero entries, equivalent to"""
+    def count_nonzero(self, axis=None):
+        """Number of non-zero entries.
+
+        Subclasses override this; ``_spbase`` itself does not implement
+        a generic counter.
+        """
         raise NotImplementedError
 
     def diagonal(self, k=0):
@@ -378,27 +383,27 @@ class spmatrix:
         else:
             return self @ other
 
-    def getH(self):
-        return self.transpose().conj()
+    def _getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
 
-    def get_shape(self):
+        Subclasses override this to provide format-specific counts.
+        Public access is via :attr:`nnz` (no axis) or
+        :meth:`spmatrix.getnnz` (matrix-only, axis-aware).
+        """
         raise NotImplementedError
 
-    # TODO(unno): Implement getcol
+    def nonzero(self):
+        """Indices of the non-zero elements.
 
-    def getformat(self):
-        """Return the format of this matrix (e.g., ``'csr'``)."""
-        return self.format
-
-    def getmaxprint(self):
-        """Return the maximum number of stored values shown in ``__str__``."""
-        return self.maxprint
-
-    def getnnz(self, axis=None):
-        """Number of stored values, including explicit zeros."""
-        raise NotImplementedError
-
-    # TODO(unno): Implement getrow
+        Returns a tuple ``(row, col)`` of cupy.ndarrays (matching
+        :meth:`scipy.sparse._base._spbase.nonzero`).  Explicit zeros are
+        excluded.
+        """
+        A = self.tocoo()
+        if not A.has_canonical_format:
+            A.sum_duplicates()
+        nz_mask = A.data != 0
+        return (A.row[nz_mask], A.col[nz_mask])
 
     def maximum(self, other):
         return self.tocsr().maximum(other)
@@ -474,9 +479,9 @@ class spmatrix:
 
     def multiply(self, other):
         """Point-wise multiplication by another matrix"""
+        if issparse(other):
+            other = other.tocsr()
         return self.tocsr().multiply(other)
-
-    # TODO(unno): Implement nonzero
 
     def power(self, n, dtype=None):
         return self.tocsr().power(n, dtype=dtype)
@@ -503,15 +508,6 @@ class spmatrix:
             return self
 
         return self.tocoo().reshape(shape, order=order)
-
-    def set_shape(self, shape):
-        """Set the shape of the matrix in-place."""
-        # ``self.reshape(shape)`` builds a new matrix and returns it
-        # (it's the immutable form).  To make the change visible on the
-        # original object, build the reshaped matrix in the same format
-        # and swap ``__dict__``.  Mirrors scipy 1.17's implementation.
-        new_self = self.reshape(shape).asformat(self.format)
-        self.__dict__ = new_self.__dict__
 
     def setdiag(self, values, k=0):
         """Set diagonal or off-diagonal elements of the array.
@@ -563,10 +559,20 @@ class spmatrix:
         if axis < 0:
             axis += 2
 
-        if axis == 0:
-            ret = self.T.dot(cupy.ones(m, dtype=self.dtype)).reshape(1, n)
-        else:  # axis == 1
-            ret = self.dot(cupy.ones(n, dtype=self.dtype)).reshape(m, 1)
+        if isinstance(self, sparray):
+            # Arrays: reduction along an axis returns 1D
+            if axis == 0:
+                ret = self.T.dot(cupy.ones(m, dtype=self.dtype))
+            else:
+                ret = self.dot(cupy.ones(n, dtype=self.dtype))
+        else:
+            # Matrices: keep 2D shape
+            if axis == 0:
+                ret = self.T.dot(
+                    cupy.ones(m, dtype=self.dtype)).reshape(1, n)
+            else:
+                ret = self.dot(
+                    cupy.ones(n, dtype=self.dtype)).reshape(m, 1)
 
         if out is not None:
             if out.shape != ret.shape:
@@ -619,16 +625,225 @@ class spmatrix:
         return self.tocsr(copy=copy).transpose(axes=axes, copy=False)
 
 
+class sparray:
+    """Namespace mixin for sparse array classes.
+
+    Sparse array classes follow NumPy semantics: ``*`` is element-wise
+    multiplication and ``**`` is element-wise power.  Use ``@`` for
+    matrix multiplication.
+
+    .. seealso:: :class:`scipy.sparse.sparray`
+    """
+    pass
+
+
+class spmatrix:
+    """Mixin for sparse matrix classes.
+
+    Sparse matrix classes follow legacy ``numpy.matrix`` semantics:
+    ``*`` is matrix multiplication and ``**`` is matrix power.  Provides
+    backward-compatibility methods (``.A``, ``.H``, ``getrow``,
+    ``getcol``, etc.) that do not exist on sparse arrays.  These APIs
+    are deprecated in favor of the sparse array interface.
+
+    .. seealso:: :class:`scipy.sparse.spmatrix`
+    """
+
+    def __init__(self, *args, maxprint=50, **kwargs):
+        self.maxprint = maxprint
+        # Cooperative MI: forward to the next __init__ in the MRO.
+        nxt = super().__init__
+        if nxt is not object.__init__:
+            nxt(*args, **kwargs)
+        elif args or kwargs:
+            # Direct instantiation of ``spmatrix(args)`` with no concrete
+            # format subclass; scipy raises here, so do the same.
+            raise TypeError(
+                'cannot instantiate spmatrix directly; use a format '
+                'subclass such as csr_matrix')
+
+    # Matrix semantics: * is matmul (overrides _spbase element-wise default)
+    def __mul__(self, other):
+        return self._matmul_dispatch(other)
+
+    def __rmul__(self, other):
+        return self._rmatmul_dispatch(other)
+
+    def __pow__(self, other):
+        """Calculates n-th power of the matrix.
+
+        This method calculates n-th power of a given matrix. The matrix must
+        be a squared matrix, and a given exponent must be an integer.
+
+        Args:
+            other (int): Exponent.
+
+        Returns:
+            cupyx.scipy.sparse.spmatrix: A sparse matrix representing n-th
+            power of this matrix.
+
+        """
+        m, n = self.shape
+        if m != n:
+            raise TypeError('matrix is not square')
+        if not isinstance(other, numbers.Integral):
+            raise ValueError("exponent must be an integer")
+
+        if _util.isintlike(other):
+            other = int(other)
+            if other < 0:
+                raise ValueError('exponent must be >= 0')
+
+            if other == 0:
+                import cupyx.scipy.sparse
+                return cupyx.scipy.sparse.identity(
+                    m, dtype=self.dtype, format='csr')
+            elif other == 1:
+                return self.copy()
+            else:
+                tmp = self.__pow__(other // 2)
+                if other % 2:
+                    return self * tmp * tmp
+                else:
+                    return tmp * tmp
+        elif _util.isscalarlike(other):
+            raise ValueError('exponent must be an integer')
+        else:
+            return NotImplemented
+
+    @property
+    def _csr_container(self):
+        from cupyx.scipy.sparse._csr import csr_matrix
+        return csr_matrix
+
+    @property
+    def _csc_container(self):
+        from cupyx.scipy.sparse._csc import csc_matrix
+        return csc_matrix
+
+    @property
+    def _coo_container(self):
+        from cupyx.scipy.sparse._coo import coo_matrix
+        return coo_matrix
+
+    @property
+    def _dia_container(self):
+        from cupyx.scipy.sparse._dia import dia_matrix
+        return dia_matrix
+
+    @property
+    def A(self):
+        """Dense ndarray representation of this matrix.
+
+        .. deprecated:: 15.0
+           Use :meth:`~cupyx.scipy.sparse.spmatrix.toarray` instead.
+
+        """
+        warnings.warn(
+            "`spmatrix.A` is deprecated; use `.toarray()` instead.",
+            DeprecationWarning, stacklevel=2)
+        return self.toarray()
+
+    @property
+    def H(self):
+        """Hermitian (conjugate) transpose of this matrix.
+
+        .. deprecated:: 15.0
+           Use ``.T.conj()`` instead.
+
+        """
+        warnings.warn(
+            "`spmatrix.H` is deprecated; use `.T.conj()` instead.",
+            DeprecationWarning, stacklevel=2)
+        return self.transpose().conj()
+
+    def get_shape(self):
+        """Return the shape of the matrix."""
+        return self._shape
+
+    def set_shape(self, shape):
+        """Set the shape of the matrix in-place."""
+        # Match scipy 1.17: build the reshaped matrix and swap __dict__
+        # so the change is visible on the original object.
+        new_self = self.reshape(shape).asformat(self.format)
+        self.__dict__ = new_self.__dict__
+
+    shape = property(
+        fget=get_shape, fset=set_shape, doc='Shape of the matrix.')
+
+    def asfptype(self):
+        """Upcasts matrix to a floating point format.
+
+        When the matrix has floating point type, the method returns itself.
+        Otherwise it makes a copy with floating point type and the same
+        format.
+
+        Returns:
+            cupyx.scipy.sparse.spmatrix: A matrix with float type.
+        """
+        if self.dtype.kind == 'f':
+            return self
+        typ = numpy.promote_types(self.dtype, 'f')
+        return self.astype(typ)
+
+    def getH(self):
+        """Hermitian (conjugate) transpose of this matrix."""
+        return self.transpose().conj()
+
+    def getrow(self, i):
+        """Return a copy of row ``i`` as a (1 x n) sparse row vector.
+
+        Matrix-only API; for sparse arrays use ``A[i]`` (or ``A[[i], :]``
+        for a 2-D result).
+        """
+        return self._getrow(i)
+
+    def getcol(self, j):
+        """Return a copy of column ``j`` as a (m x 1) sparse column vector.
+
+        Matrix-only API; for sparse arrays use ``A[:, j]`` (or
+        ``A[:, [j]]`` for a 2-D result).
+        """
+        return self._getcol(j)
+
+    def getformat(self):
+        """Return the format string of this matrix (e.g. ``'csr'``)."""
+        return self.format
+
+    def getmaxprint(self):
+        """Return the maximum number of stored values shown in ``__str__``."""
+        return self.maxprint
+
+    def getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
+
+        Args:
+            axis (None, 0, or 1): Select between the number of values
+                across the whole matrix, in each column (axis=0), or in
+                each row (axis=1).
+        """
+        return self._getnnz(axis=axis)
+
+
 def issparse(x):
-    """Checks if a given matrix is a sparse matrix.
+    """Checks if a given matrix is a sparse matrix or array.
 
     Returns:
-        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.spmatrix` that is
-        a base class of all sparse matrix classes.
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.spmatrix`
+        or :class:`cupyx.scipy.sparse.sparray`.
+
+    """
+    return isinstance(x, _spbase)
+
+
+def isspmatrix(x):
+    """Checks if a given matrix is a sparse matrix (not array).
+
+    Returns:
+        bool: Returns if ``x`` is :class:`cupyx.scipy.sparse.spmatrix`.
 
     """
     return isinstance(x, spmatrix)
 
 
 isdense = _util.isdense
-isspmatrix = issparse

--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -17,7 +17,6 @@ from cupy import _core
 from cupy._core import _scalar
 from cupy._creation import basic
 from cupyx.scipy.sparse import _base
-from cupyx.scipy.sparse import _coo
 from cupyx.scipy.sparse import _data as sparse_data
 from cupyx.scipy.sparse import _sputils
 from cupyx.scipy.sparse import _util
@@ -203,13 +202,15 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         diff = diff_out;
         ''', 'cupyx_scipy_sparse_has_canonical_format')
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False,
+                 *, maxprint=None):
         from cupyx import cusparse
 
+        if maxprint is not None:
+            self.maxprint = maxprint
+
         if shape is not None:
-            if not _util.isshape(shape):
-                raise ValueError('invalid shape (must be a 2-tuple of int)')
-            shape = int(shape[0]), int(shape[1])
+            shape = _util.check_shape(shape)
 
         if _base.issparse(arg1):
             x = arg1.asformat(self.format)
@@ -227,8 +228,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                 shape = arg1.shape
 
         elif _util.isshape(arg1):
-            m, n = arg1
-            m, n = int(m), int(n)
+            # ``isshape`` is a pure type-check; ``check_shape`` raises
+            # ``ValueError("'shape' elements cannot be negative")`` on a
+            # negative dimension to match scipy's message.
+            m, n = _util.check_shape(arg1)
             idx_dtype = _sputils.get_index_dtype(maxval=max(m, n))
             data = basic.zeros(0, dtype if dtype else 'd')
             indices = basic.zeros(0, idx_dtype)
@@ -252,15 +255,16 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                 shape = arg1.shape
 
         elif isinstance(arg1, tuple) and len(arg1) == 2:
-            # Note: This implementation is not efficient, as it first
-            # constructs a sparse matrix with coo format, then converts it to
-            # compressed format.
-            sp_coo = _coo.coo_matrix(arg1, shape=shape, dtype=dtype, copy=copy)
+            # Note: not efficient -- constructs an intermediate COO and
+            # converts.  Routes through ``self._coo_container`` (sparse-
+            # array aware) so int64 indices are not downcast by
+            # ``coo_matrix``'s ``check_contents`` path.
+            sp_coo = self._coo_container(
+                arg1, shape=shape, dtype=dtype, copy=copy)
             sp_compressed = sp_coo.asformat(self.format)
             data = sp_compressed.data
             indices = sp_compressed.indices
             indptr = sp_compressed.indptr
-            # Derived from COO's get_index_dtype call.
             idx_dtype = indices.dtype
 
         elif isinstance(arg1, tuple) and len(arg1) == 3:
@@ -274,12 +278,14 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             if len(data) != len(indices):
                 raise ValueError('indices and data should have the same size')
 
-            # Mirror scipy: choose int32 when values fit,
-            # int64 when they don't.
-            # maxval may be None if shape is not yet known; contents check
-            # handles that case.
+            # Choose int32 when all values fit, int64 otherwise.
+            # ``_get_index_dtype`` on a sparray instance disables
+            # ``check_contents`` and preserves the input dtype; the
+            # matrix path falls through to the contents check.  When
+            # ``shape`` is None, ``maxval`` is None and the contents
+            # check picks the dtype.
             maxval = max(shape) if shape is not None else None
-            idx_dtype = _sputils.get_index_dtype(
+            idx_dtype = self._get_index_dtype(
                 (indices, indptr), maxval=maxval, check_contents=True)
 
         elif _base.isdense(arg1):
@@ -304,7 +310,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         else:
             dtype = numpy.dtype(dtype)
 
-        if dtype.char not in '?fdFD':
+        if not _sputils.is_sparse_data_dtype(dtype):
             raise ValueError(
                 'Only bool, float32, float64, complex64 and complex128 '
                 'are supported')
@@ -331,50 +337,40 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
     def _from_parts(cls, data, indices, indptr, shape,
                     has_canonical_format=None,
                     has_sorted_indices=None):
-        """Construct from pre-validated arrays (no check_contents).
+        """Construct from pre-validated arrays without ``check_contents``.
 
         Internal API for building sparse matrices when the caller has
-        already determined the correct index dtype.  Skips the
-        check_contents=True downcast that the tuple-3 constructor
-        applies.
-
-        Caller must ensure *indices* and *indptr* share the same
-        integer dtype and are within bounds for *shape*.
+        already determined the correct index dtype.  ``indices`` and
+        ``indptr`` must share an integer dtype and be in bounds for
+        ``shape``.  The caller is responsible for the buffer
+        invariant ``data.size == indices.size == int(indptr[-1])``;
+        cheap shape/dtype checks below catch the easy mistakes
+        without a host sync.
 
         Args:
-            has_canonical_format (bool or None): If ``True`` or
-                ``False``, cache the flag directly (avoids the lazy
-                GPU kernel on first access).  ``None`` (default)
-                leaves the flag unset for lazy computation.
-                ``True`` implies ``has_sorted_indices=True``.
+            has_canonical_format (bool or None): If True or False,
+                cache the flag directly to skip the lazy GPU kernel on
+                first access.  None leaves the flag unset.  True
+                implies ``has_sorted_indices=True``.
             has_sorted_indices (bool or None): Same semantics.
-
-        Raises:
-            ValueError: If *indices* and *indptr* dtypes differ, the
-                ``has_canonical_format`` / ``has_sorted_indices`` flags
-                are inconsistent, ``data`` and ``indices`` lengths
-                differ, or ``indptr`` length does not match the major
-                axis of *shape*.
         """
         if indices.dtype != indptr.dtype:
             raise ValueError(
-                'indices and indptr must have the same dtype, '
-                'got {} and {}'.format(indices.dtype, indptr.dtype))
+                f'indices and indptr must have the same dtype, '
+                f'got {indices.dtype} and {indptr.dtype}')
         if has_canonical_format is True and has_sorted_indices is False:
             raise ValueError(
                 'has_canonical_format=True implies sorted indices, '
                 'but has_sorted_indices=False was passed')
         if data.size != indices.size:
             raise ValueError(
-                'data and indices must have the same length, '
-                'got {} and {}'.format(data.size, indices.size))
-        # Major axis: shape[0] for CSR (_major_axis=0), shape[1] for CSC.
-        # Subclasses must define _major_axis.
+                f'data and indices must have the same length, '
+                f'got {data.size} and {indices.size}')
         major = shape[cls._major_axis]
         if indptr.size != major + 1:
             raise ValueError(
-                'indptr has length {}, expected {} (major axis + 1)'
-                .format(indptr.size, major + 1))
+                f'indptr has length {indptr.size}, '
+                f'expected {major + 1} (major axis + 1)')
         A = cls.__new__(cls)
         sparse_data._data_matrix.__init__(A, data)
         A.indices = indices
@@ -416,6 +412,26 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             cupy.zeros(major + 1, idx),
             shape)
 
+    def _as_csr_type(self, result):
+        """Re-wrap a cuSPARSE CSR result in ``self``'s csr_container.
+
+        cuSPARSE's gemm helpers always return a ``csr_matrix``; if
+        ``self`` is a sparse-array (csr_array / csc_array) the matmul
+        result should be a ``csr_array`` instead.
+        """
+        target = self._csr_container
+        if type(result) is target:
+            return result
+        if not (_base.issparse(result) and result.format == 'csr'):
+            return result
+        # Rewrap the kind; ``result`` already has a tight buffer.
+        return target._from_parts(
+            result.data, result.indices, result.indptr, result.shape,
+            has_canonical_format=getattr(
+                result, '_has_canonical_format', None),
+            has_sorted_indices=getattr(
+                result, '_has_sorted_indices', None))
+
     def _convert_dense(self, x):
         raise NotImplementedError
 
@@ -436,7 +452,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                 raise NotImplementedError(
                     'adding a nonzero scalar to a sparse matrix is not '
                     'supported')
-        elif _base.isspmatrix(other):
+        elif _base.issparse(other):
             alpha = -1 if lhs_negative else 1
             beta = -1 if rhs_negative else 1
             return self._add_sparse(other, alpha, beta)
@@ -498,7 +514,10 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             not_found_val)
 
         if major.ndim == 1:
-            # Scipy returns `matrix` here
+            # Sparse arrays return a 1-D ndarray; sparse matrices keep
+            # the legacy 2-D shape (matching scipy).
+            if isinstance(self, _base.sparray):
+                return val
             return cupy.expand_dims(val, 0)
         return self.__class__(val.reshape(major.shape))
 
@@ -1158,29 +1177,80 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
     has_sorted_indices = property(fget=__get_sorted, fset=__set_sorted)
 
-    def get_shape(self):
-        """Returns the shape of the matrix.
-
-        Returns:
-            tuple: Shape of the matrix.
-
-        """
-        return self._shape
-
-    def getnnz(self, axis=None):
-        """Returns the number of stored values, including explicit zeros.
+    def _getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
 
         Args:
             axis: Not supported yet.
 
         Returns:
             int: The number of stored values.
-
         """
         if axis is None:
             return self.data.size
         else:
             raise ValueError
+
+    def count_nonzero(self, axis=None):
+        """Number of non-zero entries.
+
+        Unlike :attr:`nnz`, this counts only true non-zero values
+        (explicit zeros are excluded).  Duplicates are summed first.
+
+        Args:
+            axis ({-2, -1, 0, 1, ``None``}):
+                Count over the whole matrix, or along a logical
+                row/col axis.
+
+        Returns:
+            int or cupy.ndarray: Scalar count when ``axis=None``,
+            otherwise a 1-D ``cupy.ndarray`` of length
+            ``shape[1 - axis]``.
+
+        .. warning::
+            Synchronizes the device.  ``axis is not None`` reads the
+            popcount of the non-zero mask once (one D2H sync) plus
+            whatever ``sum_duplicates`` itself syncs.
+
+        .. seealso:: :meth:`scipy.sparse.csr_matrix.count_nonzero`
+        """
+        # Match scipy: dedup in place, then count.
+        self.sum_duplicates()
+        if axis is None:
+            return int(cupy.count_nonzero(self.data))
+        if axis < -2 or axis > 1:
+            raise ValueError('axis out of bounds')
+        if axis < 0:
+            axis += 2
+        # CSR's _swap is identity; CSC's swaps row/col.
+        major_axis, _ = self._swap(axis, 1 - axis)
+        major_dim, minor_dim = self._swap(*self.shape)
+        # ``cupy.bincount`` rejects empty input even with ``minlength``;
+        # short-circuit when nothing is stored.
+        if self.data.size == 0:
+            out_dim = minor_dim if major_axis == 0 else major_dim
+            return cupy.zeros(out_dim, dtype=cupy.intp)
+        mask = self.data != 0
+        # mask.sum() == size captures both "all non-zero" and the nnz of
+        # the kept set in one D2H read.
+        nnz_kept = int(mask.sum())  # synchronize!
+        all_kept = nnz_kept == mask.size
+        if major_axis == 0:
+            # axis-along-major: per-minor-index count -> bincount(indices)
+            if nnz_kept == 0:
+                return cupy.zeros(minor_dim, dtype=cupy.intp)
+            idx = self.indices if all_kept else self.indices[mask]
+            return cupy.bincount(
+                idx.astype(cupy.int64), minlength=minor_dim)
+        # axis-along-minor: per-major-index count
+        if all_kept:
+            return cupy.diff(self.indptr).astype(cupy.intp)
+        if nnz_kept == 0:
+            return cupy.zeros(major_dim, dtype=cupy.intp)
+        from cupyx.cusparse import _indptr_to_coo
+        major = _indptr_to_coo(self.indptr, nnz=self.nnz)
+        return cupy.bincount(
+            major[mask].astype(cupy.int64), minlength=major_dim)
 
     def sorted_indices(self):
         """Return a copy of this matrix with sorted indices
@@ -1192,6 +1262,30 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         A = self.copy()
         A.sort_indices()
         return A
+
+    def prune(self):
+        """Remove empty space after all non-zero elements.
+
+        After direct attribute mutation, ``indices`` and ``data``
+        buffers may be longer than the logical entry count
+        (``indptr[-1]``).  ``prune`` shrinks them to match.  CuPy's
+        own helpers always produce tight buffers, so this is mostly
+        useful when a caller manually grew the buffers.
+
+        .. seealso:: :meth:`scipy.sparse.csr_matrix.prune`
+        """
+        major_dim = self._swap(*self.shape)[0]
+        if len(self.indptr) != major_dim + 1:
+            raise ValueError('index pointer has invalid length')
+        nnz = int(self.indptr[-1])  # synchronize!
+        if len(self.indices) < nnz:
+            raise ValueError('indices array has fewer than nnz elements')
+        if len(self.data) < nnz:
+            raise ValueError('data array has fewer than nnz elements')
+        if len(self.indices) > nnz:
+            self.indices = self.indices[:nnz].copy()
+        if len(self.data) > nnz:
+            self.data = self.data[:nnz].copy()
 
     def sort_indices(self):
         # Unlike in SciPy, here this is implemented in child classes because

--- a/cupyx/scipy/sparse/_construct.py
+++ b/cupyx/scipy/sparse/_construct.py
@@ -2,11 +2,87 @@ from __future__ import annotations
 
 import numpy
 import cupy
+from cupyx.scipy.sparse import _base
 from cupyx.scipy.sparse import _coo
 from cupyx.scipy.sparse import _csc
 from cupyx.scipy.sparse import _csr
 from cupyx.scipy.sparse import _dia
 from cupyx.scipy.sparse import _sputils
+
+
+def _any_sparray(*args):
+    """Return True if any argument is a sparse array (not matrix)."""
+    return any(isinstance(a, _base.sparray) for a in args
+               if _base.issparse(a))
+
+
+def matrix_transpose(A):
+    """Transpose the last two axes of a sparse object.
+
+    Args:
+        A (cupyx.scipy.sparse): Sparse object (CuPy currently supports
+            2-D only).
+
+    Returns:
+        cupyx.scipy.sparse: ``A`` with its last two axes swapped (same
+        array vs matrix type as the input).
+
+    .. seealso:: :func:`scipy.sparse.matrix_transpose`
+    """
+    if not _base.issparse(A):
+        raise TypeError('matrix_transpose expected a sparse object')
+    return A.transpose()
+
+
+def swapaxes(A, axis1, axis2):
+    """Interchange two axes of a sparse object.
+
+    Args:
+        A (cupyx.scipy.sparse): Sparse 2-D object.
+        axis1 (int): First axis (in ``[-2, 1]``).
+        axis2 (int): Second axis (in ``[-2, 1]``).
+
+    Returns:
+        cupyx.scipy.sparse: ``A`` with axes swapped.
+
+    .. seealso:: :func:`scipy.sparse.swapaxes`
+    """
+    if not _base.issparse(A):
+        raise TypeError('swapaxes expected a sparse object')
+    a1 = axis1 + 2 if axis1 < 0 else axis1
+    a2 = axis2 + 2 if axis2 < 0 else axis2
+    if a1 not in (0, 1) or a2 not in (0, 1):
+        raise ValueError('axis out of range for 2-D sparse object')
+    if a1 == a2:
+        return A.copy()
+    return A.transpose()
+
+
+def permute_dims(A, axes=None, copy=False):
+    """Permute the axes of a sparse object.
+
+    Args:
+        A (cupyx.scipy.sparse): Sparse 2-D object.
+        axes (tuple of int or None): Permutation of axis indices.
+            Defaults to reversing the axes (i.e. transpose).
+        copy (bool): If ``True``, the result does not share data with
+            ``A``.
+
+    Returns:
+        cupyx.scipy.sparse: ``A`` with axes permuted.
+
+    .. seealso:: :func:`scipy.sparse.permute_dims`
+    """
+    if not _base.issparse(A):
+        raise TypeError('permute_dims expected a sparse object')
+    if axes is None:
+        axes = (1, 0)
+    axes = tuple(a + 2 if a < 0 else a for a in axes)
+    if sorted(axes) != [0, 1]:
+        raise ValueError('axes must be a permutation of (0, 1)')
+    if axes == (0, 1):
+        return A.copy() if copy else A
+    return A.transpose(copy=copy)
 
 
 def eye(m, n=None, k=0, dtype='d', format=None):
@@ -120,32 +196,32 @@ def _compressed_sparse_stack(blocks, axis):
         sum_dim += b.shape[axis]
         last_indptr += b.indptr[-1]
     indptr[-1] = last_indptr
+    use_array = _any_sparray(*blocks)
     if axis == 0:
-        cls = _csr.csr_matrix
+        cls = _csr.csr_array if use_array else _csr.csr_matrix
         shape = (sum_dim, constant_dim)
     else:
-        cls = _csc.csc_matrix
+        cls = _csc.csc_array if use_array else _csc.csc_matrix
         shape = (constant_dim, sum_dim)
-    return cls._from_parts(data, indices, indptr, shape)
+    return cls._from_parts(
+        data, indices, indptr, shape)
 
 
 def hstack(blocks, format=None, dtype=None):
-    """Stacks sparse matrices horizontally (column wise)
+    """Stacks sparse arrays/matrices horizontally (column wise).
 
     Args:
-        blocks (sequence of cupyx.scipy.sparse.spmatrix):
-            sparse matrices to stack
-
-        format (str):
-            sparse format of the result (e.g. "csr")
-            by default an appropriate sparse matrix format is returned.
-            This choice is subject to change.
-        dtype (dtype, optional):
-            The data-type of the output matrix.  If not given, the dtype is
-            determined from that of ``blocks``.
+        blocks (sequence of cupyx.scipy.sparse): sparse objects to stack.
+        format (str): sparse format of the result (e.g. ``'csr'``).  By
+            default an appropriate sparse format is returned.  This choice
+            is subject to change.
+        dtype (dtype, optional): The data-type of the output.  If not
+            given, the dtype is determined from that of ``blocks``.
 
     Returns:
-        cupyx.scipy.sparse.spmatrix: the stacked sparse matrix
+        cupyx.scipy.sparse: The stacked sparse object.  Returns a sparse
+        array when *any* input is a sparse array, else a sparse matrix
+        (matches scipy).
 
     .. seealso:: :func:`scipy.sparse.hstack`
 
@@ -249,14 +325,15 @@ def bmat(blocks, format=None, dtype=None):
 
     # check for fast path cases
     if (N == 1 and format in (None, 'csr') and
-            all(isinstance(b, _csr.csr_matrix)
+            all(_base.issparse(b) and b.format == 'csr'
                 for b in blocks_flat)):
         A = _compressed_sparse_stack(blocks_flat, 0)
         if dtype is not None:
             A = A.astype(dtype)
         return A
     elif (M == 1 and format in (None, 'csc')
-          and all(isinstance(b, _csc.csc_matrix) for b in blocks_flat)):
+          and all(_base.issparse(b) and b.format == 'csc'
+                  for b in blocks_flat)):
         A = _compressed_sparse_stack(blocks_flat, 1)
         if dtype is not None:
             A = A.astype(dtype)
@@ -265,6 +342,9 @@ def bmat(blocks, format=None, dtype=None):
     block_mask = numpy.zeros((M, N), dtype=bool)
     brow_lengths = numpy.zeros(M+1, dtype=numpy.int64)
     bcol_lengths = numpy.zeros(N+1, dtype=numpy.int64)
+
+    # Detect array type before COO conversion loses it
+    _use_array = _any_sparray(*blocks_flat)
 
     # Check if any input block has int64 indices before conversion
     # to COO (the COO constructor may downcast via check_contents).
@@ -343,7 +423,8 @@ def bmat(blocks, format=None, dtype=None):
         col[idx] = B.col + col_offsets[j]
         nnz += B.nnz
 
-    A = _coo.coo_matrix._from_parts(data, row, col, shape)
+    coo_cls = _coo.coo_array if _use_array else _coo.coo_matrix
+    A = coo_cls._from_parts(data, row, col, shape)
     A.has_canonical_format = False
     return A.asformat(format)
 
@@ -547,15 +628,29 @@ def kron(A, B, format=None):
     # TODO(leofang): investigate if possible to optimize performance by
     #                starting with CSR instead of COO matrices
 
-    A = _coo.coo_matrix(A)
-    B = _coo.coo_matrix(B)
+    use_array = _any_sparray(A, B)
+    coo_cls = _coo.coo_array if use_array else _coo.coo_matrix
+    # Use the array path on input conversion when any input is a sparse
+    # array so int64 indices survive the trip through COO.
+    A = coo_cls(A)
+    B = coo_cls(B)
     out_shape = (A.shape[0] * B.shape[0], A.shape[1] * B.shape[1])
 
     if A.nnz == 0 or B.nnz == 0:
-        # kronecker product is the zero matrix
-        return _coo.coo_matrix(out_shape).asformat(format)
+        return coo_cls(out_shape).asformat(format)
 
-    if max(out_shape[0], out_shape[1]) > cupy.iinfo('int32').max:
+    # Choose the output index dtype.
+    #   - Sparray path: ``_get_index_dtype`` is called from a sparray
+    #     instance so ``check_contents`` is forced off; the input
+    #     arrays' dtypes are preserved (so kron(int64, int64) stays
+    #     int64 even when the output shape would also fit int32).
+    #     Mirrors scipy 1.17.
+    #   - Matrix path: the legacy minimum-required policy (int32 unless
+    #     the output shape forces int64).  Matches scipy matrix.
+    if use_array:
+        dtype = A._get_index_dtype(
+            (A.row, A.col, B.row, B.col), maxval=max(out_shape))
+    elif max(out_shape[0], out_shape[1]) > cupy.iinfo('int32').max:
         dtype = cupy.int64
     else:
         dtype = cupy.int32
@@ -577,7 +672,7 @@ def kron(A, B, format=None):
     data = data.reshape(-1, B.nnz) * B.data
     data = data.ravel()
 
-    return _coo.coo_matrix(
+    return coo_cls(
         (data, (row, col)), shape=out_shape).asformat(format)
 
 
@@ -600,8 +695,10 @@ def kronsum(A, B, format=None):
     .. seealso:: :func:`scipy.sparse.kronsum`
 
     """
-    A = _coo.coo_matrix(A)
-    B = _coo.coo_matrix(B)
+    use_array = _any_sparray(A, B)
+    src_cls = _coo.coo_array if use_array else _coo.coo_matrix
+    A = src_cls(A)
+    B = src_cls(B)
 
     if A.shape[0] != A.shape[1]:
         raise ValueError('A is not square matrix')
@@ -615,3 +712,212 @@ def kronsum(A, B, format=None):
     R = kron(B, eye(A.shape[0], dtype=dtype), format=format)
 
     return (L + R).asformat(format)
+
+
+# --- Array-returning construction functions ---
+
+_array_containers = {
+    'csr': lambda: _csr.csr_array,
+    'csc': lambda: _csc.csc_array,
+    'coo': lambda: _coo.coo_array,
+    'dia': lambda: _dia.dia_array,
+}
+
+
+def _to_array(matrix, format=None):
+    """Convert a sparse matrix result to the matching array type.
+
+    When the requested format has no implemented array-side conversion
+    (e.g. CSR -> DIA), the result is returned as ``csr_array``.
+    """
+    fmt = format or matrix.format
+    cls = _array_containers.get(fmt, lambda: _csr.csr_array)()
+    if isinstance(matrix, cls):
+        return matrix
+    arr = _csr.csr_array(matrix)
+    if fmt and fmt != 'csr':
+        try:
+            arr = arr.asformat(fmt)
+        except NotImplementedError:
+            pass
+    return arr
+
+
+def eye_array(m, n=None, *, k=0, dtype=float, format=None):
+    """Creates a sparse array with ones on diagonal.
+
+    Args:
+        m (int): Number of rows.
+        n (int or None): Number of columns. Defaults to ``m``.
+        k (int): Diagonal to place ones on.
+        dtype: Type of array to create.
+        format (str or None): Format of the result.
+
+    Returns:
+        cupyx.scipy.sparse.sparray
+
+    .. seealso:: :func:`scipy.sparse.eye_array`
+
+    """
+    if n is None:
+        n = m
+    m, n = int(m), int(n)
+    return _to_array(eye(m, n, k=k, dtype=dtype, format=format), format)
+
+
+def diags_array(diagonals, /, *, offsets=0, shape=None, format=None,
+                dtype=None):
+    """Construct a sparse array from diagonals.
+
+    Args:
+        diagonals: Array of diagonal values.
+        offsets (int or sequence of int): Diagonals to set.
+        shape (tuple or None): Shape of the result.
+        format (str or None): Sparse format of the result.
+        dtype: Data type of the result.
+
+    Returns:
+        cupyx.scipy.sparse.sparray
+
+    .. seealso:: :func:`scipy.sparse.diags_array`
+
+    """
+    return _to_array(
+        diags(diagonals, offsets=offsets, shape=shape, format=format,
+              dtype=dtype), format)
+
+
+def block_array(blocks, *, format=None, dtype=None):
+    """Build a sparse array from sparse sub-blocks.
+
+    This is the array-returning equivalent of :func:`bmat`: even when none
+    of the input ``blocks`` are sparse arrays the result is still a
+    sparse array.
+
+    Args:
+        blocks (array_like): Grid of sparse arrays/matrices with compatible
+            shapes.  An entry of ``None`` denotes an all-zero block.
+        format (str, optional): Sparse format of the result (e.g. ``'csr'``).
+            By default, an appropriate format is chosen.
+        dtype (dtype, optional): Data type of the output.  Defaults to a
+            promotion across input dtypes.
+
+    Returns:
+        cupyx.scipy.sparse.sparray: Stacked sparse array.
+
+    .. seealso:: :func:`scipy.sparse.block_array`, :func:`bmat`
+    """
+    result = bmat(blocks, format=format, dtype=dtype)
+    # Preserve sparse-array-ness even when all inputs were matrices/dense.
+    if isinstance(result, _base.sparray):
+        return result
+    return _to_array(result, format)
+
+
+def block_diag(mats, format=None, dtype=None):
+    """Build a block-diagonal sparse object from a sequence of blocks.
+
+    Args:
+        mats (sequence): Input sparse arrays/matrices, dense ndarrays,
+            scalars, or Python lists/tuples.  Each block becomes a
+            diagonal sub-block in the output.
+        format (str, optional): Sparse format of the result.  Defaults to
+            ``'coo'`` when not specified.
+        dtype (dtype, optional): Data type of the output.
+
+    Returns:
+        cupyx.scipy.sparse: Sparse array if any input is a sparse array,
+        else sparse matrix (matching scipy).
+
+    .. seealso:: :func:`scipy.sparse.block_diag`
+    """
+    use_array = any(isinstance(a, _base.sparray) for a in mats)
+    coo_cls = _coo.coo_array if use_array else _coo.coo_matrix
+
+    def _normalize_dense(a):
+        """Promote a dense input (list/tuple/scalar/ndarray) to a 2-D
+        ``cupy.ndarray`` with a sparse-supported dtype.
+
+        Integer-typed dense input is upcast to float64 since cuSPARSE
+        won't store it.  This matches scipy's behaviour for integer
+        ``diags`` input -- the upstream FutureWarning is filtered out
+        in ``pyproject.toml``.
+        """
+        a = cupy.atleast_2d(cupy.asarray(a))
+        if not _sputils.is_sparse_data_dtype(a.dtype):
+            a = a.astype(cupy.float64, copy=False)
+        return a
+
+    rows = []
+    cols = []
+    datas = []
+    # Collect int64 coord arrays so ``get_index_dtype`` picks int64 for
+    # the assembled output when any input block needs it.  Each coord
+    # is checked independently because a ``tocoo()`` implementation
+    # could drop one side to int32.
+    idx_arrays = []
+    r_idx = 0
+    c_idx = 0
+    for a in mats:
+        if _base.issparse(a):
+            a_coo = a.tocoo()
+            if a_coo.row.dtype == cupy.int64:
+                idx_arrays.append(a_coo.row)
+            if a_coo.col.dtype == cupy.int64:
+                idx_arrays.append(a_coo.col)
+            nrows, ncols = a_coo.shape
+            rows.append(a_coo.row + r_idx)
+            cols.append(a_coo.col + c_idx)
+            datas.append(a_coo.data)
+        else:
+            ad = _normalize_dense(a)
+            nrows, ncols = ad.shape
+            r, c = cupy.divmod(
+                cupy.arange(nrows * ncols), ncols)
+            rows.append(r + r_idx)
+            cols.append(c + c_idx)
+            datas.append(ad.ravel())
+        r_idx += nrows
+        c_idx += ncols
+
+    idx_dtype = _sputils.get_index_dtype(
+        arrays=tuple(idx_arrays),
+        maxval=max(r_idx, c_idx) if r_idx or c_idx else None)
+    if rows:
+        row = cupy.concatenate(rows).astype(idx_dtype, copy=False)
+        col = cupy.concatenate(cols).astype(idx_dtype, copy=False)
+        data = cupy.concatenate(datas)
+    else:
+        # Empty input: build an explicit (0, 0) sparse output.
+        row = cupy.zeros(0, dtype=idx_dtype)
+        col = cupy.zeros(0, dtype=idx_dtype)
+        data = cupy.zeros(0, dtype=dtype if dtype is not None else 'd')
+    new_shape = (r_idx, c_idx)
+    out = coo_cls._from_parts(data, row, col, new_shape)
+    if dtype is not None:
+        out = out.astype(dtype)
+    return out.asformat(format)
+
+
+def random_array(shape, *, density=0.01, format='coo', dtype=None,
+                 rng=None, data_sampler=None):
+    """Generate a sparse random array.
+
+    Args:
+        shape (tuple): Shape of the array (m, n).
+        density (float): Density of generated values.
+        format (str): Sparse format of the result.
+        dtype: Data type of generated values.
+        rng: Random number generator (numpy or cupy).
+        data_sampler: Function that accepts a size argument.
+
+    Returns:
+        cupyx.scipy.sparse.sparray
+
+    .. seealso:: :func:`scipy.sparse.random_array`
+
+    """
+    m, n = shape
+    return _to_array(
+        random(m, n, density=density, format=format, dtype=dtype,
+               random_state=rng, data_rvs=data_sampler), format)

--- a/cupyx/scipy/sparse/_coo.py
+++ b/cupyx/scipy/sparse/_coo.py
@@ -10,42 +10,35 @@ except ImportError:
 import cupy
 from cupy import _core
 from cupyx.scipy.sparse import _base
-from cupyx.scipy.sparse import _csc
-from cupyx.scipy.sparse import _csr
 from cupyx.scipy.sparse import _data as sparse_data
 from cupyx.scipy.sparse import _util
 from cupyx.scipy.sparse import _sputils
 
 
-class coo_matrix(sparse_data._data_matrix):
+class _coo_base(sparse_data._data_matrix):
+    """COO format base (shared by ``coo_matrix`` and ``coo_array``).
 
-    """COOrdinate format sparse matrix.
+    This can be instantiated in several ways:
 
-    This can be instantiated in several ways.
-
-    ``coo_matrix(D)``
+    ``coo_*(D)``
         ``D`` is a rank-2 :class:`cupy.ndarray`.
-
-    ``coo_matrix(S)``
-        ``S`` is another sparse matrix. It is equivalent to ``S.tocoo()``.
-
-    ``coo_matrix((M, N), [dtype])``
-        It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
+    ``coo_*(S)``
+        ``S`` is another sparse object.  Equivalent to ``S.tocoo()``.
+    ``coo_*((M, N), [dtype])``
+        Constructs an empty (M, N)-shaped sparse object.  Default dtype
         is float64.
-
-    ``coo_matrix((data, (row, col)))``
-        All ``data``, ``row`` and ``col`` are one-dimenaional
-        :class:`cupy.ndarray`.
+    ``coo_*((data, (row, col)), shape=...)``
+        ``data``, ``row`` and ``col`` are 1-D :class:`cupy.ndarray`.
 
     Args:
         arg1: Arguments for the initializer.
-        shape (tuple): Shape of a matrix. Its length must be two.
-        dtype: Data type. It must be an argument of :class:`numpy.dtype`.
+        shape (tuple): Shape; must be a 2-tuple of ints.
+        dtype: Data type; must be representable as :class:`numpy.dtype`.
         copy (bool): If ``True``, copies of given data are always used.
 
     .. seealso::
+       :class:`scipy.sparse.coo_array`,
        :class:`scipy.sparse.coo_matrix`
-
     """
 
     format = 'coo'
@@ -61,7 +54,10 @@ class coo_matrix(sparse_data._data_matrix):
         diff = diff_out;
         ''', 'cupyx_scipy_sparse_coo_sum_duplicates_diff')
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False,
+                 *, maxprint=None):
+        if maxprint is not None:
+            self.maxprint = maxprint
         if shape is not None and len(shape) != 2:
             raise ValueError(
                 'Only two-dimensional sparse arrays are supported.')
@@ -142,47 +138,51 @@ class coo_matrix(sparse_data._data_matrix):
         else:
             dtype = numpy.dtype(dtype)
 
-        if dtype not in (numpy.bool_, numpy.float32, numpy.float64,
-                         numpy.complex64, numpy.complex128):
+        if not _sputils.is_sparse_data_dtype(dtype):
             raise ValueError(
                 'Only bool, float32, float64, complex64 and complex128'
                 ' are supported')
 
         data = data.astype(dtype, copy=copy)
         # Choose index dtype: int32 when values fit, int64 when they don't.
-        # Mirror scipy's get_index_dtype(check_contents=True) logic so we
-        # downcast int64 arrays whose values all fit in int32 (common case).
+        # For matrices, check_contents=True may downcast int64 to int32.
+        # For arrays, _get_index_dtype disables check_contents so user
+        # dtypes are preserved.
         if shape is not None:
             maxval = max(shape)
         else:
             maxval = None
-        idx_dtype = _sputils.get_index_dtype(
+        idx_dtype = self._get_index_dtype(
             (row, col), maxval=maxval, check_contents=True)
         row = row.astype(idx_dtype, copy=copy)
         col = col.astype(idx_dtype, copy=copy)
 
-        if shape is None:
-            if len(row) == 0 or len(col) == 0:
-                raise ValueError(
-                    'cannot infer dimensions from zero sized index arrays')
-            shape = (int(row.max()) + 1, int(col.max()) + 1)
+        if shape is None and (len(row) == 0 or len(col) == 0):
+            raise ValueError(
+                'cannot infer dimensions from zero sized index arrays')
 
         if len(data) > 0:
-            if row.max() >= shape[0]:
+            # Fuse the four max/min reductions into one D2H read so
+            # the constructor syncs once instead of up to six times.
+            bounds = cupy.stack(
+                (row.max(), col.max(), row.min(), col.min())
+            ).get()  # synchronize!
+            rmax, cmax, rmin, cmin = (int(b) for b in bounds)
+            if shape is None:
+                shape = (rmax + 1, cmax + 1)
+            if rmax >= shape[0]:
                 raise ValueError('row index exceeds matrix dimensions')
-            if col.max() >= shape[1]:
+            if cmax >= shape[1]:
                 raise ValueError('column index exceeds matrix dimensions')
-            if row.min() < 0:
+            if rmin < 0:
                 raise ValueError('negative row index found')
-            if col.min() < 0:
+            if cmin < 0:
                 raise ValueError('negative column index found')
 
         sparse_data._data_matrix.__init__(self, data)
         self.row = row
         self.col = col
-        if not _util.isshape(shape):
-            raise ValueError('invalid shape (must be a 2-tuple of int)')
-        self._shape = int(shape[0]), int(shape[1])
+        self._shape = _util.check_shape(shape)
 
     @classmethod
     def _from_parts(cls, data, row, col, shape,
@@ -210,12 +210,27 @@ class coo_matrix(sparse_data._data_matrix):
         """Return a matrix with the same sparsity structure but
         different data.  Preserves has_canonical_format.
         """
-        return coo_matrix._from_parts(
+        return type(self)._from_parts(
             data,
             self.row.copy() if copy else self.row,
             self.col.copy() if copy else self.col,
             self.shape,
             has_canonical_format=self.has_canonical_format)
+
+    @property
+    def coords(self):
+        """Tuple of coordinate arrays ``(row, col)``.
+
+        Mirrors :attr:`scipy.sparse.coo_array.coords` (CuPy is 2-D only).
+        """
+        return (self.row, self.col)
+
+    @coords.setter
+    def coords(self, value):
+        if not isinstance(value, tuple) or len(value) != 2:
+            raise ValueError(
+                'coords must be a 2-tuple of arrays for 2-D sparse')
+        self.row, self.col = value
 
     def diagonal(self, k=0):
         """Returns the k-th diagonal of the matrix.
@@ -238,7 +253,7 @@ class coo_matrix(sparse_data._data_matrix):
             row = self.row[diag_mask]
             data = self.data[diag_mask]
         else:
-            diag_coo = coo_matrix((self.data[diag_mask],
+            diag_coo = type(self)((self.data[diag_mask],
                                    (self.row[diag_mask], self.col[diag_mask])),
                                   shape=self.shape)
             diag_coo.sum_duplicates()
@@ -265,6 +280,11 @@ class coo_matrix(sparse_data._data_matrix):
         M, N = self.shape
         if (k > 0 and k >= N) or (k < 0 and -k >= M):
             raise ValueError("k exceeds matrix dimensions")
+        # Coerce list/scalar/numpy input; matches scipy's
+        # ``np.asarray(values)`` in ``_spbase.setdiag``.
+        values = cupy.asarray(values, dtype=self.dtype)
+        if values.ndim > 1:
+            raise ValueError('values must be 0-d or 1-d')
         if values.ndim and not len(values):
             return
         idx_dtype = self.row.dtype
@@ -305,20 +325,50 @@ class coo_matrix(sparse_data._data_matrix):
         self.row = self.row[ind]
         self.col = self.col[ind]
 
-    def get_shape(self):
-        """Returns the shape of the matrix.
-
-        Returns:
-            tuple: Shape of the matrix.
-        """
-        return self._shape
-
-    def getnnz(self, axis=None):
-        """Returns the number of stored values, including explicit zeros."""
+    def _getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros."""
         if axis is None:
             return self.data.size
         else:
             raise ValueError
+
+    def count_nonzero(self, axis=None):
+        """Number of non-zero entries.
+
+        Excludes explicit zeros.  Duplicates are summed first.
+
+        Args:
+            axis ({-2, -1, 0, 1, ``None``}):
+                Count over the whole matrix, or along an axis.
+
+        Returns:
+            int or cupy.ndarray: Scalar count when ``axis=None``,
+            otherwise a 1-D ``cupy.ndarray`` of length
+            ``shape[1 - axis]``.
+        """
+        # Match scipy: dedup in place, then count.  COO is already in
+        # row/col form so per-axis counts come straight from a bincount
+        # on the appropriate coord array -- no format conversion needed.
+        self.sum_duplicates()
+        if axis is None:
+            return int(cupy.count_nonzero(self.data))
+        if axis < 0:
+            axis += 2
+        if axis < 0 or axis >= 2:
+            raise ValueError('axis out of bounds')
+        # ``cupy.bincount`` errors on empty input even with ``minlength``
+        # (CUB max-reduction has no identity for zero-size arrays), so
+        # short-circuit when nothing is stored or every entry is an
+        # explicit zero.  scipy returns the zero-filled axis vector.
+        out_dim = self.shape[1 - axis]
+        if self.data.size == 0:
+            return cupy.zeros(out_dim, dtype=cupy.intp)
+        mask = self.data != 0
+        coord = (self.col if axis == 0 else self.row)[mask]
+        if coord.size == 0:
+            return cupy.zeros(out_dim, dtype=cupy.intp)
+        return cupy.bincount(
+            coord.astype(cupy.int64), minlength=out_dim)
 
     def get(self, stream=None):
         """Returns a copy of the array on host memory.
@@ -337,8 +387,11 @@ class coo_matrix(sparse_data._data_matrix):
         data = self.data.get(stream)
         row = self.row.get(stream)
         col = self.col.get(stream)
-        return scipy.sparse.coo_matrix(
-            (data, (row, col)), shape=self.shape)
+        if isinstance(self, _base.sparray):
+            sp_cls = scipy.sparse.coo_array
+        else:
+            sp_cls = scipy.sparse.coo_matrix
+        return sp_cls((data, (row, col)), shape=self.shape)
 
     def reshape(self, *shape, order='C'):
         """Gives a new shape to a sparse matrix without changing its data.
@@ -379,7 +432,7 @@ class coo_matrix(sparse_data._data_matrix):
         else:
             raise ValueError("'order' must be 'C' or 'F'")
 
-        return coo_matrix._from_parts(
+        return type(self)._from_parts(
             self.data, new_row, new_col, shape=shape)
 
     def sum_duplicates(self):
@@ -540,7 +593,7 @@ class coo_matrix(sparse_data._data_matrix):
         if self.nnz == 0:
             idx = self.col.dtype
             n = self.shape[1]
-            return _csc.csc_matrix._from_parts(
+            return self._csc_container._from_parts(
                 cupy.empty(0, self.dtype),
                 cupy.empty(0, idx),
                 cupy.zeros(n + 1, idx),
@@ -550,9 +603,11 @@ class coo_matrix(sparse_data._data_matrix):
         x = self.copy()
         x.sum_duplicates()
         cusparse.coosort(x, 'c')
-        x = cusparse.coo2csc(x)
-        x.has_canonical_format = True
-        return x
+        result = cusparse.coo2csc(x)
+        result.has_canonical_format = True
+        if not isinstance(result, self._csc_container):
+            result = self._csc_container(result)
+        return result
 
     def tocsr(self, copy=False):
         """Converts the matrix to Compressed Sparse Row format.
@@ -571,7 +626,7 @@ class coo_matrix(sparse_data._data_matrix):
         if self.nnz == 0:
             idx = self.row.dtype
             m = self.shape[0]
-            return _csr.csr_matrix._from_parts(
+            return self._csr_container._from_parts(
                 cupy.empty(0, self.dtype),
                 cupy.empty(0, idx),
                 cupy.zeros(m + 1, idx),
@@ -581,9 +636,11 @@ class coo_matrix(sparse_data._data_matrix):
         x = self.copy()
         x.sum_duplicates()
         cusparse.coosort(x, 'r')
-        x = cusparse.coo2csr(x)
-        x.has_canonical_format = True
-        return x
+        result = cusparse.coo2csr(x)
+        result.has_canonical_format = True
+        if not isinstance(result, self._csr_container):
+            result = self._csr_container(result)
+        return result
 
     def transpose(self, axes=None, copy=False):
         """Returns a transpose matrix.
@@ -609,20 +666,36 @@ class coo_matrix(sparse_data._data_matrix):
             data, row, col = self.data, self.col, self.row
         # Transposing swaps row/col, which generally destroys
         # canonical order (sorted by row then col).
-        return coo_matrix._from_parts(
+        return type(self)._from_parts(
             data, row, col, shape,
             has_canonical_format=False)
 
     def dot(self, other):
         """Ordinary dot product"""
         if _util.isscalarlike(other):
-            return coo_matrix._from_parts(
+            return type(self)._from_parts(
                 self.data * other,
                 self.row.copy(), self.col.copy(),
                 self.shape,
                 has_canonical_format=self.has_canonical_format)
         else:
             return self @ other
+
+
+class coo_matrix(_base.spmatrix, _coo_base):
+    """COOrdinate format sparse matrix.
+
+    .. seealso:: :class:`scipy.sparse.coo_matrix`
+    """
+    pass
+
+
+class coo_array(_coo_base, _base.sparray):
+    """COOrdinate format sparse array.
+
+    .. seealso:: :class:`scipy.sparse.coo_array`
+    """
+    pass
 
 
 def isspmatrix_coo(x):

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -14,7 +14,7 @@ from cupyx.scipy.sparse import _base
 from cupyx.scipy.sparse import _compressed
 
 
-class csc_matrix(_compressed._compressed_sparse_matrix):
+class _csc_base(_compressed._compressed_sparse_matrix):
 
     """Compressed Sparse Column matrix.
 
@@ -68,8 +68,11 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
         data = self.data.get(stream)
         indices = self.indices.get(stream)
         indptr = self.indptr.get(stream)
-        return scipy.sparse.csc_matrix(
-            (data, indices, indptr), shape=self._shape)
+        if isinstance(self, _base.sparray):
+            sp_cls = scipy.sparse.csc_array
+        else:
+            sp_cls = scipy.sparse.csc_matrix
+        return sp_cls((data, indices, indptr), shape=self._shape)
 
     def _convert_dense(self, x):
         from cupyx import cusparse
@@ -83,13 +86,13 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
     def _swap(self, x, y):
         return (y, x)
 
-    def __mul__(self, other):
+    def _matmul_dispatch(self, other):
         from cupyx import cusparse
 
         if cupy.isscalar(other):
             self.sum_duplicates()
             return self._with_data(self.data * other)
-        elif cupyx.scipy.sparse.isspmatrix_csr(other):
+        elif _base.issparse(other) and other.format == 'csr':
             self.sum_duplicates()
             other.sum_duplicates()
             is_int64 = (self.indices.dtype == cupy.int64
@@ -97,18 +100,19 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
             if is_int64 or cusparse.check_availability('spgemm'):
                 a = self.tocsr()
                 a.sum_duplicates()
-                return cusparse.spgemm(a, other)
+                return self._as_csr_type(cusparse.spgemm(a, other))
             elif cusparse.check_availability('csrgemm') and not runtime.is_hip:
                 # trans=True is still buggy as of ROCm 4.2.0
                 a = self.T
-                return cusparse.csrgemm(a, other, transa=True)
+                return self._as_csr_type(
+                    cusparse.csrgemm(a, other, transa=True))
             elif cusparse.check_availability('csrgemm2'):
                 a = self.tocsr()
                 a.sum_duplicates()
-                return cusparse.csrgemm2(a, other)
+                return self._as_csr_type(cusparse.csrgemm2(a, other))
             else:
                 raise AssertionError
-        elif isspmatrix_csc(other):
+        elif _base.issparse(other) and other.format == 'csc':
             self.sum_duplicates()
             other.sum_duplicates()
             is_int64 = (self.indices.dtype == cupy.int64
@@ -120,28 +124,29 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
                 b = other.tocsr()
                 a.sum_duplicates()
                 b.sum_duplicates()
-                return cusparse.spgemm(a, b)
+                return self._as_csr_type(cusparse.spgemm(a, b))
             if cusparse.check_availability('csrgemm') and not runtime.is_hip:
                 # trans=True is still buggy as of ROCm 4.2.0
                 a = self.T
                 b = other.T
-                return cusparse.csrgemm(a, b, transa=True, transb=True)
+                return self._as_csr_type(
+                    cusparse.csrgemm(a, b, transa=True, transb=True))
             elif cusparse.check_availability('csrgemm2'):
                 a = self.tocsr()
                 b = other.tocsr()
                 a.sum_duplicates()
                 b.sum_duplicates()
-                return cusparse.csrgemm2(a, b)
+                return self._as_csr_type(cusparse.csrgemm2(a, b))
             elif cusparse.check_availability('spgemm'):
                 a = self.tocsr()
                 b = other.tocsr()
                 a.sum_duplicates()
                 b.sum_duplicates()
-                return cusparse.spgemm(a, b)
+                return self._as_csr_type(cusparse.spgemm(a, b))
             else:
                 raise AssertionError
-        elif cupyx.scipy.sparse.isspmatrix(other):
-            return self * other.tocsr()
+        elif cupyx.scipy.sparse.issparse(other):
+            return self._matmul_dispatch(other.tocsr())
         elif _base.isdense(other):
             if other.ndim == 0:
                 self.sum_duplicates()
@@ -198,10 +203,16 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
         self.indices = compress.indices
         self.indptr = compress.indptr
 
-    # TODO(unno): Implement maximum
-    # TODO(unno): Implement minimum
-    # TODO(unno): Implement multiply
-    # TODO(unno): Implement prune
+    def setdiag(self, values, k=0):
+        """Set diagonal or off-diagonal elements in place."""
+        # Route through COO (which has its own setdiag) so we share the
+        # COO implementation and stay independent of the CSC layout.
+        coo = self.tocoo()
+        coo.setdiag(values, k=k)
+        new = coo.tocsc()
+        self.data = new.data
+        self.indices = new.indices
+        self.indptr = new.indptr
 
     def sort_indices(self):
         """Sorts the indices of this matrix *in place*.
@@ -273,7 +284,10 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
             csrgeam = cusparse.csrgeam
         else:
             raise NotImplementedError
-        return csrgeam(self.T, other, alpha, beta).T
+        result = csrgeam(self.T, other, alpha, beta)
+        if not isinstance(result, self._csr_container):
+            result = self._csr_container(result)
+        return result.T
 
     # TODO(unno): Implement tobsr
 
@@ -297,7 +311,10 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
             data = self.data
             indices = self.indices
 
-        return cusparse.csc2coo(self, data, indices)
+        result = cusparse.csc2coo(self, data, indices)
+        if not isinstance(result, self._coo_container):
+            result = self._coo_container(result)
+        return result
 
     def tocsc(self, copy=None):
         """Converts the matrix to Compressed Sparse Column format.
@@ -337,7 +354,10 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
         else:
             raise NotImplementedError
         # don't touch has_sorted_indices, as cuSPARSE made no guarantee
-        return csc2csr(self)
+        result = csc2csr(self)
+        if not isinstance(result, self._csr_container):
+            result = self._csr_container(result)
+        return result
 
     def _tocsx(self):
         """Inverts the format.
@@ -372,35 +392,19 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
             indptr = self.indptr.copy()
         else:
             data, indices, indptr = self.data, self.indices, self.indptr
-        return cupyx.scipy.sparse.csr_matrix._from_parts(
+        return self._csr_container._from_parts(
             data, indices, indptr, shape,
             has_canonical_format=getattr(
                 self, '_has_canonical_format', None),
             has_sorted_indices=getattr(
                 self, '_has_sorted_indices', None))
 
-    def getrow(self, i):
-        """Returns a copy of row i of the matrix, as a (1 x n)
-        CSR matrix (row vector).
-
-        Args:
-            i (integer): Row
-
-        Returns:
-            cupyx.scipy.sparse.csc_matrix: Sparse matrix with single row
-        """
+    def _getrow(self, i):
+        """Return a copy of row i as a (1 x n) CSR row vector."""
         return self._minor_slice(slice(i, i + 1), copy=True).tocsr()
 
-    def getcol(self, i):
-        """Returns a copy of column i of the matrix, as a (m x 1)
-        CSC matrix (column vector).
-
-        Args:
-            i (integer): Column
-
-        Returns:
-            cupyx.scipy.sparse.csc_matrix: Sparse matrix with single column
-        """
+    def _getcol(self, i):
+        """Return a copy of column i as an (m x 1) CSC column vector."""
         return self._major_slice(slice(i, i + 1), copy=True)
 
     def _get_intXarray(self, row, col):
@@ -425,6 +429,22 @@ class csc_matrix(_compressed._compressed_sparse_matrix):
 
     def _get_arrayXslice(self, row, col):
         return self._major_slice(col)._minor_index_fancy(row)
+
+
+class csc_matrix(_base.spmatrix, _csc_base):
+    """Compressed Sparse Column matrix.
+
+    .. seealso:: :class:`scipy.sparse.csc_matrix`
+    """
+    pass
+
+
+class csc_array(_csc_base, _base.sparray):
+    """Compressed Sparse Column array.
+
+    .. seealso:: :class:`scipy.sparse.csc_array`
+    """
+    pass
 
 
 def isspmatrix_csc(x):

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -15,41 +15,13 @@ import cupy
 from cupy.cuda import runtime
 from cupyx.scipy.sparse import _base
 from cupyx.scipy.sparse import _compressed
-from cupyx.scipy.sparse import _csc
 from cupyx.scipy.sparse import SparseEfficiencyWarning
+from cupyx.scipy.sparse import _sputils
 from cupyx.scipy.sparse import _util
 
 
-class csr_matrix(_compressed._compressed_sparse_matrix):
-
-    """Compressed Sparse Row matrix.
-
-    This can be instantiated in several ways.
-
-    ``csr_matrix(D)``
-        ``D`` is a rank-2 :class:`cupy.ndarray`.
-    ``csr_matrix(S)``
-        ``S`` is another sparse matrix. It is equivalent to ``S.tocsr()``.
-    ``csr_matrix((M, N), [dtype])``
-        It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
-        is float64.
-    ``csr_matrix((data, (row, col)))``
-        All ``data``, ``row`` and ``col`` are one-dimenaional
-        :class:`cupy.ndarray`.
-    ``csr_matrix((data, indices, indptr))``
-        All ``data``, ``indices`` and ``indptr`` are one-dimenaional
-        :class:`cupy.ndarray`.
-
-    Args:
-        arg1: Arguments for the initializer.
-        shape (tuple): Shape of a matrix. Its length must be two.
-        dtype: Data type. It must be an argument of :class:`numpy.dtype`.
-        copy (bool): If ``True``, copies of given arrays are always used.
-
-    .. seealso::
-        :class:`scipy.sparse.csr_matrix`
-
-    """
+class _csr_base(_compressed._compressed_sparse_matrix):
+    """CSR format base (shared by csr_matrix and csr_array)."""
 
     format = 'csr'
     # Index of the major axis in shape: rows for CSR.
@@ -63,7 +35,8 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 copy runs asynchronously. Otherwise, the copy is synchronous.
 
         Returns:
-            scipy.sparse.csr_matrix: Copy of the array on host memory.
+            scipy.sparse.csr_array or scipy.sparse.csr_matrix:
+                Copy of the array on host memory.
 
         """
         if not _scipy_available:
@@ -71,8 +44,11 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         data = self.data.get(stream)
         indices = self.indices.get(stream)
         indptr = self.indptr.get(stream)
-        return scipy.sparse.csr_matrix(
-            (data, indices, indptr), shape=self._shape)
+        if isinstance(self, _base.sparray):
+            sp_cls = scipy.sparse.csr_array
+        else:
+            sp_cls = scipy.sparse.csr_matrix
+        return sp_cls((data, indices, indptr), shape=self._shape)
 
     def _convert_dense(self, x):
         m = dense2csr(x)
@@ -93,16 +69,17 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             csrgeam = cusparse.csrgeam
         else:
             raise NotImplementedError
-        return csrgeam(self, other, alpha, beta)
+        return self._as_csr_type(csrgeam(self, other, alpha, beta))
 
     def _comparison(self, other, op, op_name):
+        cls = type(self)
         if _util.isscalarlike(other):
             data = cupy.asarray(other, dtype=self.dtype).reshape(1)
             if numpy.isnan(data[0]):
                 if op_name == '_ne_':
-                    return csr_matrix(cupy.ones(self.shape, dtype=numpy.bool_))
+                    return cls(cupy.ones(self.shape, dtype=numpy.bool_))
                 else:
-                    return csr_matrix(self.shape, dtype=numpy.bool_)
+                    return cls(self.shape, dtype=numpy.bool_)
             scalar = data[0]
             # Fast path: when op(0, scalar) is False, unstored
             # entries (implicit zeros) all produce False.  The result
@@ -122,20 +99,20 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 # invariants, so propagate ``has_canonical_format=True``.
                 mask = new_data
                 if mask.all():  # synchronize!
-                    return csr_matrix._from_parts(
+                    return cls._from_parts(
                         new_data, self.indices.copy(),
                         self.indptr.copy(), self.shape,
                         has_canonical_format=True)
                 from cupyx.cusparse import (
                     _indptr_to_coo, _build_indptr)
                 idx_dtype = self.indices.dtype
-                rows = _indptr_to_coo(self.indptr)
+                rows = _indptr_to_coo(self.indptr, nnz=self.nnz)
                 rows = rows[mask]
                 cols = self.indices[mask]
                 data = new_data[mask]
                 M = self._swap(*self.shape)[0]
                 indptr = _build_indptr(rows, M, idx_dtype)
-                return csr_matrix._from_parts(
+                return cls._from_parts(
                     data, cols, indptr, self.shape,
                     has_canonical_format=True)
             # Slow path: op(0, scalar) is True, so unstored entries
@@ -149,12 +126,11 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             }
             sym, alt = _inv.get(op_name, (op_name, '!='))
             warnings.warn(
-                'Comparing a sparse matrix with {} using {} is '
-                'inefficient. Try using {} instead.'
-                .format(scalar, sym, alt),
+                f'Comparing a sparse matrix with {scalar} using '
+                f'{sym} is inefficient. Try using {alt} instead.',
                 _base.SparseEfficiencyWarning)
             idx_dtype = self.indices.dtype
-            other = csr_matrix._from_parts(
+            other = cls._from_parts(
                 data,
                 cupy.zeros((1,), dtype=idx_dtype),
                 cupy.arange(2, dtype=idx_dtype),
@@ -162,7 +138,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             return binopt_csr(self, other, op_name)
         elif _util.isdense(other):
             return op(self.todense(), other)
-        elif isspmatrix_csr(other):
+        elif _is_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
             if op_name in ('_ne_', '_lt_', '_gt_'):
@@ -180,7 +156,10 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 opposite_op_name = '_lt_'
             res = binopt_csr(self, other, opposite_op_name)
             out = cupy.logical_not(res.toarray())
-            return csr_matrix(out)
+            return cls(out)
+        elif _base.issparse(other):
+            # Convert non-CSR sparse operands to CSR (matches scipy).
+            return self._comparison(other.tocsr(), op, op_name)
         raise NotImplementedError
 
     def __eq__(self, other):
@@ -201,13 +180,13 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
     def __ge__(self, other):
         return self._comparison(other, operator.ge, '_ge_')
 
-    def __mul__(self, other):
+    def _matmul_dispatch(self, other):
         from cupyx import cusparse
 
         if cupy.isscalar(other):
             self.sum_duplicates()
             return self._with_data(self.data * other)
-        elif isspmatrix_csr(other):
+        elif _is_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
             # int64: always route through cusparse.spgemm, which has a
@@ -215,14 +194,14 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             is_int64 = (self.indices.dtype == cupy.int64
                         or other.indices.dtype == cupy.int64)
             if is_int64 or cusparse.check_availability('spgemm'):
-                return cusparse.spgemm(self, other)
+                return self._as_csr_type(cusparse.spgemm(self, other))
             elif cusparse.check_availability('csrgemm2'):
-                return cusparse.csrgemm2(self, other)
+                return self._as_csr_type(cusparse.csrgemm2(self, other))
             elif cusparse.check_availability('csrgemm'):
-                return cusparse.csrgemm(self, other)
+                return self._as_csr_type(cusparse.csrgemm(self, other))
             else:
                 raise AssertionError
-        elif _csc.isspmatrix_csc(other):
+        elif _is_csc(other):
             self.sum_duplicates()
             other.sum_duplicates()
             is_int64 = (self.indices.dtype == cupy.int64
@@ -232,22 +211,23 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 # which has a pure-CuPy fallback for older cuSPARSE.
                 b = other.tocsr()
                 b.sum_duplicates()
-                return cusparse.spgemm(self, b)
+                return self._as_csr_type(cusparse.spgemm(self, b))
             if cusparse.check_availability('csrgemm') and not runtime.is_hip:
                 # trans=True is still buggy as of ROCm 4.2.0
-                return cusparse.csrgemm(self, other.T, transb=True)
+                return self._as_csr_type(
+                    cusparse.csrgemm(self, other.T, transb=True))
             elif cusparse.check_availability('spgemm'):
                 b = other.tocsr()
                 b.sum_duplicates()
-                return cusparse.spgemm(self, b)
+                return self._as_csr_type(cusparse.spgemm(self, b))
             elif cusparse.check_availability('csrgemm2'):
                 b = other.tocsr()
                 b.sum_duplicates()
-                return cusparse.csrgemm2(self, b)
+                return self._as_csr_type(cusparse.csrgemm2(self, b))
             else:
                 raise AssertionError
-        elif _base.isspmatrix(other):
-            return self * other.tocsr()
+        elif _base.issparse(other):
+            return self._matmul_dispatch(other.tocsr())
         elif _base.isdense(other):
             if other.ndim == 0:
                 self.sum_duplicates()
@@ -289,12 +269,19 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
     def __truediv__(self, other):
         """Point-wise division by another matrix, vector or scalar"""
         if _util.isscalarlike(other):
+            # Pick the result dtype.  scipy upcasts any dtype that's
+            # castable to float64 (bool/int*/float16/float32/...) before
+            # dividing; mirror that behaviour, and additionally fall
+            # back to float64 for any non-cuSPARSE-supported dtype so
+            # the result remains usable with cuSPARSE-backed ops.
+            # Real-vs-complex follows numpy's natural promotion
+            # (``result_type(float64, complex64) -> complex128``).
             dtype = self.dtype
             if dtype == numpy.float32:
-                # Note: This is a work-around to make the output dtype the same
-                # as SciPy. It might be SciPy version dependent.
                 dtype = numpy.float64
             dtype = cupy.result_type(dtype, other)
+            if not _sputils.is_sparse_data_dtype(dtype):
+                dtype = numpy.dtype(numpy.float64)
             d = cupy.reciprocal(other, dtype=dtype)
             return multiply_by_scalar(self, d)
         elif _util.isdense(other):
@@ -305,7 +292,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             ret.data = _cupy_divide_by_dense()(
                 ret.data, ret.row, ret.col, ret.shape[1], other)
             return ret
-        elif _base.isspmatrix(other):
+        elif _base.issparse(other):
             # Note: If broadcasting is needed, an exception is raised here for
             # compatibility with SciPy, as SciPy does not support broadcasting
             # in the "sparse / sparse" case.
@@ -372,18 +359,19 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         self.indptr = compress.indptr
 
     def _maximum_minimum(self, other, cupy_op, op_name, dense_check):
+        cls = type(self)
         if _util.isscalarlike(other):
             dtype = cupy.result_type(self.dtype, other)
             other = cupy.asarray(other)
             if dense_check(other):
                 other = other.astype(dtype, copy=False)
                 new_array = cupy_op(self.todense(), other)
-                return csr_matrix(new_array)
+                return cls(new_array)
             else:
                 self.sum_duplicates()
                 new_data = cupy_op(self.data, other)
                 new_data = new_data.astype(dtype, copy=False)
-                return csr_matrix._from_parts(
+                return cls._from_parts(
                     new_data, self.indices, self.indptr,
                     self.shape,
                     has_canonical_format=getattr(
@@ -394,10 +382,14 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             self.sum_duplicates()
             other = cupy.atleast_2d(other)
             return cupy_op(self.todense(), other)
-        elif isspmatrix_csr(other):
+        elif _is_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
             return binopt_csr(self, other, op_name)
+        elif _base.issparse(other):
+            # Convert non-CSR sparse operands to CSR (matches scipy).
+            return self._maximum_minimum(
+                other.tocsr(), cupy_op, op_name, dense_check)
         raise NotImplementedError
 
     def maximum(self, other):
@@ -416,24 +408,35 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             self.sum_duplicates()
             other = cupy.atleast_2d(other)
             return multiply_by_dense(self, other)
-        elif isspmatrix_csr(other):
+        elif _is_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
-            return multiply_by_csr(self, other)
+            return multiply_by_csr(self, other, out_cls=type(self))
+        elif _base.issparse(other):
+            return self.multiply(other.tocsr())
         else:
             msg = 'expected scalar, dense matrix/vector or csr matrix'
             raise TypeError(msg)
 
-    # TODO(unno): Implement prune
-
     def setdiag(self, values, k=0):
-        """Set diagonal or off-diagonal elements of the array."""
+        """Set diagonal or off-diagonal elements of the array.
+
+        Args:
+            values: New values of the diagonal elements.  Accepts a
+                scalar, list, or 1-D array; any non-cupy input is
+                coerced via :func:`cupy.asarray`.
+            k (int): Which diagonal to set.  Default 0 (main diagonal).
+        """
         rows, cols = self.shape
         row_st, col_st = max(0, -k), max(0, k)
         x_len = min(rows - row_st, cols - col_st)
         if x_len <= 0:
             raise ValueError('k exceeds matrix dimensions')
-        values = values.astype(self.dtype)
+        # Coerce list/scalar/numpy input; matches scipy's
+        # ``np.asarray(values)`` in ``_spbase.setdiag``.
+        values = cupy.asarray(values, dtype=self.dtype)
+        if values.ndim > 1:
+            raise ValueError('values must be 0-d or 1-d')
         if values.ndim == 0:
             # broadcast
             x_data = cupy.full((x_len,), values, dtype=self.dtype)
@@ -446,8 +449,11 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         x_indptr[row_st:row_st+x_len+1] = cupy.arange(
             x_len+1, dtype=idx_dtype)
         x_indptr[row_st+x_len+1:] = x_len
-        x_data -= self.diagonal(k=k)[:x_len]
-        y = self + csr_matrix._from_parts(
+        # Out-of-place subtraction: ``x_data`` may alias ``values``
+        # (slice view) when ``values`` was already a cupy array of the
+        # right dtype, so an in-place ``-=`` would mutate the caller.
+        x_data = x_data - self.diagonal(k=k)[:x_len]
+        y = self + type(self)._from_parts(
             x_data, x_indices, x_indptr, self.shape)
         self.data = y.data
         self.indices = y.indices
@@ -536,7 +542,10 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             data = self.data
             indices = self.indices
 
-        return cusparse.csr2coo(self, data, indices)
+        result = cusparse.csr2coo(self, data, indices)
+        if not isinstance(result, self._coo_container):
+            result = self._coo_container(result)
+        return result
 
     def tocsc(self, copy=False):
         """Converts the matrix to Compressed Sparse Column format.
@@ -560,7 +569,10 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         else:
             raise NotImplementedError
         # don't touch has_sorted_indices, as cuSPARSE made no guarantee
-        return csr2csc(self)
+        result = csr2csc(self)
+        if not isinstance(result, self._csc_container):
+            result = self._csc_container(result)
+        return result
 
     def tocsr(self, copy=False):
         """Converts the matrix to Compressed Sparse Row format.
@@ -596,7 +608,7 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         raise NotImplementedError
 
     def transpose(self, axes=None, copy=False):
-        """Returns a transpose matrix.
+        """Returns the transpose of this object.
 
         Args:
             axes: This option is not supported.
@@ -604,7 +616,8 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
                 Otherwise, it shared data arrays as much as possible.
 
         Returns:
-            cupyx.scipy.sparse.csc_matrix: `self` with the dimensions reversed.
+            csc_array if ``self`` is a sparse array, else csc_matrix,
+            with the dimensions reversed.
 
         """
         if axes is not None:
@@ -619,35 +632,19 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
             indptr = self.indptr.copy()
         else:
             data, indices, indptr = self.data, self.indices, self.indptr
-        return _csc.csc_matrix._from_parts(
+        return self._csc_container._from_parts(
             data, indices, indptr, shape,
             has_canonical_format=getattr(
                 self, '_has_canonical_format', None),
             has_sorted_indices=getattr(
                 self, '_has_sorted_indices', None))
 
-    def getrow(self, i):
-        """Returns a copy of row i of the matrix, as a (1 x n)
-        CSR matrix (row vector).
-
-        Args:
-            i (integer): Row
-
-        Returns:
-            cupyx.scipy.sparse.csr_matrix: Sparse matrix with single row
-        """
+    def _getrow(self, i):
+        """Return a copy of row i as a (1 x n) CSR row vector."""
         return self._major_slice(slice(i, i + 1), copy=True)
 
-    def getcol(self, i):
-        """Returns a copy of column i of the matrix, as a (m x 1)
-        CSR matrix (column vector).
-
-        Args:
-            i (integer): Column
-
-        Returns:
-            cupyx.scipy.sparse.csr_matrix: Sparse matrix with single column
-        """
+    def _getcol(self, i):
+        """Return a copy of column i as an (m x 1) CSR column vector."""
         return self._minor_slice(slice(i, i + 1), copy=True)
 
     def _get_intXarray(self, row, col):
@@ -678,6 +675,63 @@ class csr_matrix(_compressed._compressed_sparse_matrix):
         return self._major_index_fancy(row)._minor_slice(col)
 
 
+class csr_matrix(_base.spmatrix, _csr_base):
+    """Compressed Sparse Row matrix.
+
+    This can be instantiated in several ways.
+
+    ``csr_matrix(D)``
+        ``D`` is a rank-2 :class:`cupy.ndarray`.
+    ``csr_matrix(S)``
+        ``S`` is another sparse matrix. It is equivalent to ``S.tocsr()``.
+    ``csr_matrix((M, N), [dtype])``
+        It constructs an empty matrix whose shape is ``(M, N)``. Default dtype
+        is float64.
+    ``csr_matrix((data, (row, col)))``
+        All ``data``, ``row`` and ``col`` are one-dimensional
+        :class:`cupy.ndarray`.
+    ``csr_matrix((data, indices, indptr))``
+        All ``data``, ``indices`` and ``indptr`` are one-dimensional
+        :class:`cupy.ndarray`.
+
+    Args:
+        arg1: Arguments for the initializer.
+        shape (tuple): Shape of a matrix. Its length must be two.
+        dtype: Data type. It must be an argument of :class:`numpy.dtype`.
+        copy (bool): If ``True``, copies of given arrays are always used.
+
+    .. seealso::
+        :class:`scipy.sparse.csr_matrix`
+
+    """
+    pass
+
+
+class csr_array(_csr_base, _base.sparray):
+    """Compressed Sparse Row array.
+
+    Same constructor interface as :class:`csr_matrix`.
+
+    Unlike ``csr_matrix``, the ``*`` operator performs element-wise
+    multiplication (not matrix multiplication).  Use ``@`` for matmul.
+
+    .. seealso:: :class:`scipy.sparse.csr_array`
+    """
+    pass
+
+
+def _is_csr(x):
+    """True if x is any CSR sparse (array or matrix)."""
+    return isinstance(x, _csr_base)
+
+
+def _is_csc(x):
+    """True if x is any CSC sparse (array or matrix)."""
+    # Uses format string instead of isinstance(_csc_base) to avoid a
+    # circular import between _csr and _csc.
+    return _base.issparse(x) and x.format == 'csc'
+
+
 def isspmatrix_csr(x):
     """Checks if a given matrix is of CSR format.
 
@@ -703,7 +757,7 @@ def check_shape_for_pointwise_op(a_shape, b_shape, allow_broadcasting=True):
 
 def multiply_by_scalar(sp, a):
     data = sp.data * a
-    return csr_matrix._from_parts(
+    return type(sp)._from_parts(
         data, sp.indices.copy(), sp.indptr.copy(), sp.shape,
         has_canonical_format=getattr(
             sp, '_has_canonical_format', None),
@@ -738,7 +792,7 @@ def multiply_by_dense(sp, dn):
         dn, it(dn_m), it(dn_n), indptr, it(m), it(n),
         data, indices)
 
-    return csr_matrix._from_parts(
+    return type(sp)._from_parts(
         data, indices, indptr, shape=(m, n))
 
 
@@ -834,7 +888,12 @@ def _cupy_divide_by_dense():
     )
 
 
-def multiply_by_csr(a, b):
+def multiply_by_csr(a, b, *, out_cls=None):
+    # ``out_cls`` pins the result type to the caller (e.g. ``type(self)``
+    # from ``_csr_base.multiply``) so the swap below for performance
+    # doesn't leak the other operand's type into the result.
+    if out_cls is None:
+        out_cls = type(a)
     check_shape_for_pointwise_op(a.shape, b.shape)
     a_m, a_n = a.shape
     b_m, b_n = b.shape
@@ -842,10 +901,11 @@ def multiply_by_csr(a, b):
     a_nnz = a.nnz * (m // a_m) * (n // a_n)
     b_nnz = b.nnz * (m // b_m) * (n // b_n)
     if a_nnz > b_nnz:
-        return multiply_by_csr(b, a)
-    # Harmonize index dtypes so the kernel template parameter ``I`` is
-    # consistent across both operands (mirrors ``binopt_csr``).
-    # Without this, mixed int32/int64 inputs trip a type mismatch.
+        return multiply_by_csr(b, a, out_cls=out_cls)
+    # Harmonise index dtypes so the kernel's templated ``I`` parameter
+    # is consistent across both operands (mirrors ``binopt_csr``).
+    # Without this, mixed int32/int64 inputs trip ``TypeError: Type is
+    # mismatched. B_INDPTR int32 int64 I``.
     idx_dtype = numpy.promote_types(a.indices.dtype, b.indices.dtype)
     a_indices = a.indices.astype(idx_dtype, copy=False)
     a_indptr = a.indptr.astype(idx_dtype, copy=False)
@@ -883,7 +943,7 @@ def multiply_by_csr(a, b):
     # remove zero elements in matrix c
     cupy_multiply_by_csr_step2()(c_data, c_indices, flags, d_data, d_indices)
 
-    return csr_matrix._from_parts(
+    return out_cls._from_parts(
         d_data, d_indices, d_indptr, shape=(m, n))
 
 
@@ -1062,7 +1122,7 @@ def binopt_csr(a, b, op_name):
         a_info, a_valid, a_tmp_indices, a_tmp_data, it(a_nnz),
         b_info, b_valid, b_tmp_indices, b_tmp_data, it(b_nnz),
         c_indices, c_data, size=_size)
-    return csr_matrix._from_parts(
+    return type(a)._from_parts(
         c_data, c_indices, c_indptr, shape=(m, n))
 
 

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -5,8 +5,8 @@ import numpy as np
 from cupy._core import internal
 from cupy import _util
 from cupyx.scipy.sparse import _base
-from cupyx.scipy.sparse import _coo
 from cupyx.scipy.sparse import _sputils
+from cupyx.scipy.sparse import _util as _sparse_util
 
 
 _ufuncs = [
@@ -16,7 +16,7 @@ _ufuncs = [
 ]
 
 
-class _data_matrix(_base.spmatrix):
+class _data_matrix(_base._spbase):
 
     def __init__(self, data):
         self.data = data
@@ -33,21 +33,84 @@ class _data_matrix(_base.spmatrix):
         """Elementwise absolute."""
         return self._with_data(abs(self.data))
 
+    def __round__(self, ndigits=0):
+        """Elementwise rounding (matches :func:`numpy.around`)."""
+        return self._with_data(cupy.around(self.data, decimals=ndigits))
+
     def __neg__(self):
         """Elementwise negative."""
+        if self.dtype.kind == 'b':
+            # Match scipy 1.17: raise NotImplementedError instead of letting
+            # the underlying cupy error surface.
+            raise NotImplementedError(
+                'negating a boolean sparse array is not supported')
         return self._with_data(-self.data)
 
-    def astype(self, t):
-        """Casts the array to given data type.
+    @staticmethod
+    def _scalar_op_dtype(self_dtype, other):
+        """Pick the dtype for ``self.data * other`` / ``... / other``.
+
+        numpy's natural promotion can land outside the cuSPARSE-supported
+        set (e.g. ``bool * int -> int64``).  Upcast to ``float64`` in
+        that case so the result remains usable.  Mirrors scipy which
+        promotes bool / int sparse to float on division.
+        """
+        out = np.result_type(self_dtype, other)
+        if not _sputils.is_sparse_data_dtype(out):
+            out = np.dtype(np.float64)
+        return out
+
+    def __imul__(self, other):
+        # In-place scalar multiply mutates ``self.data`` to preserve
+        # object identity.  Non-scalar falls through to NotImplemented
+        # so Python rebinds via ``self = self * other``.  Unlike scipy,
+        # which raises ``UFuncTypeError`` on out-of-set promotions
+        # (e.g. ``bool *= int``), CuPy reassigns ``self.data`` to a
+        # cuSPARSE-supported dtype.  Identity of ``self`` is preserved;
+        # identity of ``self.data`` is not.
+        if _sparse_util.isscalarlike(other):
+            new_dtype = self._scalar_op_dtype(self.dtype, other)
+            if new_dtype != self.dtype:
+                self.data = self.data.astype(new_dtype) * other
+            else:
+                self.data *= other
+            return self
+        return NotImplemented
+
+    def __itruediv__(self, other):
+        # In-place scalar division mutates ``self.data``.  See
+        # ``__imul__`` for the upcast rationale; division additionally
+        # promotes int dividends to float (``int / 2`` is ``float``
+        # in Python and ``self.data /= 2`` would otherwise raise on
+        # int data).
+        if _sparse_util.isscalarlike(other):
+            recip = 1.0 / other
+            new_dtype = self._scalar_op_dtype(self.dtype, recip)
+            if new_dtype != self.dtype:
+                self.data = self.data.astype(new_dtype) * recip
+            else:
+                self.data *= recip
+            return self
+        return NotImplemented
+
+    def astype(self, dtype, copy=True):
+        """Cast the array elements to a specified type.
 
         Args:
-            dtype: Type specifier.
+            dtype: Target dtype.
+            copy (bool): If ``True`` (default), the returned array does
+                not share memory with ``self``.  If ``False``, ``self``
+                is returned unchanged when the dtype already matches.
 
         Returns:
-            A copy of the array with a given type.
-
+            Sparse object with the requested dtype and the same format.
         """
-        return self._with_data(self.data.astype(t))
+        dtype = np.dtype(dtype)
+        if self.dtype != dtype:
+            return self._with_data(self.data.astype(dtype, copy=copy))
+        if copy:
+            return self.copy()
+        return self
 
     def conj(self, copy=True):
         if cupy.issubdtype(self.dtype, cupy.complexfloating):
@@ -57,7 +120,7 @@ class _data_matrix(_base.spmatrix):
         else:
             return self
 
-    conj.__doc__ = _base.spmatrix.conj.__doc__
+    conj.__doc__ = _base._spbase.conj.__doc__
 
     @property
     def real(self):
@@ -70,22 +133,31 @@ class _data_matrix(_base.spmatrix):
     def copy(self):
         return self._with_data(self.data.copy(), copy=True)
 
-    copy.__doc__ = _base.spmatrix.copy.__doc__
+    copy.__doc__ = _base._spbase.copy.__doc__
 
-    def count_nonzero(self):
-        """Returns number of non-zero entries.
+    def count_nonzero(self, axis=None):
+        """Number of non-zero entries.
 
-        .. note::
-           This method counts the actual number of non-zero entries, which
-           does not include explicit zero entries.
-           Instead ``nnz`` returns the number of entries including explicit
-           zeros.
+        Unlike :attr:`nnz` (length of ``data``), this counts only true
+        non-zero values; explicit-zero stored entries are excluded.
+
+        Args:
+            axis (``None``, optional): Only ``None`` is handled here;
+                CSR/CSC/COO override this to support ``0``, ``1``,
+                ``-1``, ``-2``.
 
         Returns:
-            Number of non-zero entries.
-
+            int or cupy.ndarray: Scalar count when ``axis`` is
+            ``None``; otherwise a 1-D array (from format override).
         """
-        return cupy.count_nonzero(self.data)
+        # Match scipy: dedup in place before counting.
+        if hasattr(self, 'sum_duplicates'):
+            self.sum_duplicates()
+        if axis is None:
+            return int(cupy.count_nonzero(self.data))
+        raise NotImplementedError(
+            'axis-aware count_nonzero is not implemented for '
+            f'{type(self).__name__}')
 
     def mean(self, axis=None, dtype=None, out=None):
         """Compute the arithmetic mean along the specified axis.
@@ -123,6 +195,15 @@ class _data_matrix(_base.spmatrix):
             dtype: Type specifier.
 
         """
+        # Non-scalar check must come first: ``n == 0`` on an array
+        # produces a bool array and ``if`` on that raises.
+        if not _sparse_util.isscalarlike(n):
+            raise NotImplementedError('input is not scalar')
+        if n == 0:
+            raise NotImplementedError(
+                'zero power is not supported as it would densify the '
+                'matrix.\n'
+                'Use cupy.ones(A.shape, dtype=A.dtype) for this case.')
         if dtype is None:
             data = self.data.copy()
         else:
@@ -180,14 +261,14 @@ class _minmax_mixin:
         n = len(value)
         zeros = cupy.zeros(n, dtype=idx_dtype)
         value = value.astype(self.dtype, copy=False)
-        if axis == 0:
-            return _coo.coo_matrix._from_parts(
-                value, zeros, major_index,
-                shape=(1, M))
-        else:
-            return _coo.coo_matrix._from_parts(
-                value, major_index, zeros,
-                shape=(M, 1))
+        # Use the appropriate container so the result inherits the
+        # array vs matrix type from ``self``.  CuPy COO is 2-D-only, so
+        # reductions return (1, M) / (M, 1) for both array and matrix
+        # (scipy sparse arrays return shape (M,)).
+        coo_cls = self._coo_container
+        row, col = (zeros, major_index) if axis == 0 else (major_index, zeros)
+        shape = (1, M) if axis == 0 else (M, 1)
+        return coo_cls._from_parts(value, row, col, shape=shape)
 
     def _min_or_max(self, axis, out, min_or_max, explicit):
         if out is not None:
@@ -232,6 +313,10 @@ class _minmax_mixin:
         # Do the reduction
         value = mat._arg_minor_reduce(op, axis)
 
+        # Sparse arrays return a 1-D ndarray; sparse matrices keep
+        # the legacy 2-D shape (matching scipy).
+        if isinstance(self, _base.sparray):
+            return value
         if axis == 0:
             return value[None, :]
         else:

--- a/cupyx/scipy/sparse/_dia.py
+++ b/cupyx/scipy/sparse/_dia.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import cupy
 from cupy import _core
-from cupyx.scipy.sparse import _csc
+from cupyx.scipy.sparse import _base
 from cupyx.scipy.sparse import _data
 from cupyx.scipy.sparse import _sputils
 from cupyx.scipy.sparse import _util
@@ -16,9 +16,10 @@ from cupyx.scipy.sparse import _util
 
 # TODO(leofang): The current implementation is CSC-based, which is troublesome
 # on ROCm/HIP. We should convert it to CSR-based for portability.
-class dia_matrix(_data._data_matrix):
+class _dia_base(_data._data_matrix):
+    """DIA format base (shared by dia_matrix and dia_array).
 
-    """Sparse matrix with DIAgonal storage.
+    Sparse matrix with DIAgonal storage.
 
     Now it has only one initializer format below:
 
@@ -37,7 +38,10 @@ class dia_matrix(_data._data_matrix):
 
     format = 'dia'
 
-    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+    def __init__(self, arg1, shape=None, dtype=None, copy=False,
+                 *, maxprint=None):
+        if maxprint is not None:
+            self.maxprint = maxprint
         if _scipy_available and scipy.sparse.issparse(arg1):
             x = arg1.todia()
             data = x.data
@@ -80,18 +84,29 @@ class dia_matrix(_data._data_matrix):
 
         self.data = data
         self.offsets = offsets
-        if not _util.isshape(shape):
-            raise ValueError('invalid shape (must be a 2-tuple of int)')
-        self._shape = int(shape[0]), int(shape[1])
+        self._shape = _util.check_shape(shape)
 
     def _with_data(self, data, copy=True):
-        """Returns a matrix with the same sparsity structure as self,
+        """Return a sparse object with the same sparsity structure as self,
         but with different data.  By default the structure arrays are copied.
+
+        Preserves the concrete leaf type (``dia_array`` vs ``dia_matrix``).
         """
         if copy:
-            return dia_matrix((data, self.offsets.copy()), shape=self.shape)
+            return type(self)(
+                (data, self.offsets.copy()), shape=self.shape)
         else:
-            return dia_matrix((data, self.offsets), shape=self.shape)
+            return type(self)((data, self.offsets), shape=self.shape)
+
+    def __repr__(self):
+        # Match scipy's DIA repr which annotates the diagonal count.
+        format_name = _base._format_names.get(self.format, self.format)
+        sparse_cls = (
+            'array' if isinstance(self, _base.sparray) else 'matrix')
+        return (
+            f"<{format_name} sparse {sparse_cls} of dtype '{self.dtype}'\n"
+            f"\twith {self.nnz} stored elements ({len(self.offsets)} "
+            f"diagonals) and shape {self.shape}>")
 
     def get(self, stream=None):
         """Returns a copy of the array on host memory.
@@ -108,25 +123,20 @@ class dia_matrix(_data._data_matrix):
             raise RuntimeError('scipy is not available')
         data = self.data.get(stream)
         offsets = self.offsets.get(stream)
-        return scipy.sparse.dia_matrix((data, offsets), shape=self._shape)
+        if isinstance(self, _base.sparray):
+            sp_cls = scipy.sparse.dia_array
+        else:
+            sp_cls = scipy.sparse.dia_matrix
+        return sp_cls((data, offsets), shape=self._shape)
 
-    def get_shape(self):
-        """Returns the shape of the matrix.
-
-        Returns:
-            tuple: Shape of the matrix.
-        """
-        return self._shape
-
-    def getnnz(self, axis=None):
-        """Returns the number of stored values, including explicit zeros.
+    def _getnnz(self, axis=None):
+        """Number of stored values, including explicit zeros.
 
         Args:
-            axis: Not supported yet.
+            axis: Not supported.
 
         Returns:
-            int: The number of stored values.
-
+            int: Number of stored values.
         """
         if axis is not None:
             raise NotImplementedError(
@@ -147,6 +157,42 @@ class dia_matrix(_data._data_matrix):
             'a + b', 'nnz = a', '0', 'dia_nnz')(
                 self.offsets, it(m), it(L))
         return int(nnz)
+
+    def _data_mask(self):
+        """Boolean mask the same shape as ``self.data`` indicating
+        which entries fall inside the matrix.
+
+        ``mask[i, j]`` is True iff position ``(j - offsets[i], j)``
+        lies within ``self.shape``.  Used to filter ``data`` for
+        operations that should ignore the buffer's pad columns
+        (``count_nonzero``, dense expansion, etc.).
+
+        Mirrors :meth:`scipy.sparse._dia._dia_base._data_mask`.
+        """
+        num_rows, num_cols = self.shape
+        offset_inds = cupy.arange(self.data.shape[1])
+        row = offset_inds - self.offsets[:, None]
+        mask = (row >= 0)
+        mask &= (row < num_rows)
+        mask &= (offset_inds < num_cols)
+        return mask
+
+    def count_nonzero(self, axis=None):
+        """Number of non-zero entries.
+
+        Excludes explicit zeros and entries that lie outside the
+        matrix shape (DIA's ``data`` buffer can be wider than
+        ``num_cols``; those pad entries don't count).  DIA doesn't
+        support per-axis counts -- use ``tocsr().count_nonzero(axis)``.
+
+        .. seealso:: :meth:`scipy.sparse.dia_matrix.count_nonzero`
+        """
+        if axis is not None:
+            raise NotImplementedError(
+                'count_nonzero over an axis is not implemented for '
+                'DIA format')
+        mask = self._data_mask()
+        return int(cupy.count_nonzero(self.data[mask]))
 
     def toarray(self, order=None, out=None):
         """Returns a dense matrix representing the same value."""
@@ -179,7 +225,7 @@ class dia_matrix(_data._data_matrix):
 
         """
         if self.data.size == 0:
-            return _csc.csc_matrix(self.shape, dtype=self.dtype)
+            return self._csc_container(self.shape, dtype=self.dtype)
 
         num_rows, num_cols = self.shape
         num_offsets, offset_len = self.data.shape
@@ -202,17 +248,18 @@ class dia_matrix(_data._data_matrix):
                 self.offsets[:, None].astype(idx_dtype, copy=False),
                 it(num_rows), it(num_cols), self.data)
         indptr = cupy.zeros(num_cols + 1, dtype=idx_dtype)
-        # When ``offset_len`` exceeds ``num_cols`` (data buffer wider
-        # than the matrix), the trailing columns lie outside the matrix
-        # and their mask entries are all False, so truncate to
-        # ``num_cols`` for the indptr write.
+        # Each column of ``data`` contributes one count to the matching
+        # output column.  When ``offset_len`` exceeds ``num_cols`` (data
+        # buffer wider than the matrix), the extra trailing columns lie
+        # outside the matrix and their mask entries are all False, so
+        # truncate to ``num_cols`` for the indptr write.
         col_counts = mask.sum(axis=0)
         eff_len = min(offset_len, num_cols)
         indptr[1: eff_len + 1] = cupy.cumsum(col_counts[:eff_len])
         indptr[eff_len + 1:] = indptr[eff_len]
         indices = row.T[mask.T].astype(idx_dtype, copy=False)
         data = self.data.T[mask.T]
-        return _csc.csc_matrix(
+        return self._csc_container(
             (data, indices, indptr), shape=self.shape, dtype=self.dtype)
 
     def tocsr(self, copy=False):
@@ -247,6 +294,22 @@ class dia_matrix(_data._data_matrix):
         if idx.size == 0:
             return cupy.zeros(last_col - first_col, dtype=self.data.dtype)
         return self.data[idx[0], first_col:last_col]
+
+
+class dia_matrix(_base.spmatrix, _dia_base):
+    """Sparse matrix with DIAgonal storage.
+
+    .. seealso:: :class:`scipy.sparse.dia_matrix`
+    """
+    pass
+
+
+class dia_array(_dia_base, _base.sparray):
+    """Sparse array with DIAgonal storage.
+
+    .. seealso:: :class:`scipy.sparse.dia_array`
+    """
+    pass
 
 
 def isspmatrix_dia(x):

--- a/cupyx/scipy/sparse/_extract.py
+++ b/cupyx/scipy/sparse/_extract.py
@@ -6,78 +6,88 @@ import cupyx
 from cupyx.scipy import sparse
 
 
+def _is_sparray(A):
+    return sparse.issparse(A) and isinstance(A, sparse.sparray)
+
+
 def find(A):
-    """Returns the indices and values of the nonzero elements of a matrix
+    """Return the indices and values of nonzero elements of a sparse object.
 
     Args:
-        A (cupy.ndarray or cupyx.scipy.sparse.spmatrix): Matrix whose nonzero
-            elements are desired.
+        A (cupy.ndarray or cupyx.scipy.sparse): Object whose nonzero elements
+            are desired.
 
     Returns:
         tuple of cupy.ndarray:
-            It returns (``I``, ``J``, ``V``). ``I``, ``J``, and ``V`` contain
-            respectively the row indices, column indices, and values of the
-            nonzero matrix entries.
+            ``(I, J, V)`` containing the row indices, column indices, and
+            values of the nonzero entries.
 
     .. seealso:: :func:`scipy.sparse.find`
     """
     _check_A_type(A)
-    A = sparse.coo_matrix(A, copy=True)
+    use_array = _is_sparray(A)
+    coo_cls = sparse.coo_array if use_array else sparse.coo_matrix
+    A = coo_cls(A, copy=True)
     A.sum_duplicates()
     nz_mask = A.data != 0
     return A.row[nz_mask], A.col[nz_mask], A.data[nz_mask]
 
 
 def tril(A, k=0, format=None):
-    """Returns the lower triangular portion of a matrix in sparse format
+    """Return the lower triangular portion of a sparse object.
 
     Args:
-        A (cupy.ndarray or cupyx.scipy.sparse.spmatrix): Matrix whose lower
-            triangular portion is desired.
+        A (cupy.ndarray or cupyx.scipy.sparse): Input array/matrix.
         k (integer): The top-most diagonal of the lower triangle.
-        format (string): Sparse format of the result, e.g. 'csr', 'csc', etc.
+        format (string): Sparse format of the result, e.g. ``'csr'``,
+            ``'csc'``.
 
     Returns:
-        cupyx.scipy.sparse.spmatrix:
-            Lower triangular portion of A in sparse format.
+        cupyx.scipy.sparse: Lower triangular portion of ``A``.  Returns a
+        sparse array when ``A`` is a sparse array, else a sparse matrix.
 
     .. seealso:: :func:`scipy.sparse.tril`
     """
     _check_A_type(A)
-    A = sparse.coo_matrix(A, copy=False)
+    use_array = _is_sparray(A)
+    coo_cls = sparse.coo_array if use_array else sparse.coo_matrix
+    A = coo_cls(A, copy=False)
     mask = A.row + k >= A.col
-    return _masked_coo(A, mask).asformat(format)
+    return _masked_coo(A, mask, use_array).asformat(format)
 
 
 def triu(A, k=0, format=None):
-    """Returns the upper triangular portion of a matrix in sparse format
+    """Return the upper triangular portion of a sparse object.
 
     Args:
-        A (cupy.ndarray or cupyx.scipy.sparse.spmatrix): Matrix whose upper
-            triangular portion is desired.
+        A (cupy.ndarray or cupyx.scipy.sparse): Input array/matrix.
         k (integer): The bottom-most diagonal of the upper triangle.
-        format (string): Sparse format of the result, e.g. 'csr', 'csc', etc.
+        format (string): Sparse format of the result, e.g. ``'csr'``,
+            ``'csc'``.
 
     Returns:
-        cupyx.scipy.sparse.spmatrix:
-            Upper triangular portion of A in sparse format.
+        cupyx.scipy.sparse: Upper triangular portion of ``A``.  Returns a
+        sparse array when ``A`` is a sparse array, else a sparse matrix.
 
     .. seealso:: :func:`scipy.sparse.triu`
     """
     _check_A_type(A)
-    A = sparse.coo_matrix(A, copy=False)
+    use_array = _is_sparray(A)
+    coo_cls = sparse.coo_array if use_array else sparse.coo_matrix
+    A = coo_cls(A, copy=False)
     mask = A.row + k <= A.col
-    return _masked_coo(A, mask).asformat(format)
+    return _masked_coo(A, mask, use_array).asformat(format)
 
 
 def _check_A_type(A):
-    if not (isinstance(A, cupy.ndarray) or cupyx.scipy.sparse.isspmatrix(A)):
-        msg = 'A must be cupy.ndarray or cupyx.scipy.sparse.spmatrix'
+    if not (isinstance(A, cupy.ndarray) or cupyx.scipy.sparse.issparse(A)):
+        msg = 'A must be cupy.ndarray or cupyx.scipy.sparse'
         raise TypeError(msg)
 
 
-def _masked_coo(A, mask):
+def _masked_coo(A, mask, use_array=False):
     row = A.row[mask]
     col = A.col[mask]
     data = A.data[mask]
-    return sparse.coo_matrix((data, (row, col)), shape=A.shape, dtype=A.dtype)
+    coo_cls = sparse.coo_array if use_array else sparse.coo_matrix
+    return coo_cls._from_parts(data, row, col, shape=A.shape)

--- a/cupyx/scipy/sparse/_index.py
+++ b/cupyx/scipy/sparse/_index.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 import cupy
 from cupy import _core
 
+from cupyx.scipy.sparse._base import _spbase
 from cupyx.scipy.sparse._base import issparse
-from cupyx.scipy.sparse._base import isspmatrix
-from cupyx.scipy.sparse._base import spmatrix
 
 from cupy.cuda import device
 from cupy.cuda import runtime
@@ -428,7 +427,7 @@ class IndexMixin:
         if i.shape != j.shape:
             raise IndexError('number of row and column indices differ')
 
-        if isspmatrix(x):
+        if issparse(x):
             if i.ndim == 1:
                 # Inner indexing, so treat them like row vectors.
                 i = i[None]
@@ -500,32 +499,6 @@ class IndexMixin:
 
         return x % length
 
-    def getrow(self, i):
-        """Return a copy of row i of the matrix, as a (1 x n) row vector.
-
-        Args:
-            i (integer): Row
-
-        Returns:
-            cupyx.scipy.sparse.spmatrix: Sparse matrix with single row
-        """
-        M, N = self.shape
-        i = _normalize_index(i, M, 'index')
-        return self._get_intXslice(i, slice(None))
-
-    def getcol(self, i):
-        """Return a copy of column i of the matrix, as a (m x 1) column vector.
-
-        Args:
-            i (integer): Column
-
-        Returns:
-            cupyx.scipy.sparse.spmatrix: Sparse matrix with single column
-        """
-        M, N = self.shape
-        i = _normalize_index(i, N, 'index')
-        return self._get_sliceXint(slice(None), i)
-
     def _get_intXint(self, row, col):
         raise NotImplementedError()
 
@@ -569,9 +542,10 @@ class IndexMixin:
         self._set_arrayXarray(row, col, x)
 
 
-def _try_is_scipy_spmatrix(index):
+def _try_is_scipy_sparse(index):
+    """True for any scipy.sparse object (matrix or array)."""
     if scipy_available:
-        return isinstance(index, scipy.sparse.spmatrix)
+        return scipy.sparse.issparse(index)
     return False
 
 
@@ -587,9 +561,9 @@ def _unpack_index(index):
           assumed to be all (e.g., [maj, :]).
     """
     # First, check if indexing with single boolean matrix.
-    if ((isinstance(index, (spmatrix, cupy.ndarray,
+    if ((isinstance(index, (_spbase, cupy.ndarray,
                             numpy.ndarray))
-         or _try_is_scipy_spmatrix(index))
+         or _try_is_scipy_sparse(index))
             and index.ndim == 2 and index.dtype.kind == 'b'):
         return index.nonzero()
 
@@ -615,7 +589,7 @@ def _unpack_index(index):
         elif idx.ndim == 2:
             return idx.nonzero()
     # Next, check for validity and transform the index as needed.
-    if isspmatrix(row) or isspmatrix(col):
+    if issparse(row) or issparse(col):
         # Supporting sparse boolean indexing with both row and col does
         # not work because spmatrix.ndim is always 2.
         raise IndexError(

--- a/cupyx/scipy/sparse/_sputils.py
+++ b/cupyx/scipy/sparse/_sputils.py
@@ -9,6 +9,20 @@ from cupy._core._dtype import get_dtype
 supported_dtypes = [get_dtype(x) for x in
                     ('single', 'double', 'csingle', 'cdouble')]
 
+# dtype kind chars that cuSPARSE accepts for sparse ``data`` arrays:
+#   '?' bool, 'f' float32, 'd' float64, 'F' complex64, 'D' complex128.
+_SPARSE_DATA_KINDS = frozenset('?fdFD')
+
+
+def is_sparse_data_dtype(dtype):
+    """Return True if ``dtype`` can be stored in a sparse ``data`` array.
+
+    cuSPARSE-backed ops accept only bool, float32, float64, complex64,
+    and complex128 for ``data``.
+    """
+    return numpy.dtype(dtype).char in _SPARSE_DATA_KINDS
+
+
 _upcast_memo: dict = {}
 
 
@@ -19,6 +33,73 @@ def isdense(x):
 def isscalarlike(x):
     """Is x either a scalar, an array scalar, or a 0-dim array?"""
     return cupy.isscalar(x) or (isdense(x) and x.ndim == 0)
+
+
+def safely_cast_index_arrays(A, idx_dtype=numpy.int32, msg=""):
+    """Safely cast sparse array indices to ``idx_dtype``.
+
+    Check the shape of *A* to determine if it is safe to cast its index
+    arrays to dtype *idx_dtype*.  If any dimension in shape is larger than
+    fits in the dtype, casting is unsafe so raise :class:`ValueError`.
+    If safe, cast the index arrays to ``idx_dtype`` and return the result
+    without changing the input *A*.  The caller can assign the results to
+    *A*'s attributes if desired or use the recast index arrays directly.
+
+    Unless downcasting is needed, the original index arrays are returned.
+    You can test e.g. ``A.indptr is new_indptr`` to see if downcasting
+    occurred.
+
+    Args:
+        A (cupyx.scipy.sparse): The array for which index arrays should
+            be (potentially) downcast.
+        idx_dtype (dtype): Desired index dtype.  Defaults to ``numpy.int32``.
+        msg (str, optional): String appended to the ``ValueError`` message
+            when ``A.shape`` is too big to fit in ``idx_dtype``.
+
+    Returns:
+        ndarray or tuple of ndarrays:
+            For CSR/CSC, ``(indices, indptr)``.
+            For COO, ``(row, col)`` (CuPy is currently 2-D-only).
+            For DIA, ``offsets``.
+
+    Raises:
+        ValueError: When the dtype cannot represent ``A``'s shape or
+            existing index values.
+
+    .. seealso:: :func:`scipy.sparse.safely_cast_index_arrays`
+    """
+    idx_dtype = numpy.dtype(idx_dtype)
+    if not msg:
+        msg = f"dtype {idx_dtype}"
+    max_value = numpy.iinfo(idx_dtype).max
+
+    if A.format in ('csc', 'csr'):
+        # indptr is monotonically nondecreasing, so its last element is
+        # the largest representable value.
+        if int(A.indptr[-1]) > max_value:  # synchronize!
+            raise ValueError(f"indptr values too large for {msg}")
+        if max(A.shape) > max_value:
+            if bool((A.indices > max_value).any()):  # synchronize!
+                raise ValueError(f"indices values too large for {msg}")
+        return (A.indices.astype(idx_dtype, copy=False),
+                A.indptr.astype(idx_dtype, copy=False))
+
+    if A.format == 'coo':
+        if max(A.shape) > max_value:
+            if (bool((A.row > max_value).any())  # synchronize!
+                    or bool((A.col > max_value).any())):
+                raise ValueError(f"coords values too large for {msg}")
+        return (A.row.astype(idx_dtype, copy=False),
+                A.col.astype(idx_dtype, copy=False))
+
+    if A.format == 'dia':
+        if max(A.shape) > max_value:
+            if bool((A.offsets > max_value).any()):  # synchronize!
+                raise ValueError(f"offsets values too large for {msg}")
+        return A.offsets.astype(idx_dtype, copy=False)
+
+    raise TypeError(
+        f'Format {A.format} is not associated with index arrays.')
 
 
 def get_index_dtype(arrays=(), maxval=None, check_contents=False):

--- a/cupyx/scipy/sparse/_util.py
+++ b/cupyx/scipy/sparse/_util.py
@@ -20,9 +20,35 @@ def isscalarlike(x):
 
 
 def isshape(x):
+    """Return ``True`` if ``x`` is a 2-tuple of intlike values.
+
+    Pure type check; does not reject negative dimensions.  Use
+    :func:`check_shape` (or a follow-up explicit check) to enforce
+    non-negativity with a scipy-compatible error message.
+    """
     if not isinstance(x, tuple) or len(x) != 2:
         return False
     m, n = x
     if isinstance(n, tuple):
         return False
     return isintlike(m) and isintlike(n)
+
+
+def check_shape(shape):
+    """Validate ``shape`` and return it canonicalized to ``(int, int)``.
+
+    Accepts any 2-element iterable (tuple, list, etc.) of intlike
+    values.  Raises ``ValueError`` with the same message scipy uses
+    when the shape is not a 2-tuple of intlike values or contains a
+    negative dimension.
+    """
+    try:
+        shape_tuple = tuple(shape)
+    except TypeError:
+        raise ValueError('invalid shape (must be a 2-tuple of int)')
+    if not isshape(shape_tuple):
+        raise ValueError('invalid shape (must be a 2-tuple of int)')
+    m, n = int(shape_tuple[0]), int(shape_tuple[1])
+    if m < 0 or n < 0:
+        raise ValueError("'shape' elements cannot be negative")
+    return m, n

--- a/cupyx/scipy/sparse/csgraph/_traversal.py
+++ b/cupyx/scipy/sparse/csgraph/_traversal.py
@@ -46,8 +46,12 @@ def connected_components(csgraph, directed=True, connection='weak',
     if csgraph.ndim != 2:
         raise ValueError('graph should have two dimensions')
 
-    if not cupyx.scipy.sparse.isspmatrix_csr(csgraph):
-        csgraph = cupyx.scipy.sparse.csr_matrix(csgraph)
+    def _ensure_csr(g):
+        if cupyx.scipy.sparse.issparse(g):
+            return g if g.format == 'csr' else g.tocsr()
+        return cupyx.scipy.sparse.csr_matrix(g)
+
+    csgraph = _ensure_csr(csgraph)
     m, m1 = csgraph.shape
     if m != m1:
         raise ValueError('graph should be a square array')
@@ -60,9 +64,7 @@ def connected_components(csgraph, directed=True, connection='weak',
             offsets=csgraph.indptr, indices=csgraph.indices, weights=None,
             num_verts=m, num_edges=csgraph.nnz, labels=labels)
     else:
-        csgraph += csgraph.T
-        if not cupyx.scipy.sparse.isspmatrix_csr(csgraph):
-            csgraph = cupyx.scipy.sparse.csr_matrix(csgraph)
+        csgraph = _ensure_csr(csgraph + csgraph.T)
         _, labels = pylibcugraph.weakly_connected_components(
             resource_handle=None,
             graph=None,

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -186,7 +186,7 @@ def _lanczos_fast(A, n, ncv):
         raise TypeError('invalid dtype ({})'.format(A.dtype))
 
     cusparse_handle = None
-    if _csr.isspmatrix_csr(A) and cusparse.check_availability('spmv'):
+    if _csr._is_csr(A) and cusparse.check_availability('spmv'):
         cusparse_handle = device.get_cusparse_handle()
         spmv_op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
         spmv_alpha = numpy.array(1.0, A.dtype)

--- a/cupyx/scipy/sparse/linalg/_interface.py
+++ b/cupyx/scipy/sparse/linalg/_interface.py
@@ -558,7 +558,7 @@ def aslinearoperator(A):
         A = cupy.atleast_2d(A)
         return MatrixLinearOperator(A)
 
-    elif sparse.isspmatrix(A):
+    elif sparse.issparse(A):
         return MatrixLinearOperator(A)
 
     else:

--- a/cupyx/scipy/sparse/linalg/_iterative.py
+++ b/cupyx/scipy/sparse/linalg/_iterative.py
@@ -465,7 +465,7 @@ def _make_fast_matvec(A):
     from cupy_backends.cuda.libs import cusparse as _cusparse
     from cupyx import cusparse
 
-    if _csr.isspmatrix_csr(A) and cusparse.check_availability('spmv'):
+    if _csr._is_csr(A) and cusparse.check_availability('spmv'):
         handle = device.get_cusparse_handle()
         op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
         alpha = numpy.array(1.0, A.dtype)

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -48,13 +48,14 @@ def lsqr(A, b):
 
     if runtime.is_hip:
         raise RuntimeError('HIP does not support lsqr')
-    if not sparse.isspmatrix_csr(A):
+    if not (sparse.issparse(A) and A.format == "csr"):
         A = sparse.csr_matrix(A)
-    # cuSOLVER's csrlsvqr is int32-only; mirror the guard on spsolve.
-    cusparse._check_int32_indices(A, 'lsqr')
     # csr_matrix is 2d
     _util._assert_stacked_square(A)
     _util._assert_cupy_array(b)
+    # cuSOLVER's csrlsvqr is int32-only; mirror the guard already
+    # present in spsolve (which dispatches to the same backend).
+    cusparse._check_int32_indices(A, 'lsqr')
     m = A.shape[0]
     if b.ndim != 1 or len(b) != m:
         raise ValueError('b must be 1-d array whose size is same as A')
@@ -438,7 +439,7 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
             cusparse.check_availability('csrsm2')):
         raise NotImplementedError
 
-    if not sparse.isspmatrix(A):
+    if not sparse.issparse(A):
         raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
     if not isinstance(b, cupy.ndarray):
         raise TypeError('b must be cupy.ndarray')
@@ -454,9 +455,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         raise TypeError(f'unsupported dtype (actual: {A.dtype})')
 
     if cusparse.check_availability('spsm') and _should_use_spsm(b):
-        if not (sparse.isspmatrix_csr(A) or
-                sparse.isspmatrix_csc(A) or
-                sparse.isspmatrix_coo(A)):
+        if not (sparse.issparse(A)
+                and A.format in ('csr', 'csc', 'coo')):
             warnings.warn('CSR, CSC or COO format is required. Converting to '
                           'CSR format.', sparse.SparseEfficiencyWarning)
             A = A.tocsr()
@@ -466,7 +466,8 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         # csrsm2 is int32-only; raise with the user-facing function name
         # rather than the internal "csrsm2" name.
         cusparse._check_int32_indices(A, 'spsolve_triangular')
-        if not (sparse.isspmatrix_csr(A) or sparse.isspmatrix_csc(A)):
+        if not (sparse.issparse(A)
+                and A.format in ('csr', 'csc')):
             warnings.warn('CSR or CSC format is required. Converting to CSR '
                           'format.', sparse.SparseEfficiencyWarning)
             A = A.tocsr()
@@ -506,7 +507,7 @@ def spsolve(A, b):
 
     if not cupyx.cusolver.check_availability('csrlsvqr'):
         raise NotImplementedError
-    if not sparse.isspmatrix(A):
+    if not sparse.issparse(A):
         raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
     if not isinstance(b, cupy.ndarray):
         raise TypeError('b must be cupy.ndarray')
@@ -519,7 +520,7 @@ def spsolve(A, b):
         raise ValueError('matrix dimension mismatch (A.shape: {}, b.shape: {})'
                          .format(A.shape, b.shape))
 
-    if not sparse.isspmatrix_csr(A):
+    if not (sparse.issparse(A) and A.format == "csr"):
         warnings.warn('CSR format is required. Converting to CSR format.',
                       sparse.SparseEfficiencyWarning)
         A = A.tocsr()
@@ -640,7 +641,7 @@ class CusparseLU(SuperLU):
         """
         if not scipy_available:
             raise RuntimeError('scipy is not available')
-        if not sparse.isspmatrix_csr(a):
+        if not (sparse.issparse(a) and a.format == 'csr'):
             raise TypeError('a must be cupyx.scipy.sparse.csr_matrix')
 
         self.shape = a.shape
@@ -706,7 +707,7 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None, relax=None,
     """
     if not scipy_available:
         raise RuntimeError('scipy is not available')
-    if not sparse.isspmatrix(A):
+    if not sparse.issparse(A):
         raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
     if A.shape[0] != A.shape[1]:
         raise ValueError('A must be a square matrix (A.shape: {})'
@@ -757,7 +758,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None,
     """
     if not scipy_available:
         raise RuntimeError('scipy is not available')
-    if not sparse.isspmatrix(A):
+    if not sparse.issparse(A):
         raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
     if A.shape[0] != A.shape[1]:
         raise ValueError('A must be a square matrix (A.shape: {})'
@@ -767,7 +768,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None,
 
     if fill_factor == 1:
         # Computes ILU(0) on the GPU using cuSparse functions
-        if not sparse.isspmatrix_csr(A):
+        if not (sparse.issparse(A) and A.format == "csr"):
             a = A.tocsr()
         else:
             a = A.copy()

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/csgraph_tests/test_traversal.py
@@ -25,23 +25,24 @@ from cupy import testing
     'directed': [True, False],
     'connection': ['weak', 'strong'],
     'return_labels': [True, False],
+    'use_array': [True, False],
 }))
 @unittest.skipUnless(scipy_available and pylibcugraph_available,
                      'requires scipy and pylibcugraph')
 class TestConnectedComponents(unittest.TestCase):
 
-    def _make_matrix(self, dtype, xp):
+    def _make_matrix(self, dtype, xp, sp):
         shape = (self.m, self.m)
         density = self.nnz_per_row / self.m
         a = testing.shaped_random(shape, xp, dtype=dtype, scale=1)
         a = a / density
         a[a > 1] = 0
-        return a
+        cls = sp.csr_array if self.use_array else sp.csr_matrix
+        return cls(a)
 
     @testing.numpy_cupy_array_equal(sp_name='sp')
     def test_connected_components(self, xp, sp):
-        a = self._make_matrix(self.dtype, xp)
-        a = sp.csr_matrix(a)
+        a = self._make_matrix(self.dtype, xp, sp)
         if self.return_labels:
             n, labels = sp.csgraph.connected_components(
                 a, directed=self.directed, connection=self.connection,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_base.py
@@ -20,17 +20,17 @@ class TestSpmatrix(unittest.TestCase):
 
     def dummy_class(self, sp):
         if sp is sparse:
-            class DummySparseGPU(sparse.spmatrix):
+            class DummySparseGPU(sparse.spmatrix, sparse._spbase):
 
                 def __init__(self, maxprint=50, shape=None, nnz=0):
-                    super().__init__(maxprint)
+                    super().__init__(maxprint=maxprint)
                     self._shape = shape
                     self._nnz = nnz
 
                 def get_shape(self):
                     return self._shape
 
-                def getnnz(self):
+                def _getnnz(self, axis=None):
                     return self._nnz
 
             return DummySparseGPU
@@ -49,13 +49,13 @@ class TestSpmatrix(unittest.TestCase):
             return DummySparseCPU
 
     def test_instantiation(self):
-        for sp in (scipy.sparse, sparse):
-            with pytest.raises(ValueError):
-                if sp is scipy.sparse:
-                    sp._base._spbase(None)
-                else:
-                    # TODO(asi1024): Replace with sp._base._spbase
-                    sp.spmatrix()
+        # SciPy's _spbase rejects direct instantiation
+        with pytest.raises((ValueError, TypeError)):
+            scipy.sparse._base._spbase(None)
+        # CuPy's spmatrix is a mixin -- instantiation is technically
+        # possible but useless.  We just check it doesn't crash.
+        m = sparse.spmatrix()
+        assert isinstance(m, sparse.spmatrix)
 
     def test_len(self):
         for sp in (scipy.sparse, sparse):
@@ -90,16 +90,59 @@ class TestSpmatrix(unittest.TestCase):
         return s.maxprint
 
 
-class TestSpmatrixOnlyApi:
-    """Matrix-only APIs whose status mirrors scipy 1.17.
+class TestIssparse:
+    """Test issparse and isspmatrix with both arrays and matrices."""
 
-    SciPy 1.14 *removed* ``.A``/``.H`` from the array side.  CuPy keeps
-    them on ``spmatrix`` for now but emits ``DeprecationWarning`` so user
-    code has a migration breadcrumb.
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_issparse_matrix(self, fmt):
+        cls = getattr(sparse, f'{fmt}_matrix')
+        m = cls((2, 3))
+        assert sparse.issparse(m)
 
-    SciPy 1.14 deprecated and 1.17 *un-deprecated* ``asfptype``,
-    ``getformat``, ``getmaxprint``, ``set_shape`` (et al.) — they remain
-    plain matrix-side conveniences.  CuPy follows: no warning.
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_issparse_array(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        a = cls((2, 3))
+        assert sparse.issparse(a)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_isspmatrix_matrix(self, fmt):
+        cls = getattr(sparse, f'{fmt}_matrix')
+        m = cls((2, 3))
+        assert sparse.isspmatrix(m)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_isspmatrix_not_array(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        a = cls((2, 3))
+        assert not sparse.isspmatrix(a)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_sparray_not_spmatrix(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        a = cls((2, 3))
+        assert isinstance(a, sparse.sparray)
+        assert not isinstance(a, sparse.spmatrix)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_spmatrix_not_sparray(self, fmt):
+        cls = getattr(sparse, f'{fmt}_matrix')
+        m = cls((2, 3))
+        assert isinstance(m, sparse.spmatrix)
+        assert not isinstance(m, sparse.sparray)
+
+
+class TestDeprecatedSpmatrixApi:
+    """Matrix-only APIs that don't exist on sparse arrays.
+
+    SciPy 1.14 deprecated several matrix-only APIs that SciPy 1.17
+    subsequently un-deprecated (kept on ``spmatrix`` only, no warning):
+    ``asfptype``, ``get_shape``, ``getformat``, ``getmaxprint``,
+    ``set_shape``, ``getrow``, ``getcol``.  CuPy follows the same
+    policy.
+
+    Two attributes are still removed on arrays *and* still warn on
+    matrices: ``A`` (use ``.toarray()``) and ``H`` (use ``.T.conj()``).
     """
 
     @pytest.fixture
@@ -108,51 +151,70 @@ class TestSpmatrixOnlyApi:
                                              [0.0, 2.0, 0.0],
                                              [0.0, 0.0, 3.0]]))
 
-    @pytest.mark.parametrize("attr", ["A", "H"])
-    def test_attr_warns(self, m, attr):
-        with pytest.warns(DeprecationWarning,
-                          match=fr"`spmatrix\.{attr}`"):
-            getattr(m, attr)
+    @pytest.fixture
+    def a(self):
+        return sparse.csr_array(cupy.array([[1.0, 0.0, 0.0],
+                                            [0.0, 2.0, 0.0],
+                                            [0.0, 0.0, 3.0]]))
 
-    @pytest.mark.parametrize("name", [
-        "asfptype", "getformat", "getmaxprint",
-        "getnnz", "get_shape", "set_shape",
+    def test_A_warns(self, m):
+        with pytest.warns(DeprecationWarning, match=r"`spmatrix\.A`"):
+            result = m.A
+        testing.assert_array_equal(result, m.toarray())
+
+    def test_H_warns(self, m):
+        with pytest.warns(DeprecationWarning, match=r"`spmatrix\.H`"):
+            result = m.H
+        testing.assert_array_equal(
+            result.toarray(), m.transpose().conj().toarray())
+
+    @pytest.mark.parametrize('name,check', [
+        ('asfptype', lambda r, m: r.dtype.kind == 'f'),
+        ('get_shape', lambda r, m: r == m.shape),
+        ('getformat', lambda r, m: r == m.format),
+        ('getmaxprint', lambda r, m: r == m.maxprint),
+        ('getnnz', lambda r, m: r == m.nnz),
     ])
-    def test_plain_method_no_warn(self, m, name):
+    def test_plain_method_no_warn(self, m, name, check):
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            if name == "set_shape":
-                m.set_shape(m.shape)
-            else:
-                getattr(m, name)()
+            result = getattr(m, name)()
+        assert check(result, m)
 
-    def test_shape_setter_no_warn(self, m):
+    def test_set_shape_no_warn_and_in_place(self, m):
+        old_shape = m.shape
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            m.shape = m.shape
+            m.set_shape((9, 1))
+        assert m.shape == (9, 1)
+        # Reset for cleanliness in case the fixture is reused.
+        m.set_shape(old_shape)
 
-    @pytest.mark.parametrize("via", ["set_shape", "shape="])
-    def test_shape_mutates_in_place(self, via):
-        # Regression for the silent no-op: ``reshape`` returned a new
-        # matrix and the result was discarded.  Now the change must be
-        # visible on ``self``.
-        m = sparse.csr_matrix(cupy.array([[1.0, 0.0, 2.0],
-                                          [0.0, 3.0, 0.0]]))
-        if via == "set_shape":
-            m.set_shape((3, 2))
-        else:
-            m.shape = (3, 2)
-        assert m.shape == (3, 2)
+    def test_shape_setter_does_not_warn(self, m):
+        old_shape = m.shape
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            m.shape = (9, 1)
+        assert m.shape == (9, 1)
+        m.shape = old_shape
 
-    def test_warning_attributed_to_caller(self, m):
+    def test_warning_is_attributed_to_caller(self, m):
         # ``stacklevel=2`` should make the warning point at the user's
         # frame (this test file) rather than ``_base.py``.
         with pytest.warns(DeprecationWarning) as record:
             m.A
-        assert record[0].filename.endswith("test_base.py")
+        assert record[0].filename.endswith('test_base.py')
+
+    @pytest.mark.parametrize(
+        'attr', ['A', 'H', 'asfptype', 'get_shape', 'getformat',
+                 'getmaxprint', 'getnnz', 'getrow', 'getcol', 'set_shape']
+    )
+    def test_array_does_not_have_deprecated_attr(self, a, attr):
+        with pytest.raises(AttributeError):
+            getattr(a, attr)
 
 
-class TestSetShape(unittest.TestCase):
+class TestSetShape:
     """``set_shape`` must mutate ``self`` in place.  Plain
     ``self.reshape(shape)`` returns a new matrix and discards the
     reshaped result; the in-place wrapper has to swap ``__dict__``.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
@@ -14,6 +14,29 @@ from cupy import testing
 from cupyx.scipy import sparse
 
 
+SPARSE_FORMATS = ('csr', 'csc', 'coo', 'dia')
+
+
+def _make_small_sparse(
+        fmt, *, array=True, shape=(2, 3), dtype=numpy.float64,
+        xp=cupy, spmod=sparse):
+    """Return a small sparse array/matrix with values on the main diagonal."""
+    kind = 'array' if array else 'matrix'
+    if fmt == 'dia':
+        width = min(shape)
+        data = xp.ones((1, width), dtype=dtype)
+        offsets = xp.array([0], dtype='i')
+        cls = spmod.dia_array if array else spmod.dia_matrix
+        return cls((data, offsets), shape=shape)
+    cls = getattr(spmod, f'{fmt}_{kind}')
+    dense = xp.zeros(shape, dtype=dtype)
+    diag_n = min(shape)
+    if diag_n:
+        diag_idx = xp.arange(diag_n)
+        dense[diag_idx, diag_idx] = xp.arange(1, diag_n + 1, dtype=dtype)
+    return cls(dense)
+
+
 def _make_csr(xp, sp, dtype, *, array=False):
     """3x4 CSR with 4 nonzeros."""
     data = xp.array([0, 1, 2, 3], dtype)
@@ -41,6 +64,15 @@ def _make_csr_sq2(xp, sp, dtype, *, array=False):
     return cls((data, indices, indptr), shape=(3, 3))
 
 
+def _make_csc(xp, sp, dtype, *, array=False):
+    """3x3 diagonal CSC with values [1, 2, 3]."""
+    data = xp.array([1, 2, 3], dtype)
+    indices = xp.array([0, 1, 2], 'i')
+    indptr = xp.array([0, 1, 2, 3], 'i')
+    cls = sp.csc_array if array else sp.csc_matrix
+    return cls((data, indices, indptr), shape=(3, 3))
+
+
 def _make_for_matmul(xp, sp, dtype, *, array=False):
     """4x3 CSR for matmul with 3x4."""
     data = xp.array([1, 2, 3, 4, 5], dtype)
@@ -53,36 +85,31 @@ def _make_for_matmul(xp, sp, dtype, *, array=False):
 class TestSparseArrayTypeIdentity:
     """issparse, isspmatrix, isinstance checks for all formats."""
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_array_issparse(self, fmt):
-        cls = getattr(sparse, f'{fmt}_array')
-        A = cls((2, 3), dtype=numpy.float64)
+        A = _make_small_sparse(fmt, array=True)
         assert sparse.issparse(A)
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_array_not_isspmatrix(self, fmt):
-        cls = getattr(sparse, f'{fmt}_array')
-        A = cls((2, 3), dtype=numpy.float64)
+        A = _make_small_sparse(fmt, array=True)
         assert not sparse.isspmatrix(A)
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_array_isinstance_sparray(self, fmt):
-        cls = getattr(sparse, f'{fmt}_array')
-        A = cls((2, 3), dtype=numpy.float64)
+        A = _make_small_sparse(fmt, array=True)
         assert isinstance(A, sparse.sparray)
         assert not isinstance(A, sparse.spmatrix)
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_matrix_isinstance_spmatrix(self, fmt):
-        cls = getattr(sparse, f'{fmt}_matrix')
-        M = cls((2, 3), dtype=numpy.float64)
+        M = _make_small_sparse(fmt, array=False)
         assert isinstance(M, sparse.spmatrix)
         assert not isinstance(M, sparse.sparray)
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_matrix_issparse(self, fmt):
-        cls = getattr(sparse, f'{fmt}_matrix')
-        M = cls((2, 3), dtype=numpy.float64)
+        M = _make_small_sparse(fmt, array=False)
         assert sparse.issparse(M)
         assert sparse.isspmatrix(M)
 
@@ -136,21 +163,14 @@ class TestSparseArrayTypeIdentity:
                         [1., 0., 1., 0.],
                         [0., 1., 0., 1.]]))
 
-    def test_block_diag_arrays(self):
-        A = sparse.csr_array(cupy.array([[1, 2]], dtype='d'))
-        B = sparse.csr_array(cupy.array([[3]], dtype='d'))
+    @pytest.mark.parametrize('use_array', [True, False])
+    def test_block_diag_type_and_values(self, use_array):
+        cls = sparse.csr_array if use_array else sparse.csr_matrix
+        expected_type = sparse.sparray if use_array else sparse.spmatrix
+        A = cls(cupy.array([[1, 2]], dtype='d'))
+        B = cls(cupy.array([[3]], dtype='d'))
         result = sparse.block_diag((A, B))
-        assert isinstance(result, sparse.sparray)
-        cupy.testing.assert_array_equal(
-            result.toarray(),
-            cupy.array([[1., 2., 0.],
-                        [0., 0., 3.]]))
-
-    def test_block_diag_matrices(self):
-        A = sparse.csr_matrix(cupy.array([[1, 2]], dtype='d'))
-        B = sparse.csr_matrix(cupy.array([[3]], dtype='d'))
-        result = sparse.block_diag((A, B))
-        assert isinstance(result, sparse.spmatrix)
+        assert isinstance(result, expected_type)
         cupy.testing.assert_array_equal(
             result.toarray(),
             cupy.array([[1., 2., 0.],
@@ -229,20 +249,19 @@ class TestSparseArrayTypeIdentity:
         with pytest.raises(ValueError):
             sparse.permute_dims(A, (0, 0))
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_array_maxprint_kwarg(self, fmt):
-        cls = getattr(sparse, f'{fmt}_array')
-        A = cls(cupy.array([[1., 2.]]), maxprint=10)
+        if fmt == 'dia':
+            data = cupy.array([[1., 2.]])
+            offsets = cupy.array([0], dtype='i')
+            A = sparse.dia_array((data, offsets), shape=(2, 2), maxprint=10)
+            B = sparse.dia_array((data, offsets), shape=(2, 2))
+        else:
+            cls = getattr(sparse, f'{fmt}_array')
+            A = cls(cupy.array([[1., 2.]]), maxprint=10)
+            B = cls(cupy.array([[1., 2.]]))
         assert A.maxprint == 10
-        # Default
-        B = cls(cupy.array([[1., 2.]]))
         assert B.maxprint == 50
-
-    def test_dia_array_maxprint_kwarg(self):
-        data = cupy.array([[1., 2., 3.]])
-        offsets = cupy.array([0])
-        A = sparse.dia_array((data, offsets), shape=(3, 3), maxprint=10)
-        assert A.maxprint == 10
 
     def test_negate_bool_array_raises(self):
         # Match scipy 1.17: NotImplementedError, not TypeError.
@@ -262,6 +281,10 @@ class TestSparseArrayTypeIdentity:
         assert isinstance(res, cupy.ndarray)
         cupy.testing.assert_array_equal(
             res, cupy.array([1., 0., 0., 3.]))
+
+    def test_copy_preserves_array_type(self):
+        a = _make_csr(cupy, sparse, numpy.float64, array=True)
+        assert isinstance(a.copy(), sparse.sparray)
 
     def test_csc_array_matmul_preserves_array_type(self):
         # SciPy gh-fix: csc_array @ csc_array (or csr_array) returns
@@ -313,7 +336,7 @@ class TestSparseArrayTypeIdentity:
                         [0., 2., 0.],
                         [0., 0., 3.]]))
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', ('csr', 'csc', 'coo'))
     def test_setdiag_python_types(self, fmt):
         # Regression: setdiag used to call ``values.astype(...)`` (or
         # ``values.ndim``) directly on the input, raising AttributeError
@@ -340,7 +363,7 @@ class TestSparseArrayTypeIdentity:
                         [4., 99., 6.],
                         [7., 8., 99.]]))
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', ('csr', 'csc', 'coo'))
     def test_inplace_scalar_preserves_identity(self, fmt):
         # ``A *= 2`` and ``A /= 2`` must mutate ``self.data`` in place
         # so the bound name still refers to the same object (matches
@@ -391,7 +414,7 @@ class TestSparseArrayTypeIdentity:
             A.toarray(),
             cupy.array([[2., 0., 0.], [0., 4., 0.], [0., 0., 6.]]))
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', ('csr', 'csc', 'coo'))
     def test_setdiag_does_not_mutate_input(self, fmt):
         # Regression: CSR setdiag used ``x_data -= self.diagonal(k)``
         # in place.  Now that input is coerced via ``cupy.asarray``
@@ -535,7 +558,7 @@ class TestSparseArrayTypeIdentity:
         assert m.count_nonzero() == 2  # the 0 at (0, 0) doesn't count
         assert m.nnz == 3                # but it is stored
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', ('csr', 'csc', 'coo'))
     def test_count_nonzero_axis_empty(self, fmt):
         # Regression: ``count_nonzero(axis=)`` on an empty sparse object
         # used to crash because ``cupy.bincount`` errors on zero-size
@@ -554,7 +577,7 @@ class TestSparseArrayTypeIdentity:
         cupy.testing.assert_array_equal(
             A.count_nonzero(axis=-2), cupy.zeros(5, dtype=cupy.intp))
 
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', ('csr', 'csc', 'coo'))
     def test_count_nonzero_axis_all_explicit_zero(self, fmt):
         # When every stored value is an explicit zero, the
         # bincount-on-mask path also produces a zero-size input that
@@ -583,18 +606,14 @@ class TestSparseArrayTypeIdentity:
             A.count_nonzero(axis=1), cupy.zeros(2, dtype=cupy.intp))
 
     @testing.with_requires('scipy')
-    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('fmt', SPARSE_FORMATS)
     def test_type_system_matches_scipy(self, fmt):
         """CuPy and SciPy type predicates should agree."""
-        sp_arr_cls = getattr(scipy.sparse, f'{fmt}_array')
-        sp_mat_cls = getattr(scipy.sparse, f'{fmt}_matrix')
-        cp_arr_cls = getattr(sparse, f'{fmt}_array')
-        cp_mat_cls = getattr(sparse, f'{fmt}_matrix')
-
-        sp_a = sp_arr_cls((2, 3))
-        sp_m = sp_mat_cls((2, 3))
-        cp_a = cp_arr_cls((2, 3))
-        cp_m = cp_mat_cls((2, 3))
+        sp_a = _make_small_sparse(fmt, xp=numpy, spmod=scipy.sparse)
+        sp_m = _make_small_sparse(
+            fmt, array=False, xp=numpy, spmod=scipy.sparse)
+        cp_a = _make_small_sparse(fmt)
+        cp_m = _make_small_sparse(fmt, array=False)
 
         assert sparse.issparse(cp_a) == scipy.sparse.issparse(sp_a)
         assert sparse.issparse(cp_m) == scipy.sparse.issparse(sp_m)
@@ -602,49 +621,48 @@ class TestSparseArrayTypeIdentity:
         assert sparse.isspmatrix(cp_m) == scipy.sparse.isspmatrix(sp_m)
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
-}))
+@pytest.mark.parametrize(
+    'dtype', [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
 @testing.with_requires('scipy')
 class TestCsrArrayConstruction:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_from_data_indices_indptr(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_from_data_indices_indptr(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         assert m.format == 'csr'
         assert isinstance(m, sp.sparray)
         return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_from_dense(self, xp, sp):
-        dense = xp.array([[1, 0, 2], [0, 3, 0]], dtype=self.dtype)
+    def test_from_dense(self, xp, sp, dtype):
+        dense = xp.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
         m = sp.csr_array(dense)
         assert isinstance(m, sp.sparray)
         return m
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_from_coo_tuple(self, xp, sp):
-        data = xp.array([1, 2, 3], self.dtype)
+    def test_from_coo_tuple(self, xp, sp, dtype):
+        data = xp.array([1, 2, 3], dtype)
         row = xp.array([0, 1, 2], 'i')
         col = xp.array([2, 0, 1], 'i')
         m = sp.csr_array((data, (row, col)), shape=(3, 3))
         assert isinstance(m, sp.sparray)
         return m
 
-    def test_empty(self):
-        m = sparse.csr_array((3, 4), dtype=numpy.float64)
+    def test_empty(self, dtype):
+        m = sparse.csr_array((3, 4), dtype=dtype)
         assert m.shape == (3, 4)
         assert m.nnz == 0
         assert isinstance(m, sparse.sparray)
 
-    def test_from_coo_tuple_preserves_int64_indices(self):
+    def test_from_coo_tuple_preserves_int64_indices(self, dtype):
         # Regression: csr_array((data, (row, col))) used to construct
         # an intermediate ``coo_matrix`` (not ``coo_array``), which ran
         # ``_get_index_dtype(check_contents=True)`` and silently
         # downcast int64 row/col arrays to int32.  Now uses
         # ``self._coo_container`` so the sparse-array dtype-preservation
         # promise is honored.
-        data = cupy.array([1.0, 2.0], dtype=self.dtype)
+        data = cupy.array([1.0, 2.0], dtype=dtype)
         row = cupy.array([0, 1], dtype=cupy.int64)
         col = cupy.array([0, 1], dtype=cupy.int64)
         m = sparse.csr_array((data, (row, col)), shape=(3, 3))
@@ -659,172 +677,118 @@ class TestCsrArrayConstruction:
         assert m.indices.dtype == cupy.int32
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestCsrArrayStarIsElementwise:
     """Verify that * is element-wise for csr_array (matching scipy.sparse)."""
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_star_sparse(self, xp, sp):
+    def test_star_sparse(self, xp, sp, dtype):
         """array * array should be element-wise."""
-        a = _make_csr_sq(xp, sp, self.dtype, array=True)
-        b = _make_csr_sq(xp, sp, self.dtype, array=True)
-        return a * b
+        a = _make_csr_sq(xp, sp, dtype, array=True)
+        b = _make_csr_sq(xp, sp, dtype, array=True)
+        result = a * b
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_star_scalar(self, xp, sp):
+    def test_star_scalar(self, xp, sp, dtype):
         """array * scalar should be scalar multiplication."""
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return a * self.dtype(2.0)
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = a * dtype(2.0)
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_rstar_scalar(self, xp, sp):
+    def test_rstar_scalar(self, xp, sp, dtype):
         """scalar * array should be scalar multiplication."""
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return self.dtype(3.0) * a
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = dtype(3.0) * a
+        assert isinstance(result, sp.sparray)
+        return result
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestCsrArrayMatmul:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_matmul_sparse(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        b = _make_for_matmul(xp, sp, self.dtype, array=True)
-        return a @ b
+    def test_matmul_sparse(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        b = _make_for_matmul(xp, sp, dtype, array=True)
+        result = a @ b
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_matmul_dense_vector(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        x = xp.arange(4).astype(self.dtype)
+    def test_matmul_dense_vector(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        x = xp.arange(4).astype(dtype)
         return a @ x
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
-    def test_matmul_dense_matrix(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        x = xp.arange(8).reshape(4, 2).astype(self.dtype)
+    def test_matmul_dense_matrix(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        x = xp.arange(8).reshape(4, 2).astype(dtype)
         return a @ x
 
-    def test_matmul_scalar_raises(self):
-        a = _make_csr_sq(cupy, sparse, numpy.float64, array=True)
+    def test_matmul_scalar_raises(self, dtype):
+        a = _make_csr_sq(cupy, sparse, dtype, array=True)
         with pytest.raises(ValueError):
             a @ 5.0
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestCsrArrayPower:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_power_elementwise(self, xp, sp):
+    def test_power_elementwise(self, xp, sp, dtype):
         """array ** n should be element-wise, not matrix power."""
-        a = _make_csr_sq(xp, sp, self.dtype, array=True)
-        return a ** 2
+        a = _make_csr_sq(xp, sp, dtype, array=True)
+        result = a ** 2
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_power_matches_dense(self, xp, sp):
+    def test_power_matches_dense(self, xp, sp, dtype):
         """Verify ** gives same result as dense element-wise power."""
-        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        a = _make_csr_sq(xp, sp, dtype, array=True)
         result_sparse = (a ** 2).toarray()
         result_dense = a.toarray() ** 2
         xp.testing.assert_allclose(result_sparse, result_dense)
         return result_sparse
 
-    def test_power_zero_raises(self):
+    def test_power_zero_raises(self, dtype):
         """Array ** 0 raises NotImplementedError (would densify)."""
-        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        a = _make_csr_sq(cupy, sparse, dtype, array=True)
         with pytest.raises(NotImplementedError):
             a ** 0
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestCsrMatrixStarIsMatmul:
     """Verify that * is still matmul for csr_matrix (unchanged)."""
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_star_matmul(self, xp, sp):
+    def test_star_matmul(self, xp, sp, dtype):
         """matrix * matrix should be matmul."""
-        a = _make_csr(xp, sp, self.dtype)
-        b = _make_for_matmul(xp, sp, self.dtype)
+        a = _make_csr(xp, sp, dtype)
+        b = _make_for_matmul(xp, sp, dtype)
         return a * b
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_star_scalar(self, xp, sp):
+    def test_star_scalar(self, xp, sp, dtype):
         """matrix * scalar should still work."""
-        a = _make_csr(xp, sp, self.dtype)
-        return a * self.dtype(2.0)
+        a = _make_csr(xp, sp, dtype)
+        return a * dtype(2.0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_pow_matrix_power(self, xp, sp):
+    def test_pow_matrix_power(self, xp, sp, dtype):
         """matrix ** n should be matrix power."""
-        a = _make_csr_sq(xp, sp, self.dtype)
+        a = _make_csr_sq(xp, sp, dtype)
         return a ** 2
-
-
-class TestCsrArrayTypePreservation:
-    """Operations on csr_array should return csr_array (not csr_matrix)."""
-
-    dtype = numpy.float64
-
-    def _check_array(self, result):
-        assert isinstance(result, sparse.sparray), (
-            f'Expected sparray, got {type(result).__name__}')
-        assert not isinstance(result, sparse.spmatrix)
-
-    def test_star(self):
-        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
-        b = _make_csr_sq(cupy, sparse, self.dtype, array=True)
-        self._check_array(a * b)
-
-    def test_matmul(self):
-        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
-        b = _make_csr_sq2(cupy, sparse, self.dtype, array=True)
-        self._check_array(a @ b)
-
-    def test_add(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        b = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(a + b)
-
-    def test_sub(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        b = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(a - b)
-
-    def test_neg(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(-a)
-
-    def test_scalar_mul(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(a * self.dtype(2.0))
-
-    def test_pow(self):
-        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
-        self._check_array(a ** 2)
-
-    def test_copy(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(a.copy())
-
-    def test_abs(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        self._check_array(abs(a))
-
-    def test_T(self):
-        a = _make_csr(cupy, sparse, self.dtype, array=True)
-        result = a.T
-        assert isinstance(result, sparse.sparray)
 
 
 class TestMultiplyMixedSparrayMatrix:
@@ -873,44 +837,6 @@ class TestMultiplyMixedSparrayMatrix:
         cupy.testing.assert_array_equal(result.toarray(), hi * lo)
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
-@testing.with_requires('scipy')
-class TestCsrArrayConversions:
-
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_tocsc(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
-        result = m.tocsc()
-        assert isinstance(result, sp.sparray)
-        assert result.format == 'csc'
-        return result
-
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_tocoo(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
-        result = m.tocoo()
-        assert isinstance(result, sp.sparray)
-        assert result.format == 'coo'
-        return result
-
-    @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_toarray(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
-        return m.toarray()
-
-    def test_tocsr_returns_self(self):
-        m = _make_csr(cupy, sparse, numpy.float64, array=True)
-        assert m.tocsr() is m
-
-    def test_tocsr_copy(self):
-        m = _make_csr(cupy, sparse, numpy.float64, array=True)
-        n = m.tocsr(copy=True)
-        assert n is not m
-        assert isinstance(n, sparse.sparray)
-
-
 @testing.with_requires('scipy')
 class TestCsrArrayGet:
 
@@ -932,122 +858,84 @@ class TestCsrArrayGet:
         return m.toarray()
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
-}))
+@pytest.mark.parametrize(
+    'dtype', [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128])
 @testing.with_requires('scipy')
 class TestCsrArrayArithmeticSciPyComparison:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_add(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        b = _make_csr(xp, sp, self.dtype, array=True)
-        return a + b
+    def test_add(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        b = _make_csr(xp, sp, dtype, array=True)
+        result = a + b
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_sub(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        b = _make_csr(xp, sp, self.dtype, array=True)
-        return (a - b).toarray()
+    def test_sub(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        b = _make_csr(xp, sp, dtype, array=True)
+        result = a - b
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_neg(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return (-a).toarray()
+    def test_neg(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = -a
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_mul_elementwise(self, xp, sp):
-        a = _make_csr_sq(xp, sp, self.dtype, array=True)
-        b = _make_csr_sq(xp, sp, self.dtype, array=True)
-        return a * b
+    def test_mul_elementwise(self, xp, sp, dtype):
+        a = _make_csr_sq(xp, sp, dtype, array=True)
+        b = _make_csr_sq(xp, sp, dtype, array=True)
+        result = a * b
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_mul_scalar(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return a * self.dtype(2.5)
+    def test_mul_scalar(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = a * dtype(2.5)
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_matmul(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        b = _make_for_matmul(xp, sp, self.dtype, array=True)
-        return a @ b
+    def test_matmul(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        b = _make_for_matmul(xp, sp, dtype, array=True)
+        result = a @ b
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_power_elementwise(self, xp, sp):
-        a = _make_csr_sq(xp, sp, self.dtype, array=True)
-        return a ** 2
+    def test_power_elementwise(self, xp, sp, dtype):
+        a = _make_csr_sq(xp, sp, dtype, array=True)
+        result = a ** 2
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_abs(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return abs(a)
+    def test_abs(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = abs(a)
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_transpose(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return a.T
+    def test_transpose(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = a.T
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_conj(self, xp, sp):
-        a = _make_csr(xp, sp, self.dtype, array=True)
-        return a.conj()
-
-
-class TestCsrArrayRemovedMethods:
-
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        self.arr = sparse.csr_array(
-            (cupy.array([1.0]), cupy.array([0], dtype='i'),
-             cupy.array([0, 1], dtype='i')), shape=(1, 2))
-
-    def test_no_A(self):
-        with pytest.raises(AttributeError):
-            self.arr.A
-
-    def test_no_H(self):
-        with pytest.raises(AttributeError):
-            self.arr.H
-
-    def test_no_getrow(self):
-        with pytest.raises(AttributeError):
-            self.arr.getrow(0)
-
-    def test_no_getcol(self):
-        with pytest.raises(AttributeError):
-            self.arr.getcol(0)
-
-    def test_no_getH(self):
-        with pytest.raises(AttributeError):
-            self.arr.getH()
-
-    def test_no_asfptype(self):
-        with pytest.raises(AttributeError):
-            self.arr.asfptype()
-
-    def test_no_getformat(self):
-        with pytest.raises(AttributeError):
-            self.arr.getformat()
-
-    def test_no_getmaxprint(self):
-        with pytest.raises(AttributeError):
-            self.arr.getmaxprint()
-
-    def test_no_shape_setter(self):
-        with pytest.raises(AttributeError):
-            self.arr.shape = (2, 1)
-
-    def test_has_shape(self):
-        assert self.arr.shape == (1, 2)
-
-    def test_has_nnz(self):
-        assert self.arr.nnz == 1
-
-    def test_has_format(self):
-        assert self.arr.format == 'csr'
-
-    def test_has_ndim(self):
-        assert self.arr.ndim == 2
+    def test_conj(self, xp, sp, dtype):
+        a = _make_csr(xp, sp, dtype, array=True)
+        result = a.conj()
+        assert isinstance(result, sp.sparray)
+        return result
 
 
 # Matrix-only APIs that don't exist on sparray.  In SciPy 1.14 most of
@@ -1059,44 +947,62 @@ class TestCsrArrayRemovedMethods:
 @pytest.mark.filterwarnings(
     "ignore:`spmatrix\\.(A|H)`:DeprecationWarning"
 )
-class TestCsrMatrixLegacyMethods:
+class TestLegacyApiSurfaceVia:
+    """Legacy array/matrix API surface checks using CSR as the
+    representative sparse format.
 
-    @pytest.fixture(autouse=True)
-    def setUp(self):
-        self.mat = sparse.csr_matrix(
-            (cupy.array([1.0]), cupy.array([0], dtype='i'),
-             cupy.array([0, 1], dtype='i')), shape=(1, 2))
+    Intent: validate common array-vs-matrix API contract (attribute
+    presence/absence and shape-setter behavior) without multiplying by
+    all formats.  Some legacy methods (e.g. getrow/getcol) dispatch to
+    format-specific hooks, so keeping this class CSR-focused avoids
+    mixing format-implementation tests into API-surface checks.
+    """
 
-    def test_has_A(self):
-        result = self.mat.A
-        assert isinstance(result, cupy.ndarray)
+    @pytest.fixture
+    def arr(self):
+        return _make_small_sparse('csr', array=True, shape=(1, 2))
 
-    def test_has_H(self):
-        result = self.mat.H
-        assert sparse.issparse(result)
+    @pytest.fixture
+    def mat(self):
+        return _make_small_sparse('csr', array=False, shape=(1, 2))
 
-    def test_has_getH(self):
-        result = self.mat.getH()
-        assert sparse.issparse(result)
+    @pytest.mark.parametrize(
+        'attr', ['A', 'H', 'getrow', 'getcol', 'getH', 'asfptype',
+                 'getformat', 'getmaxprint']
+    )
+    def test_array_has_no_matrix_only_api(self, arr, attr):
+        with pytest.raises(AttributeError):
+            getattr(arr, attr)
 
-    def test_has_asfptype(self):
-        result = self.mat.asfptype()
-        assert sparse.issparse(result)
+    def test_array_has_basic_surface(self, arr):
+        assert arr.shape == (1, 2)
+        assert arr.nnz == 1
+        assert arr.format == 'csr'
+        assert arr.ndim == 2
 
-    def test_has_getformat(self):
-        assert self.mat.getformat() == 'csr'
+    def test_array_has_no_shape_setter(self, arr):
+        with pytest.raises(AttributeError):
+            arr.shape = (2, 1)
 
-    def test_has_getrow(self):
-        result = self.mat.getrow(0)
-        assert sparse.issparse(result)
+    def test_matrix_A_and_H_exist(self, mat):
+        assert isinstance(mat.A, cupy.ndarray)
+        assert sparse.issparse(mat.H)
 
-    def test_has_getcol(self):
-        result = self.mat.getcol(0)
-        assert sparse.issparse(result)
+    @pytest.mark.parametrize('name,args', [
+        ('getH', ()),
+        ('asfptype', ()),
+        ('getrow', (0,)),
+        ('getcol', (0,)),
+    ])
+    def test_matrix_legacy_methods_exist(self, mat, name, args):
+        assert sparse.issparse(getattr(mat, name)(*args))
 
-    def test_has_shape_setter(self):
+    def test_matrix_getformat_exists(self, mat):
+        assert mat.getformat() == 'csr'
+
+    def test_matrix_shape_setter_exists(self, mat):
         # shape setter exists on matrices (even if reshape is no-op here)
-        self.mat.shape = (1, 2)
+        mat.shape = (1, 2)
 
 
 # Index dtype policy: arrays preserve int64, matrices may downcast
@@ -1141,51 +1047,75 @@ class TestCsrArrayIndexDtype:
         assert A.col.dtype == cupy.int64
 
 
-# CSC/COO array conversion type preservation
+# Sparse array format conversions
 
-class TestNonCsrArrayConversions:
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+class TestSparseArrayConversions:
 
-    def test_coo_array_tocsr_type(self):
-        A = sparse.coo_array(
-            (cupy.array([1.0]), (cupy.array([0], dtype='i'),
-             cupy.array([0], dtype='i'))), shape=(2, 2))
-        B = A.tocsr()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'csr'
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('src_fmt', SPARSE_FORMATS)
+    @pytest.mark.parametrize('dst_fmt', SPARSE_FORMATS)
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_conversion_values_match_scipy(
+            self, xp, sp, src_fmt, dst_fmt, dtype):
+        if dst_fmt == 'dia' and src_fmt != 'dia':
+            # CuPy does not implement non-DIA -> DIA yet.
+            pytest.skip('non-DIA -> DIA conversion is not implemented')
+        A = _make_small_sparse(
+            src_fmt, array=True, shape=(2, 2), dtype=dtype, xp=xp, spmod=sp)
+        return getattr(A, f'to{dst_fmt}')().toarray()
 
-    def test_coo_array_tocsc_type(self):
-        A = sparse.coo_array(
-            (cupy.array([1.0]), (cupy.array([0], dtype='i'),
-             cupy.array([0], dtype='i'))), shape=(2, 2))
-        B = A.tocsc()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'csc'
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('src_fmt', SPARSE_FORMATS)
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_toarray(self, xp, sp, src_fmt, dtype):
+        m = _make_small_sparse(
+            src_fmt, array=True, shape=(2, 2), dtype=dtype, xp=xp, spmod=sp)
+        return m.toarray()
 
-    def test_csc_array_tocsr_type(self):
-        data = cupy.array([1.0, 2.0], dtype='d')
-        indices = cupy.array([0, 1], dtype='i')
-        indptr = cupy.array([0, 1, 2], dtype='i')
-        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
-        B = A.tocsr()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'csr'
-
-    def test_csc_array_tocoo_type(self):
-        data = cupy.array([1.0, 2.0], dtype='d')
-        indices = cupy.array([0, 1], dtype='i')
-        indptr = cupy.array([0, 1, 2], dtype='i')
-        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
-        B = A.tocoo()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'coo'
-
-    def test_csc_array_transpose_type(self):
-        data = cupy.array([1.0, 2.0], dtype='d')
-        indices = cupy.array([0, 1], dtype='i')
-        indptr = cupy.array([0, 1, 2], dtype='i')
-        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
+    @pytest.mark.parametrize(
+        'src_fmt,expected_fmt',
+        [('csr', 'csc'),
+         ('csc', 'csr'),
+         ('coo', 'coo'),
+         # DIA has no transpose override yet; routes via tocsr() → CSC.
+         ('dia', 'csc')])
+    def test_array_transpose_type(self, src_fmt, expected_fmt, dtype):
+        A = _make_small_sparse(src_fmt, array=True, shape=(2, 2), dtype=dtype)
         AT = A.T
         assert isinstance(AT, sparse.sparray)
+        assert AT.format == expected_fmt
+
+    @pytest.mark.parametrize('src_fmt', SPARSE_FORMATS)
+    @pytest.mark.parametrize('dst_fmt', SPARSE_FORMATS)
+    def test_conversion_type_and_format(
+            self, src_fmt, dst_fmt, dtype):
+        A = _make_small_sparse(src_fmt, array=True, shape=(2, 2), dtype=dtype)
+        op = getattr(A, f'to{dst_fmt}')
+        if dst_fmt == 'dia' and src_fmt != 'dia':
+            # Non-DIA -> DIA currently routes to CSR.todia(), which is not
+            # implemented yet.
+            with pytest.raises(NotImplementedError):
+                op()
+            return
+        result = op()
+        assert isinstance(result, sparse.sparray)
+        assert result.format == dst_fmt
+        if src_fmt == dst_fmt:
+            assert result is A
+
+    @pytest.mark.parametrize('src_fmt', SPARSE_FORMATS)
+    @pytest.mark.parametrize('copy', [False, True])
+    def test_same_format_conversion_copy_semantics(
+            self, src_fmt, copy, dtype):
+        A = _make_small_sparse(src_fmt, array=True, shape=(2, 2), dtype=dtype)
+        result = getattr(A, f'to{src_fmt}')(copy=copy)
+        assert isinstance(result, sparse.sparray)
+        assert result.format == src_fmt
+        if copy:
+            assert result is not A
+        else:
+            assert result is A
 
 
 # Construction functions
@@ -1236,91 +1166,50 @@ class TestConstructionFunctions:
 
 class TestTypeAwareConstruct:
 
-    @pytest.fixture
-    def arr_pair(self):
+    def _make_pair(self, use_array):
+        cls = sparse.csr_array if use_array else sparse.csr_matrix
         d = cupy.array([[1, 0], [0, 2]], dtype='d')
-        return sparse.csr_array(d), sparse.csr_array(d)
+        return cls(d), cls(d)
 
-    @pytest.fixture
-    def mat_pair(self):
-        d = cupy.array([[1, 0], [0, 2]], dtype='d')
-        return sparse.csr_matrix(d), sparse.csr_matrix(d)
-
-    def test_hstack_arrays(self, arr_pair):
-        result = sparse.hstack(list(arr_pair))
-        assert isinstance(result, sparse.sparray)
-
-    def test_hstack_matrices(self, mat_pair):
-        result = sparse.hstack(list(mat_pair))
-        assert isinstance(result, sparse.spmatrix)
-
-    def test_vstack_arrays(self, arr_pair):
-        result = sparse.vstack(list(arr_pair))
-        assert isinstance(result, sparse.sparray)
-
-    def test_vstack_matrices(self, mat_pair):
-        result = sparse.vstack(list(mat_pair))
-        assert isinstance(result, sparse.spmatrix)
-
-    def test_kron_arrays(self, arr_pair):
-        result = sparse.kron(*arr_pair)
-        assert isinstance(result, sparse.sparray)
-
-    def test_kron_matrices(self, mat_pair):
-        result = sparse.kron(*mat_pair)
-        assert isinstance(result, sparse.spmatrix)
-
-    def test_tril_array(self, arr_pair):
-        result = sparse.tril(arr_pair[0])
-        assert isinstance(result, sparse.sparray)
-
-    def test_tril_matrix(self, mat_pair):
-        result = sparse.tril(mat_pair[0])
-        assert isinstance(result, sparse.spmatrix)
-
-    def test_triu_array(self, arr_pair):
-        result = sparse.triu(arr_pair[0])
-        assert isinstance(result, sparse.sparray)
-
-    def test_triu_matrix(self, mat_pair):
-        result = sparse.triu(mat_pair[0])
-        assert isinstance(result, sparse.spmatrix)
+    @pytest.mark.parametrize('use_array', [True, False])
+    @pytest.mark.parametrize('op_name', ['hstack', 'vstack', 'kron',
+                                         'tril', 'triu'])
+    def test_construct_type_propagation(self, use_array, op_name):
+        pair = self._make_pair(use_array)
+        expected_type = sparse.sparray if use_array else sparse.spmatrix
+        op = getattr(sparse, op_name)
+        if op_name in ('hstack', 'vstack'):
+            result = op(list(pair))
+        elif op_name == 'kron':
+            result = op(*pair)
+        else:
+            result = op(pair[0])
+        assert isinstance(result, expected_type)
 
 
 # CSC array arithmetic
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestCscArrayArithmetic:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_add(self, xp, sp):
-        data = xp.array([1, 2, 3], self.dtype)
-        indices = xp.array([0, 1, 2], 'i')
-        indptr = xp.array([0, 1, 2, 3], 'i')
-        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        return a + b
+    def test_add(self, xp, sp, dtype):
+        a = _make_csc(xp, sp, dtype, array=True)
+        result = a + a
+        assert isinstance(result, sp.sparray)
+        return result
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
-    def test_sub(self, xp, sp):
-        data = xp.array([1, 2, 3], self.dtype)
-        indices = xp.array([0, 1, 2], 'i')
-        indptr = xp.array([0, 1, 2, 3], 'i')
-        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        return (a - b).toarray()
+    def test_sub(self, xp, sp, dtype):
+        a = _make_csc(xp, sp, dtype, array=True)
+        result = a - a
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
-    def test_add_preserves_type(self):
-        data = cupy.array([1, 2, 3], numpy.float64)
-        indices = cupy.array([0, 1, 2], 'i')
-        indptr = cupy.array([0, 1, 2, 3], 'i')
-        a = sparse.csc_array((data, indices, indptr), shape=(3, 3))
-        b = sparse.csc_array((data, indices, indptr), shape=(3, 3))
-        result = a + b
-        assert isinstance(result, sparse.sparray)
+    def test_add_preserves_type(self, dtype):
+        a = _make_csc(cupy, sparse, dtype, array=True)
+        assert isinstance(a + a, sparse.sparray)
 
 
 # Cross-format multiply
@@ -1331,85 +1220,77 @@ class TestCrossFormatMultiply:
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_coo_star_coo(self, xp, sp):
         """COO * COO element-wise should work."""
-        data = xp.array([1, 2, 3], numpy.float64)
-        row = xp.array([0, 1, 2], 'i')
-        col = xp.array([0, 1, 2], 'i')
-        a = sp.coo_array((data, (row, col)), shape=(3, 3))
-        b = sp.coo_array((data, (row, col)), shape=(3, 3))
-        return (a * b).toarray()
+        a = sp.coo_array(_make_csr_sq(xp, sp, numpy.float64, array=True))
+        result = a * a
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
     def test_csc_star_csc(self, xp, sp):
         """CSC * CSC element-wise should work."""
-        data = xp.array([1, 2, 3], numpy.float64)
-        indices = xp.array([0, 1, 2], 'i')
-        indptr = xp.array([0, 1, 2, 3], 'i')
-        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
-        return (a * b).toarray()
+        a = _make_csc(xp, sp, numpy.float64, array=True)
+        result = a * a
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_csr_star_coo(self, xp, sp):
         """CSR * COO cross-format multiply should work."""
-        data = xp.array([1, 2, 3], numpy.float64)
-        indices = xp.array([0, 1, 2], 'i')
-        indptr = xp.array([0, 1, 2, 3], 'i')
-        a = sp.csr_array((data, indices, indptr), shape=(3, 3))
-        row = xp.array([0, 1, 2], 'i')
-        col = xp.array([0, 1, 2], 'i')
-        b = sp.coo_array((data, (row, col)), shape=(3, 3))
-        return (a * b).toarray()
+        a = _make_csr_sq(xp, sp, numpy.float64, array=True)
+        b = sp.coo_array(a)
+        result = a * b
+        assert isinstance(result, sp.sparray)
+        return result.toarray()
 
 
 # Reduction 1D shaping
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float64],
-}))
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
 @testing.with_requires('scipy')
 class TestArrayReductions:
 
     @testing.numpy_cupy_equal(sp_name='sp')
-    def test_sum_axis0_ndim(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_sum_axis0_ndim(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         result = m.sum(axis=0)
         return result.ndim
 
     @testing.numpy_cupy_equal(sp_name='sp')
-    def test_sum_axis1_ndim(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_sum_axis1_ndim(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         result = m.sum(axis=1)
         return result.ndim
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_sum_axis0_values(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_sum_axis0_values(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         return m.sum(axis=0)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_sum_axis1_values(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_sum_axis1_values(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         return m.sum(axis=1)
 
     @testing.numpy_cupy_allclose(sp_name='sp')
-    def test_mean_axis0(self, xp, sp):
-        m = _make_csr(xp, sp, self.dtype, array=True)
+    def test_mean_axis0(self, xp, sp, dtype):
+        m = _make_csr(xp, sp, dtype, array=True)
         return m.mean(axis=0)
 
-    def test_matrix_sum_stays_2d(self):
+    def test_matrix_sum_stays_2d(self, dtype):
         """Matrix sum(axis=0) should still be 2D."""
-        m = _make_csr(cupy, sparse, numpy.float64, array=False)
+        m = _make_csr(cupy, sparse, dtype, array=False)
         result = m.sum(axis=0)
         assert result.ndim == 2
 
-    def test_min_max_axis_returns_2d_known_gap(self):
+    def test_min_max_axis_returns_2d_known_gap(self, dtype):
         # KNOWN GAP vs scipy: scipy sparse *arrays* return 1-D from min/max
         # over an axis (shape ``(M,)``), as sum()/argmin() already do here.
         # CuPy's COO is 2-D-only, so min/max(axis=) currently returns 2-D
         # (``(1, M)`` / ``(M, 1)``) for arrays too -- an inconsistency with
         # sum/argmin.  Pinned so the divergence is tracked; tighten to 1-D
         # if/when 1-D sparse arrays land.  See ``_data.py._min_or_max_axis``.
-        a = sparse.csr_array(cupy.array([[1.0, 0.0, 2.0], [0.0, 3.0, 0.0]]))
+        a = sparse.csr_array(
+            cupy.array([[1.0, 0.0, 2.0], [0.0, 3.0, 0.0]], dtype=dtype))
         assert a.min(axis=0).shape == (1, 3)
         assert a.max(axis=1).shape == (2, 1)
         # Contrast: sum(axis=) IS 1-D for arrays (the consistent behavior).
@@ -1421,27 +1302,9 @@ class TestArrayReductions:
 class TestDiaArrayBasic:
 
     def test_construction(self):
-        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
-        offsets = cupy.array([0])
-        A = sparse.dia_array((data, offsets), shape=(3, 3))
+        A = _make_small_sparse('dia', array=True, shape=(3, 3))
         assert isinstance(A, sparse.sparray)
         assert A.format == 'dia'
-
-    def test_tocsr(self):
-        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
-        offsets = cupy.array([0])
-        A = sparse.dia_array((data, offsets), shape=(3, 3))
-        B = A.tocsr()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'csr'
-
-    def test_tocsc(self):
-        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
-        offsets = cupy.array([0])
-        A = sparse.dia_array((data, offsets), shape=(3, 3))
-        B = A.tocsc()
-        assert isinstance(B, sparse.sparray)
-        assert B.format == 'csc'
 
     @testing.with_requires('scipy')
     @testing.numpy_cupy_allclose(sp_name='sp')
@@ -1470,26 +1333,17 @@ class TestLinearOperatorFromArray:
 
 class TestSpsolveArray:
 
-    def test_spsolve_csr_array(self):
+    @pytest.mark.parametrize('use_array', [True, False])
+    def test_spsolve_csr_input(self, use_array):
         from cupyx.scipy.sparse.linalg import spsolve
         n = 8
         A_dense = cupy.zeros((n, n), dtype=numpy.float64)
         A_dense[cupy.arange(n), cupy.arange(n)] = 4
         A_dense[cupy.arange(n - 1), cupy.arange(1, n)] = 1
         A_dense[cupy.arange(1, n), cupy.arange(n - 1)] = 1
-        A = sparse.csr_array(A_dense)
+        cls = sparse.csr_array if use_array else sparse.csr_matrix
+        A = cls(A_dense)
         b = cupy.arange(1, n + 1, dtype=numpy.float64)
         x = spsolve(A, b)
-        cupy.testing.assert_allclose(A @ x, b, rtol=1e-10)
-
-    def test_spsolve_csr_matrix(self):
-        from cupyx.scipy.sparse.linalg import spsolve
-        n = 8
-        A_dense = cupy.zeros((n, n), dtype=numpy.float64)
-        A_dense[cupy.arange(n), cupy.arange(n)] = 4
-        A_dense[cupy.arange(n - 1), cupy.arange(1, n)] = 1
-        A_dense[cupy.arange(1, n), cupy.arange(n - 1)] = 1
-        M = sparse.csr_matrix(A_dense)
-        b = cupy.arange(1, n + 1, dtype=numpy.float64)
-        x = spsolve(M, b)
-        cupy.testing.assert_allclose(M * x, b, rtol=1e-10)
+        lhs = A @ x if use_array else A * x
+        cupy.testing.assert_allclose(lhs, b, rtol=1e-10)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
@@ -1,0 +1,1495 @@
+"""Tests for sparse array classes (csr_array, csc_array, coo_array, dia_array).
+"""
+from __future__ import annotations
+
+import numpy
+import pytest
+try:
+    import scipy.sparse  # noqa: F401
+except ImportError:
+    pass
+
+import cupy
+from cupy import testing
+from cupyx.scipy import sparse
+
+
+def _make_csr(xp, sp, dtype, *, array=False):
+    """3x4 CSR with 4 nonzeros."""
+    data = xp.array([0, 1, 2, 3], dtype)
+    indices = xp.array([0, 1, 3, 2], 'i')
+    indptr = xp.array([0, 2, 3, 4], 'i')
+    cls = sp.csr_array if array else sp.csr_matrix
+    return cls((data, indices, indptr), shape=(3, 4))
+
+
+def _make_csr_sq(xp, sp, dtype, *, array=False):
+    """3x3 square CSR."""
+    data = xp.array([1, 2, 3], dtype)
+    indices = xp.array([0, 1, 2], 'i')
+    indptr = xp.array([0, 1, 2, 3], 'i')
+    cls = sp.csr_array if array else sp.csr_matrix
+    return cls((data, indices, indptr), shape=(3, 3))
+
+
+def _make_csr_sq2(xp, sp, dtype, *, array=False):
+    """Another 3x3 square CSR (different values)."""
+    data = xp.array([4, 5, 6], dtype)
+    indices = xp.array([2, 0, 1], 'i')
+    indptr = xp.array([0, 1, 2, 3], 'i')
+    cls = sp.csr_array if array else sp.csr_matrix
+    return cls((data, indices, indptr), shape=(3, 3))
+
+
+def _make_for_matmul(xp, sp, dtype, *, array=False):
+    """4x3 CSR for matmul with 3x4."""
+    data = xp.array([1, 2, 3, 4, 5], dtype)
+    indices = xp.array([0, 2, 1, 0, 2], 'i')
+    indptr = xp.array([0, 1, 3, 3, 5], 'i')
+    cls = sp.csr_array if array else sp.csr_matrix
+    return cls((data, indices, indptr), shape=(4, 3))
+
+
+class TestSparseArrayTypeIdentity:
+    """issparse, isspmatrix, isinstance checks for all formats."""
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_array_issparse(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls((2, 3), dtype=numpy.float64)
+        assert sparse.issparse(A)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_array_not_isspmatrix(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls((2, 3), dtype=numpy.float64)
+        assert not sparse.isspmatrix(A)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_array_isinstance_sparray(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls((2, 3), dtype=numpy.float64)
+        assert isinstance(A, sparse.sparray)
+        assert not isinstance(A, sparse.spmatrix)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_matrix_isinstance_spmatrix(self, fmt):
+        cls = getattr(sparse, f'{fmt}_matrix')
+        M = cls((2, 3), dtype=numpy.float64)
+        assert isinstance(M, sparse.spmatrix)
+        assert not isinstance(M, sparse.sparray)
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_matrix_issparse(self, fmt):
+        cls = getattr(sparse, f'{fmt}_matrix')
+        M = cls((2, 3), dtype=numpy.float64)
+        assert sparse.issparse(M)
+        assert sparse.isspmatrix(M)
+
+    def test_dense_not_sparse(self):
+        assert not sparse.issparse(cupy.array([1, 2]))
+        assert not sparse.isspmatrix(cupy.array([1, 2]))
+
+    def test_coo_array_coords_property(self):
+        data = cupy.array([1.0, 2.0, 3.0])
+        row = cupy.array([0, 1, 2], dtype='i')
+        col = cupy.array([2, 0, 1], dtype='i')
+        A = sparse.coo_array((data, (row, col)), shape=(3, 3))
+        assert isinstance(A.coords, tuple)
+        assert len(A.coords) == 2
+        assert A.coords[0] is A.row
+        assert A.coords[1] is A.col
+
+    def test_repr_array(self):
+        A = sparse.csr_array(
+            (cupy.array([1.0, 2.0]), cupy.array([0, 1], 'i'),
+             cupy.array([0, 1, 2], 'i')), shape=(2, 2))
+        r = repr(A)
+        assert 'sparse array' in r
+        assert 'sparse matrix' not in r
+        assert 'Compressed Sparse Row' in r
+
+    def test_repr_matrix(self):
+        M = sparse.csr_matrix(
+            (cupy.array([1.0, 2.0]), cupy.array([0, 1], 'i'),
+             cupy.array([0, 1, 2], 'i')), shape=(2, 2))
+        r = repr(M)
+        assert 'sparse matrix' in r
+        assert 'sparse array' not in r
+
+    def test_mT_property(self):
+        A = sparse.csr_array(
+            (cupy.array([1.0, 2.0]), cupy.array([0, 1], 'i'),
+             cupy.array([0, 1, 2], 'i')), shape=(2, 2))
+        assert A.mT.shape == (2, 2)
+        assert isinstance(A.mT, sparse.sparray)
+
+    def test_block_array_returns_sparray(self):
+        # 2x2 grid of 2x2 identity blocks tiles into a 4x4.
+        A = sparse.csr_array(cupy.array([[1, 0], [0, 1]], dtype='d'))
+        result = sparse.block_array([[A, A], [A, A]])
+        assert isinstance(result, sparse.sparray)
+        cupy.testing.assert_array_equal(
+            result.toarray(),
+            cupy.array([[1., 0., 1., 0.],
+                        [0., 1., 0., 1.],
+                        [1., 0., 1., 0.],
+                        [0., 1., 0., 1.]]))
+
+    def test_block_diag_arrays(self):
+        A = sparse.csr_array(cupy.array([[1, 2]], dtype='d'))
+        B = sparse.csr_array(cupy.array([[3]], dtype='d'))
+        result = sparse.block_diag((A, B))
+        assert isinstance(result, sparse.sparray)
+        cupy.testing.assert_array_equal(
+            result.toarray(),
+            cupy.array([[1., 2., 0.],
+                        [0., 0., 3.]]))
+
+    def test_block_diag_matrices(self):
+        A = sparse.csr_matrix(cupy.array([[1, 2]], dtype='d'))
+        B = sparse.csr_matrix(cupy.array([[3]], dtype='d'))
+        result = sparse.block_diag((A, B))
+        assert isinstance(result, sparse.spmatrix)
+        cupy.testing.assert_array_equal(
+            result.toarray(),
+            cupy.array([[1., 2., 0.],
+                        [0., 0., 3.]]))
+
+    def test_safely_cast_index_arrays_csr(self):
+        A = sparse.csr_array(cupy.array([[1, 0], [0, 2]], dtype='d'))
+        ind, ptr = sparse.safely_cast_index_arrays(A, numpy.int32)
+        assert ind.dtype == numpy.int32
+        assert ptr.dtype == numpy.int32
+
+    def test_safely_cast_index_arrays_coo(self):
+        A = sparse.coo_array(
+            (cupy.array([1.0]), (cupy.array([0], 'i'),
+             cupy.array([0], 'i'))), shape=(2, 2))
+        row, col = sparse.safely_cast_index_arrays(A, numpy.int32)
+        assert row.dtype == numpy.int32
+        assert col.dtype == numpy.int32
+
+    def test_get_index_dtype_export(self):
+        assert sparse.get_index_dtype(maxval=10) == numpy.int32
+        assert (sparse.get_index_dtype(maxval=2**33)
+                == numpy.int64)
+
+    def test_nonzero_array(self):
+        A = sparse.csr_array(
+            cupy.array([[1.0, 2.0, 0.0], [0.0, 0.0, 3.0]]))
+        row, col = A.nonzero()
+        assert row.shape == (3,)
+        assert col.shape == (3,)
+        cupy.testing.assert_array_equal(row, cupy.array([0, 0, 1]))
+        cupy.testing.assert_array_equal(col, cupy.array([0, 1, 2]))
+
+    def test_round_array(self):
+        A = sparse.csr_array(
+            cupy.array([[1.4, 2.6, 0.0], [0.0, 0.0, 3.5]]))
+        R = round(A)
+        assert isinstance(R, sparse.sparray)
+        cupy.testing.assert_array_equal(
+            R.toarray(),
+            cupy.array([[1.0, 3.0, 0.0], [0.0, 0.0, 4.0]]))
+
+    def test_matrix_transpose_function(self):
+        dense = cupy.array([[1., 2.], [3., 4.]])
+        A = sparse.csr_array(dense)
+        T = sparse.matrix_transpose(A)
+        # csr_array.T is csc_array (same data, different format).
+        assert isinstance(T, sparse.sparray)
+        cupy.testing.assert_array_equal(T.toarray(), dense.T)
+
+    def test_swapaxes(self):
+        dense = cupy.array([[1., 2., 3.], [4., 5., 6.]])
+        A = sparse.csr_array(dense)
+        T = sparse.swapaxes(A, 0, 1)
+        assert isinstance(T, sparse.sparray)
+        cupy.testing.assert_array_equal(T.toarray(), dense.T)
+        T_neg = sparse.swapaxes(A, -2, -1)
+        cupy.testing.assert_array_equal(T_neg.toarray(), dense.T)
+        # Identity swap returns the same data.
+        T_id = sparse.swapaxes(A, 0, 0)
+        cupy.testing.assert_array_equal(T_id.toarray(), dense)
+
+    def test_permute_dims(self):
+        dense = cupy.array([[1., 2., 3.], [4., 5., 6.]])
+        A = sparse.csr_array(dense)
+        # Default reverses axes.
+        P = sparse.permute_dims(A)
+        cupy.testing.assert_array_equal(P.toarray(), dense.T)
+        # Identity preserves data.
+        P_id = sparse.permute_dims(A, (0, 1))
+        cupy.testing.assert_array_equal(P_id.toarray(), dense)
+        # Explicit reversal.
+        P_rev = sparse.permute_dims(A, (1, 0))
+        cupy.testing.assert_array_equal(P_rev.toarray(), dense.T)
+        # Bad permutation raises.
+        with pytest.raises(ValueError):
+            sparse.permute_dims(A, (0, 0))
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_array_maxprint_kwarg(self, fmt):
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls(cupy.array([[1., 2.]]), maxprint=10)
+        assert A.maxprint == 10
+        # Default
+        B = cls(cupy.array([[1., 2.]]))
+        assert B.maxprint == 50
+
+    def test_dia_array_maxprint_kwarg(self):
+        data = cupy.array([[1., 2., 3.]])
+        offsets = cupy.array([0])
+        A = sparse.dia_array((data, offsets), shape=(3, 3), maxprint=10)
+        assert A.maxprint == 10
+
+    def test_negate_bool_array_raises(self):
+        # Match scipy 1.17: NotImplementedError, not TypeError.
+        B = sparse.csr_array(
+            cupy.array([[True, False], [False, True]]))
+        with pytest.raises(NotImplementedError, match='boolean'):
+            -B
+
+    def test_bool_sparse_mask_indexing_returns_dense(self):
+        # Boolean sparse-array indexing returns a 1-D dense ndarray
+        # (matches scipy 1.17).
+        A = sparse.csr_array(
+            cupy.array([[1., 2., 0.], [0., 0., 3.]]))
+        mask = sparse.csr_array(
+            cupy.array([[True, False, True], [True, False, True]]))
+        res = A[mask]
+        assert isinstance(res, cupy.ndarray)
+        cupy.testing.assert_array_equal(
+            res, cupy.array([1., 0., 0., 3.]))
+
+    def test_csc_array_matmul_preserves_array_type(self):
+        # SciPy gh-fix: csc_array @ csc_array (or csr_array) returns
+        # csr_array, not csr_matrix.
+        A = sparse.csc_array(cupy.array([[1., 2.], [3., 4.]]))
+        B = sparse.csc_array(cupy.array([[1., 2.], [3., 4.]]))
+        assert isinstance(A @ B, sparse.sparray)
+        C = sparse.csr_array(cupy.array([[1., 2.], [3., 4.]]))
+        assert isinstance(A @ C, sparse.sparray)
+
+    def test_setitem_scalar_from_sparse_rhs(self):
+        # Assigning a 1x1 sparse RHS to a scalar position works
+        # (densifies the RHS first).  Used to crash with TypeError.
+        A = sparse.csr_array(cupy.array([[1., 2.], [3., 4.]]))
+        rhs = sparse.csr_array(cupy.array([[7.]]))
+        A[0, 0] = rhs
+        cupy.testing.assert_array_equal(
+            A.toarray(), cupy.array([[7., 2.], [3., 4.]]))
+
+    def test_get_array_module_sparray(self):
+        # cupy.get_array_module and cupyx.scipy.get_array_module recognize
+        # sparray, not just spmatrix.
+        import cupyx.scipy as cscipy
+        A = sparse.csr_array(cupy.array([[1., 2.]]))
+        M = sparse.csr_matrix(cupy.array([[1., 2.]]))
+        assert cupy.get_array_module(A) is cupy
+        assert cupy.get_array_module(M) is cupy
+        assert cscipy.get_array_module(A).__name__ == 'cupyx.scipy'
+        assert cscipy.get_array_module(M).__name__ == 'cupyx.scipy'
+
+    def test_dia_tocsc_data_wider_than_matrix(self):
+        # Regression: DIA with data buffer wider than the matrix used to
+        # raise a broadcast-shape ValueError in tocsc().
+        data = cupy.array([[1., 2., 3., 4., 5., 6.]])
+        offsets = cupy.array([0])
+        m = sparse.dia_array((data, offsets), shape=(3, 4))
+        cupy.testing.assert_array_equal(
+            m.tocsc().toarray(),
+            cupy.array([[1., 0., 0., 0.],
+                        [0., 2., 0., 0.],
+                        [0., 0., 3., 0.]]))
+
+    def test_csc_setdiag(self):
+        A = sparse.csc_matrix(cupy.zeros((3, 3)))
+        A.setdiag(cupy.array([1., 2., 3.]))
+        cupy.testing.assert_array_equal(
+            A.toarray(),
+            cupy.array([[1., 0., 0.],
+                        [0., 2., 0.],
+                        [0., 0., 3.]]))
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_setdiag_python_types(self, fmt):
+        # Regression: setdiag used to call ``values.astype(...)`` (or
+        # ``values.ndim``) directly on the input, raising AttributeError
+        # for Python lists / scalars.  scipy's ``_spbase.setdiag`` does
+        # ``np.asarray(values)`` first; cupy now mirrors that.
+        cls = getattr(sparse, f'{fmt}_array')
+        expected = cupy.array([[10., 2., 3.],
+                               [4., 20., 6.],
+                               [7., 8., 9.]])
+        for arg in ([10., 20.], (10., 20.), numpy.array([10., 20.])):
+            A = cls(cupy.array([[1., 2., 3.],
+                                [4., 5., 6.],
+                                [7., 8., 9.]]))
+            A.setdiag(arg)
+            cupy.testing.assert_array_equal(A.toarray(), expected)
+        # Scalar broadcasts to whole diagonal.
+        A = cls(cupy.array([[1., 2., 3.],
+                            [4., 5., 6.],
+                            [7., 8., 9.]]))
+        A.setdiag(99.0)
+        cupy.testing.assert_array_equal(
+            A.toarray(),
+            cupy.array([[99., 2., 3.],
+                        [4., 99., 6.],
+                        [7., 8., 99.]]))
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_inplace_scalar_preserves_identity(self, fmt):
+        # ``A *= 2`` and ``A /= 2`` must mutate ``self.data`` in place
+        # so the bound name still refers to the same object (matches
+        # scipy's ``_data._data_matrix.__imul__``).  Without these
+        # specials, ``A *= 2`` rebinds via ``A = A * 2`` and silently
+        # allocates a new sparse matrix every time.
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls(cupy.array([[1., 2.], [3., 4.]]))
+        old = A
+        old_data_id = id(A.data)
+        A *= 2
+        assert A is old
+        assert id(A.data) == old_data_id
+        cupy.testing.assert_array_equal(
+            A.toarray(), cupy.array([[2., 4.], [6., 8.]]))
+        A /= 2
+        assert A is old
+        cupy.testing.assert_array_equal(
+            A.toarray(), cupy.array([[1., 2.], [3., 4.]]))
+
+    def test_inplace_scalar_promotes_dtype(self):
+        # ``bool *= int`` violates numpy's same_kind cast rule and would
+        # raise; CuPy intentionally diverges from scipy here (which
+        # raises ``UFuncTypeError``) and reassigns ``self.data`` to a
+        # cuSPARSE-supported dtype.  Object identity of ``self`` is
+        # preserved; identity of ``self.data`` is not.
+        A = sparse.csr_array(
+            cupy.array([[True, False], [False, True]]))
+        old = A
+        old_data_id = id(A.data)
+        A *= 2
+        assert A is old
+        assert A.dtype == cupy.float64
+        assert id(A.data) != old_data_id
+        cupy.testing.assert_array_equal(
+            A.toarray(), cupy.array([[2., 0.], [0., 2.]]))
+
+    def test_inplace_scalar_dia(self):
+        # DIA only accepts the ``(data, offsets)`` tuple constructor
+        # (C2 pre-existing limitation), so it gets its own test.
+        data = cupy.array([[1., 2., 3.]])
+        offsets = cupy.array([0])
+        A = sparse.dia_array((data, offsets), shape=(3, 3))
+        old = A
+        A *= 2
+        assert A is old
+        cupy.testing.assert_array_equal(
+            A.toarray(),
+            cupy.array([[2., 0., 0.], [0., 4., 0.], [0., 0., 6.]]))
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_setdiag_does_not_mutate_input(self, fmt):
+        # Regression: CSR setdiag used ``x_data -= self.diagonal(k)``
+        # in place.  Now that input is coerced via ``cupy.asarray``
+        # (no copy when dtype matches), the in-place subtraction would
+        # mutate the caller's array -- switched to out-of-place ``-``.
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls(cupy.array([[1., 2., 3.],
+                            [4., 5., 6.],
+                            [7., 8., 9.]]))
+        v = cupy.array([10., 20., 30.])
+        v_orig = v.copy()
+        A.setdiag(v)
+        cupy.testing.assert_array_equal(v, v_orig)
+
+    def test_prune_csr(self):
+        # ``prune()`` trims data/indices to ``indptr[-1]``.  The only
+        # way to construct slack today is direct attribute mutation
+        # (internal helpers always produce tight buffers); that path
+        # is what ``prune()`` is for.
+        A = sparse.csr_array(
+            (cupy.array([1.0, 2.0, 3.0]),
+             cupy.array([0, 1, 2], dtype='i'),
+             cupy.array([0, 1, 2, 3], dtype='i')),
+            shape=(3, 3))
+        A.data = cupy.concatenate([A.data, cupy.array([99.0, 99.0])])
+        A.indices = cupy.concatenate(
+            [A.indices, cupy.array([99, 99], dtype='i')])
+        assert A.data.shape == (5,)  # buffer has slack
+        A.prune()
+        assert A.data.shape == (3,)
+        assert A.indices.shape == (3,)
+        cupy.testing.assert_array_equal(A.data, cupy.array([1.0, 2.0, 3.0]))
+        cupy.testing.assert_array_equal(A.indices, cupy.array([0, 1, 2]))
+
+    def test_astype_copy_param(self):
+        A = sparse.csr_array(cupy.array([[1., 2.]]))
+        # No-op when dtype matches and copy=False
+        B = A.astype(cupy.float64, copy=False)
+        assert B is A
+        # New object when copy=True
+        C = A.astype(cupy.float64, copy=True)
+        assert C is not A
+        # Different dtype always returns new object
+        D = A.astype(cupy.float32)
+        assert D.dtype == cupy.float32
+        assert D is not A
+
+    def test_dia_todia_returns_self(self):
+        # DIA todia() previously hit ``_csr_base.todia`` which is
+        # ``raise NotImplementedError``.  ``_dia_base.todia`` overrides
+        # to return ``self`` (or a copy), avoiding the round-trip.
+        data = cupy.array([[1., 2., 3.]])
+        offsets = cupy.array([0])
+        m = sparse.dia_array((data, offsets), shape=(3, 3))
+        assert m.todia() is m
+        # copy=True returns a new object
+        n = m.todia(copy=True)
+        assert n is not m
+        cupy.testing.assert_array_equal(n.toarray(), m.toarray())
+
+    def test_block_diag_int_dense(self):
+        # block_diag with integer-typed Python list/scalar/tuple input
+        # used to fail because cuSPARSE rejects the int dtype; now we
+        # promote to float64 first.
+        res = sparse.block_diag([[[1, 2], [3, 4]], [[5]]])
+        cupy.testing.assert_array_equal(
+            res.toarray(),
+            cupy.array([[1., 2., 0.],
+                        [3., 4., 0.],
+                        [0., 0., 5.]]))
+
+    def test_block_diag_tuple_input(self):
+        res = sparse.block_diag([(1, 2), [[3]]])
+        cupy.testing.assert_array_equal(
+            res.toarray(),
+            cupy.array([[1., 2., 0.],
+                        [0., 0., 3.]]))
+
+    def test_block_diag_scalars(self):
+        res = sparse.block_diag([1.0, 2.0, 3.0])
+        cupy.testing.assert_array_equal(
+            res.toarray(),
+            cupy.array([[1., 0., 0.],
+                        [0., 2., 0.],
+                        [0., 0., 3.]]))
+
+    def test_count_nonzero_csr_axis(self):
+        # CSR/CSC count_nonzero(axis=...) uses the bincount fast path
+        # (no tocoo round-trip).  Result matches per-row / per-col
+        # counts of the dense form.
+        A = sparse.csr_array(
+            cupy.array([[1., 0., 2., 0.],
+                        [0., 0., 0., 3.],
+                        [4., 5., 0., 6.]]))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=0), cupy.array([2, 1, 1, 2]))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=1), cupy.array([2, 1, 3]))
+        # Dedupes first: stored zero excluded.
+        data = cupy.array([1.0, 2.0, 0.0, 3.0])
+        ind = cupy.array([0, 1, 2, 0], dtype='i')
+        ptr = cupy.array([0, 1, 3, 4], dtype='i')
+        B = sparse.csr_array._from_parts(data, ind, ptr, (3, 3))
+        assert B.count_nonzero() == 3  # explicit zero excluded
+
+    def test_count_nonzero_coo_axis(self):
+        A = sparse.coo_array(
+            cupy.array([[1., 0., 2.],
+                        [0., 3., 0.]]))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=0), cupy.array([1, 1, 1]))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=1), cupy.array([2, 1]))
+
+    def test_count_nonzero_dia_axis_raises(self):
+        # DIA axis-aware count_nonzero matches scipy: NotImplementedError.
+        # Users can convert to CSR/CSC for per-axis counts.
+        m = sparse.dia_array(
+            (cupy.array([[1., 2., 3.]]), cupy.array([0])),
+            shape=(3, 3))
+        assert m.count_nonzero() == 3
+        with pytest.raises(NotImplementedError):
+            m.count_nonzero(axis=0)
+
+    def test_count_nonzero_dia_data_wider_than_matrix(self):
+        # When ``data`` is wider than the matrix, the pad columns lie
+        # outside the matrix and must be excluded -- matching scipy.
+        m = sparse.dia_array(
+            (cupy.array([[1., 2., 3., 4., 5., 6.]]),
+             cupy.array([0])),
+            shape=(3, 4))
+        # Only data[0:3] correspond to in-matrix positions (0,0), (1,1),
+        # (2,2); the pad columns 3..5 are outside the (3, 4) matrix.
+        assert m.count_nonzero() == 3
+
+    def test_count_nonzero_dia_excludes_explicit_zero(self):
+        # Explicit zero in the diagonal data is excluded.
+        m = sparse.dia_array(
+            (cupy.array([[0., 1., 2.]]), cupy.array([0])),
+            shape=(3, 3))
+        assert m.count_nonzero() == 2  # the 0 at (0, 0) doesn't count
+        assert m.nnz == 3                # but it is stored
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_count_nonzero_axis_empty(self, fmt):
+        # Regression: ``count_nonzero(axis=)`` on an empty sparse object
+        # used to crash because ``cupy.bincount`` errors on zero-size
+        # input even with ``minlength``.  scipy returns the zero-filled
+        # axis vector.
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls((3, 5))
+        assert A.count_nonzero() == 0
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=0), cupy.zeros(5, dtype=cupy.intp))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=1), cupy.zeros(3, dtype=cupy.intp))
+        # Negative axes work the same.
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=-1), cupy.zeros(3, dtype=cupy.intp))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=-2), cupy.zeros(5, dtype=cupy.intp))
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_count_nonzero_axis_all_explicit_zero(self, fmt):
+        # When every stored value is an explicit zero, the
+        # bincount-on-mask path also produces a zero-size input that
+        # would otherwise crash.
+        cls = getattr(sparse, f'{fmt}_array')
+        A = cls(cupy.zeros((2, 3)) + 0.0)
+        # Stored explicit zeros: build via _from_parts to keep them.
+        if fmt == 'csr':
+            A = sparse.csr_array._from_parts(
+                cupy.zeros(3), cupy.array([0, 1, 2], 'i'),
+                cupy.array([0, 2, 3], 'i'), (2, 3))
+        elif fmt == 'csc':
+            A = sparse.csc_array._from_parts(
+                cupy.zeros(3), cupy.array([0, 1, 0], 'i'),
+                cupy.array([0, 1, 2, 3], 'i'), (2, 3))
+        else:
+            A = sparse.coo_array._from_parts(
+                cupy.zeros(3),
+                cupy.array([0, 0, 1], 'i'),
+                cupy.array([0, 1, 2], 'i'),
+                (2, 3))
+        assert A.count_nonzero() == 0
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=0), cupy.zeros(3, dtype=cupy.intp))
+        cupy.testing.assert_array_equal(
+            A.count_nonzero(axis=1), cupy.zeros(2, dtype=cupy.intp))
+
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_type_system_matches_scipy(self, fmt):
+        """CuPy and SciPy type predicates should agree."""
+        sp_arr_cls = getattr(scipy.sparse, f'{fmt}_array')
+        sp_mat_cls = getattr(scipy.sparse, f'{fmt}_matrix')
+        cp_arr_cls = getattr(sparse, f'{fmt}_array')
+        cp_mat_cls = getattr(sparse, f'{fmt}_matrix')
+
+        sp_a = sp_arr_cls((2, 3))
+        sp_m = sp_mat_cls((2, 3))
+        cp_a = cp_arr_cls((2, 3))
+        cp_m = cp_mat_cls((2, 3))
+
+        assert sparse.issparse(cp_a) == scipy.sparse.issparse(sp_a)
+        assert sparse.issparse(cp_m) == scipy.sparse.issparse(sp_m)
+        assert sparse.isspmatrix(cp_a) == scipy.sparse.isspmatrix(sp_a)
+        assert sparse.isspmatrix(cp_m) == scipy.sparse.isspmatrix(sp_m)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayConstruction:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_from_data_indices_indptr(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        assert m.format == 'csr'
+        assert isinstance(m, sp.sparray)
+        return m
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_from_dense(self, xp, sp):
+        dense = xp.array([[1, 0, 2], [0, 3, 0]], dtype=self.dtype)
+        m = sp.csr_array(dense)
+        assert isinstance(m, sp.sparray)
+        return m
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_from_coo_tuple(self, xp, sp):
+        data = xp.array([1, 2, 3], self.dtype)
+        row = xp.array([0, 1, 2], 'i')
+        col = xp.array([2, 0, 1], 'i')
+        m = sp.csr_array((data, (row, col)), shape=(3, 3))
+        assert isinstance(m, sp.sparray)
+        return m
+
+    def test_empty(self):
+        m = sparse.csr_array((3, 4), dtype=numpy.float64)
+        assert m.shape == (3, 4)
+        assert m.nnz == 0
+        assert isinstance(m, sparse.sparray)
+
+    def test_from_coo_tuple_preserves_int64_indices(self):
+        # Regression: csr_array((data, (row, col))) used to construct
+        # an intermediate ``coo_matrix`` (not ``coo_array``), which ran
+        # ``_get_index_dtype(check_contents=True)`` and silently
+        # downcast int64 row/col arrays to int32.  Now uses
+        # ``self._coo_container`` so the sparse-array dtype-preservation
+        # promise is honored.
+        data = cupy.array([1.0, 2.0], dtype=self.dtype)
+        row = cupy.array([0, 1], dtype=cupy.int64)
+        col = cupy.array([0, 1], dtype=cupy.int64)
+        m = sparse.csr_array((data, (row, col)), shape=(3, 3))
+        assert m.indices.dtype == cupy.int64
+        assert m.indptr.dtype == cupy.int64
+        # csc_array path is symmetric.
+        m = sparse.csc_array((data, (row, col)), shape=(3, 3))
+        assert m.indices.dtype == cupy.int64
+        assert m.indptr.dtype == cupy.int64
+        # Matrix variant should still downcast (matches scipy convention).
+        m = sparse.csr_matrix((data, (row, col)), shape=(3, 3))
+        assert m.indices.dtype == cupy.int32
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayStarIsElementwise:
+    """Verify that * is element-wise for csr_array (matching scipy.sparse)."""
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_star_sparse(self, xp, sp):
+        """array * array should be element-wise."""
+        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        b = _make_csr_sq(xp, sp, self.dtype, array=True)
+        return a * b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_star_scalar(self, xp, sp):
+        """array * scalar should be scalar multiplication."""
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return a * self.dtype(2.0)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_rstar_scalar(self, xp, sp):
+        """scalar * array should be scalar multiplication."""
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return self.dtype(3.0) * a
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayMatmul:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_matmul_sparse(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        b = _make_for_matmul(xp, sp, self.dtype, array=True)
+        return a @ b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_matmul_dense_vector(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        x = xp.arange(4).astype(self.dtype)
+        return a @ x
+
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_matmul_dense_matrix(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        x = xp.arange(8).reshape(4, 2).astype(self.dtype)
+        return a @ x
+
+    def test_matmul_scalar_raises(self):
+        a = _make_csr_sq(cupy, sparse, numpy.float64, array=True)
+        with pytest.raises(ValueError):
+            a @ 5.0
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayPower:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_power_elementwise(self, xp, sp):
+        """array ** n should be element-wise, not matrix power."""
+        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        return a ** 2
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_power_matches_dense(self, xp, sp):
+        """Verify ** gives same result as dense element-wise power."""
+        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        result_sparse = (a ** 2).toarray()
+        result_dense = a.toarray() ** 2
+        xp.testing.assert_allclose(result_sparse, result_dense)
+        return result_sparse
+
+    def test_power_zero_raises(self):
+        """Array ** 0 raises NotImplementedError (would densify)."""
+        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        with pytest.raises(NotImplementedError):
+            a ** 0
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCsrMatrixStarIsMatmul:
+    """Verify that * is still matmul for csr_matrix (unchanged)."""
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_star_matmul(self, xp, sp):
+        """matrix * matrix should be matmul."""
+        a = _make_csr(xp, sp, self.dtype)
+        b = _make_for_matmul(xp, sp, self.dtype)
+        return a * b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_star_scalar(self, xp, sp):
+        """matrix * scalar should still work."""
+        a = _make_csr(xp, sp, self.dtype)
+        return a * self.dtype(2.0)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_pow_matrix_power(self, xp, sp):
+        """matrix ** n should be matrix power."""
+        a = _make_csr_sq(xp, sp, self.dtype)
+        return a ** 2
+
+
+class TestCsrArrayTypePreservation:
+    """Operations on csr_array should return csr_array (not csr_matrix)."""
+
+    dtype = numpy.float64
+
+    def _check_array(self, result):
+        assert isinstance(result, sparse.sparray), (
+            f'Expected sparray, got {type(result).__name__}')
+        assert not isinstance(result, sparse.spmatrix)
+
+    def test_star(self):
+        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        b = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        self._check_array(a * b)
+
+    def test_matmul(self):
+        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        b = _make_csr_sq2(cupy, sparse, self.dtype, array=True)
+        self._check_array(a @ b)
+
+    def test_add(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        b = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(a + b)
+
+    def test_sub(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        b = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(a - b)
+
+    def test_neg(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(-a)
+
+    def test_scalar_mul(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(a * self.dtype(2.0))
+
+    def test_pow(self):
+        a = _make_csr_sq(cupy, sparse, self.dtype, array=True)
+        self._check_array(a ** 2)
+
+    def test_copy(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(a.copy())
+
+    def test_abs(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        self._check_array(abs(a))
+
+    def test_T(self):
+        a = _make_csr(cupy, sparse, self.dtype, array=True)
+        result = a.T
+        assert isinstance(result, sparse.sparray)
+
+
+class TestMultiplyMixedSparrayMatrix:
+    """Cross-type element-wise multiply preserves the caller's type.
+
+    ``multiply_by_csr`` swaps operands for performance when
+    ``a.nnz > b.nnz``; before the ``out_cls`` parameter was added it
+    would derive the result class from the post-swap first arg, which
+    leaked the other operand's type into the result.
+    """
+
+    @pytest.fixture
+    def dense_pair(self):
+        hi_nnz = cupy.array([[1., 1., 1.],
+                             [0., 1., 1.],
+                             [0., 0., 1.]])
+        lo_nnz = cupy.array([[1., 0., 0.],
+                             [0., 1., 0.],
+                             [0., 0., 1.]])
+        return hi_nnz, lo_nnz
+
+    def test_array_times_matrix_when_array_has_more_nnz(self, dense_pair):
+        hi, lo = dense_pair
+        A = sparse.csr_array(hi)  # 6 nnz
+        M = sparse.csr_matrix(lo)  # 3 nnz -- swap fires
+        result = A.multiply(M)
+        assert isinstance(result, sparse.sparray)
+        assert not isinstance(result, sparse.spmatrix)
+        cupy.testing.assert_array_equal(result.toarray(), hi * lo)
+
+    def test_matrix_times_array_when_matrix_has_more_nnz(self, dense_pair):
+        hi, lo = dense_pair
+        M = sparse.csr_matrix(hi)  # 6 nnz
+        A = sparse.csr_array(lo)  # 3 nnz -- swap fires
+        result = M.multiply(A)
+        assert isinstance(result, sparse.spmatrix)
+        assert not isinstance(result, sparse.sparray)
+        cupy.testing.assert_array_equal(result.toarray(), hi * lo)
+
+    def test_array_times_matrix_no_swap(self, dense_pair):
+        hi, lo = dense_pair
+        A = sparse.csr_array(lo)  # 3 nnz -- no swap
+        M = sparse.csr_matrix(hi)  # 6 nnz
+        result = A.multiply(M)
+        assert isinstance(result, sparse.sparray)
+        cupy.testing.assert_array_equal(result.toarray(), hi * lo)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayConversions:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_tocsc(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        result = m.tocsc()
+        assert isinstance(result, sp.sparray)
+        assert result.format == 'csc'
+        return result
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_tocoo(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        result = m.tocoo()
+        assert isinstance(result, sp.sparray)
+        assert result.format == 'coo'
+        return result
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        return m.toarray()
+
+    def test_tocsr_returns_self(self):
+        m = _make_csr(cupy, sparse, numpy.float64, array=True)
+        assert m.tocsr() is m
+
+    def test_tocsr_copy(self):
+        m = _make_csr(cupy, sparse, numpy.float64, array=True)
+        n = m.tocsr(copy=True)
+        assert n is not m
+        assert isinstance(n, sparse.sparray)
+
+
+@testing.with_requires('scipy')
+class TestCsrArrayGet:
+
+    def test_array_get_returns_scipy_array(self):
+        m = _make_csr(cupy, sparse, numpy.float64, array=True)
+        sp_m = m.get()
+        assert isinstance(sp_m, scipy.sparse.csr_array)
+        assert isinstance(sp_m, scipy.sparse.sparray)
+
+    def test_matrix_get_returns_scipy_matrix(self):
+        m = _make_csr(cupy, sparse, numpy.float64, array=False)
+        sp_m = m.get()
+        assert isinstance(sp_m, scipy.sparse.csr_matrix)
+        assert isinstance(sp_m, scipy.sparse.spmatrix)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_array_get_values(self, xp, sp):
+        m = _make_csr(xp, sp, numpy.float64, array=True)
+        return m.toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
+}))
+@testing.with_requires('scipy')
+class TestCsrArrayArithmeticSciPyComparison:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_add(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        b = _make_csr(xp, sp, self.dtype, array=True)
+        return a + b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sub(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        b = _make_csr(xp, sp, self.dtype, array=True)
+        return (a - b).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_neg(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return (-a).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mul_elementwise(self, xp, sp):
+        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        b = _make_csr_sq(xp, sp, self.dtype, array=True)
+        return a * b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mul_scalar(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return a * self.dtype(2.5)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_matmul(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        b = _make_for_matmul(xp, sp, self.dtype, array=True)
+        return a @ b
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_power_elementwise(self, xp, sp):
+        a = _make_csr_sq(xp, sp, self.dtype, array=True)
+        return a ** 2
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_abs(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return abs(a)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_transpose(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return a.T
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_conj(self, xp, sp):
+        a = _make_csr(xp, sp, self.dtype, array=True)
+        return a.conj()
+
+
+class TestCsrArrayRemovedMethods:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.arr = sparse.csr_array(
+            (cupy.array([1.0]), cupy.array([0], dtype='i'),
+             cupy.array([0, 1], dtype='i')), shape=(1, 2))
+
+    def test_no_A(self):
+        with pytest.raises(AttributeError):
+            self.arr.A
+
+    def test_no_H(self):
+        with pytest.raises(AttributeError):
+            self.arr.H
+
+    def test_no_getrow(self):
+        with pytest.raises(AttributeError):
+            self.arr.getrow(0)
+
+    def test_no_getcol(self):
+        with pytest.raises(AttributeError):
+            self.arr.getcol(0)
+
+    def test_no_getH(self):
+        with pytest.raises(AttributeError):
+            self.arr.getH()
+
+    def test_no_asfptype(self):
+        with pytest.raises(AttributeError):
+            self.arr.asfptype()
+
+    def test_no_getformat(self):
+        with pytest.raises(AttributeError):
+            self.arr.getformat()
+
+    def test_no_getmaxprint(self):
+        with pytest.raises(AttributeError):
+            self.arr.getmaxprint()
+
+    def test_no_shape_setter(self):
+        with pytest.raises(AttributeError):
+            self.arr.shape = (2, 1)
+
+    def test_has_shape(self):
+        assert self.arr.shape == (1, 2)
+
+    def test_has_nnz(self):
+        assert self.arr.nnz == 1
+
+    def test_has_format(self):
+        assert self.arr.format == 'csr'
+
+    def test_has_ndim(self):
+        assert self.arr.ndim == 2
+
+
+# Matrix-only APIs that don't exist on sparray.  In SciPy 1.14 most of
+# these were deprecated; SciPy 1.17 un-deprecated everything except
+# ``A`` and ``H`` (those still emit DeprecationWarning on CuPy until
+# users have a release cycle to migrate).  The ``A`` / ``H``
+# DeprecationWarnings are silenced here; warning behaviour itself is
+# exercised by ``test_base.py::TestDeprecatedSpmatrixApi``.
+@pytest.mark.filterwarnings(
+    "ignore:`spmatrix\\.(A|H)`:DeprecationWarning"
+)
+class TestCsrMatrixLegacyMethods:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.mat = sparse.csr_matrix(
+            (cupy.array([1.0]), cupy.array([0], dtype='i'),
+             cupy.array([0, 1], dtype='i')), shape=(1, 2))
+
+    def test_has_A(self):
+        result = self.mat.A
+        assert isinstance(result, cupy.ndarray)
+
+    def test_has_H(self):
+        result = self.mat.H
+        assert sparse.issparse(result)
+
+    def test_has_getH(self):
+        result = self.mat.getH()
+        assert sparse.issparse(result)
+
+    def test_has_asfptype(self):
+        result = self.mat.asfptype()
+        assert sparse.issparse(result)
+
+    def test_has_getformat(self):
+        assert self.mat.getformat() == 'csr'
+
+    def test_has_getrow(self):
+        result = self.mat.getrow(0)
+        assert sparse.issparse(result)
+
+    def test_has_getcol(self):
+        result = self.mat.getcol(0)
+        assert sparse.issparse(result)
+
+    def test_has_shape_setter(self):
+        # shape setter exists on matrices (even if reshape is no-op here)
+        self.mat.shape = (1, 2)
+
+
+# Index dtype policy: arrays preserve int64, matrices may downcast
+
+@testing.with_requires('scipy')
+class TestCsrArrayIndexDtype:
+
+    def test_array_preserves_int64(self):
+        data = cupy.array([1.0, 2.0, 3.0])
+        indices = cupy.array([0, 1, 2], dtype=cupy.int64)
+        indptr = cupy.array([0, 1, 2, 3], dtype=cupy.int64)
+        A = sparse.csr_array((data, indices, indptr), shape=(3, 3))
+        assert A.indices.dtype == cupy.int64
+        assert A.indptr.dtype == cupy.int64
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_array_int64_matches_scipy(self, xp, sp):
+        data = xp.array([1.0, 2.0, 3.0])
+        indices = xp.array([0, 1, 2], dtype='int64')
+        indptr = xp.array([0, 1, 2, 3], dtype='int64')
+        A = sp.csr_array((data, indices, indptr), shape=(3, 3))
+        return A.indices.dtype == 'int64'
+
+    def test_matrix_downcasts_int64_when_values_fit(self):
+        # Matrix path keeps the legacy policy: ``check_contents=True``
+        # downcasts int64 index buffers to int32 when every value fits
+        # in int32 (the array path preserves int64 unconditionally;
+        # see ``test_array_preserves_int64`` above).
+        data = cupy.array([1.0, 2.0, 3.0])
+        indices = cupy.array([0, 1, 2], dtype=cupy.int64)
+        indptr = cupy.array([0, 1, 2, 3], dtype=cupy.int64)
+        M = sparse.csr_matrix((data, indices, indptr), shape=(3, 3))
+        assert M.indices.dtype == cupy.int32
+        assert M.indptr.dtype == cupy.int32
+
+    def test_coo_array_preserves_int64(self):
+        data = cupy.array([1.0, 2.0, 3.0])
+        row = cupy.array([0, 1, 2], dtype=cupy.int64)
+        col = cupy.array([0, 1, 2], dtype=cupy.int64)
+        A = sparse.coo_array((data, (row, col)), shape=(3, 3))
+        assert A.row.dtype == cupy.int64
+        assert A.col.dtype == cupy.int64
+
+
+# CSC/COO array conversion type preservation
+
+class TestNonCsrArrayConversions:
+
+    def test_coo_array_tocsr_type(self):
+        A = sparse.coo_array(
+            (cupy.array([1.0]), (cupy.array([0], dtype='i'),
+             cupy.array([0], dtype='i'))), shape=(2, 2))
+        B = A.tocsr()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'csr'
+
+    def test_coo_array_tocsc_type(self):
+        A = sparse.coo_array(
+            (cupy.array([1.0]), (cupy.array([0], dtype='i'),
+             cupy.array([0], dtype='i'))), shape=(2, 2))
+        B = A.tocsc()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'csc'
+
+    def test_csc_array_tocsr_type(self):
+        data = cupy.array([1.0, 2.0], dtype='d')
+        indices = cupy.array([0, 1], dtype='i')
+        indptr = cupy.array([0, 1, 2], dtype='i')
+        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
+        B = A.tocsr()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'csr'
+
+    def test_csc_array_tocoo_type(self):
+        data = cupy.array([1.0, 2.0], dtype='d')
+        indices = cupy.array([0, 1], dtype='i')
+        indptr = cupy.array([0, 1, 2], dtype='i')
+        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
+        B = A.tocoo()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'coo'
+
+    def test_csc_array_transpose_type(self):
+        data = cupy.array([1.0, 2.0], dtype='d')
+        indices = cupy.array([0, 1], dtype='i')
+        indptr = cupy.array([0, 1, 2], dtype='i')
+        A = sparse.csc_array((data, indices, indptr), shape=(2, 2))
+        AT = A.T
+        assert isinstance(AT, sparse.sparray)
+
+
+# Construction functions
+
+class TestConstructionFunctions:
+
+    def test_eye_array_exists(self):
+        A = sparse.eye_array(3)
+        assert isinstance(A, sparse.sparray)
+        assert A.shape == (3, 3)
+
+    @testing.with_requires('scipy')
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_eye_array_values(self, xp, sp):
+        return sp.eye_array(4, k=1, dtype='d').toarray()
+
+    def test_eye_array_format(self):
+        A = sparse.eye_array(3, format='csc')
+        assert isinstance(A, sparse.sparray)
+        assert A.format == 'csc'
+
+    def test_diags_array(self):
+        A = sparse.diags_array([1, 2, 3])
+        assert isinstance(A, sparse.sparray)
+        assert A.shape == (3, 3)
+
+    @testing.with_requires('scipy')
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_diags_array_values(self, xp, sp):
+        # Use explicit float dtype to sidestep the SciPy 1.17 FutureWarning
+        # for integer-input ``diags_array`` calls (will become an error in
+        # SciPy 1.19).  CuPy's ``diags_array`` already requires a float
+        # storage dtype.
+        return sp.diags_array([1, 2, 3], offsets=0, dtype=float).toarray()
+
+    def test_random_array(self):
+        A = sparse.random_array((10, 10), density=0.5)
+        assert isinstance(A, sparse.sparray)
+        assert A.shape == (10, 10)
+
+    def test_random_array_format(self):
+        A = sparse.random_array((5, 5), format='csr')
+        assert isinstance(A, sparse.sparray)
+        assert A.format == 'csr'
+
+
+# Type-aware construction: kron, hstack, vstack, tril, triu
+
+class TestTypeAwareConstruct:
+
+    @pytest.fixture
+    def arr_pair(self):
+        d = cupy.array([[1, 0], [0, 2]], dtype='d')
+        return sparse.csr_array(d), sparse.csr_array(d)
+
+    @pytest.fixture
+    def mat_pair(self):
+        d = cupy.array([[1, 0], [0, 2]], dtype='d')
+        return sparse.csr_matrix(d), sparse.csr_matrix(d)
+
+    def test_hstack_arrays(self, arr_pair):
+        result = sparse.hstack(list(arr_pair))
+        assert isinstance(result, sparse.sparray)
+
+    def test_hstack_matrices(self, mat_pair):
+        result = sparse.hstack(list(mat_pair))
+        assert isinstance(result, sparse.spmatrix)
+
+    def test_vstack_arrays(self, arr_pair):
+        result = sparse.vstack(list(arr_pair))
+        assert isinstance(result, sparse.sparray)
+
+    def test_vstack_matrices(self, mat_pair):
+        result = sparse.vstack(list(mat_pair))
+        assert isinstance(result, sparse.spmatrix)
+
+    def test_kron_arrays(self, arr_pair):
+        result = sparse.kron(*arr_pair)
+        assert isinstance(result, sparse.sparray)
+
+    def test_kron_matrices(self, mat_pair):
+        result = sparse.kron(*mat_pair)
+        assert isinstance(result, sparse.spmatrix)
+
+    def test_tril_array(self, arr_pair):
+        result = sparse.tril(arr_pair[0])
+        assert isinstance(result, sparse.sparray)
+
+    def test_tril_matrix(self, mat_pair):
+        result = sparse.tril(mat_pair[0])
+        assert isinstance(result, sparse.spmatrix)
+
+    def test_triu_array(self, arr_pair):
+        result = sparse.triu(arr_pair[0])
+        assert isinstance(result, sparse.sparray)
+
+    def test_triu_matrix(self, mat_pair):
+        result = sparse.triu(mat_pair[0])
+        assert isinstance(result, sparse.spmatrix)
+
+
+# CSC array arithmetic
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestCscArrayArithmetic:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_add(self, xp, sp):
+        data = xp.array([1, 2, 3], self.dtype)
+        indices = xp.array([0, 1, 2], 'i')
+        indptr = xp.array([0, 1, 2, 3], 'i')
+        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        return a + b
+
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_sub(self, xp, sp):
+        data = xp.array([1, 2, 3], self.dtype)
+        indices = xp.array([0, 1, 2], 'i')
+        indptr = xp.array([0, 1, 2, 3], 'i')
+        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        return (a - b).toarray()
+
+    def test_add_preserves_type(self):
+        data = cupy.array([1, 2, 3], numpy.float64)
+        indices = cupy.array([0, 1, 2], 'i')
+        indptr = cupy.array([0, 1, 2, 3], 'i')
+        a = sparse.csc_array((data, indices, indptr), shape=(3, 3))
+        b = sparse.csc_array((data, indices, indptr), shape=(3, 3))
+        result = a + b
+        assert isinstance(result, sparse.sparray)
+
+
+# Cross-format multiply
+
+@testing.with_requires('scipy')
+class TestCrossFormatMultiply:
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_coo_star_coo(self, xp, sp):
+        """COO * COO element-wise should work."""
+        data = xp.array([1, 2, 3], numpy.float64)
+        row = xp.array([0, 1, 2], 'i')
+        col = xp.array([0, 1, 2], 'i')
+        a = sp.coo_array((data, (row, col)), shape=(3, 3))
+        b = sp.coo_array((data, (row, col)), shape=(3, 3))
+        return (a * b).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_csc_star_csc(self, xp, sp):
+        """CSC * CSC element-wise should work."""
+        data = xp.array([1, 2, 3], numpy.float64)
+        indices = xp.array([0, 1, 2], 'i')
+        indptr = xp.array([0, 1, 2, 3], 'i')
+        a = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        b = sp.csc_array((data, indices, indptr), shape=(3, 3))
+        return (a * b).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_csr_star_coo(self, xp, sp):
+        """CSR * COO cross-format multiply should work."""
+        data = xp.array([1, 2, 3], numpy.float64)
+        indices = xp.array([0, 1, 2], 'i')
+        indptr = xp.array([0, 1, 2, 3], 'i')
+        a = sp.csr_array((data, indices, indptr), shape=(3, 3))
+        row = xp.array([0, 1, 2], 'i')
+        col = xp.array([0, 1, 2], 'i')
+        b = sp.coo_array((data, (row, col)), shape=(3, 3))
+        return (a * b).toarray()
+
+
+# Reduction 1D shaping
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float64],
+}))
+@testing.with_requires('scipy')
+class TestArrayReductions:
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_sum_axis0_ndim(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        result = m.sum(axis=0)
+        return result.ndim
+
+    @testing.numpy_cupy_equal(sp_name='sp')
+    def test_sum_axis1_ndim(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        result = m.sum(axis=1)
+        return result.ndim
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sum_axis0_values(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        return m.sum(axis=0)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sum_axis1_values(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        return m.sum(axis=1)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mean_axis0(self, xp, sp):
+        m = _make_csr(xp, sp, self.dtype, array=True)
+        return m.mean(axis=0)
+
+    def test_matrix_sum_stays_2d(self):
+        """Matrix sum(axis=0) should still be 2D."""
+        m = _make_csr(cupy, sparse, numpy.float64, array=False)
+        result = m.sum(axis=0)
+        assert result.ndim == 2
+
+    def test_min_max_axis_returns_2d_known_gap(self):
+        # KNOWN GAP vs scipy: scipy sparse *arrays* return 1-D from min/max
+        # over an axis (shape ``(M,)``), as sum()/argmin() already do here.
+        # CuPy's COO is 2-D-only, so min/max(axis=) currently returns 2-D
+        # (``(1, M)`` / ``(M, 1)``) for arrays too -- an inconsistency with
+        # sum/argmin.  Pinned so the divergence is tracked; tighten to 1-D
+        # if/when 1-D sparse arrays land.  See ``_data.py._min_or_max_axis``.
+        a = sparse.csr_array(cupy.array([[1.0, 0.0, 2.0], [0.0, 3.0, 0.0]]))
+        assert a.min(axis=0).shape == (1, 3)
+        assert a.max(axis=1).shape == (2, 1)
+        # Contrast: sum(axis=) IS 1-D for arrays (the consistent behavior).
+        assert a.sum(axis=0).shape == (3,)
+
+
+# DIA array
+
+class TestDiaArrayBasic:
+
+    def test_construction(self):
+        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
+        offsets = cupy.array([0])
+        A = sparse.dia_array((data, offsets), shape=(3, 3))
+        assert isinstance(A, sparse.sparray)
+        assert A.format == 'dia'
+
+    def test_tocsr(self):
+        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
+        offsets = cupy.array([0])
+        A = sparse.dia_array((data, offsets), shape=(3, 3))
+        B = A.tocsr()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'csr'
+
+    def test_tocsc(self):
+        data = cupy.array([[1, 2, 3]], dtype=numpy.float64)
+        offsets = cupy.array([0])
+        A = sparse.dia_array((data, offsets), shape=(3, 3))
+        B = A.tocsc()
+        assert isinstance(B, sparse.sparray)
+        assert B.format == 'csc'
+
+    @testing.with_requires('scipy')
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_toarray_matches_scipy(self, xp, sp):
+        data = xp.array([[1, 2, 3]], dtype=numpy.float64)
+        offsets = xp.array([0])
+        A = sp.dia_array((data, offsets), shape=(3, 3))
+        return A.toarray()
+
+
+# LinearOperator from array
+
+class TestLinearOperatorFromArray:
+
+    def test_aslinearoperator_csr_array(self):
+        from cupyx.scipy.sparse.linalg import aslinearoperator
+        m = _make_csr_sq(cupy, sparse, numpy.float64, array=True)
+        op = aslinearoperator(m)
+        v = cupy.ones(3, dtype=numpy.float64)
+        result = op @ v
+        expected = m @ v
+        cupy.testing.assert_allclose(result, expected)
+
+
+# Linalg solvers accept arrays
+
+class TestSpsolveArray:
+
+    def test_spsolve_csr_array(self):
+        from cupyx.scipy.sparse.linalg import spsolve
+        n = 8
+        A_dense = cupy.zeros((n, n), dtype=numpy.float64)
+        A_dense[cupy.arange(n), cupy.arange(n)] = 4
+        A_dense[cupy.arange(n - 1), cupy.arange(1, n)] = 1
+        A_dense[cupy.arange(1, n), cupy.arange(n - 1)] = 1
+        A = sparse.csr_array(A_dense)
+        b = cupy.arange(1, n + 1, dtype=numpy.float64)
+        x = spsolve(A, b)
+        cupy.testing.assert_allclose(A @ x, b, rtol=1e-10)
+
+    def test_spsolve_csr_matrix(self):
+        from cupyx.scipy.sparse.linalg import spsolve
+        n = 8
+        A_dense = cupy.zeros((n, n), dtype=numpy.float64)
+        A_dense[cupy.arange(n), cupy.arange(n)] = 4
+        A_dense[cupy.arange(n - 1), cupy.arange(1, n)] = 1
+        A_dense[cupy.arange(1, n), cupy.arange(n - 1)] = 1
+        M = sparse.csr_matrix(A_dense)
+        b = cupy.arange(1, n + 1, dtype=numpy.float64)
+        x = spsolve(M, b)
+        cupy.testing.assert_allclose(M * x, b, rtol=1e-10)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_int64_indices.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_int64_indices.py
@@ -3637,3 +3637,52 @@ class TestMultiplyMixedInt32Int64:
         b = sparse.csr_matrix(cupy.array([[1.0, 0.0], [0.0, 1.0]]))
         c = a.multiply(b)
         assert c.indices.dtype == cupy.int32
+
+
+class TestKronSparrayDtypePreservation:
+    # sparray path preserves input dtype; matrix path uses the
+    # minimum-required dtype based on output shape.
+
+    def test_kron_sparray_int64_preserved(self):
+        a = sparse.eye_array(8, format='csr', dtype=cupy.float64)
+        a_int64 = sparse.csr_array._from_parts(
+            a.data, a.indices.astype(cupy.int64),
+            a.indptr.astype(cupy.int64), a.shape)
+        k = sparse.kron(a_int64, a_int64)
+        assert k.row.dtype == cupy.int64
+
+    def test_kronsum_sparray_int64_preserved(self):
+        a = sparse.eye_array(8, format='csr', dtype=cupy.float64)
+        a_int64 = sparse.csr_array._from_parts(
+            a.data, a.indices.astype(cupy.int64),
+            a.indptr.astype(cupy.int64), a.shape)
+        k = sparse.kronsum(a_int64, a_int64)
+        assert k.indices.dtype == cupy.int64
+
+    def test_kron_matrix_legacy_dtype(self):
+        # Matrix path: minimum-required dtype based on output shape.
+        a = sparse.eye(8, format='csr', dtype=cupy.float64)
+        a_int64 = sparse.csr_matrix._from_parts(
+            a.data, a.indices.astype(cupy.int64),
+            a.indptr.astype(cupy.int64), a.shape)
+        k = sparse.kron(a_int64, a_int64)
+        # Output shape (64, 64) fits int32.  Matrix path downcasts.
+        assert k.row.dtype == cupy.int32
+
+    def test_kron_sparray_int32_unchanged(self):
+        a = sparse.csr_array(cupy.array([[1.0, 2.0], [3.0, 4.0]]))
+        k = sparse.kron(a, a)
+        assert k.row.dtype == cupy.int32
+
+
+class TestSparseTypingAliases:
+
+    def test_csr_array_typing(self):
+        import types
+        alias = sparse.csr_array[int]
+        assert isinstance(alias, types.GenericAlias)
+
+    def test_csr_matrix_typing(self):
+        import types
+        alias = sparse.csr_matrix[float, int]
+        assert isinstance(alias, types.GenericAlias)


### PR DESCRIPTION
Introduce sparse *array* types (csr_array, csc_array, coo_array, dia_array) alongside the existing sparse matrix types, mirroring scipy.sparse's array/matrix duality.

Structure:
- `_spbase` becomes the common base for all sparse types; `sparray` and `spmatrix` are mixins that select array vs legacy-matrix semantics.
- Each format gains a shared `_<fmt>_base` implementation with `<fmt>_matrix` and `<fmt>_array` leaf classes (csr, csc, coo, dia).
- Array semantics: `*` and `**` are element-wise and `@` is matmul; matrices keep legacy `*`=matmul / `**`=matrix-power via `_matmul_dispatch`. Result types propagate through container properties (`_csr_container`, `_coo_container`, ...).

Dispatch:
- Internal `isspmatrix_<fmt>` checks converted to `issparse()` + `.format` so array and matrix inputs are handled uniformly (cusparse.py, scipy.sparse.linalg, csgraph, distributed NCCL).

New scipy-parity API:
- Construction: block_array, block_diag, diags_array, eye_array, random_array; axis ops matrix_transpose, swapaxes, permute_dims.
- Methods: count_nonzero(axis), prune, nonzero, coords, mT, __round__, in-place __imul__/__itruediv__, and CSC setdiag.
- Index-dtype utilities get_index_dtype / safely_cast_index_arrays re-exported to match scipy.sparse.

Tests: new test_sparray.py; test_base.py updated for the array/matrix split; csgraph traversal parametrized over array and matrix; int64 kron dtype-preservation and typing-alias coverage added.

This is the first of three stacked splits of the `sparray` branch (PR #9910), separated to ease review. This layer is the largely mechanical introduction of the array classes and type-aware dispatch; behavior changes and judgement-call work are deferred to the two subsequent splits.