### PR TITLE
Enable NumPy 2.5 support (shape deprecation warning)

### DIFF
--- a/cupy/_padding/pad.py
+++ b/cupy/_padding/pad.py
@@ -404,8 +404,7 @@ def _as_pairs(x, ndim, as_index=False):
 
     # Converting the array with `tolist` seems to improve performance
     # when iterating and indexing the result (see usage in `pad`)
-    x_view = x.view()
-    x_view.shape = (ndim, 2)
+    x_view = x.reshape(ndim, 2)
     return x_view.tolist()
 
 # def _pad_dispatcher(array, pad_width, mode=None, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ filterwarnings = [
   # setuptools 65+
   # TODO(kmaehashi): Remove distutils from cupy_builder to remove this
   "ignore:Absolute path '(.+?)' is being replaced with a relative path '(.+?)' for outputs:DeprecationWarning:distutils",
+  # Older SciPy versions + NumPy 2.5+ do not avoid this warning.
+  "ignore:Setting the shape on a NumPy:DeprecationWarning:scipy",
 ]
 
 [tool.coverage.run]

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -256,6 +256,9 @@ class TestNdarrayCopy:
                     b, numpy.array([0, 0], dtype=numpy.uint64))
 
 
+@pytest.mark.filterwarnings(
+    # Shape setting is deprecated starting NumPy 2.5
+    'ignore:Setting the shape on a NumPy:DeprecationWarning')
 class TestNdarrayShape(unittest.TestCase):
 
     @testing.numpy_cupy_array_equal()


### PR DESCRIPTION
Closes gh-10035 addresses much of gh-10036

I think I'd like to get the SciPy 1.17 one in first and then finish the last things to actually run the test suite with 2.5 here.
That said, this is also self-contained as is and we could just put it in.