### PR TITLE
TST: Make new pytest versions happy

### DIFF
--- a/tests/cupy_tests/core_tests/test_gufuncs.py
+++ b/tests/cupy_tests/core_tests/test_gufuncs.py
@@ -292,7 +292,7 @@ class TestGUFuncSignatures:
             else:
                 assert dtypes_access[dtype] == default
 
-    @pytest.mark.parametrize('sig,', ['ii->i', 'i', ('i', 'i', 'i')])
+    @pytest.mark.parametrize('sig', ['ii->i', 'i', ('i', 'i', 'i')])
     def test_signature_lookup(self, sig):
         called = False
 
@@ -320,7 +320,7 @@ class TestGUFuncSignatures:
         assert z.dtype == numpy.int32
         assert called
 
-    @pytest.mark.parametrize('sigs,', [('i',), ('',), ('iii->i',), ('ii->',)])
+    @pytest.mark.parametrize('sigs', [('i',), ('',), ('iii->i',), ('ii->',)])
     def test_invalid_signatures(self, sigs):
 
         def default(x, y):
@@ -329,7 +329,7 @@ class TestGUFuncSignatures:
         with pytest.raises(ValueError):
             _GUFunc(default, '(i),(i)->(i)', signatures=sigs)
 
-    @pytest.mark.parametrize('sig,', ['i->i', 'id->i', ''])
+    @pytest.mark.parametrize('sig', ['i->i', 'id->i', ''])
     def test_invalid_lookup(self, sig):
 
         def default(x, y):

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -15,20 +15,21 @@ from cupy import testing
 class TestArrayReduction:
 
     @pytest.fixture(scope='class')
-    def exclude_cutensor(self):
+    @classmethod
+    def exclude_cutensor(cls):
         # cuTENSOR seems to have issues in handling inf/nan in reduction-based
         # routines, so we use this fixture to skip testing it
-        self.old_routine_accelerators = _acc.get_routine_accelerators()
-        self.old_reduction_accelerators = _acc.get_reduction_accelerators()
+        old_routine_accelerators = _acc.get_routine_accelerators()
+        old_reduction_accelerators = _acc.get_reduction_accelerators()
 
-        rot_acc = self.old_routine_accelerators.copy()
+        rot_acc = old_routine_accelerators.copy()
         try:
             rot_acc.remove(_acc.ACCELERATOR_CUTENSOR)
         except ValueError:
             pass
         _acc.set_routine_accelerators(rot_acc)
 
-        red_acc = self.old_reduction_accelerators.copy()
+        red_acc = old_reduction_accelerators.copy()
         try:
             red_acc.remove(_acc.ACCELERATOR_CUTENSOR)
         except ValueError:
@@ -37,8 +38,8 @@ class TestArrayReduction:
 
         yield
 
-        _acc.set_routine_accelerators(self.old_routine_accelerators)
-        _acc.set_reduction_accelerators(self.old_reduction_accelerators)
+        _acc.set_routine_accelerators(old_routine_accelerators)
+        _acc.set_reduction_accelerators(old_reduction_accelerators)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -502,7 +502,8 @@ class TestReductionSizeOverInt32Max:
 class TestCuTensorReduction:
 
     @pytest.fixture(autouse=True, scope='class')
-    def setup(self):
+    @classmethod
+    def setup(cls):
         old_accelerators = cupy._core.get_routine_accelerators()
         cupy._core.set_routine_accelerators(['cutensor'])
         yield

--- a/tests/cupy_tests/statistics_tests/test_histogram.py
+++ b/tests/cupy_tests/statistics_tests/test_histogram.py
@@ -353,7 +353,8 @@ class TestHistogram(unittest.TestCase):
 @unittest.skipUnless(cupy.cuda.cub.available, 'The CUB routine is not enabled')
 class TestCubHistogram(unittest.TestCase):
     @pytest.fixture(autouse=True, scope='class')
-    def setup(self):
+    @classmethod
+    def setup(cls):
         old_accelerators = _accelerator.get_routine_accelerators()
         _accelerator.set_routine_accelerators(['cub'])
         yield

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_dia.py
@@ -175,7 +175,7 @@ class TestDiaMatrix(unittest.TestCase):
 class TestDiaMatrixInit:
 
     @pytest.fixture(autouse=True)
-    def _setup(self, dtype, scope='class'):
+    def _setup(self, dtype):
         self.dtype = dtype
         self.shape = (3, 4)
 

--- a/tests/typing_tests/test_run.py
+++ b/tests/typing_tests/test_run.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.parametrize("t", map(str, Path(__file__).parent.glob("**/*.pyi")))
+@pytest.mark.parametrize(
+    "t", list(map(str, Path(__file__).parent.glob("**/*.pyi"))))
 def test_run(t: Path) -> None:
     assert not t.endswith("._numpy.pyi")
 


### PR DESCRIPTION
Removing the `,` makes a lot of sense, although pytest actually seems to barf on it (rather than just giving a DeprecationWarning). I have mixed feelings on deprecating iterators (rather than auto converting them to lists) for parametrizations, but it's trivial enough here.

Also added a commit to make sure that any "class" scoped fixture uses a classmethod.
(I just deleted the `scope='class'` from the dia test because it _wasn't_ class scoped and unless I transition it away from `@testing.parametrize` I think it'll be a mess.)