### PR TITLE
ENH: It seems cooperative groups do not need rdc (anymore)

### DIFF
--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -609,10 +609,6 @@ def _compile_with_cache_cuda(
     if to_ltoir:
         options += ('-dlto',)
 
-    if enable_cooperative_groups:
-        # `cooperative_groups` requires relocatable device code.
-        options += ('--device-c',)
-
     # TODO(leofang): check if this works for LTO IR
     if _get_bool_env_variable('CUPY_CUDA_COMPILE_WITH_DEBUG', False):
         options += ('--device-debug', '--generate-line-info')

--- a/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/fusion_utils.py
@@ -142,6 +142,6 @@ def can_use_grid_synchronization():
     return (
         not cupy.cuda.runtime.is_hip and
         int(cupy.cuda.device.get_compute_capability()) >= 70 and
-        (cupy.cuda.runtime.runtimeGetVersion() <=
-         cupy.cuda.runtime.driverGetVersion())  # depends on PTX
+        cupy.cuda.runtime.deviceGetAttribute(
+            cupy.cuda.runtime.cudaDevAttrCooperativeLaunch, 0)
     )

--- a/tests/cupy_tests/core_tests/fusion_tests/test_example.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_example.py
@@ -11,6 +11,10 @@ from cupy_tests.core_tests.fusion_tests import fusion_utils
 @testing.slow
 @pytest.mark.skipif(
     cupy.cuda.runtime.is_hip, reason='HIP does not support this')
+@pytest.mark.skipif(
+    not fusion_utils.can_use_grid_synchronization(),
+    reason='Requires CUDA grid synchronization'
+)
 class TestFusionExample(unittest.TestCase):
     def generate_inputs(self, xp):
         shape = (8, 64, 112, 112)


### PR DESCRIPTION
I am not sure where this changed, search finds references for CUDA 9 requiring it, but I even tried compiling with `nvcc` and things are fine without this.

This enables cooperative groups tests to run and succeed for me removing the long "test_batchnorm" is failing.

Note, that the *way* test_batchnorm failed is actually not fixed by this (I'll try to open another PR for that).

I am curious if this passes on all of the CI...