### PR TITLE
refactor: special-case scalar literal powers (arr**2, **0.5, **-1) for performance

### DIFF
--- a/cupy/_core/_routines_math.pxd
+++ b/cupy/_core/_routines_math.pxd
@@ -31,6 +31,8 @@ cdef object _negative
 cdef object _multiply
 cdef object _divide
 cdef object _power
+cdef object _square
+cdef object _reciprocal
 cdef object _subtract
 cdef object _true_divide
 cdef object _floor_divide

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1042,6 +1042,35 @@ _power = create_ufunc(
     ''')
 
 
+_square = create_ufunc(
+    'cupy_square',
+    ('b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L', 'q->q',
+     'Q->Q', 'e->e', *bf16_loop(), 'f->f', 'd->d', 'F->F', 'D->D'),
+    'out0 = in0 * in0',
+    doc='''Elementwise square function.
+
+    .. seealso:: :data:`numpy.square`
+
+    ''')
+
+
+_reciprocal = create_ufunc(
+    'cupy_reciprocal',
+    ('b', 'B', 'h', 'H', 'i', 'I', 'l', 'L', 'q', 'Q',
+     ('e', 'out0 = 1 / in0'),
+     *bf16_loop(code='out0 = 1 / in0'),
+     ('f', 'out0 = 1 / in0'),
+     ('d', 'out0 = 1 / in0'),
+     ('F', 'out0 = in0_type(1) / in0'),
+     ('D', 'out0 = in0_type(1) / in0')),
+    'out0 = in0 == 0 ? 0 : (1 / in0)',
+    doc='''Computes ``1 / x`` elementwise.
+
+    .. seealso:: :data:`numpy.reciprocal`
+
+    ''')
+
+
 def _subtract_boolean_error():
     raise TypeError(
         'cupy boolean subtract, the `-` operator, is deprecated, use the '
@@ -1162,6 +1191,8 @@ negative = _negative
 multiply = _multiply
 divide = _divide
 power = _power
+square = _square
+reciprocal = _reciprocal
 subtract = _subtract
 true_divide = _true_divide
 floor_divide = _floor_divide

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -118,6 +118,96 @@ cdef inline _should_use_rop(x, y):
     yp = getattr(y, '__array_priority__', 0)
     return xp < yp
 
+
+cdef inline bint _power_scalar_type_matches(
+        _ndarray_base x, object y, object out_dtype) except*:
+    try:
+        return numpy.result_type(x.dtype, y) == out_dtype
+    except TypeError:
+        return False
+
+
+cdef inline bint _power_scalar_matches_square(
+        _ndarray_base x, object y) except*:
+    cdef object out_dtype
+
+    if type(y) is int:
+        if y != 2:
+            return False
+        if x.dtype.kind == 'b':
+            return True
+        return _power_scalar_type_matches(x, y, x.dtype)
+
+    if type(y) is float:
+        return y == 2.0 and _power_scalar_type_matches(x, y, x.dtype)
+
+    if isinstance(y, numpy.generic):
+        if y != 2 or y.dtype.kind not in 'iuf':
+            return False
+        if x.dtype.kind == 'b':
+            out_dtype = numpy.dtype(numpy.int8)
+        else:
+            out_dtype = x.dtype
+        return _power_scalar_type_matches(x, y, out_dtype)
+
+    return False
+
+
+cdef inline bint _power_scalar_matches_sqrt(
+        _ndarray_base x, object y) except*:
+    if x.dtype.kind not in 'fc':
+        return False
+
+    if type(y) is float:
+        return y == 0.5 and _power_scalar_type_matches(x, y, x.dtype)
+
+    if isinstance(y, numpy.generic):
+        if y != 0.5 or y.dtype.kind != 'f':
+            return False
+        return _power_scalar_type_matches(x, y, x.dtype)
+
+    return False
+
+
+cdef inline bint _power_scalar_matches_reciprocal(
+        _ndarray_base x, object y) except*:
+    if x.dtype.kind not in 'fc':
+        return False
+
+    if type(y) is int:
+        return y == -1 and _power_scalar_type_matches(x, y, x.dtype)
+
+    if type(y) is float:
+        return y == -1.0 and _power_scalar_type_matches(x, y, x.dtype)
+
+    if isinstance(y, numpy.generic):
+        if y != -1 or y.dtype.kind not in 'iuf':
+            return False
+        return _power_scalar_type_matches(x, y, x.dtype)
+
+    return False
+
+
+cdef inline object _power_scalar_fast_path(
+        _ndarray_base x, object y, object out) except*:
+    if _power_scalar_matches_square(x, y):
+        if out is None:
+            return _math._square(x)
+        return _math._square(x, out)
+
+    if _power_scalar_matches_sqrt(x, y):
+        if out is None:
+            return _math._sqrt(x)
+        return _math._sqrt(x, out)
+
+    if _power_scalar_matches_reciprocal(x, y):
+        if out is None:
+            return _math._reciprocal(x)
+        return _math._reciprocal(x, out)
+
+    return None
+
+
 cdef bint _is_ump_enabled = (int(os.environ.get('CUPY_ENABLE_UMP', '0')) != 0)
 
 cdef inline bint is_ump_supported(int device_id) except*:
@@ -1624,6 +1714,9 @@ cdef class _ndarray_base:
         elif _should_use_rop(x, y):
             return NotImplemented
         else:
+            result = _power_scalar_fast_path(x, y, None)
+            if result is not None:
+                return result
             return numpy.power(x, y)
 
     def __lshift__(x, y):
@@ -1690,6 +1783,9 @@ cdef class _ndarray_base:
         return _math._remainder(self, other, self)
 
     def __ipow__(self, other):
+        result = _power_scalar_fast_path(self, other, self)
+        if result is not None:
+            return result
         return _math._power(self, other, self)
 
     def __ilshift__(self, other):

--- a/tests/cupy_tests/math_tests/test_arithmetic.py
+++ b/tests/cupy_tests/math_tests/test_arithmetic.py
@@ -26,6 +26,21 @@ negative_no_complex_types = [numpy.bool_] + float_types + signed_int_types
 no_complex_types = [numpy.bool_] + float_types + int_types
 
 
+def _scalar_power_values(xp, dtype, shape, exponent):
+    if shape == ():
+        value = 4 if exponent == 0.5 else 2
+        return xp.asarray(value, dtype=dtype)
+    if 0 in shape:
+        return xp.empty(shape, dtype=dtype)
+    if exponent == 0.5:
+        values = [0, 1, 4, 9, 16, 25]
+    elif exponent == -1:
+        values = [-4, -2, -1, 1, 2, 4]
+    else:
+        values = [-3, -2, -1, 0, 2, 3]
+    return xp.asarray(values, dtype=dtype).reshape(shape)
+
+
 @testing.parameterize(*(
     testing.product({
         'nargs': [1],
@@ -375,6 +390,67 @@ class TestArithmeticBinary3(ArithmeticBinaryBase):
                 y = func(arg1, arg2, **dtype_arg)
 
         return y
+
+
+class TestNdarrayScalarPowerSpecialCases:
+
+    @pytest.mark.parametrize('shape', [(2, 3), (), (3, 0, 2)])
+    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+    @pytest.mark.parametrize(
+        'exponent',
+        [2, numpy.float32(2), 0.5, numpy.float32(0.5),
+         -1, numpy.float32(-1)])
+    @testing.numpy_cupy_array_equal()
+    def test_scalar_power_matches_power_ufunc(
+            self, xp, dtype, shape, exponent):
+        a = _scalar_power_values(xp, dtype, shape, exponent)
+        with numpy.errstate(divide='ignore'):
+            actual = a ** exponent
+            expected = xp.power(a, exponent)
+        assert actual.dtype == expected.dtype
+        testing.assert_array_equal(actual, expected)
+        return actual
+
+    @pytest.mark.parametrize(
+        'exponent', [numpy.int64(2), numpy.float64(0.5),
+                     numpy.int64(-1), 2.5])
+    @testing.numpy_cupy_allclose()
+    def test_scalar_power_fallback_matches_power_ufunc(self, xp, exponent):
+        a = xp.asarray([1, 4, 9, 16], dtype=numpy.float32)
+        with numpy.errstate(divide='ignore'):
+            actual = a ** exponent
+            expected = xp.power(a, exponent)
+        assert actual.dtype == expected.dtype
+        testing.assert_allclose(actual, expected)
+        return actual
+
+    @testing.for_int_dtypes()
+    @testing.numpy_cupy_array_equal()
+    def test_integer_power_two_dtype(self, xp, dtype):
+        a = xp.asarray([0, 1, 2, 3], dtype=dtype)
+        return a ** 2
+
+    @pytest.mark.parametrize('dtype', [numpy.int32, numpy.uint32])
+    def test_integer_power_negative_one_matches_power_ufunc(self, dtype):
+        a = cupy.asarray([0, 1, 2], dtype=dtype)
+        try:
+            expected = cupy.power(a, -1)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                a ** -1
+        else:
+            actual = a ** -1
+            assert actual.dtype == expected.dtype
+            testing.assert_array_equal(actual, expected)
+
+    @pytest.mark.parametrize('exponent', [2, 0.5, -1])
+    @pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+    @testing.numpy_cupy_array_equal()
+    def test_inplace_scalar_power(self, xp, dtype, exponent):
+        a = _scalar_power_values(xp, dtype, (2, 3), exponent)
+        with numpy.errstate(divide='ignore'):
+            a **= exponent
+        return a
 
 
 class UfuncTestBase:


### PR DESCRIPTION
## Summary
In `cupy/_core/core.pyx`, special-case `__pow__` and `__ipow__` when the exponent is a Python/NumPy scalar equal to a recognized literal: route `2` to the `square` path, `0.5` to `sqrt`, and `-1` to `reciprocal`, falling back to the existing `power` path otherwise. Wire these to the existing ufuncs in `cupy/_core/_routines_math.pyx` (`_sqrt`/`sqrt` already live there; add or expose a `square`/`reciprocal` routine at this layer if not reachable, plus an optional `_cube` ufunc for `**3`). Critically, preserve NumPy promotion semantics: only take the fast path when the resulting dtype matches what `power` would produce (notably guard the integer `**-1` case, which NumPy treats specially) so output dtype and values are identical to the slow path.

## Why this matters
Maintainer seberg (MEMBER, issue author, `prio:high` / `cat:performance`) notes that `arr**2`, `arr**3`, `arr**0.5`, and `arr**-1` are common, idiomatic patterns that currently route through the general `power` ufunc and pay an unnecessary performance penalty, when they map directly to faster unary ufuncs (`square`, `sqrt`, `reciprocal`). `__pow__`/`__ipow__` in `cupy/_core/core.pyx` (around lines 1620 and 1693) dispatch scalar exponents to `numpy.power(x, y)` / `_math._power`. seberg explicitly flags two caveats: `**-1` has different/odd promotion rules for integers, and there may be no `**3` ufunc yet. He defers the "lower into the power ufunc itself" redesign as uncertain.

See https://github.com/cupy/cupy/issues/10043.

## Testing
- Happy path: `arr**2`, `arr**0.5`, `arr**-1` (and `**3` if added) produce values bit-identical to the current `power`-based result across float32/float64. - Edge cases: integer arrays with `**-1` and `**2` keep NumPy-matching dtype promotion (no silent dtype change); negative/zero bases; 0-d and broadcasted inputs; in-place `__ipow__`. - Fallback path: non-recognized exponents (e.g. `**2.5`, array exponents) still route through `power` unchanged.

Fixes #10043
