### PR TITLE
Show build- and run-time versions for NumPy, cuTENSOR, and cuSPARSELt in show_config()

### DIFF
--- a/cupy/_util.pyx
+++ b/cupy/_util.pyx
@@ -13,6 +13,7 @@ from cupy_backends.cuda.api cimport runtime
 
 
 cython_build_ver = CUPY_CYTHON_VERSION
+numpy_build_ver = CUPY_NUMPY_VERSION
 
 
 ENABLE_SLICE_COPY = bool(

--- a/cupy_backends/cuda/libs/cutensor.pyx
+++ b/cupy_backends/cuda/libs/cutensor.pyx
@@ -273,6 +273,9 @@ available = True
 # Version information
 ###############################################################################
 
+def get_build_version():
+    return CUTENSOR_VERSION
+
 cpdef size_t get_version():
     return cutensorGetVersion()
 

--- a/cupyx/_runtime.py
+++ b/cupyx/_runtime.py
@@ -36,6 +36,15 @@ def _load_and_get_path(lib_name):
         return loaded_dl.abs_path
 
 
+def _get_cusparselt_runtime_version(cusparselt):
+    handle = cusparselt.Handle()
+    cusparselt.init(handle)
+    try:
+        return cusparselt.getVersion(handle)
+    finally:
+        cusparselt.destroy(handle)
+
+
 def _version_and_path(ver_seq, path_seq):
     assert len(ver_seq) >= len(path_seq)
     result = []
@@ -117,13 +126,16 @@ class _RuntimeInfo:
     nccl_path = None
     cub_build_version = None
     jitify_build_version = None
+    cutensor_build_version = None
     cutensor_version = None
     cutensor_path = None
+    cusparselt_build_version = None
     cusparselt_version = None
     cusparselt_path = None
     cython_build_version = None
     cython_version = None
 
+    numpy_build_version = None
     numpy_version = None
     scipy_version = None
 
@@ -273,6 +285,7 @@ class _RuntimeInfo:
         # cuTENSOR
         try:
             from cupy_backends.cuda.libs import cutensor
+            self.cutensor_build_version = cutensor.get_build_version()
             self.cutensor_version = cutensor.get_version()
         except ImportError:
             pass
@@ -282,7 +295,11 @@ class _RuntimeInfo:
         # cuSparseLT
         try:
             from cupy_backends.cuda.libs import cusparselt
-            self.cusparselt_version = cusparselt.get_build_version()
+            self.cusparselt_build_version = cusparselt.get_build_version()
+            if full:
+                self.cusparselt_version = _eval_or_error(
+                    lambda: _get_cusparselt_runtime_version(cusparselt),
+                    Exception)
         except ImportError:
             pass
         if full and not is_hip:
@@ -297,6 +314,7 @@ class _RuntimeInfo:
             pass
 
         # NumPy
+        self.numpy_build_version = cupy._util.numpy_build_ver
         self.numpy_version = numpy.version.full_version
 
         # SciPy
@@ -314,7 +332,8 @@ class _RuntimeInfo:
             ('Python Version', platform.python_version()),
             ('CuPy Version', self.cupy_version),
             ('CuPy Platform', 'NVIDIA CUDA' if not is_hip else 'AMD ROCm'),
-            ('NumPy Version', self.numpy_version),
+            ('NumPy Build Version', self.numpy_build_version),
+            ('NumPy Runtime Version', self.numpy_version),
             ('SciPy Version', self.scipy_version),
             ('Cython Build Version', self.cython_build_version),
             ('Cython Runtime Version', self.cython_version),
@@ -372,14 +391,19 @@ class _RuntimeInfo:
             records += [('NCCL Path', self.nccl_path)]
 
         records += [
-            ('cuTENSOR Version', self.cutensor_version),
+            ('cuTENSOR Build Version', self.cutensor_build_version),
+            ('cuTENSOR Runtime Version', self.cutensor_version),
         ]
         if full and not is_hip:
             records += [('cuTENSOR Path', self.cutensor_path)]
 
         records += [
-            ('cuSPARSELt Build Version', self.cusparselt_version),
+            ('cuSPARSELt Build Version', self.cusparselt_build_version),
         ]
+        if full:
+            records += [
+                ('cuSPARSELt Runtime Version', self.cusparselt_version),
+            ]
         if full and not is_hip:
             records += [('cuSPARSELt Path', self.cusparselt_path)]
 

--- a/install/cupy_builder/_command.py
+++ b/install/cupy_builder/_command.py
@@ -102,6 +102,8 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
         # the user does not have Cython installed.
         import Cython.Build
 
+        import numpy
+
         ctx = cupy_builder.get_context()
         compiler_directives = {
             'linetrace': ctx.linetrace,
@@ -130,6 +132,7 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
 
         compile_time_env['CUPY_CUFFT_STATIC'] = False
         compile_time_env['CUPY_CYTHON_VERSION'] = Cython.__version__
+        compile_time_env['CUPY_NUMPY_VERSION'] = numpy.__version__
         if ctx.use_stub:  # on RTD
             compile_time_env['CUPY_CUDA_VERSION'] = 0
             compile_time_env['CUPY_HIP_VERSION'] = 0

--- a/tests/cupyx_tests/test_runtime.py
+++ b/tests/cupyx_tests/test_runtime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+import numpy
+
 import cupy
 import cupyx
 
@@ -18,6 +20,21 @@ class TestRuntime(unittest.TestCase):
         runtime = cupyx.get_runtime_info()
         assert cupy.__version__ == runtime.cupy_version
         assert cupy.__version__ in str(runtime)
+
+    def test_build_and_runtime_versions(self):
+        runtime = cupyx.get_runtime_info()
+        assert runtime.numpy_build_version is not None
+        assert numpy.version.full_version == runtime.numpy_version
+        output = str(runtime)
+        for record in (
+                'NumPy Build Version',
+                'NumPy Runtime Version',
+                'cuTENSOR Build Version',
+                'cuTENSOR Runtime Version',
+                'cuSPARSELt Build Version',
+                'cuSPARSELt Runtime Version',
+        ):
+            assert record in output
 
     def test_error(self):
         runtime = cupyx.get_runtime_info()


### PR DESCRIPTION
Closes #9560.

This makes `cupy.show_config()` report both build- and run-time versions for the remaining libraries, as requested in the issue:

- **NumPy**: the build-time version is captured at build via a new `CUPY_NUMPY_VERSION` compile-time env (same mechanism as `CUPY_CYTHON_VERSION`) and exposed as `cupy._util.numpy_build_ver`. Displayed as `NumPy Build Version` / `NumPy Runtime Version`, following the existing Cython records.
- **cuTENSOR**: added `get_build_version()` to the binding (returns the `CUTENSOR_VERSION` macro, 0 on stub builds, mirroring the cuSPARSELt binding). Displayed as `cuTENSOR Build Version` / `cuTENSOR Runtime Version`.
- **cuSPARSELt**: the runtime version is now queried via the existing `getVersion(handle)` wrapper (handle is created/initialized/destroyed just for the query, only when `full=True`, consistent with how cuBLAS/cuSPARSE handles are used). Displayed as `cuSPARSELt Build Version` / `cuSPARSELt Runtime Version`.

Notes for reviewers:

- The `NumPy Version` record was renamed to `NumPy Build Version` + `NumPy Runtime Version`. If output compatibility matters, I can keep the original label for the runtime record.
- On `_RuntimeInfo`, `cusparselt_version` now holds the runtime version (build moved to `cusparselt_build_version`), matching the `cutensor_*` naming. Happy to keep the old semantics instead if preferred.

Added a test in `tests/cupyx_tests/test_runtime.py` checking that the new records appear in the output.