### PR TITLE
BUG: Fix real sign(NaN) -> NaN and complex sign(0) -> 0

### DIFF
--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -252,7 +252,9 @@ sign = _core.create_ufunc(
     _float_sign,
     doc='''Elementwise sign function.
 
-    It returns -1, 0, or 1 depending on the sign of the input.
+    Returns -1, 0, or 1 depending on the sign of the input. NaN is returned
+    for NaN inputs.
+    For complex values, sign returns ``x/abs(x)`` (and ``0 if x == 0``).
 
     .. seealso:: :data:`numpy.sign`
 

--- a/cupy/_math/misc.py
+++ b/cupy/_math/misc.py
@@ -221,18 +221,35 @@ fabs = _core.create_ufunc(
     ''')
 
 
+_signed_sign = 'out0 = (in0 > 0) - (in0 < 0)'
 _unsigned_sign = 'out0 = in0 > 0'
 _complex_sign = '''
-out0 = in0 / abs(in0)
+using real_t = in0_type::value_type;
+real_t abs_val = abs(in0);
+if (abs_val == 0) {
+  out0 = static_cast<in0_type>(0);
+} else {
+  out0 = in0 / abs_val;
+}
 '''
+_float_sign = '''
+if (in0 < 0 || in0 > 0) {
+  out0 = copysign(static_cast<in0_type>(1), in0);
+} else {
+  out0 = in0 - in0;
+}
+'''
+
 sign = _core.create_ufunc(
     'cupy_sign',
-    ('b->b', ('B->B', _unsigned_sign), 'h->h', ('H->H', _unsigned_sign),
-     'i->i', ('I->I', _unsigned_sign), 'l->l', ('L->L', _unsigned_sign),
-     'q->q', ('Q->Q', _unsigned_sign),
+    (('b->b', _signed_sign), ('B->B', _unsigned_sign),
+     ('h->h', _signed_sign), ('H->H', _unsigned_sign),
+     ('i->i', _signed_sign), ('I->I', _unsigned_sign),
+     ('l->l', _signed_sign), ('L->L', _unsigned_sign),
+     ('q->q', _signed_sign), ('Q->Q', _unsigned_sign),
      'e->e', *bf16_loop(), 'f->f', 'd->d',
      ('F->F', _complex_sign), ('D->D', _complex_sign)),
-    'out0 = (in0 > 0) - (in0 < 0)',
+    _float_sign,
     doc='''Elementwise sign function.
 
     It returns -1, 0, or 1 depending on the sign of the input.

--- a/tests/cupy_tests/math_tests/test_misc.py
+++ b/tests/cupy_tests/math_tests/test_misc.py
@@ -36,17 +36,20 @@ class TestMisc:
             a += (a * 1j).astype(dtype)
         return getattr(xp, name)(a)
 
+    def _get_inf_array(self, xp, dtype):
+        inf = numpy.inf
+        if numpy.dtype(dtype).kind != 'c':
+            return xp.array([0, -1, 1, -inf, inf], dtype=dtype)
+        else:
+            return xp.array([complex(x, y)
+                             for x in [0, -1, 1, -inf, inf]
+                             for y in [0, -1, 1, -inf, inf]],
+                            dtype=dtype)
+
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
     @testing.numpy_cupy_allclose(atol=1e-5)
     def check_unary_inf(self, name, xp, dtype, **kwargs):
-        inf = numpy.inf
-        if numpy.dtype(dtype).kind != 'c':
-            a = xp.array([0, -1, 1, -inf, inf], dtype=dtype)
-        else:
-            a = xp.array([complex(x, y)
-                          for x in [0, -1, 1, -inf, inf]
-                          for y in [0, -1, 1, -inf, inf]],
-                         dtype=dtype)
+        a = self._get_inf_array(xp, dtype)
         return getattr(xp, name)(a, **kwargs)
 
     @testing.for_dtypes(['e', 'f', 'd', 'F', 'D'])
@@ -173,7 +176,6 @@ class TestMisc:
         a = xp.array([2, 3, 4], dtype=dtype)
         return xp.fabs(a)
 
-    @testing.with_requires("numpy>=2.0")
     @testing.for_all_dtypes(no_complex=True)
     @testing.numpy_cupy_allclose(atol=1e-5)
     def test_fabs_negative(self, xp, dtype):
@@ -182,13 +184,34 @@ class TestMisc:
         a = xp.array([-2.0, -4.0, 0.0, 4.0], dtype=dtype)
         return xp.fabs(a)
 
-    @testing.with_requires('numpy>=2.0')
     def test_sign(self):
         self.check_unary('sign', no_bool=True)
 
-    @testing.with_requires('numpy>=2.0')
     def test_sign_negative(self):
         self.check_unary_negative('sign', no_bool=True)
+
+    @pytest.mark.parametrize('dtype', ['e', 'f', 'd', 'F', 'D'])
+    @testing.numpy_cupy_array_equal()
+    def test_sign_signed_zero(self, xp, dtype):
+        a = xp.array([-0.0, 0.0], dtype=dtype)
+        sign = xp.sign(a)
+        signbit = xp.signbit(sign.real)
+        return sign, signbit
+
+    @pytest.mark.parametrize('dtype', [
+        'e', 'f', 'd',
+        pytest.param(
+            'F', marks=pytest.mark.xfail(reason='no inf special case')),
+        pytest.param(
+            'D', marks=pytest.mark.xfail(reason='no inf special case'))
+    ])
+    @testing.numpy_cupy_array_equal()
+    def test_sign_inf(self, xp, dtype):
+        a = self._get_inf_array(xp, dtype)
+        return xp.sign(a)
+
+    def test_sign_nan(self):
+        self.check_unary_nan('sign')
 
     def test_maximum(self):
         self.check_binary('maximum')


### PR DESCRIPTION
This aligns closer with NumPy/Array API sign, while a small corner case to some degree, this seems to me right.

I have ommitted special cases for the complex `abs(x) == inf` case for which NumPy avoids a NaN result in most cases as it felt more niche, but we can add it (as there are two divisions, I'll doubt adding the extra logic will be a huge speed loss).

The new code seems _faster_ than the old, although this is generally memory bound so hard to test.
(the two comparisons should get compiled into a single op, I think.)

Closes gh-8327

EDIT: Needed/desired for https://github.com/cupy/cupy/pull/10030 as that PR adds work-arounds to fix this specifically for sparse matrix/array...

---

Speed check details:

<details>

I (or my agent) generated a fun little script to check the speed that tries to do the operation multiple times, because otherwise even on my T400 the speed difference is zero because it seems memory bound.  With this, the new code seems actually the fastest version (on a T400 2-3 repeats are enough, but on my monster B6000 you need more than 20 iterations).

```
import cupy as cp
from cupyx.profiler import benchmark
def make_kernel(name, body, repeat=2):
    return cp.ElementwiseKernel(
        "T x",
        "T y",
        f"""
        T v = x;
        T acc = 0;
        #pragma unroll 1
        for (int j = 0; j < {repeat}; ++j) {{
            {body}
            v = v * 1.0000001f + 1.0e-7f;
        }}
        y = acc;
        """,
        name,
        options=("--std=c++17",),
    )
kernels = {
    "cmp_nan": make_kernel(
        "bench_cmp_nan",
        'acc += !isnan(v) ? (v > 0.0f) - (v < 0.0f) : nanf("");',
    ),
    "cmp": make_kernel(
        "bench_cmp",
        "acc += (v > 0) - (v < 0);",
    ),
    "if_chain": make_kernel(
        "bench_if_chain",
        """    acc += (v > 0) ? static_cast<T>(1)
         : (v < 0) ? static_cast<T>(-1)
         : (v == 0) ? static_cast<T>(0)
         : v;""",
    ),
    "copysign": make_kernel(
        "bench_copysign",
        """if (v < 0 || v > 0) {
  acc += copysign(static_cast<T>(1), v);
} else {
  acc += static_cast<T>(v - v);
}""",
    ),
}
n = 1 << 25
x = cp.random.standard_normal(n, dtype=cp.float64)
y = cp.empty_like(x)
for name, ker in kernels.items():
    ker(x, y)  # compile/warmup
    r = benchmark(lambda: ker(x, y), (), n_repeat=100, n_warmup=10)
    print(name, r.gpu_times.mean(), "us")
import cupy as cp
from cupyx.profiler import benchmark
def make_kernel(name, body, repeat=20):
    return cp.ElementwiseKernel(
        "T x",
        "T y",
        f"""
        T v = x;
        T acc = 0;
        #pragma unroll 1
        for (int j = 0; j < {repeat}; ++j) {{
            {body}
            v = v * 1.0000001f + 1.0e-7f;
        }}
        y = acc;
        """,
        name,
        options=("--std=c++17",),
    )
kernels = {
    "cmp_nan": make_kernel(
        "bench_cmp_nan",
        'acc += !isnan(v) ? (v > 0.0f) - (v < 0.0f) : nanf("");',
    ),
    "cmp": make_kernel(
        "bench_cmp",
        "acc += (v > 0) - (v < 0);",
    ),
    "if_chain": make_kernel(
        "bench_if_chain",
        """    acc += (v > 0) ? static_cast<T>(1)
         : (v < 0) ? static_cast<T>(-1)
         : (v == 0) ? static_cast<T>(0)
         : v;""",
    ),
    "copysign": make_kernel(
        "bench_copysign",
        """if (v < 0 || v > 0) {
  acc += copysign(static_cast<T>(1), v);
} else {
  acc += static_cast<T>(v - v);
}""",
    ),
}
n = 1 << 25
x = cp.random.standard_normal(n, dtype=cp.float64)
y = cp.empty_like(x)
for name, ker in kernels.items():
    ker(x, y)  # compile/warmup
    r = benchmark(lambda: ker(x, y), (), n_repeat=100, n_warmup=10)
    print(name, r.gpu_times.mean(), "us")

```