### PR TITLE
refactor: remove obsolete _setup_win32_dll_directory now that cuda.pathfinder handles discovery

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -10,7 +10,6 @@ from cupy import _version
 
 
 _environment._detect_duplicate_installation()  # NOQA
-_environment._setup_win32_dll_directory()  # NOQA
 _environment._preload_library('cutensor')  # NOQA
 
 

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -265,60 +265,6 @@ def _get_cub_path():
     return _cub_path
 
 
-def _setup_win32_dll_directory():
-    # Setup DLL directory to load CUDA Toolkit libs and shared libraries
-    # added during the build process.
-    if sys.platform.startswith('win32'):
-        # see _can_attempt_preload()
-        config = get_preload_config()
-        is_conda = (config is not None and (config['packaging'] == 'conda'))
-
-        # Path to the CUDA Toolkit binaries
-        cuda_path = get_cuda_path()
-        if cuda_path is not None:
-            if is_conda:
-                cuda_bin_path = cuda_path
-            else:
-                cuda_bin_path = os.path.join(cuda_path, 'bin')
-        else:
-            cuda_bin_path = None
-            if not is_conda:
-                warnings.warn(
-                    'CUDA path could not be detected.'
-                    ' Set CUDA_PATH environment variable if CuPy '
-                    'fails to load.')
-        _log('CUDA_PATH: {}'.format(cuda_path))
-
-        # Path to shared libraries in wheel
-        wheel_libdir = os.path.join(
-            get_cupy_install_path(), 'cupy', '.data', 'lib')
-        if os.path.isdir(wheel_libdir):
-            _log('Wheel shared libraries: {}'.format(wheel_libdir))
-        else:
-            _log('Not wheel distribution ({} not found)'.format(
-                wheel_libdir))
-            wheel_libdir = None
-
-        if (3, 8) <= sys.version_info:
-            if cuda_bin_path is not None:
-                _log('Adding DLL search path: {}'.format(cuda_bin_path))
-                os.add_dll_directory(cuda_bin_path)
-                cuda_bin_x64_path = os.path.join(cuda_bin_path, 'x64')
-                if os.path.exists(cuda_bin_x64_path):
-                    _log('Adding DLL search path (for CUDA 13): '
-                         f'{cuda_bin_x64_path}')
-                    os.add_dll_directory(cuda_bin_x64_path)
-            if wheel_libdir is not None:
-                _log('Adding DLL search path: {}'.format(wheel_libdir))
-                os.add_dll_directory(wheel_libdir)
-        else:
-            # Users are responsible for adding `%CUDA_PATH%/bin` to PATH.
-            if wheel_libdir is not None:
-                _log('Adding to PATH: {}'.format(wheel_libdir))
-                path = os.environ.get('PATH', '')
-                os.environ['PATH'] = wheel_libdir + os.pathsep + path
-
-
 def get_cupy_install_path():
     # Path to the directory where the package is installed.
     return os.path.abspath(


### PR DESCRIPTION
## Summary
Remove the import-time call `_environment._setup_win32_dll_directory()` from `cupy/__init__.py` (line 13) and delete the now-unused `_setup_win32_dll_directory` function (defined at `cupy/_environment.py:268`, including the x64-hardcoded `os.add_dll_directory(...)` blocks around lines 305-313). Confirm no other call sites reference the symbol before deleting (grep shows only `cupy/__init__.py` and the definition). Because CUDA library discovery now flows through `cuda.pathfinder`, the wheel/`PATH`-based directory injection is redundant; the change is import-path cleanup with no public API surface.

## Why this matters
Maintainer leofang (MEMBER, issue author, `prio:high` / `cat:code-fix`) reports that CuPy calls `os.add_dll_directory` at import time on Windows via `_environment._setup_win32_dll_directory()` (invoked from `cupy/__init__.py` line 13). Now that CUDA discovery has moved to `cuda.pathfinder`, this hook is considered obsolete and may even interfere with how pathfinder locates libraries. It is also an active blocker for Windows-on-Arm bring-up because `_setup_win32_dll_directory` hard-codes x64 paths. leofang's directive: "We should remove it and, if anything breaks, fix it in the pathfinder."

See https://github.com/cupy/cupy/issues/10044.

## Testing
- Happy path: `import cupy` succeeds on Windows x64 with CUDA libs resolved via cuda.pathfinder (Windows CI), and on POSIX where the function was already a no-op. - Edge case: Windows-on-Arm import no longer hits the x64-hardcoded path injection. - Regression guard: no remaining references to `_setup_win32_dll_directory` in the tree (the deleted symbol is fully orphaned).

Fixes #10044
