### PR TITLE
Add pytest support to @testing.for_contiguous_axes decorator

### DIFF
--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -1245,8 +1245,8 @@ def for_contiguous_axes(name='axis'):
     def decorator(impl):
         @_wraps_partial(impl, name)
         def test_func(self, *args, **kw):
-            ndim = len(self.shape)
-            order = self.order
+            ndim = len(kw['shape'])
+            order = kw['order']
             for i in range(ndim):
                 a = ()
                 if order in ('c', 'C'):
@@ -1262,7 +1262,7 @@ def for_contiguous_axes(name='axis'):
                     impl(self, *args, **kw)
                 except Exception:
                     print(name, 'is', a, ', ndim is', ndim, ', shape is',
-                          self.shape, ', order is', order)
+                          ndim, ', order is', order)
                     raise
         return test_func
     return decorator

--- a/cupy/testing/_loops.py
+++ b/cupy/testing/_loops.py
@@ -1262,7 +1262,7 @@ def for_contiguous_axes(name='axis'):
                     impl(self, *args, **kw)
                 except Exception:
                     print(name, 'is', a, ', ndim is', ndim, ', shape is',
-                          ndim, ', order is', order)
+                          kw['shape'], ', order is', order)
                     raise
         return test_func
     return decorator

--- a/tests/cupy_tests/core_tests/test_cub_reduction.py
+++ b/tests/cupy_tests/core_tests/test_cub_reduction.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from itertools import combinations
-import unittest
 import sys
 
 import pytest
@@ -17,13 +16,14 @@ from cupy.cuda import memory
 # This test class and its children below only test if CUB backend can be used
 # or not; they don't verify its correctness as it's already extensively covered
 # by existing tests
-class CubReductionTestBase(unittest.TestCase):
+class CubReductionTestBase:
     """
     Note: call self.can_use() when arrays are already allocated, otherwise
     call self._test_can_use().
     """
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def configure(self):
         if _environment.get_cub_path() is None:
             pytest.skip('CUB not found')
         if cupy.cuda.runtime.is_hip:
@@ -34,8 +34,7 @@ class CubReductionTestBase(unittest.TestCase):
 
         self.old_accelerators = _accelerator.get_reduction_accelerators()
         _accelerator.set_reduction_accelerators(['cub'])
-
-    def tearDown(self):
+        yield
         _accelerator.set_reduction_accelerators(self.old_accelerators)
 
     def _test_can_use(
@@ -46,34 +45,36 @@ class CubReductionTestBase(unittest.TestCase):
         assert result is expected
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)],
-    'order': ('C', 'F'),
-}))
+@pytest.mark.parametrize(
+    "shape", [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)]
+)
+@pytest.mark.parametrize(
+    "order", ['C', 'F'],
+)
 class TestSimpleCubReductionKernelContiguity(CubReductionTestBase):
 
     @testing.for_contiguous_axes()
-    def test_can_use_cub_contiguous(self, axis):
+    def test_can_use_cub_contiguous(self, axis, shape, order):
         r_axis = axis
-        i_shape = self.shape
+        i_shape = shape
         o_axis = tuple(i for i in range(len(i_shape)) if i not in r_axis)
-        o_shape = tuple(self.shape[i] for i in o_axis)
-        self._test_can_use(i_shape, o_shape, r_axis, o_axis, self.order, True)
+        o_shape = tuple(shape[i] for i in o_axis)
+        self._test_can_use(i_shape, o_shape, r_axis, o_axis, order, True)
 
     @testing.for_contiguous_axes()
-    def test_can_use_cub_non_contiguous(self, axis):
+    def test_can_use_cub_non_contiguous(self, axis, shape, order):
         # array is contiguous, but reduce_axis is not
-        dim = len(self.shape)
+        dim = len(shape)
         r_dim = len(axis)
         non_contiguous_axes = [i for i in combinations(range(dim), r_dim)
                                if i != axis]
 
-        i_shape = self.shape
+        i_shape = shape
         for r_axis in non_contiguous_axes:
             o_axis = tuple(i for i in range(dim) if i not in r_axis)
-            o_shape = tuple(self.shape[i] for i in o_axis)
+            o_shape = tuple(shape[i] for i in o_axis)
             self._test_can_use(i_shape, o_shape, r_axis, o_axis,
-                               self.order, False)
+                               order, False)
 
 
 class TestSimpleCubReductionKernelMisc(CubReductionTestBase):

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import combinations
+
 import numpy
 import pytest
 
@@ -9,9 +11,7 @@ from cupy._core import _cub_reduction
 from cupy import testing
 
 
-@testing.parameterize(*testing.product({
-    'order': ('C', 'F'),
-}))
+@pytest.mark.parametrize("order", ['C', 'F'])
 class TestArrayReduction:
 
     @pytest.fixture(scope='class')
@@ -43,326 +43,321 @@ class TestArrayReduction:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_max_all(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.max()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_max_all_keepdims(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.max(keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+    def test_max_axis_large(self, xp, dtype, order):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_max_axis0(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.max(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_max_axis1(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.max(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_max_axis2(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.max(axis=2)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_max_multiple_axes(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.max(axis=(1, 2))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_max_multiple_axes_keepdims(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.max(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_nan(self, xp, dtype, exclude_cutensor):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_max_nan(self, exclude_cutensor, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.max()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_max_nan_real(self, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.max()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+    def test_max_nan_imag(self, xp, dtype, order):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=order)
         return a.max()
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_max_inf(self, exclude_cutensor, xp, dtype):
+    def test_max_inf(self, exclude_cutensor, xp, dtype, order):
         # cupy/cupy#8180
-        a = xp.array([-float('inf'), -float('inf')], dtype, order=self.order)
+        a = xp.array([-float('inf'), -float('inf')], dtype, order=order)
         return a.max()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_min_all(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.min()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_all_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_min_all_keepdims(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.min(keepdims=True)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+    def test_min_axis_large(self, xp, dtype, order):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_min_axis0(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.min(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_min_axis1(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.min(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_min_axis2(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.min(axis=2)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_multiple_axes(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_min_multiple_axes(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.min(axis=(1, 2))
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_multiple_axes_keepdims(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_min_multiple_axes_keepdims(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.min(axis=(1, 2), keepdims=True)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_nan(self, xp, dtype, exclude_cutensor):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_min_nan(self, exclude_cutensor, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.min()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_min_nan_real(self, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.min()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+    def test_min_nan_imag(self, xp, dtype, order):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=order)
         return a.min()
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_min_inf(self, xp, dtype, exclude_cutensor):
+    def test_min_inf(self, exclude_cutensor, xp, dtype, order):
         # cupy/cupy#8180
-        a = xp.array([float('inf'), float('inf')], dtype, order=self.order)
+        a = xp.array([float('inf'), float('inf')], dtype, order=order)
         return a.min()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_argmax_all(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.argmax()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+    def test_argmax_axis_large(self, xp, dtype, order):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=order)
         return a.argmax(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmax_axis0(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmax(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmax_axis1(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmax(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmax_axis2(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmax(axis=2)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_nan(self, xp, dtype, exclude_cutensor):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_argmax_nan(self, exclude_cutensor, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.argmax()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_argmax_nan_real(self, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.argmax()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmax_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+    def test_argmax_nan_imag(self, xp, dtype, order):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=order)
         return a.argmax()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_all(self, xp, dtype):
-        a = testing.shaped_random((2, 3), xp, dtype, order=self.order)
+    def test_argmin_all(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3), xp, dtype, order=order)
         return a.argmin()
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_axis_large(self, xp, dtype):
-        a = testing.shaped_random((3, 1000), xp, dtype, order=self.order)
+    def test_argmin_axis_large(self, xp, dtype, order):
+        a = testing.shaped_random((3, 1000), xp, dtype, order=order)
         return a.argmin(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_axis0(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmin_axis0(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmin(axis=0)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_axis1(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmin_axis1(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmin(axis=1)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_axis2(self, xp, dtype):
-        a = testing.shaped_random((2, 3, 4), xp, dtype, order=self.order)
+    def test_argmin_axis2(self, xp, dtype, order):
+        a = testing.shaped_random((2, 3, 4), xp, dtype, order=order)
         return a.argmin(axis=2)
 
     @testing.for_float_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_nan(self, xp, dtype, exclude_cutensor):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_argmin_nan(self, exclude_cutensor, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.argmin()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_nan_real(self, xp, dtype):
-        a = xp.array([float('nan'), 1, -1], dtype, order=self.order)
+    def test_argmin_nan_real(self, xp, dtype, order):
+        a = xp.array([float('nan'), 1, -1], dtype, order=order)
         return a.argmin()
 
     @testing.for_complex_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_argmin_nan_imag(self, xp, dtype):
-        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=self.order)
+    def test_argmin_nan_imag(self, xp, dtype, order):
+        a = xp.array([float('nan')*1.j, 1.j, -1.j], dtype, order=order)
         return a.argmin()
 
 
-@testing.parameterize(*testing.product({
-    # TODO(leofang): make a @testing.for_all_axes decorator
-    'shape_and_axis': [
-        ((), None),
-        ((0,), (0,)),
-        ((0, 2), (0,)),
-        ((0, 2), (1,)),
-        ((0, 2), (0, 1)),
-        ((2, 0), (0,)),
-        ((2, 0), (1,)),
-        ((2, 0), (0, 1)),
-        ((0, 2, 3), (0,)),
-        ((0, 2, 3), (1,)),
-        ((0, 2, 3), (2,)),
-        ((0, 2, 3), (0, 1)),
-        ((0, 2, 3), (1, 2)),
-        ((0, 2, 3), (0, 2)),
-        ((0, 2, 3), (0, 1, 2)),
-        ((2, 0, 3), (0,)),
-        ((2, 0, 3), (1,)),
-        ((2, 0, 3), (2,)),
-        ((2, 0, 3), (0, 1)),
-        ((2, 0, 3), (1, 2)),
-        ((2, 0, 3), (0, 2)),
-        ((2, 0, 3), (0, 1, 2)),
-        ((2, 3, 0), (0,)),
-        ((2, 3, 0), (1,)),
-        ((2, 3, 0), (2,)),
-        ((2, 3, 0), (0, 1)),
-        ((2, 3, 0), (1, 2)),
-        ((2, 3, 0), (0, 2)),
-        ((2, 3, 0), (0, 1, 2)),
-    ],
-    'order': ('C', 'F'),
-    'func': ('min', 'max', 'argmax', 'argmin'),
-}))
+def _axes_for_shape(shape):
+    if shape == ():
+        return [None]
+    ndim = len(shape)
+    return [
+        combo
+        for r in range(1, ndim + 1)
+        for combo in combinations(range(ndim), r)
+    ]
+
+
+@pytest.mark.parametrize(
+    "shape,axis",
+    [
+        (shape, axis)
+        for shape in [
+            (),
+            (0,),
+            (0, 2),
+            (2, 0),
+            (0, 2, 3),
+            (2, 0, 3),
+            (2, 3, 0)
+        ]
+        for axis in _axes_for_shape(shape)
+    ]
+)
+@pytest.mark.parametrize("order", ['C', 'F'])
+@pytest.mark.parametrize("func", ['min', 'max', 'argmax', 'argmin'])
 class TestArrayReductionZeroSize:
 
     @testing.numpy_cupy_allclose(
         contiguous_check=False, accept_error=ValueError)
-    def test_zero_size(self, xp):
-        shape, axis = self.shape_and_axis
+    def test_zero_size(self, xp, shape, axis, order, func):
         # NumPy only supports axis being an int
-        if self.func in ('argmax', 'argmin'):
+        if func in ('argmax', 'argmin'):
             if axis is not None and len(axis) == 1:
                 axis = axis[0]
             else:
                 pytest.skip(
-                    f"NumPy does not support axis={axis} for {self.func}")
+                    f"NumPy does not support axis={axis} for {func}")
         # dtype is irrelevant here, just pick one
-        a = testing.shaped_random(shape, xp, xp.float32, order=self.order)
-        return getattr(a, self.func)(axis=axis)
+        a = testing.shaped_random(shape, xp, xp.float32, order=order)
+        return getattr(a, func)(axis=axis)
 
 
 # This class compares CUB results against NumPy's. ("fallback" is CuPy's
 # original kernel, also tested here to reduce code duplication.)
-@testing.parameterize(*testing.product({
-    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40),
-              # skip (2, 3, 0) because it would not hit the CUB code path
-              (0,), (2, 0), (0, 2), (0, 2, 3), (2, 3, 0)],
-    'order': ('C', 'F'),
-    'backend': ('device', 'block', 'fallback'),
-}))
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (10,), (10, 20), (10, 20, 30), (10, 20, 30, 40),
+        # skip (2, 3, 0) because it would not hit the CUB code path
+        (0,), (2, 0), (0, 2), (0, 2, 3), (2, 3, 0)
+    ]
+)
+@pytest.mark.parametrize("order", ['C', 'F'])
+@pytest.mark.parametrize("backend", ['device', 'block', 'fallback'])
 @pytest.mark.skipif(
     not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
 @pytest.mark.thread_unsafe(reason="unsafe setUp and AssertFunctionIsCalled.")
 class TestCubReduction:
 
     @pytest.fixture(autouse=True)
-    def setUp(self):
+    def setUp(self, backend):
         self.old_routine_accelerators = _acc.get_routine_accelerators()
         self.old_reduction_accelerators = _acc.get_reduction_accelerators()
-        if self.backend == 'device':
+        if backend == 'device':
             _acc.set_routine_accelerators(['cub'])
             _acc.set_reduction_accelerators([])
-        elif self.backend == 'block':
+        elif backend == 'block':
             _acc.set_routine_accelerators([])
             _acc.set_reduction_accelerators(['cub'])
-        elif self.backend == 'fallback':
+        elif backend == 'fallback':
             _acc.set_routine_accelerators([])
             _acc.set_reduction_accelerators([])
         yield
@@ -373,28 +368,28 @@ class TestCubReduction:
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(
         contiguous_check=False, accept_error=ValueError)
-    def test_cub_min(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
+    def test_cub_min(self, xp, dtype, axis, shape, order, backend):
+        a = testing.shaped_random(shape, xp, dtype, order=order)
 
         if xp is numpy:
             return a.min(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if self.backend == 'device':
+        if backend == 'device':
             func_name = 'cupy._core._routines_statistics.cub.'
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 func_name += 'device_reduce'
             else:
                 func_name += 'device_segmented_reduce'
             with testing.AssertFunctionIsCalled(func_name, return_value=ret):
                 a.min(axis=axis)
-        elif self.backend == 'block':
+        elif backend == 'block':
             # this is the only function we can mock; the rest is cdef'd
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 times_called = 2  # two passes
             else:
                 times_called = 1  # one pass
@@ -403,43 +398,45 @@ class TestCubReduction:
             with testing.AssertFunctionIsCalled(
                     func_name, wraps=func, times_called=times_called):
                 a.min(axis=axis)
-        elif self.backend == 'fallback':
+        elif backend == 'fallback':
             pass
         # ...then perform the actual computation
         return a.min(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_cub_min_empty_axis(self, xp, dtype, contiguous_check=False):
-        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
+    def test_cub_min_empty_axis(
+        self, xp, dtype, shape, order, contiguous_check=False
+    ):
+        a = testing.shaped_random(shape, xp, dtype, order=order)
         return a.min(axis=())
 
     @testing.for_contiguous_axes()
     @testing.for_all_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(
         contiguous_check=False, accept_error=ValueError)
-    def test_cub_max(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
+    def test_cub_max(self, xp, dtype, axis, shape, order, backend):
+        a = testing.shaped_random(shape, xp, dtype, order=order)
 
         if xp is numpy:
             return a.max(axis=axis)
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if self.backend == 'device':
+        if backend == 'device':
             func_name = 'cupy._core._routines_statistics.cub.'
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 func_name += 'device_reduce'
             else:
                 func_name += 'device_segmented_reduce'
             with testing.AssertFunctionIsCalled(func_name, return_value=ret):
                 a.max(axis=axis)
-        elif self.backend == 'block':
+        elif backend == 'block':
             # this is the only function we can mock; the rest is cdef'd
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 times_called = 2  # two passes
             else:
                 times_called = 1  # one pass
@@ -448,13 +445,13 @@ class TestCubReduction:
             with testing.AssertFunctionIsCalled(
                     func_name, wraps=func, times_called=times_called):
                 a.max(axis=axis)
-        elif self.backend == 'fallback':
+        elif backend == 'fallback':
             pass
         # ...then perform the actual computation
         return a.max(axis=axis)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_cub_max_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype, order=self.order)
+    def test_cub_max_empty_axis(self, xp, dtype, shape, order):
+        a = testing.shaped_random(shape, xp, dtype, order=order)
         return a.max(axis=())

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import math
 
+from itertools import product as iproduct
+
 import numpy
 import pytest
 
@@ -206,23 +208,27 @@ class TestSumprod:
 
 
 # This class compares CUB results against NumPy's
-@testing.parameterize(*testing.product({
-    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
-    'order': ('C', 'F'),
-    'backend': ('device', 'block'),
-}))
+@pytest.mark.parametrize(
+    "shape", [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)]
+)
+@pytest.mark.parametrize(
+    "order", ['C', 'F'],
+)
+@pytest.mark.parametrize(
+    "backend", ['device', 'block'],
+)
 @pytest.mark.skipif(
     not cupy.cuda.cub.available, reason='The CUB routine is not enabled')
 class TestCubReduction:
 
     @pytest.fixture(autouse=True)
-    def setUp(self):
+    def setUp(self, backend):
         old_routine_accelerators = _acc.get_routine_accelerators()
         old_reduction_accelerators = _acc.get_reduction_accelerators()
-        if self.backend == 'device':
+        if backend == 'device':
             _acc.set_routine_accelerators(['cub'])
             _acc.set_reduction_accelerators([])
-        elif self.backend == 'block':
+        elif backend == 'block':
             _acc.set_routine_accelerators([])
             _acc.set_reduction_accelerators(['cub'])
         yield
@@ -234,11 +240,11 @@ class TestCubReduction:
     @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5)
     @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
-    def test_cub_sum(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+    def test_cub_sum(self, xp, dtype, axis, shape, order, backend):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
 
         if xp is numpy:
@@ -246,20 +252,20 @@ class TestCubReduction:
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if self.backend == 'device':
+        if backend == 'device':
             func_name = 'cupy._core._routines_math.cub.'
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 func_name += 'device_reduce'
             else:
                 func_name += 'device_segmented_reduce'
             with testing.AssertFunctionIsCalled(func_name, return_value=ret):
                 a.sum(axis=axis)
-        elif self.backend == 'block':
+        elif backend == 'block':
             # this is the only function we can mock; the rest is cdef'd
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 times_called = 2  # two passes
             else:
                 times_called = 1  # one pass
@@ -272,11 +278,11 @@ class TestCubReduction:
     # sum supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cub_sum_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+    def test_cub_sum_empty_axis(self, xp, dtype, shape, order, backend):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
         return a.sum(axis=())
 
@@ -285,11 +291,11 @@ class TestCubReduction:
     # prod supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5)
-    def test_cub_prod(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+    def test_cub_prod(self, xp, dtype, axis, shape, order, backend):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
 
         if xp is numpy:
@@ -297,20 +303,20 @@ class TestCubReduction:
 
         # xp is cupy, first ensure we really use CUB
         ret = cupy.empty(())  # Cython checks return type, need to fool it
-        if self.backend == 'device':
+        if backend == 'device':
             func_name = 'cupy._core._routines_math.cub.'
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 func_name += 'device_reduce'
             else:
                 func_name += 'device_segmented_reduce'
             with testing.AssertFunctionIsCalled(func_name, return_value=ret):
                 a.prod(axis=axis)
-        elif self.backend == 'block':
+        elif backend == 'block':
             # this is the only function we can mock; the rest is cdef'd
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(self.shape):
+            if len(axis) == len(shape):
                 times_called = 2  # two passes
             else:
                 times_called = 1  # one pass
@@ -325,14 +331,14 @@ class TestCubReduction:
     @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
     @testing.for_dtypes('bhilBHILfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-4)
-    def test_cub_cumsum(self, xp, dtype):
-        if self.backend == 'block':
+    def test_cub_cumsum(self, xp, dtype, shape, order, backend):
+        if backend == 'block':
             pytest.skip('does not support')
 
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
 
         if xp is numpy:
@@ -351,14 +357,14 @@ class TestCubReduction:
     @pytest.mark.thread_unsafe(reason="unsafe AssertFunctionIsCalled.")
     @testing.for_dtypes('bhilBHILfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-4)
-    def test_cub_cumprod(self, xp, dtype):
-        if self.backend == 'block':
+    def test_cub_cumprod(self, xp, dtype, shape, order, backend):
+        if backend == 'block':
             pytest.skip('does not support')
 
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
 
         if xp is numpy:
@@ -492,10 +498,12 @@ class TestReductionSizeOverInt32Max:
 
 
 # This class compares cuTENSOR results against NumPy's
-@testing.parameterize(*testing.product({
-    'shape': [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
-    'order': ('C', 'F'),
-}))
+@pytest.mark.parametrize(
+    "shape", [(10,), (10, 20), (10, 20, 30), (10, 20, 30, 40)],
+)
+@pytest.mark.parametrize(
+    "order", ['C', 'F'],
+)
 @pytest.mark.skipif(
     not cupy.cuda.cutensor.available,
     reason='The cuTENSOR routine is not enabled')
@@ -514,11 +522,11 @@ class TestCuTensorReduction:
     # sum supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_sum(self, xp, dtype, axis):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+    def test_cutensor_sum(self, xp, dtype, axis, shape, order):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
 
         if xp is numpy:
@@ -535,111 +543,107 @@ class TestCuTensorReduction:
     # sum supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')
     @testing.numpy_cupy_allclose(rtol=1E-5, contiguous_check=False)
-    def test_cutensor_sum_empty_axis(self, xp, dtype):
-        a = testing.shaped_random(self.shape, xp, dtype)
-        if self.order in ('c', 'C'):
+    def test_cutensor_sum_empty_axis(self, xp, dtype, shape, order):
+        a = testing.shaped_random(shape, xp, dtype)
+        if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
-        elif self.order in ('f', 'F'):
+        elif order in ('f', 'F'):
             a = xp.asfortranarray(a)
         return a.sum(axis=())
 
 
-@testing.parameterize(
-    *testing.product({
-        'shape': [(2, 3, 4), (20, 30, 40)],
-        'axis': [0, 1],
-        'transpose_axes': [True, False],
-        'keepdims': [True, False],
-        'func': ['nansum', 'nanprod']
-    })
-)
+@pytest.mark.parametrize("shape", [(2, 3, 4), (20, 30, 40)])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("transpose_axes", [True, False])
+@pytest.mark.parametrize("keepdims", [True, False])
+@pytest.mark.parametrize("func", ['nansum', 'nanprod'])
 class TestNansumNanprodLong:
 
-    def _do_transposed_axis_test(self):
-        return not self.transpose_axes and self.axis != 1
+    def _do_transposed_axis_test(self, transpose_axes, axis):
+        return not transpose_axes and axis != 1
 
-    def _numpy_nanprod_implemented(self):
-        return (self.func == 'nanprod' and
+    def _numpy_nanprod_implemented(self, func):
+        return (func == 'nanprod' and
                 numpy.__version__ >= numpy.lib.NumpyVersion('1.10.0'))
 
-    def _test(self, xp, dtype):
-        a = testing.shaped_arange(self.shape, xp, dtype)
-        if self.transpose_axes:
+    def _test(self, xp, dtype, shape, axis, transpose_axes, keepdims, func):
+        a = testing.shaped_arange(shape, xp, dtype)
+        if transpose_axes:
             a = a.transpose(2, 0, 1)
         if not issubclass(dtype, xp.integer):
             a[:, 1] = xp.nan
-        func = getattr(xp, self.func)
-        return func(a, axis=self.axis, keepdims=self.keepdims)
+        func = getattr(xp, func)
+        return func(a, axis=axis, keepdims=keepdims)
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose()
-    def test_nansum_all(self, xp, dtype):
-        if (not self._numpy_nanprod_implemented() or
-                not self._do_transposed_axis_test()):
+    def test_nansum_all(
+        self, xp, dtype, shape, axis, transpose_axes, keepdims, func
+    ):
+        if (not self._numpy_nanprod_implemented(func) or
+                not self._do_transposed_axis_test(transpose_axes, axis)):
             return xp.array(())
-        return self._test(xp, dtype)
+        return self._test(
+            xp, dtype, shape, axis, transpose_axes, keepdims, func
+        )
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_nansum_axis_transposed(self, xp, dtype):
-        if (not self._numpy_nanprod_implemented() or
-                not self._do_transposed_axis_test()):
+    def test_nansum_axis_transposed(
+        self, xp, dtype, shape, axis, transpose_axes, keepdims, func
+    ):
+        if (not self._numpy_nanprod_implemented(func) or
+                not self._do_transposed_axis_test(transpose_axes, axis)):
             return xp.array(())
-        return self._test(xp, dtype)
+        return self._test(
+            xp, dtype, shape, axis, transpose_axes, keepdims, func
+        )
 
 
-@testing.parameterize(
-    *testing.product({
-        'shape': [(2, 3, 4), (20, 30, 40)],
-    })
-)
+@pytest.mark.parametrize("shape", [(2, 3, 4), (20, 30, 40)])
 class TestNansumNanprodExtra:
 
-    def test_nansum_axis_float16(self):
+    def test_nansum_axis_float16(self, shape):
         # Note that the above test example overflows in float16. We use a
         # smaller array instead, just return if array is too large.
-        if (numpy.prod(self.shape) > 24):
+        if (numpy.prod(shape) > 24):
             return
-        a = testing.shaped_arange(self.shape, dtype='e')
+        a = testing.shaped_arange(shape, dtype='e')
         a[:, 1] = cupy.nan
         sa = cupy.nansum(a, axis=1)
-        b = testing.shaped_arange(self.shape, numpy, dtype='f')
+        b = testing.shaped_arange(shape, numpy, dtype='f')
         b[:, 1] = numpy.nan
         sb = numpy.nansum(b, axis=1)
         testing.assert_allclose(sa, sb.astype('e'))
 
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose()
-    def test_nansum_out(self, xp, dtype):
-        a = testing.shaped_arange(self.shape, xp, dtype)
+    def test_nansum_out(self, xp, dtype, shape):
+        a = testing.shaped_arange(shape, xp, dtype)
         if not issubclass(dtype, xp.integer):
             a[:, 1] = xp.nan
-        b = xp.empty((self.shape[0], self.shape[2]), dtype=dtype)
+        b = xp.empty((shape[0], shape[2]), dtype=dtype)
         xp.nansum(a, axis=1, out=b)
         return b
 
-    def test_nansum_out_wrong_shape(self):
-        a = testing.shaped_arange(self.shape)
+    def test_nansum_out_wrong_shape(self, shape):
+        a = testing.shaped_arange(shape)
         a[:, 1] = cupy.nan
         b = cupy.empty((2, 3))
         with pytest.raises(ValueError):
             cupy.nansum(a, axis=1, out=b)
 
 
-@testing.parameterize(
-    *testing.product({
-        'shape': [(2, 3, 4, 5), (20, 30, 40, 50)],
-        'axis': [(1, 3), (0, 2, 3)],
-    })
-)
+@pytest.mark.parametrize("shape", [(2, 3, 4, 5), (20, 30, 40, 50)])
+@pytest.mark.parametrize("axis", [(1, 3), (0, 2, 3)])
 class TestNansumNanprodAxes:
     @testing.for_all_dtypes(no_bool=True, no_float16=True)
     @testing.numpy_cupy_allclose(rtol=1e-6)
-    def test_nansum_axes(self, xp, dtype):
-        a = testing.shaped_arange(self.shape, xp, dtype)
+    def test_nansum_axes(self, xp, dtype, shape, axis):
+        a = testing.shaped_arange(shape, xp, dtype)
         if not issubclass(dtype, xp.integer):
             a[:, 1] = xp.nan
-        return xp.nansum(a, axis=self.axis)
+        return xp.nansum(a, axis=axis)
 
 
 class TestNansumNanprodHuge:
@@ -665,7 +669,6 @@ class TestNansumNanprodHuge:
 axes = [0, 1, 2]
 
 
-@testing.parameterize(*testing.product({'axis': axes}))
 class TestCumsum:
 
     def _cumsum(self, xp, a, *args, **kwargs):
@@ -702,46 +705,51 @@ class TestCumsum:
         a = testing.shaped_arange((4, 5), xp, dtype)
         return self._cumsum(xp, a)
 
+    @pytest.mark.parametrize("axis", axes)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_cumsum_axis(self, xp, dtype):
+    def test_cumsum_axis(self, xp, dtype, axis):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
-        return self._cumsum(xp, a, axis=self.axis)
+        return self._cumsum(xp, a, axis=axis)
 
+    @pytest.mark.parametrize("axis", axes)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_cumsum_axis_out(self, xp, dtype):
+    def test_cumsum_axis_out(self, xp, dtype, axis):
         n = len(axes)
         shape = tuple(range(4, 4 + n))
         a = testing.shaped_arange(shape, xp, dtype)
         out = xp.zeros(shape, dtype=dtype)
-        self._cumsum(xp, a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=axis, out=out)
         return out
 
+    @pytest.mark.parametrize("axis", axes)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_cumsum_axis_out_noncontiguous(self, xp, dtype):
+    def test_cumsum_axis_out_noncontiguous(self, xp, dtype, axis):
         n = len(axes)
         shape = tuple(range(4, 4 + n))
         a = testing.shaped_arange(shape, xp, dtype)
         out = xp.zeros((8,)+shape[1:], dtype=dtype)[::2]  # Non contiguous view
-        self._cumsum(xp, a, axis=self.axis, out=out)
+        self._cumsum(xp, a, axis=axis, out=out)
         return out
 
+    @pytest.mark.parametrize("axis", axes)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose(contiguous_check=False)
-    def test_ndarray_cumsum_axis(self, xp, dtype):
+    def test_ndarray_cumsum_axis(self, xp, dtype, axis):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(4, 4 + n)), xp, dtype)
-        return a.cumsum(axis=self.axis)
+        return a.cumsum(axis=axis)
 
+    @pytest.mark.parametrize("axis", axes)
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_cumsum_axis_empty(self, xp, dtype):
+    def test_cumsum_axis_empty(self, xp, dtype, axis):
         n = len(axes)
         a = testing.shaped_arange(tuple(range(0, n)), xp, dtype)
-        return self._cumsum(xp, a, axis=self.axis)
+        return self._cumsum(xp, a, axis=axis)
 
     @testing.for_all_dtypes()
     def test_invalid_axis_lower1(self, dtype):
@@ -879,24 +887,22 @@ class TestCumprod:
             return cupy.cumprod(a_numpy)
 
 
-@testing.parameterize(*testing.product({
-    'shape': [(20,), (7, 6), (3, 4, 5)],
-    'axis': [None, 0, 1, 2],
-    'func': ('nancumsum', 'nancumprod'),
-}))
+@pytest.mark.parametrize("shape", [(20,), (7, 6), (3, 4, 5)])
+@pytest.mark.parametrize("axis", [None, 0, 1, 2])
+@pytest.mark.parametrize("func", ['nancumsum', 'nancumprod'])
 class TestNanCumSumProd:
 
     zero_density = 0.25
 
-    def _make_array(self, dtype):
+    def _make_array(self, dtype, shape):
         dtype = numpy.dtype(dtype)
         if dtype.char in 'efdFD':
             r_dtype = dtype.char.lower()
-            a = testing.shaped_random(self.shape, numpy, dtype=r_dtype,
+            a = testing.shaped_random(shape, numpy, dtype=r_dtype,
                                       scale=1)
             if dtype.char in 'FD':
                 ai = a
-                aj = testing.shaped_random(self.shape, numpy, dtype=r_dtype,
+                aj = testing.shaped_random(shape, numpy, dtype=r_dtype,
                                            scale=1)
                 ai[ai < math.sqrt(self.zero_density)] = 0
                 aj[aj < math.sqrt(self.zero_density)] = 0
@@ -905,30 +911,30 @@ class TestNanCumSumProd:
                 a[a < self.zero_density] = 0
             a = a / a
         else:
-            a = testing.shaped_random(self.shape, numpy, dtype=dtype)
+            a = testing.shaped_random(shape, numpy, dtype=dtype)
         return a
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_nancumsumprod(self, xp, dtype):
-        if self.axis is not None and self.axis >= len(self.shape):
+    def test_nancumsumprod(self, xp, dtype, shape, axis, func):
+        if axis is not None and axis >= len(shape):
             pytest.skip()
-        a = xp.array(self._make_array(dtype))
-        out = getattr(xp, self.func)(a, axis=self.axis)
+        a = xp.array(self._make_array(dtype, shape))
+        out = getattr(xp, func)(a, axis=axis)
         return xp.ascontiguousarray(out)
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_allclose()
-    def test_nancumsumprod_out(self, xp, dtype):
+    def test_nancumsumprod_out(self, xp, dtype, shape, axis, func):
         dtype = numpy.dtype(dtype)
-        if self.axis is not None and self.axis >= len(self.shape):
+        if axis is not None and axis >= len(shape):
             pytest.skip()
-        if len(self.shape) > 1 and self.axis is None:
+        if len(shape) > 1 and axis is None:
             # Skip the cases where np.nancum{sum|prod} raise AssertionError.
             pytest.skip()
-        a = xp.array(self._make_array(dtype))
-        out = xp.empty(self.shape, dtype=dtype)
-        getattr(xp, self.func)(a, axis=self.axis, out=out)
+        a = xp.array(self._make_array(dtype, shape))
+        out = xp.empty(shape, dtype=dtype)
+        getattr(xp, func)(a, axis=axis, out=out)
         return xp.ascontiguousarray(out)
 
 
@@ -997,27 +1003,32 @@ class TestDiff:
                 xp.diff(a, axis=-4)
 
 
-# This class compares CUB results against NumPy's
-@testing.parameterize(*testing.product_dict(
-    testing.product({
-        'shape': [()],
-        'axis': [None, ()],
-        'spacing': [(), (1.2,)],
-    })
-    + testing.product({
-        'shape': [(33,)],
-        'axis': [None, 0, -1, (0,)],
-        'spacing': [(), (1.2,), 'sequence of int', 'arrays'],
-    })
-    + testing.product({
-        'shape': [(10, 20), (10, 20, 30)],
-        'axis': [None, 0, -1, (0, -1), (1, 0)],
-        'spacing': [(), (1.2,), 'sequence of int', 'arrays', 'mixed'],
-    }),
-    testing.product({
-        'edge_order': [1, 2],
-    }),
-))
+# This class compares CUB results against NumPy's\
+@pytest.mark.parametrize(
+    "shape,axis,spacing",
+    list(iproduct(
+        [()],
+        [None, ()],
+        [(), (1.2,)]
+    ))
+    + list(iproduct(
+        [(33,)],
+        [None, 0, -1, (0,)],
+        [(), (1.2,), 'sequence of int', 'arrays']
+    ))
+    + list(iproduct(
+        [(10, 20), (10, 20, 30)],
+        [None, 0, -1, (0, -1), (1, 0)],
+        [(), (1.2,), 'sequence of int', 'arrays', 'mixed']
+    ))
+)
+@pytest.mark.parametrize(
+    "edge_order",
+    [
+        pytest.param(1, id='edge_order'),
+        pytest.param(2, id='edge_order'),
+    ]
+)
 class TestGradient:
 
     def _gradient(self, xp, dtype, shape, spacing, axis, edge_order):
@@ -1047,23 +1058,24 @@ class TestGradient:
 
     @testing.for_dtypes('fFdD')
     @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-5)
-    def test_gradient_floating(self, xp, dtype):
-        return self._gradient(xp, dtype, self.shape, self.spacing, self.axis,
-                              self.edge_order)
+    def test_gradient_floating(
+        self, xp, dtype, shape, axis, spacing, edge_order
+    ):
+        return self._gradient(xp, dtype, shape, spacing, axis, edge_order)
 
     # unsigned int behavior fixed in 1.18.1
     # https://github.com/numpy/numpy/issues/15207
     @testing.with_requires('numpy>=1.18.1')
     @testing.for_int_dtypes(no_bool=True)
     @testing.numpy_cupy_allclose(atol=1e-6, rtol=1e-5)
-    def test_gradient_int(self, xp, dtype):
-        return self._gradient(xp, dtype, self.shape, self.spacing, self.axis,
-                              self.edge_order)
+    def test_gradient_int(self, xp, dtype, shape, axis, spacing, edge_order):
+        return self._gradient(xp, dtype, shape, spacing, axis, edge_order)
 
     @testing.numpy_cupy_allclose(atol=2e-2, rtol=1e-3)
-    def test_gradient_float16(self, xp):
-        return self._gradient(xp, numpy.float16, self.shape, self.spacing,
-                              self.axis, self.edge_order)
+    def test_gradient_float16(self, xp, shape, axis, spacing, edge_order):
+        return self._gradient(
+            xp, numpy.float16, shape, spacing, axis, edge_order
+        )
 
 
 class TestGradientErrors:

--- a/tests/example_tests/test_custom_struct.py
+++ b/tests/example_tests/test_custom_struct.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import re
-import unittest
 
 from example_tests import example_test
 
 
-class TestCustomStruct(unittest.TestCase):
+class TestCustomStruct:
 
     def test_builtin_vectors(self):
         output = example_test.run_example('custom_struct/builtin_vectors.py')

--- a/tests/example_tests/test_finance.py
+++ b/tests/example_tests/test_finance.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-import unittest
 
 from example_tests import example_test
 
@@ -13,7 +12,7 @@ def _normalize_regexp_eol(pattern):
     return pattern.replace(r'\n', re.escape(os.linesep))
 
 
-class TestBlackScholes(unittest.TestCase):
+class TestBlackScholes:
 
     def test_black_scholes(self):
         output = example_test.run_example(
@@ -27,7 +26,7 @@ class TestBlackScholes(unittest.TestCase):
         assert re.search(pattern, output.decode('utf-8'))
 
 
-class TestMonteCarlo(unittest.TestCase):
+class TestMonteCarlo:
 
     def test_monte_carlo(self):
         output = example_test.run_example(
@@ -44,7 +43,7 @@ class TestMonteCarlo(unittest.TestCase):
         assert re.search(pattern, output.decode('utf-8'))
 
 
-class TestMonteCarloWithMultiGPU(unittest.TestCase):
+class TestMonteCarloWithMultiGPU:
 
     @testing.multi_gpu(2)
     def test_monte_carlo_multigpu(self):

--- a/tests/example_tests/test_gemm.py
+++ b/tests/example_tests/test_gemm.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import unittest
-
 from example_tests import example_test
 
 
-class TestGEMM(unittest.TestCase):
+class TestGEMM:
 
     def test_sgemm(self):
         example_test.run_example('gemm/sgemm.py')

--- a/tests/example_tests/test_gmm.py
+++ b/tests/example_tests/test_gmm.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import tempfile
-import unittest
 
 from cupy import testing
 
@@ -16,7 +15,7 @@ os.environ['MPLBACKEND'] = 'Agg'
 
 @testing.with_requires('matplotlib')
 @testing.with_requires('scipy')
-class TestGMM(unittest.TestCase):
+class TestGMM:
 
     def test_gmm(self):
         output = example_test.run_example('gmm/gmm.py', '--num', '10')

--- a/tests/example_tests/test_kmeans.py
+++ b/tests/example_tests/test_kmeans.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import tempfile
-import unittest
 
 from cupy import testing
 
@@ -15,7 +14,7 @@ os.environ['MPLBACKEND'] = 'Agg'
 
 
 @testing.with_requires('matplotlib')
-class TestKmeans(unittest.TestCase):
+class TestKmeans:
 
     def test_default(self):
         output = example_test.run_example(


### PR DESCRIPTION
Right now, the `@testing.for_contiguous_axes` decorator relies on an object having two attributes set: `self.shape` and `self.order`. In order to migrate some test modules using `for_contiguous_axes` to pytest (to use `pytest.mark.parametrize`), the decorator needs to be tweaked so it retrieves the value from `kwargs` instead.