### PR TITLE
Fix #9756 and #9760: Fix structure check and sequence modes regressions in ndimage

### DIFF
--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -545,7 +545,7 @@ def _prewitt_or_sobel(input, axis, output, mode, cval, weights):
         return cupy.array([-1, 0, 1], dtype=weights.dtype) if is_diff else weights  # noqa
 
     axes = tuple(range(input.ndim))
-    modes = (mode,) * input.ndim
+    modes = _util._fix_sequence_arg(mode, input.ndim, 'mode')
     return _run_1d_correlates(input, axes,
                               [a == axis for a in range(input.ndim)], get,
                               output, modes, cval)
@@ -906,12 +906,14 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
         size = ftprnt
         ftprnt = None
 
-    axes, ftprnt, origins, modes, int_type = _filters_core._check_nd_args(
-        input, ftprnt, mode, origin, 'footprint', sizes=size, axes=axes,
-        raise_on_zero_size_weight=True)
-    num_axes = len(axes)
+    orig_axes = _util._check_axes(axes, input.ndim)
+    orig_num_axes = len(orig_axes)
     sizes, ftprnt, structure = _filters_core._check_size_footprint_structure(
-        num_axes, size, ftprnt, structure)
+        orig_num_axes, size, ftprnt, structure)
+
+    axes, ftprnt, origins, modes, int_type = _filters_core._check_nd_args(
+        input, ftprnt, mode, origin, 'footprint', sizes=sizes, axes=orig_axes,
+        raise_on_zero_size_weight=True)
     if cval is cupy.nan:
         raise NotImplementedError("NaN cval is unsupported")
 
@@ -925,15 +927,9 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
     if ftprnt.size == 0:
         return cupy.zeros_like(input)
 
-    if num_axes < input.ndim:
-        # expand origins ,footprint and structure if num_axes < input.ndim
-        ftprnt = _util._expand_footprint(input.ndim, axes, ftprnt)
-        origins = _util._expand_origin(input.ndim, axes, origin)
-        modes = tuple(_util._expand_mode(input.ndim, axes, modes))
-
     if structure is not None:
         structure = _util._expand_footprint(
-            input.ndim, axes, structure, footprint_name="structure"
+            input.ndim, orig_axes, structure, footprint_name="structure"
         )
 
     offsets = _filters_core._origins_to_offsets(origins, ftprnt.shape)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1062,4 +1062,3 @@ class TestSequenceModeRegression:
     def test_prewitt_sequence_mode(self, xp, scp):
         arr = xp.asarray([[1., 0., 0], [1, 1, 0], [0, 0, 0]])
         return scp.ndimage.prewitt(arr, mode=['reflect', 'reflect'])
-

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1054,3 +1054,12 @@ class TestInvalidOrigin(FilterTestCaseBase):
     def test_invalid_origin_pos(self, xp, scp):
         self.origin = self.ksize - self.ksize // 2
         return self._filter(xp, scp)
+
+
+class TestSequenceModeRegression:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_prewitt_sequence_mode(self, xp, scp):
+        arr = xp.asarray([[1., 0., 0], [1, 1, 0], [0, 0, 0]])
+        return scp.ndimage.prewitt(arr, mode=['reflect', 'reflect'])
+

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -877,3 +877,17 @@ class TestGreyMorphologyAxes:
     def test_grey_morphology_axes(self, xp, scp):
         x = testing.shaped_random(self.shape, xp, self.x_dtype)
         return self._filter(xp, scp, x)
+
+
+class TestGreyMorphologyRegression:
+
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_white_tophat_structure_only(self, xp, scp):
+        x = xp.array([[True, False, False],
+                      [False, True, False],
+                      [False, False, True]], dtype=bool)
+        structure = xp.array([[True, True, True],
+                              [True, True, True],
+                              [True, True, True]], dtype=bool)
+        return scp.ndimage.white_tophat(x, structure=structure)
+

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py
@@ -890,4 +890,3 @@ class TestGreyMorphologyRegression:
                               [True, True, True],
                               [True, True, True]], dtype=bool)
         return scp.ndimage.white_tophat(x, structure=structure)
-


### PR DESCRIPTION
### Summary
- In `grey_erosion`, passing a custom `structure` while keeping both `size` and `footprint` as `None` caused a `ValueError` because the footprint wasn't resolved before validating arguments.
- In `prewitt` (and potentially `sobel`), passing a list/sequence of modes per-axis (e.g. `mode=['reflect', 'reflect']`) crashed because the mode parameter was incorrectly multiplied as a nested tuple of lists rather than resolving individual mode per axis.

### Root cause
1. In `_min_or_max_filter`, `_filters_core._check_nd_args` was called before `_filters_core._check_size_footprint_structure`. If `structure` is provided but `footprint` and `size` are both `None`, the validation inside `_check_nd_args` saw both `weights` (i.e. `ftprnt`) and `sizes` (i.e. `size`) as `None` and raised `ValueError("must specify either weights array or sizes")` before the footprint could be initialized from the structure.
2. In `_prewitt_or_sobel`, `modes = (mode,) * input.ndim` was used to expand the mode across dimensions. If `mode` was already a sequence (e.g., a list of strings), this resulted in a nested sequence (e.g., a tuple of lists) which failed string validation inside `_check_mode`.

### Fix
1. Updated `_min_or_max_filter` to first resolve size, footprint, and structure using `_check_size_footprint_structure` before calling `_check_nd_args`, and pass the resolved footprint/sizes to `_check_nd_args`. Deleted duplicate expansion blocks for `ftprnt`, `origins`, and `modes` as they are already handled inside `_check_nd_args`.
2. Updated `_prewitt_or_sobel` to use `_util._fix_sequence_arg(mode, input.ndim, 'mode')` to properly normalize the mode sequence.

### Testing
- Executed existing parameterized tests in `tests/cupyx_tests/scipy_tests/ndimage_tests/test_morphology.py` (which passed successfully).
- Added `TestGreyMorphologyRegression` to verify that `white_tophat` behaves correctly with `structure` only.
- Added `TestSequenceModeRegression` to verify `prewitt` with per-axis modes sequence.
- Verified both regression tests pass successfully on the GPU-enabled Windows test environment.

Fixes #9756
Fixes #9760
