### PR TITLE
ENH: Implement numpy.unstack

### DIFF
--- a/cupy/_manipulation/join.py
+++ b/cupy/_manipulation/join.py
@@ -164,3 +164,20 @@ def stack(tup, axis=0, out=None, *, dtype=None, casting='same_kind'):
     """
     return concatenate([cupy.expand_dims(x, axis) for x in tup], axis, out,
                        dtype=dtype, casting=casting)
+
+def unstack(x, axis=0, /):
+    """Splits an array into a sequence of arrays along the given axis.
+
+    Args:
+        x (cupy.ndarray): The array to be unstacked.
+        axis (int): Axis along which the array is unstacked. Defaults to 0.
+
+    Returns:
+        tuple of cupy.ndarray: Tuple of unstacked arrays.
+
+    .. seealso:: :func:`numpy.unstack`
+    """
+    if x.ndim == 0:
+        raise ValueError("Cannot unstack a 0-dimensional array.")
+        
+    return tuple(cupy.moveaxis(x, axis, 0))

--- a/tests/cupy_tests/manipulation_tests/test_join.py
+++ b/tests/cupy_tests/manipulation_tests/test_join.py
@@ -534,3 +534,48 @@ class TestJoin:
         b = cupy.zeros((4, 3))
         with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
             cupy.row_stack((a, b))
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_unstack_1d_axis_0(self, xp):
+        a = xp.arange(5)
+        return xp.unstack(a, axis=0)
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_unstack_1d_axis_negative_1(self, xp):
+        a = xp.arange(5)
+        return xp.unstack(a, axis=-1)
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_unstack_3d_positive_axis(self, xp):
+        a = xp.arange(24).reshape((2, 3, 4))
+        return xp.unstack(a, axis=1)
+
+    @testing.numpy_cupy_array_list_equal()
+    def test_unstack_3d_negative_axis(self, xp):
+        a = xp.arange(24).reshape((2, 3, 4))
+        return xp.unstack(a, axis=-2)
+
+    @testing.numpy_cupy_raises(accept_errors=(ValueError,))
+    def test_unstack_0d_array(self, xp):
+        a = xp.array(42)
+        xp.unstack(a, axis=0)
+
+    @testing.numpy_cupy_raises(accept_errors=(numpy.AxisError,))
+    def test_unstack_1d_invalid_positive(self, xp):
+        a = xp.zeros((5,))
+        xp.unstack(a, axis=1)
+
+    @testing.numpy_cupy_raises(accept_errors=(numpy.AxisError,))
+    def test_unstack_2d_invalid_positive(self, xp):
+        a = xp.zeros((3, 4))
+        xp.unstack(a, axis=2)
+
+    @testing.numpy_cupy_raises(accept_errors=(numpy.AxisError,))
+    def test_unstack_2d_invalid_negative(self, xp):
+        a = xp.zeros((3, 4))
+        xp.unstack(a, axis=-3)
+
+    @testing.numpy_cupy_raises(accept_errors=(numpy.AxisError,))
+    def test_unstack_3d_invalid_negative(self, xp):
+        a = xp.zeros((2, 3, 4))
+        xp.unstack(a, axis=-4)


### PR DESCRIPTION

This PR implements cupy.unstack to mirror the functionality of numpy.unstack as tracked in #6078. 

The implementation was placed in cupy/_manipulation/join.py ,I have used cupy.moveaxis to rotate the target axis to the 0th position before unpacking it into a tuple of sub-arrays.

Added a comprehensive test suite in tests/cupy_tests/manipulation_tests/test_join.py covering:
* 1D and 3D array unstacking.
* Positive and negative axis behavior using @testing.numpy_cupy_array_list_equal.
* 0-dimensional edge cases ensuring ValueError matching.
* Out-of-bounds axis testing ensuring numpy.AxisError matching via @testing.numpy_cupy_raises.

Please let me know if there are any preferred structural changes or documentation requirements.