### PR TITLE
feat: add complex keyword to cupyx.scipy.signal.chirp

### DIFF
--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -418,6 +418,26 @@ _chirp_phase_quad_kernel = cupy.ElementwiseKernel(
     "_chirp_phase_quad_kernel",
 )
 
+_chirp_phase_quad_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi, bool vertex_zero",
+    "Y phase",
+    """
+    T temp {};
+    const T beta { (f1 - f0) / (t1 * t1) };
+    if ( vertex_zero ) {
+        temp = 2 * M_PI * (f0 * t + beta * (t * t * t) / 3);
+    } else {
+        temp = 2 * M_PI *
+            ( f1 * t + beta *
+            ( ( (t1 - t) * (t1 - t) * (t1 - t) ) - (t1 * t1 * t1)) / 3);
+    }
+    // Convert  phi to radians.
+    const T phase_tmp { temp + phi };
+    phase = Y(cos(phase_tmp), sin(phase_tmp));
+    """,
+    "_chirp_phase_quad_kernel",
+)
+
 _chirp_phase_log_kernel = cupy.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi",
     "T phase",
@@ -431,6 +451,24 @@ _chirp_phase_log_kernel = cupy.ElementwiseKernel(
     }
     // Convert  phi to radians.
     phase = cos(temp + phi);
+    """,
+    "_chirp_phase_log_kernel",
+)
+
+_chirp_phase_log_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi",
+    "Y phase",
+    """
+    T temp {};
+    if ( f0 == f1 ) {
+        temp = 2 * M_PI * f0 * t;
+    } else {
+        T beta { t1 / log(f1 / f0) };
+        temp = 2 * M_PI * beta * f0 * ( pow(f1 / f0, t / t1) - 1.0 );
+    }
+    // Convert  phi to radians.
+    const T phase_tmp { temp + phi };
+    phase = Y(cos(phase_tmp), sin(phase_tmp));
     """,
     "_chirp_phase_log_kernel",
 )
@@ -453,7 +491,35 @@ _chirp_phase_hyp_kernel = cupy.ElementwiseKernel(
 )
 
 
-def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
+_chirp_phase_hyp_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi",
+    "Y phase",
+    """
+    T temp {};
+    if ( f0 == f1 ) {
+        temp = 2 * M_PI * f0 * t;
+    } else {
+        T sing { -f1 * t1 / (f0 - f1) };
+        temp = 2 * M_PI * ( -sing * f0 ) * log( abs( 1 - t / sing ) );
+    }
+    // Convert  phi to radians.
+    const T phase_tmp { temp + phi };
+    phase = Y(cos(phase_tmp), sin(phase_tmp));
+    """,
+    "_chirp_phase_hyp_kernel",
+)
+
+
+def _chirp_complex_dtype(t):
+    if t.dtype.kind == 'c':
+        return t.dtype
+    if t.dtype.kind == 'f' and t.dtype.itemsize == 8:
+        return cupy.complex128
+    return cupy.complex64
+
+
+def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True, *,
+          complex=False):
     """Frequency-swept cosine generator.
 
     In the following, 'Hz' should be interpreted as 'cycles per unit';
@@ -480,14 +546,19 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
         This parameter is only used when `method` is 'quadratic'.
         It determines whether the vertex of the parabola that is the graph
         of the frequency is at t=0 or t=t1.
+    complex : bool, optional
+        If True, return a complex-valued analytic signal. Default is False.
 
     Returns
     -------
     y : ndarray
         A numpy array containing the signal evaluated at `t` with the
         requested time-varying frequency.  More precisely, the function
-        returns ``cos(phase + (pi/180)*phi)`` where `phase` is the integral
-        (from 0 to `t`) of ``2*pi*f(t)``. ``f(t)`` is defined below.
+        returns ``exp(1j * (phase + (pi/180)*phi))`` if `complex` is True,
+        and ``cos(phase + (pi/180)*phi)`` otherwise, where `phase` is the
+        integral (from 0 to `t`) of ``2*pi*f(t)``. ``f(t)`` is defined below.
+        Complex output is complex64 or complex128 depending on the precision
+        of `t`.
 
     Examples
     --------
@@ -535,23 +606,24 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
         t = t.astype(cupy.float64)
 
     phi *= np.pi / 180
-    type = 'real'
+    type = 'complex' if complex else 'real'
 
     if method in ["linear", "lin", "li"]:
         if type == "real":
             return _chirp_phase_lin_kernel_real(t, f0, t1, f1, phi)
         elif type == "complex":
-            # type hard-coded to 'real' above, so this code path is never used
-            if t.real.dtype.kind == 'f' and t.dtype.itemsize == 8:
-                phase = cupy.empty(t.shape, dtype=cupy.complex128)
-            else:
-                phase = cupy.empty(t.shape, dtype=cupy.complex64)
+            phase = cupy.empty(t.shape, dtype=_chirp_complex_dtype(t))
             _chirp_phase_lin_kernel_cplx(t, f0, t1, f1, phi, phase)
             return phase
         else:
             raise NotImplementedError("No kernel for type {}".format(type))
 
     elif method in ["quadratic", "quad", "q"]:
+        if type == "complex":
+            phase = cupy.empty(t.shape, dtype=_chirp_complex_dtype(t))
+            _chirp_phase_quad_kernel_cplx(
+                t, f0, t1, f1, phi, vertex_zero, phase)
+            return phase
         return _chirp_phase_quad_kernel(t, f0, t1, f1, phi, vertex_zero)
 
     elif method in ["logarithmic", "log", "lo"]:
@@ -560,12 +632,20 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
                 "For a logarithmic chirp, f0 and f1 must be "
                 "nonzero and have the same sign."
             )
+        if type == "complex":
+            phase = cupy.empty(t.shape, dtype=_chirp_complex_dtype(t))
+            _chirp_phase_log_kernel_cplx(t, f0, t1, f1, phi, phase)
+            return phase
         return _chirp_phase_log_kernel(t, f0, t1, f1, phi)
 
     elif method in ["hyperbolic", "hyp"]:
         if f0 == 0 or f1 == 0:
             raise ValueError(
                 "For a hyperbolic chirp, f0 and f1 must be " "nonzero.")
+        if type == "complex":
+            phase = cupy.empty(t.shape, dtype=_chirp_complex_dtype(t))
+            _chirp_phase_hyp_kernel_cplx(t, f0, t1, f1, phi, phase)
+            return phase
         return _chirp_phase_hyp_kernel(t, f0, t1, f1, phi)
 
     else:

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
@@ -48,6 +48,68 @@ class TestChirp:
             t=0, f0=10.0, f1=1.0, t1=1.0, method='hyperbolic')
         return w
 
+    @pytest.mark.parametrize('method, f0, f1, kwargs', [
+        ('linear', 1.0, 3.0, {}),
+        ('quadratic', 1.0, 3.0, {}),
+        ('quadratic', 1.0, 3.0, {'vertex_zero': False}),
+        ('logarithmic', 1.0, 3.0, {}),
+        ('hyperbolic', 3.0, 1.0, {}),
+    ])
+    @testing.with_requires('scipy>=1.15.0')
+    @testing.numpy_cupy_allclose(
+        scipy_name="scp", rtol=1e-6, atol=1e-6)
+    def test_complex(self, method, f0, f1, kwargs, xp, scp):
+        t = xp.linspace(0, 1, 50)
+        w = scp.signal.chirp(
+            t, f0, 1.0, f1, method=method, complex=True, **kwargs)
+        return w
+
+    @testing.with_requires('scipy>=1.15.0')
+    @testing.numpy_cupy_allclose(
+        scipy_name="scp", rtol=1e-6, atol=1e-6)
+    def test_complex_phi(self, xp, scp):
+        t = xp.linspace(-1, 1, 50)
+        w = scp.signal.chirp(
+            t, 1.0, 1.0, 3.0, phi=45.0, complex=True)
+        return w
+
+    @testing.with_requires('scipy>=1.15.0')
+    def test_complex_real_part_and_magnitude(self):
+        t = cupy.linspace(0, 1, 50)
+        real = cupyx.scipy.signal.chirp(t, 1.0, 1.0, 3.0)
+        analytic = cupyx.scipy.signal.chirp(
+            t, 1.0, 1.0, 3.0, complex=True)
+
+        testing.assert_allclose(analytic.real, real, rtol=1e-7, atol=1e-7)
+        testing.assert_allclose(
+            cupy.abs(analytic), cupy.ones_like(real), rtol=1e-7, atol=1e-7)
+
+    @pytest.mark.parametrize('dtype, expected_dtype', [
+        ('float32', cupy.complex64),
+        ('float64', cupy.complex128),
+    ])
+    @testing.with_requires('scipy>=1.15.0')
+    def test_complex_dtype(self, dtype, expected_dtype):
+        t = cupy.linspace(0, 1, 50, dtype=dtype)
+        actual = cupyx.scipy.signal.chirp(
+            t, 1.0, 1.0, 3.0, complex=True)
+
+        assert actual.dtype == expected_dtype
+        expected = scipy.signal.chirp(
+            np.linspace(0, 1, 50, dtype=dtype), 1.0, 1.0, 3.0,
+            complex=True)
+        testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+    @pytest.mark.parametrize('complex_', [1, "yes", None])
+    @testing.with_requires('scipy>=1.15.0')
+    @testing.numpy_cupy_allclose(
+        scipy_name="scp", rtol=1e-6, atol=1e-6)
+    def test_complex_non_bool(self, complex_, xp, scp):
+        t = xp.linspace(0, 1, 50)
+        w = scp.signal.chirp(
+            t, 1.0, 1.0, 3.0, complex=complex_)
+        return w
+
     def test_hyperbolic_zero_freq(self):
         # f0=0 or f1=0 must raise a ValueError.
         method = 'hyperbolic'
@@ -73,6 +135,19 @@ class TestChirp:
 
             with pytest.raises(ValueError):
                 scp.signal.chirp(t, f0, t1, f1, method)
+
+    @testing.with_requires('scipy>=1.15.0')
+    def test_unknown_method_complex(self):
+        method = "foo"
+        f0 = 10.0
+        f1 = 20.0
+        t1 = 1.0
+
+        for xp, scp in [(cupy, cupyx.scipy), (np, scipy)]:
+            t = xp.linspace(0, t1, 10)
+
+            with pytest.raises(ValueError):
+                scp.signal.chirp(t, f0, t1, f1, method, complex=True)
 
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_integer_t1(self, xp, scp):


### PR DESCRIPTION
## Summary
Adds a `complex` keyword to `cupyx.scipy.signal.chirp`, matching SciPy 1.15's addition. When `complex=True` the function returns the analytic (complex exponential) chirp instead of the real cosine, via a dedicated complex-phase `ElementwiseKernel`. Default `complex=False` preserves existing behavior.

Adds tests covering the complex output for all four sweep methods.

Fixes #10029
