### PR TITLE
fix: allow non-integer arrays for ndimage labelling

### DIFF
--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -107,6 +107,30 @@ class TestLabelSpecialCases:
         labels, num_features = scp.ndimage.label(x)
         return labels
 
+    @testing.for_dtypes([numpy.float32, numpy.float64])
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_label_float_nonzero_values(self, xp, scp, dtype):
+        x = xp.array([[0, -1.5, 0, 0, numpy.inf],
+                      [0, 2.25, 0, 0, 0],
+                      [0, 0, 0, numpy.nan, 0],
+                      [0, 0, 0, -numpy.inf, 0]], dtype=dtype)
+        structure = numpy.array([[0, 1, 0],
+                                 [0, 1, 0],
+                                 [0, 1, 0]], dtype=bool)
+        return scp.ndimage.label(x, structure=structure)
+
+    @testing.numpy_cupy_array_equal(scipy_name='scp')
+    def test_label_bool(self, xp, scp):
+        x = xp.array([[True, False, True],
+                      [False, True, False]], dtype=bool)
+        return scp.ndimage.label(x)
+
+    @testing.for_complex_dtypes()
+    @testing.numpy_cupy_array_equal(scipy_name='scp', accept_error=TypeError)
+    def test_label_complex_unsupported(self, xp, scp, dtype):
+        x = xp.ones((2, 2), dtype=dtype)
+        return scp.ndimage.label(x)
+
 
 @testing.parameterize(*testing.product({
     'op': stats_ops,


### PR DESCRIPTION
## Summary
`cupyx.scipy.ndimage.label` already accepts non-integer input on the current branch (the only dtype guard rejects complex types; nonzero elements are treated as foreground, matching SciPy's implicit `input != 0`). Per #10041, the remaining piece is the "matches SciPy" regression test, so a future integer-only guard doesn't silently reintroduce the SciPy CI regression from gh-9859.

This adds `test_label_float_nonzero_values`, comparing cupy against SciPy for float32/float64 input including negative, inf, and nan values.

Fixes #10041
