### PR TITLE
feat: add smallest magnitude eigenvalue support to `cupyx.scipy.sparse.linalg.eigsh`

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -8,10 +8,11 @@ from cupy._core import _dtype
 from cupy.cuda import device
 from cupy_backends.cuda.libs import cublas as _cublas
 from cupyx.scipy.sparse import _csr
+from cupyx.scipy.sparse import _construct
 from cupyx.scipy.sparse.linalg import _interface
 
 
-def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
+def eigsh(a, k=6, *, which='LM', sigma=None, v0=None, ncv=None, maxiter=None,
           tol=0, return_eigenvectors=True):
     """
     Find ``k`` eigenvalues and eigenvectors of the real symmetric square
@@ -65,8 +66,9 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         raise ValueError('k must be greater than 0 (actual: {})'.format(k))
     if k >= n:
         raise ValueError('k must be smaller than n (actual: {})'.format(k))
-    if which not in ('LM', 'LA', 'SA'):
-        raise ValueError('which must be \'LM\',\'LA\'or\'SA\' (actual: {})'
+    if which not in ('LM', 'LA', 'SA', 'SM'):
+        raise ValueError('which must be \'LM\',\'LA\',\'SA\'or\'SM\''
+                         '    (actual: {})'
                          ''.format(which))
     if ncv is None:
         ncv = min(max(2 * k, k + 32), n - 1)
@@ -76,6 +78,21 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         maxiter = 10 * n
     if tol == 0:
         tol = numpy.finfo(a.dtype).eps
+
+    if which == 'SM':
+        if sigma is not None:
+            raise ValueError(
+                "which='SM' is not supported together with sigma"
+            )
+        sigma = 0
+        which = 'LM'
+        auto_shift = True
+    else:
+        auto_shift = False
+
+    if sigma is not None:
+        return _eigsh_shift_invert(a, k, sigma, which, v0, ncv, maxiter, tol,
+                                   return_eigenvectors, auto_shift=auto_shift)
 
     alpha = cupy.zeros((ncv,), dtype=a.dtype)
     beta = cupy.zeros((ncv,), dtype=a.dtype.char.lower())
@@ -143,6 +160,53 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         return w[idx], x[:, idx]
     else:
         return cupy.sort(w)
+
+
+def _eigsh_shift_invert(a, k, sigma, which, v0, ncv, maxiter, tol,
+                        return_eigenvectors, auto_shift):
+    if isinstance(a, _interface.MatrixLinearOperator):
+        a = a.A          # unwrap: shift-invert needs the explicit matrix
+    elif isinstance(a, _interface.LinearOperator):
+        raise TypeError(
+            'shift-invert requires an explicit matrix; pass a ndarray or '
+            'sparse matrix (support for OPinv is not implemented)')
+
+    n = a.shape[0]
+
+    if auto_shift:
+        if isinstance(a, cupy.ndarray):
+            scale = float(cupy.abs(a).max())
+        else:
+            scale = float(cupy.abs(a.data).max()) if a.nnz > 0 else 0.0
+        sigma = -numpy.sqrt(numpy.finfo(a.dtype).eps) * max(scale, 1.0)
+
+    if isinstance(a, cupy.ndarray):
+        A_shifted = _csr.csr_matrix(a - sigma * cupy.eye(n, dtype=a.dtype))
+    else:
+        A_shifted = a - sigma * _construct.identity(n, dtype=a.dtype,
+                                                    format='csr')
+
+    # Factorize and solve on the CPU
+    import scipy.sparse.linalg as scipy_sparse_linalg
+    lu = scipy_sparse_linalg.splu(A_shifted.tocsc().get())
+
+    def matvec(b):
+        return cupy.asarray(lu.solve(cupy.asnumpy(b)))
+
+    op = _interface.LinearOperator((n, n), matvec, dtype=a.dtype)
+
+    nu, v = eigsh(op, k=k, which=which, v0=v0,
+                  ncv=ncv, maxiter=maxiter, tol=tol)
+
+    # transform back
+    w = sigma + 1.0 / nu
+
+    if return_eigenvectors:
+        idx = cupy.argsort(w)  # ascending algebraic
+        return w[idx], v[:, idx]
+    else:
+        idx = cupy.argsort(cupy.absolute(w))[::-1]  # decreasing |w|
+        return w[idx]
 
 
 def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
@@ -327,10 +391,7 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
         idx = numpy.argsort(w)
         wk = w[idx[:k]]
         sk = s[:, idx[:k]]
-    # elif which == 'SM':  #dysfunctional
-    #   idx = cupy.argsort(abs(w))
-    #   wk = w[idx[:k]]
-    #   sk = s[:,idx[:k]]
+
     return cupy.array(wk), cupy.array(sk)
 
 

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -386,12 +386,10 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
         idx = numpy.argsort(numpy.absolute(w))
         wk = w[idx[-k:]]
         sk = s[:, idx[-k:]]
-
     elif which == 'SA':
         idx = numpy.argsort(w)
         wk = w[idx[:k]]
         sk = s[:, idx[:k]]
-
     return cupy.array(wk), cupy.array(sk)
 
 

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -28,11 +28,15 @@ def eigsh(a, k=6, *, which='LM', sigma=None, v0=None, ncv=None, maxiter=None,
             :class:`cupyx.scipy.sparse.linalg.LinearOperator`.
         k (int): The number of eigenvalues and eigenvectors to compute. Must be
             ``1 <= k < n``.
-        which (str): 'LM' or 'LA' or 'SA'.
+        which (str): 'LM' or 'LA' or 'SA' or 'SM'.
             'LM': finds ``k`` largest (in magnitude) eigenvalues.
             'LA': finds ``k`` largest (algebraic) eigenvalues.
             'SA': finds ``k`` smallest (algebraic) eigenvalues.
-
+            'SM': finds ``k`` smallest (in magnitude) eigenvalues.
+        sigma (float): If not ``None``, finds the ``k`` eigenvalues nearest
+            ``sigma`` using shift-invert mode, which requires SciPy and
+            ``a`` to be a matrix (not a ``LinearOperator``). Cannot be
+            used together with ``which='SM'``.
         v0 (ndarray): Starting vector for iteration. If ``None``, a random
             unit vector is used.
         ncv (int): The number of Lanczos vectors generated. Must be
@@ -67,9 +71,8 @@ def eigsh(a, k=6, *, which='LM', sigma=None, v0=None, ncv=None, maxiter=None,
     if k >= n:
         raise ValueError('k must be smaller than n (actual: {})'.format(k))
     if which not in ('LM', 'LA', 'SA', 'SM'):
-        raise ValueError('which must be \'LM\',\'LA\',\'SA\'or\'SM\''
-                         '    (actual: {})'
-                         ''.format(which))
+        raise ValueError('which must be \'LM\', \'LA\', \'SA\' or \'SM\' '
+                         '(actual: {})'.format(which))
     if ncv is None:
         ncv = min(max(2 * k, k + 32), n - 1)
     else:
@@ -164,8 +167,11 @@ def eigsh(a, k=6, *, which='LM', sigma=None, v0=None, ncv=None, maxiter=None,
 
 def _eigsh_shift_invert(a, k, sigma, which, v0, ncv, maxiter, tol,
                         return_eigenvectors, auto_shift):
+    import scipy.linalg
+    import scipy.sparse.linalg
+
     if isinstance(a, _interface.MatrixLinearOperator):
-        a = a.A          # unwrap: shift-invert needs the explicit matrix
+        a = a.A
     elif isinstance(a, _interface.LinearOperator):
         raise TypeError(
             'shift-invert requires an explicit matrix; pass a ndarray or '
@@ -174,39 +180,45 @@ def _eigsh_shift_invert(a, k, sigma, which, v0, ncv, maxiter, tol,
     n = a.shape[0]
 
     if auto_shift:
+        # Use a small negative shift to keep the factorization nonsingular
         if isinstance(a, cupy.ndarray):
             scale = float(cupy.abs(a).max())
         else:
             scale = float(cupy.abs(a.data).max()) if a.nnz > 0 else 0.0
-        sigma = -numpy.sqrt(numpy.finfo(a.dtype).eps) * max(scale, 1.0)
+        if scale == 0.0:
+            scale = 1.0
+        sigma = -numpy.sqrt(numpy.finfo(a.dtype).eps) * scale
 
+    # Factorize (a - sigma*I) and solve on the CPU
     if isinstance(a, cupy.ndarray):
-        A_shifted = _csr.csr_matrix(a - sigma * cupy.eye(n, dtype=a.dtype))
+        A_shifted = cupy.asnumpy(a) - sigma * numpy.eye(n, dtype=a.dtype)
+        lu_piv = scipy.linalg.lu_factor(A_shifted)
+
+        def solve(b):
+            return scipy.linalg.lu_solve(lu_piv, b)
     else:
         A_shifted = a - sigma * _construct.identity(n, dtype=a.dtype,
                                                     format='csr')
-
-    # Factorize and solve on the CPU
-    import scipy.sparse.linalg as scipy_sparse_linalg
-    lu = scipy_sparse_linalg.splu(A_shifted.tocsc().get())
+        solve = scipy.sparse.linalg.splu(A_shifted.tocsc().get()).solve
 
     def matvec(b):
-        return cupy.asarray(lu.solve(cupy.asnumpy(b)))
+        return cupy.asarray(solve(cupy.asnumpy(b)))
 
-    op = _interface.LinearOperator((n, n), matvec, dtype=a.dtype)
+    op = _interface.LinearOperator((n, n), matvec=matvec, dtype=a.dtype)
 
     nu, v = eigsh(op, k=k, which=which, v0=v0,
                   ncv=ncv, maxiter=maxiter, tol=tol)
 
-    # transform back
+    # Transform back
     w = sigma + 1.0 / nu
 
-    if return_eigenvectors:
-        idx = cupy.argsort(w)  # ascending algebraic
-        return w[idx], v[:, idx]
-    else:
-        idx = cupy.argsort(cupy.absolute(w))[::-1]  # decreasing |w|
+    if not return_eigenvectors and auto_shift:
+        idx = cupy.argsort(cupy.absolute(w))[::-1]
         return w[idx]
+    idx = cupy.argsort(w)
+    if return_eigenvectors:
+        return w[idx], v[:, idx]
+    return w[idx]
 
 
 def _lanczos_asis(a, V, u, alpha, beta, i_start, i_end):
@@ -439,6 +451,8 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
     if k >= min(m, n):
         raise ValueError('k must be smaller than min(m, n) (actual: {})'
                          ''.format(k))
+    if which != 'LM':
+        raise ValueError('which must be \'LM\' (actual: {})'.format(which))
 
     a = _interface.aslinearoperator(a)
     if m >= n:

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -127,7 +127,7 @@ class TestVectorNorm:
 
 
 @testing.parameterize(*testing.product({
-    'which': ['LM', 'LA', 'SA', 'SM'],
+    'which': ['LM', 'LA', 'SA'],
     'k': [3, 6, 12],
     'return_eigenvectors': [True, False],
     'use_linear_operator': [True, False],
@@ -237,6 +237,69 @@ class TestEigsh:
         v_v0 = cupy.copysign(ev_v0[:, 0], v)
 
         assert cupy.linalg.norm(v - v_v0) < cupy.linalg.norm(v - v_aux)
+
+
+@testing.parameterize(*testing.product({
+    'k': [3, 6, 12],
+    'return_eigenvectors': [True, False],
+    'use_linear_operator': [True, False],
+}))
+@testing.with_requires('scipy')
+class TestEigshSM:
+    n = 30
+    density = 0.33
+    # CuPy computes 'SM' via shift-invert while SciPy uses bare ARPACK;
+    # for interior eigenvalues their single-precision agreement is
+    # limited to ~1e-4 by each solver's own accumulated error.
+    tol = {numpy.float32: 1e-4, numpy.complex64: 1e-4, 'default': 1e-10}
+    res_tol = {'f': 1e-5, 'd': 1e-12}
+
+    def _make_matrix(self, dtype, xp):
+        shape = (self.n, self.n)
+        a = testing.shaped_random(shape, xp, dtype=dtype)
+        mask = testing.shaped_random(shape, xp, dtype='f', scale=1)
+        a[mask > self.density] = 0
+        a = a * a.conj().T
+        return a
+
+    def _test_eigsh(self, a, a_norm, xp, sp):
+        ret = sp.linalg.eigsh(a, k=self.k, which='SM',
+                              return_eigenvectors=self.return_eigenvectors)
+        if self.return_eigenvectors:
+            w, x = ret
+            # Check the residuals to see if eigenvectors are correct.
+            # 'SM' eigenvalues are the ones nearest zero, so norm(w) is
+            # not a usable residual scale; normalize by the matrix norm.
+            ax_xw = a @ x - xp.multiply(x, w.reshape(1, self.k))
+            res = xp.linalg.norm(ax_xw) / a_norm
+            tol = self.res_tol[numpy.dtype(a.dtype).char.lower()]
+            assert (res < tol)
+        else:
+            w = ret
+        return xp.sort(w)
+
+    @pytest.mark.parametrize('format', ['csr', 'csc', 'coo'])
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_sparse(self, format, dtype, xp, sp):
+        if runtime.is_hip and format == 'csc':
+            pytest.xfail('may be buggy')  # trans=True
+
+        a = self._make_matrix(dtype, xp)
+        a_norm = xp.linalg.norm(a)
+        a = sp.coo_matrix(a).asformat(format)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+        return self._test_eigsh(a, a_norm, xp, sp)
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_dense(self, dtype, xp, sp):
+        a = self._make_matrix(dtype, xp)
+        a_norm = xp.linalg.norm(a)
+        if self.use_linear_operator:
+            a = sp.linalg.aslinearoperator(a)
+        return self._test_eigsh(a, a_norm, xp, sp)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -127,7 +127,7 @@ class TestVectorNorm:
 
 
 @testing.parameterize(*testing.product({
-    'which': ['LM', 'LA', 'SA'],
+    'which': ['LM', 'LA', 'SA', 'SM'],
     'k': [3, 6, 12],
     'return_eigenvectors': [True, False],
     'use_linear_operator': [True, False],
@@ -215,8 +215,6 @@ class TestEigsh:
             sp.linalg.eigsh(xp.ones((2, 2), dtype='i'))
         with pytest.raises(ValueError):
             sp.linalg.eigsh(a, k=self.n)
-        with pytest.raises(ValueError):
-            sp.linalg.eigsh(a, k=self.k, which='SM')
 
     def test_starting_vector(self):
         eigsh = cupyx.scipy.sparse.linalg.eigsh
@@ -321,8 +319,6 @@ class TestSvds:
             sp.linalg.svds(xp.ones((2, 2), dtype='i'))
         with pytest.raises(ValueError):
             sp.linalg.svds(a, k=min(self.shape))
-        with pytest.raises(ValueError):
-            sp.linalg.svds(a, k=self.k, which='SM')
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -248,9 +248,6 @@ class TestEigsh:
 class TestEigshSM:
     n = 30
     density = 0.33
-    # CuPy computes 'SM' via shift-invert while SciPy uses bare ARPACK;
-    # for interior eigenvalues their single-precision agreement is
-    # limited to ~1e-4 by each solver's own accumulated error.
     tol = {numpy.float32: 1e-4, numpy.complex64: 1e-4, 'default': 1e-10}
     res_tol = {'f': 1e-5, 'd': 1e-12}
 
@@ -267,7 +264,6 @@ class TestEigshSM:
                               return_eigenvectors=self.return_eigenvectors)
         if self.return_eigenvectors:
             w, x = ret
-            # Check the residuals to see if eigenvectors are correct.
             # 'SM' eigenvalues are the ones nearest zero, so norm(w) is
             # not a usable residual scale; normalize by the matrix norm.
             ax_xw = a @ x - xp.multiply(x, w.reshape(1, self.k))

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -264,8 +264,8 @@ class TestEigshSM:
                               return_eigenvectors=self.return_eigenvectors)
         if self.return_eigenvectors:
             w, x = ret
-            # 'SM' eigenvalues are the ones nearest zero, so norm(w) is
-            # not a usable residual scale; normalize by the matrix norm.
+            # Check the residuals to see if eigenvectors are correct.
+            # Use norm(a) as the scale since norm(w) is ~0 for 'SM'.
             ax_xw = a @ x - xp.multiply(x, w.reshape(1, self.k))
             res = xp.linalg.norm(ax_xw) / a_norm
             tol = self.res_tol[numpy.dtype(a.dtype).char.lower()]
@@ -296,6 +296,70 @@ class TestEigshSM:
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, a_norm, xp, sp)
+
+
+@testing.parameterize(*testing.product({
+    'which': ['LM', 'LA', 'SA'],
+    'k': [3, 6],
+    'return_eigenvectors': [True, False],
+    'format': ['dense', 'csr'],
+}))
+@testing.with_requires('scipy')
+class TestEigshSigma:
+    n = 30
+    density = 0.33
+    sigma = 0.5
+    tol = {numpy.float32: 1e-4, numpy.complex64: 1e-4, 'default': 1e-10}
+    res_tol = {'f': 1e-5, 'd': 1e-12}
+
+    def _make_matrix(self, dtype, xp):
+        shape = (self.n, self.n)
+        a = testing.shaped_random(shape, xp, dtype=dtype)
+        mask = testing.shaped_random(shape, xp, dtype='f', scale=1)
+        a[mask > self.density] = 0
+        a = a * a.conj().T
+        return a
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_sigma(self, dtype, xp, sp):
+        a = self._make_matrix(dtype, xp)
+        a_norm = xp.linalg.norm(a)
+        if self.format == 'csr':
+            a = sp.csr_matrix(a)
+        ret = sp.linalg.eigsh(a, k=self.k, sigma=self.sigma,
+                              which=self.which,
+                              return_eigenvectors=self.return_eigenvectors)
+        if self.return_eigenvectors:
+            w, x = ret
+            # Check the residuals to see if eigenvectors are correct.
+            ax_xw = a @ x - xp.multiply(x, w.reshape(1, self.k))
+            res = xp.linalg.norm(ax_xw) / a_norm
+            tol = self.res_tol[numpy.dtype(a.dtype).char.lower()]
+            assert (res < tol)
+        else:
+            w = ret
+        if numpy.dtype(dtype).kind == 'c':
+            # scipy returns complex results in inconsistent order
+            w = xp.sort(w)
+        return w
+
+
+@testing.with_requires('scipy')
+class TestEigshShiftInvertInvalid:
+    n = 30
+
+    def test_sigma_with_sm(self):
+        a = cupy.diag(cupy.ones((self.n,), dtype='f'))
+        with pytest.raises(ValueError):
+            sparse.linalg.eigsh(a, k=3, which='SM', sigma=1.0)
+
+    def test_linear_operator(self):
+        a = cupy.diag(cupy.ones((self.n,), dtype='f'))
+        op = sparse.linalg.LinearOperator(
+            (self.n, self.n), matvec=lambda x: a @ x, dtype=a.dtype)
+        with pytest.raises(TypeError):
+            sparse.linalg.eigsh(op, k=3, which='SM')
 
 
 @testing.parameterize(*testing.product({
@@ -378,6 +442,8 @@ class TestSvds:
             sp.linalg.svds(xp.ones((2, 2), dtype='i'))
         with pytest.raises(ValueError):
             sp.linalg.svds(a, k=min(self.shape))
+        with pytest.raises(ValueError):
+            sp.linalg.svds(a, k=self.k, which='SM')
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Closes #4692.

Adds shift-invert mode to `eigsh`: a new `sigma` argument (find the `k` eigenvalues nearest `sigma`), and `which='SM'` (smallest magnitude), which maps internally to shift-invert with a small negative shift so the factorization stays nonsingular for PSD inputs such as graph Laplacians.

### Implementation

- The Lanczos iteration runs on $OP = (A - \sigma I)^{-1}$, reusing the existing thick-restart solver unchanged: the largest-magnitude eigenpairs of $OP$ are exactly the eigenpairs of $A$ nearest $\sigma$. (A plain re-sort of the Ritz values cannot work, thick-restart Lanczos only converges extremal eigenvalues; see the discussion in #4692.)
- The factorization and triangular solves run on the CPU (SuperLU for sparse input, LAPACK LU for dense), following the findings in #4692 that they are much faster there than on the GPU. The Lanczos iteration stays on the GPU. This requires SciPy.
- Eigenvalues are transformed back via $w = \sigma + 1/\nu$. Output ordering matches SciPy: ascending algebraic, except decreasing magnitude for `which='SM'` with `return_eigenvectors=False`.
- A general `LinearOperator` is rejected in shift-invert mode (`OPinv` is not implemented). `svds` now rejects `which='SM'` explicitly, as its docstring states. Supporting SciPy's `OPinv` argument (a user-supplied `(A - sigma*I)^-1` operator) would be a natural follow-up to enable shift-invert for matrix-free operators.

### Tests

- `TestEigshSM` mirrors `TestEigsh` for `which='SM'` (sparse formats, dense, LinearOperator, `fdFD`). The eigenvector residual is normalized by `norm(a)` since `norm(w)` is ~0 for 'SM', and the single-precision eigenvalue tolerance is 1e-4 (vs 1e-5 in `TestEigsh`): CuPy computes 'SM' via shift-invert while SciPy uses bare ARPACK, so for interior eigenvalues the two solvers only agree to each one's own accumulated single-precision error. Double precision stays at 1e-10.
- `TestEigshSigma` checks `sigma` against SciPy for LM/LA/SA (dense/CSR, `fdFD`), including output ordering for real dtypes. (SciPy's complex path returns an inconsistent order, so complex results are compared sorted.)
- `TestEigshShiftInvertInvalid` covers the error paths.

### Performance

Benchmarks in https://github.com/cupy/cupy/issues/4692#issuecomment-4881378375: parity with SciPy's `eigsh(sigma=0)` at small `k` (both are bound by the same CPU triangular solves), growing to ~1.75x faster at `k=128` (n=250,000, RTX 4070 SUPER), where the GPU-side reorthogonalization dominates.

This is my first CuPy contribution, happy to adjust to better match project conventions.