### PR TITLE
WIP,DRAFT: Use WarpReduce for short-axis generic CUB block reductions

### DIFF
--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -17,6 +17,7 @@ from cupy_backends.cuda.libs cimport nvrtc
 
 
 import math
+import os
 import string
 from cupy import _environment
 from cupy._core._kernel import _get_param_info
@@ -25,7 +26,7 @@ from cupy import _util
 
 
 cdef function.Function _create_cub_reduction_function(
-        name, block_size, items_per_thread,
+        name, block_size, items_per_thread, reduce_group_threads,
         reduce_type, params, arginfos, identity,
         pre_map_expr, reduce_expr, post_map_expr,
         _kernel._TypeMap type_map, preamble, options):
@@ -71,6 +72,7 @@ static_assert(sizeof(_type_reduce) <= 32,
 // Compile-time constants for CUB template specializations
 #define ITEMS_PER_THREAD  ${items_per_thread}
 #define BLOCK_SIZE        ${block_size}
+#define REDUCE_GROUP_THREADS ${reduce_group_threads}
 
 // for hipCUB: use the hipcub namespace
 #ifdef __HIP_DEVICE_COMPILE__
@@ -100,10 +102,9 @@ struct _reduction_op {
 
 extern "C"
 __global__ void ${name}(${params}) {
-  unsigned int _tid = threadIdx.x;
 '''
 
-    if pre_map_expr == 'in0':
+    if reduce_group_threads == block_size and pre_map_expr == 'in0':
         module_code += '''
   // Specialize BlockLoad type for faster (?) loading
   typedef cub::BlockLoad<_type_reduce, BLOCK_SIZE,
@@ -113,12 +114,14 @@ __global__ void ${name}(${params}) {
   __shared__ typename BlockLoadT::TempStorage temp_storage_load;
 '''
 
-    module_code += '''
+        module_code += '''
+  unsigned int _tid = threadIdx.x;
+
   // Specialize BlockReduce type for our thread block
-  typedef cub::BlockReduce<_type_reduce, BLOCK_SIZE> BlockReduceT;
+  typedef cub::BlockReduce<_type_reduce, BLOCK_SIZE> SegmentReduceT;
 
   // Shared memory for reduction
-  __shared__ typename BlockReduceT::TempStorage temp_storage;
+  __shared__ typename SegmentReduceT::TempStorage temp_storage;
 
   // Declare reduction operation
   _reduction_op op;
@@ -163,40 +166,17 @@ __global__ void ${name}(${params}) {
       if (_seg_size - i <= tile_size) { tile_size = _seg_size - i; }
 '''
 
-    if pre_map_expr == 'in0':
         module_code += '''
       // load a tile
       BlockLoadT(temp_storage_load).Load(segment_head + i, _sdata, tile_size,
                                          _type_reduce(${identity}));
 '''
-    else:  # pre_map_expr could be something like "in0 != type_in0_raw(0)"
+
         module_code += '''
-      // load a tile
-      #pragma unroll
-      for (int j = 0; j < ITEMS_PER_THREAD; j++) {
-          // index of the element in a tile
-          int e_idx = _tid * ITEMS_PER_THREAD + j;
-
-          // some pre_map_expr uses _J internally...
-          #if defined FIRST_PASS
-          IndexT _J = (segment_idx + i + e_idx);
-          #else  // only one pass
-          IndexT _J = (segment_idx + i + e_idx) % _seg_size;
-          #endif
-
-          if (e_idx < tile_size) {
-              const type_mid_in in0 = *(segment_head + i + e_idx);
-              _sdata[j] = static_cast<_type_reduce>(${pre_map_expr});
-          } else {
-              _sdata[j] = _type_reduce(${identity});
-          }
-      }
-'''
-
-    module_code += '''
       // Compute block reduction
       // Note that the output is only meaningful for thread 0
-      aggregate = op(aggregate, BlockReduceT(temp_storage).Reduce(_sdata, op));
+      aggregate = op(aggregate, SegmentReduceT(temp_storage).Reduce(
+          _sdata, op));
 
       __syncthreads();  // for reusing temp_storage
   }
@@ -207,14 +187,92 @@ __global__ void ${name}(${params}) {
   }
 }
 '''
+
+    else:
+        module_code += '''
+  typedef ${collective_type} SegmentReduceT;
+  static const int segments_per_block = ${segments_per_block};
+
+  unsigned int _tid = threadIdx.x;
+  unsigned int group_id = _tid / REDUCE_GROUP_THREADS;
+  unsigned int lane = _tid % REDUCE_GROUP_THREADS;
+
+  // Shared memory for one or more independent segment reductions per block.
+  __shared__ typename SegmentReduceT::TempStorage
+      temp_storage[segments_per_block];
+
+  // Declare reduction operation
+  _reduction_op op;
+
+  // input & output raw pointers
+  const type_mid_in* _in0 = static_cast<const type_mid_in*>(_raw_in0);
+  type_mid_out* _out0 = static_cast<type_mid_out*>(_raw_out0);
+
+  // Each logical warp group or block handles one fixed-size segment.
+  size_t segment_id = size_t(blockIdx.x) * segments_per_block + group_id;
+  size_t segment_idx = segment_id * _segment_size;
+  const type_mid_in* segment_head = _in0 + segment_idx;
+  sizeT _seg_size = _segment_size;
+  bool valid_segment = true;
+
+  #if defined FIRST_PASS
+  // for two-pass reduction only: "last segment" is special
+  if (_array_size > 0) {
+      if (_array_size - segment_idx <= _segment_size) {
+          _seg_size = _array_size - segment_idx;
+      }
+      #ifdef __HIP_DEVICE_COMPILE__
+      // We don't understand HIP...
+      __syncthreads();  // Propagate the new value back to memory
+      #endif
+  }
+  #elif !defined SECOND_PASS
+  // For one-pass partial reductions, _array_size carries num_segments.
+  valid_segment = segment_id < _array_size;
+  #endif
+
+  // Loop over one segment. For logical-warp mode, one block handles multiple
+  // segments; for block mode, REDUCE_GROUP_THREADS == BLOCK_SIZE.
+  _type_reduce aggregate = _type_reduce(${identity});
+  for (size_t i = lane; valid_segment && i < _seg_size;
+       i += REDUCE_GROUP_THREADS) {
+      // some pre_map_expr uses _J internally...
+      #if defined FIRST_PASS
+      IndexT _J = segment_idx + i;
+      #else
+      IndexT _J = i;
+      #endif
+      const type_mid_in in0 = *(segment_head + i);
+      aggregate = op(aggregate,
+                     static_cast<_type_reduce>(${pre_map_expr}));
+  }
+
+  aggregate = SegmentReduceT(temp_storage[group_id]).Reduce(aggregate, op);
+
+  if (valid_segment && lane == 0) {
+      type_mid_out& out0 = *(_out0 + segment_id);
+      POST_MAP(aggregate);
+  }
+}
+'''
+
     type_decls = set()
     params = _get_cub_kernel_params(params, arginfos, type_decls)
     type_preambles = type_map.get_typedef_code(type_decls)
+    segments_per_block = block_size // reduce_group_threads
+    if reduce_group_threads == block_size:
+        collective_type = 'cub::BlockReduce<_type_reduce, BLOCK_SIZE>'
+    else:
+        collective_type = (
+            'cub::WarpReduce<_type_reduce, REDUCE_GROUP_THREADS>')
 
     module_code = string.Template(module_code).substitute(
         name=name,
         block_size=block_size,
         items_per_thread=items_per_thread,
+        reduce_group_threads=reduce_group_threads,
+        collective_type=collective_type,
+        segments_per_block=segments_per_block,
         reduce_type=reduce_type,
         params=params,
         type_decls=_scalar.format_type_decls(type_decls),
@@ -241,11 +299,13 @@ def _SimpleCubReductionKernel_get_cached_function(
         map_expr, reduce_expr, post_map_expr, reduce_type,
         params, arginfos, _kernel._TypeMap type_map,
         name, block_size, identity, preamble,
-        options, items_per_thread):
+        options, cub_params):
+    items_per_thread = cub_params[0]
+    reduce_group_threads = cub_params[3]
     name = name.replace('cupy_', 'cupy_cub_')
     name = name.replace('cupyx_', 'cupyx_cub_')
     return _create_cub_reduction_function(
-        name, block_size, items_per_thread,
+        name, block_size, items_per_thread, reduce_group_threads,
         reduce_type, params, arginfos, identity,
         map_expr, reduce_expr, post_map_expr,
         type_map, preamble, options)
@@ -267,6 +327,7 @@ cdef str _get_cub_header_include():
         _cub_header = '''
 #include <cub/block/block_reduce.cuh>
 #include <cub/block/block_load.cuh>
+#include <cub/warp/warp_reduce.cuh>
 '''
     elif _cub_path == '<ROCm>':
         # As of ROCm 3.5.0, the block headers cannot be included by themselves
@@ -377,6 +438,42 @@ cdef Py_ssize_t _cub_default_block_size = (
     256 if runtime._is_hip_environment else 512)
 
 
+cpdef Py_ssize_t _get_cub_segment_group_threads(
+        Py_ssize_t contiguous_size, Py_ssize_t block_size) except -1:
+    cdef Py_ssize_t warp_size = 64 if runtime._is_hip_environment else 32
+    cdef Py_ssize_t group_threads
+    # Short-axis policy for generic CUB reductions: use the fallback kernel
+    # through 64 elements, WarpReduce<16> from 128 to 4096, and BlockReduce
+    # for larger segments.  CUPY_CUB_REDUCTION_GROUP_THREADS overrides this
+    # for testing (0/fallback, block, or a divisor of block_size).
+    override = os.environ.get('CUPY_CUB_REDUCTION_GROUP_THREADS')
+
+    if override is not None:
+        if override == 'fallback':
+            return 0
+        if override == 'block':
+            return block_size
+        group_threads = int(override)
+        if group_threads < 1 or group_threads > block_size:
+            raise ValueError('invalid CUPY_CUB_REDUCTION_GROUP_THREADS')
+        if block_size % group_threads != 0:
+            raise ValueError('CUPY_CUB_REDUCTION_GROUP_THREADS must divide '
+                             'the CUB reduction block size')
+        return group_threads
+
+    if contiguous_size <= 64:
+        return 0
+    if contiguous_size >= 4096:
+        return block_size
+
+    group_threads = 16
+    if group_threads > block_size:
+        group_threads = block_size
+    elif group_threads > warp_size:
+        group_threads = warp_size
+    return group_threads
+
+
 @cython.cdivision(True)
 cdef (Py_ssize_t, Py_ssize_t) _get_cub_block_specs(  # NOQA
         Py_ssize_t contiguous_size) noexcept:
@@ -446,6 +543,7 @@ cdef inline void _cub_two_pass_launch(
     inout_args = [in_args[0], out_args[0],
                   _cub_convert_to_c_scalar(segment_size, contiguous_size),
                   _cub_convert_to_c_scalar(segment_size, segment_size)]
+    cub_params = (items_per_thread, contiguous_size, True, block_size)
 
     if 'mean' in name:
         post_map_expr1 = post_map_expr.replace('_in_ind.size()', '1.0')
@@ -471,7 +569,7 @@ cdef inline void _cub_two_pass_launch(
         _kernel._get_arginfos(inout_args),
         type_map,
         name, block_size, identity, preamble,
-        ('-DFIRST_PASS=1',), items_per_thread)
+        ('-DFIRST_PASS=1',), cub_params)
 
     # Kernel arguments passed to the __global__ function.
     gridx = <size_t>(out_block_num * block_size)
@@ -505,7 +603,7 @@ cdef inline void _cub_two_pass_launch(
         _kernel._get_arginfos(inout_args),
         type_map,
         name, block_size, identity, preamble,
-        ('-DSECOND_PASS=1',), items_per_thread)
+        ('-DSECOND_PASS=1',), cub_params)
 
     # Kernel arguments passed to the __global__ function.
     gridx = <size_t>(out_block_num * block_size)
@@ -522,12 +620,15 @@ cdef inline void _launch_cub(
         stream, params, cub_params) except *:
     cdef bint full_reduction
     cdef Py_ssize_t contiguous_size, items_per_thread
+    cdef Py_ssize_t reduce_group_threads, segments_per_block
     cdef function.Function func
+    cdef size_t gridx
 
     # Kernel arguments passed to the __global__ function.
     items_per_thread = cub_params[0]
     contiguous_size = cub_params[1]
     full_reduction = cub_params[2]
+    reduce_group_threads = cub_params[3]
 
     if full_reduction:
         _cub_two_pass_launch(
@@ -542,16 +643,19 @@ cdef inline void _launch_cub(
             [_cub_convert_to_c_scalar(
                 contiguous_size, contiguous_size),
              _cub_convert_to_c_scalar(
-                 contiguous_size, 0)])
+                 contiguous_size, out_block_num)])
         arginfos = _kernel._get_arginfos(inout_args)
         func = _SimpleCubReductionKernel_get_cached_function(
             map_expr, reduce_expr, post_map_expr, reduce_type,
             params, arginfos, type_map,
             self.name, block_size, self.identity, self.preamble,
-            (), items_per_thread)
+            (), cub_params)
 
+        segments_per_block = block_size // reduce_group_threads
+        gridx = <size_t>(
+            (out_block_num + segments_per_block - 1) // segments_per_block)
         func.linear_launch(
-            out_block_num * block_size, inout_args, 0, block_size, stream)
+            gridx * block_size, inout_args, 0, block_size, stream)
 
 
 def _get_cub_optimized_params(
@@ -568,8 +672,11 @@ def _get_cub_optimized_params(
 
     def target_func(block_size, items_per_thread):
         block_stride = block_size * items_per_thread
+        reduce_group_threads = block_size if full_reduction else (
+            _get_cub_segment_group_threads(contiguous_size, block_size))
         cub_params = (
-            items_per_thread, contiguous_size, full_reduction)
+            items_per_thread, contiguous_size, full_reduction,
+            reduce_group_threads)
         _launch_cub(
             self,
             out_block_num, block_size, block_stride, in_args, out_args,
@@ -616,6 +723,7 @@ cdef bint _try_to_call_cub_reduction(
     cdef Py_ssize_t i
     cdef Py_ssize_t contiguous_size = -1
     cdef Py_ssize_t block_size, block_stride, out_block_num = 0
+    cdef Py_ssize_t items_per_thread, reduce_group_threads
 
     # decide to use CUB or not
     can_use_cub = _can_use_cub_block_reduction(
@@ -672,13 +780,16 @@ cdef bint _try_to_call_cub_reduction(
         ))
 
     # Calculate the reduction block dimensions.
+    items_per_thread, block_size = _get_cub_block_specs(contiguous_size)
+    reduce_group_threads = block_size if full_reduction else (
+        _get_cub_segment_group_threads(contiguous_size, block_size))
+    if reduce_group_threads == 0:
+        return False
+
     optimize_context = _optimize_config.get_current_context()
-    if optimize_context is None:
-        # Calculate manually
-        items_per_thread, block_size = _get_cub_block_specs(contiguous_size)
-    else:
+    if optimize_context is not None:
         # Optimize dynamically
-        key = ('cub_reduction',) + key
+        key = ('cub_reduction', reduce_group_threads) + key
         opt_params = optimize_context.get_params(key)
         if opt_params is None:
             opt_params = _get_cub_optimized_params(
@@ -689,9 +800,13 @@ cdef bint _try_to_call_cub_reduction(
                 full_reduction, out_block_num, contiguous_size, params)
             optimize_context.set_params(key, opt_params)
         items_per_thread, block_size = opt_params
+        reduce_group_threads = block_size if full_reduction else (
+            _get_cub_segment_group_threads(contiguous_size, block_size))
 
     block_stride = block_size * items_per_thread
-    cub_params = (items_per_thread, contiguous_size, full_reduction)
+    cub_params = (
+        items_per_thread, contiguous_size, full_reduction,
+        reduce_group_threads)
 
     _launch_cub(
         self,

--- a/cupy/cuda/cub.pyx
+++ b/cupy/cuda/cub.pyx
@@ -258,6 +258,8 @@ def device_segmented_reduce(_ndarray_base x, op, tuple reduce_axis,
     # get workspace size and then fire up
     ws_size = cub_device_segmented_reduce_get_workspace_size(
         x_ptr, y_ptr, n_segments, contiguous_size, s, op, dtype_id)
+    # When `ws_size` is 1 we don't need a scratch space, but passing NULL would
+    # discover the number of bytes needed...
     ws = memory.alloc(ws_size)
     ws_ptr = <void*>ws.ptr
     op_code = <int>op

--- a/cupy/cuda/cupy_cub.cu
+++ b/cupy/cuda/cupy_cub.cu
@@ -759,8 +759,18 @@ struct _cub_reduce_sum {
 struct _cub_segmented_reduce_sum {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, size_t segment_size, seg_offset_itr offset_start,
+        cudaStream_t s)
     {
+#ifndef CUPY_USE_HIP
+        if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+        {
+            DeviceSegmentedReduce::Sum(workspace, workspace_size,
+                static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                static_cast<int>(segment_size), s);
+            return;
+        }
+#endif
         DeviceSegmentedReduce::Sum(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             offset_start, offset_start+1, s);
@@ -786,11 +796,22 @@ struct _cub_reduce_prod {
 struct _cub_segmented_reduce_prod {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, size_t segment_size, seg_offset_itr offset_start,
+        cudaStream_t s)
     {
         _multiply product_op;
         // the init value is cast from 1.0f because on host __half can only be
         // initialized by float or double; static_cast<__half>(1) = 0 on host.
+#ifndef CUPY_USE_HIP
+        if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+        {
+            DeviceSegmentedReduce::Reduce(workspace, workspace_size,
+                static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                static_cast<int>(segment_size),
+                product_op, static_cast<T>(1.0f), s);
+            return;
+        }
+#endif
         DeviceSegmentedReduce::Reduce(workspace, workspace_size,
             static_cast<T*>(x), static_cast<T*>(y), num_segments,
             offset_start, offset_start+1,
@@ -823,10 +844,21 @@ struct _cub_reduce_min {
 struct _cub_segmented_reduce_min {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, size_t segment_size, seg_offset_itr offset_start,
+        cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
+#ifndef CUPY_USE_HIP
+            if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+            {
+                DeviceSegmentedReduce::Reduce(workspace, workspace_size,
+                    static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                    static_cast<int>(segment_size),
+                    typename select_min<T>::type{}, std::numeric_limits<T>::infinity(), s);
+                return;
+            }
+#endif
             DeviceSegmentedReduce::Reduce(workspace, workspace_size,
                 static_cast<T*>(x), static_cast<T*>(y), num_segments,
                 offset_start, offset_start+1,
@@ -834,6 +866,15 @@ struct _cub_segmented_reduce_min {
         }
         else
         {
+#ifndef CUPY_USE_HIP
+            if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+            {
+                DeviceSegmentedReduce::Min(workspace, workspace_size,
+                    static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                    static_cast<int>(segment_size), s);
+                return;
+            }
+#endif
             DeviceSegmentedReduce::Min(workspace, workspace_size,
                 static_cast<T*>(x), static_cast<T*>(y), num_segments,
                 offset_start, offset_start+1, s);
@@ -877,13 +918,24 @@ struct _cub_reduce_max {
 struct _cub_segmented_reduce_max {
     template <typename T>
     void operator()(void* workspace, size_t& workspace_size, void* x, void* y,
-        int num_segments, seg_offset_itr offset_start, cudaStream_t s)
+        size_t num_segments, size_t segment_size, seg_offset_itr offset_start,
+        cudaStream_t s)
     {
         if constexpr (std::numeric_limits<T>::has_infinity)
         {
             // to avoid compiler error: invalid argument type '__half' to unary expression on HIP...
             if constexpr (std::is_same_v<T, __half>)
             {
+#ifndef CUPY_USE_HIP
+                if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+                {
+                    DeviceSegmentedReduce::Reduce(workspace, workspace_size,
+                        static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                        static_cast<int>(segment_size),
+                        typename select_max<T>::type{}, half_negate_inf(), s);
+                    return;
+                }
+#endif
                 DeviceSegmentedReduce::Reduce(workspace, workspace_size,
                     static_cast<T*>(x), static_cast<T*>(y), num_segments,
                     offset_start, offset_start+1,
@@ -891,6 +943,16 @@ struct _cub_segmented_reduce_max {
             }
             else
             {
+#ifndef CUPY_USE_HIP
+                if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+                {
+                    DeviceSegmentedReduce::Reduce(workspace, workspace_size,
+                        static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                        static_cast<int>(segment_size),
+                        typename select_max<T>::type{}, -std::numeric_limits<T>::infinity(), s);
+                    return;
+                }
+#endif
                 DeviceSegmentedReduce::Reduce(workspace, workspace_size,
                     static_cast<T*>(x), static_cast<T*>(y), num_segments,
                     offset_start, offset_start+1,
@@ -899,6 +961,15 @@ struct _cub_segmented_reduce_max {
         }
         else
         {
+#ifndef CUPY_USE_HIP
+            if (segment_size <= static_cast<size_t>(std::numeric_limits<int>::max()))
+            {
+                DeviceSegmentedReduce::Max(workspace, workspace_size,
+                    static_cast<T*>(x), static_cast<T*>(y), num_segments,
+                    static_cast<int>(segment_size), s);
+                return;
+            }
+#endif
             DeviceSegmentedReduce::Max(workspace, workspace_size,
                 static_cast<T*>(x), static_cast<T*>(y), num_segments,
                 offset_start, offset_start+1, s);
@@ -1079,16 +1150,20 @@ void cub_device_segmented_reduce(void* workspace, size_t& workspace_size,
     switch(op) {
     case CUPY_CUB_SUM:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_sum(),
-                   workspace, workspace_size, x, y, num_segments, itr, stream);
+                   workspace, workspace_size, x, y, num_segments,
+                   segment_size, itr, stream);
     case CUPY_CUB_MIN:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_min(),
-                   workspace, workspace_size, x, y, num_segments, itr, stream);
+                   workspace, workspace_size, x, y, num_segments,
+                   segment_size, itr, stream);
     case CUPY_CUB_MAX:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_max(),
-                   workspace, workspace_size, x, y, num_segments, itr, stream);
+                   workspace, workspace_size, x, y, num_segments,
+                   segment_size, itr, stream);
     case CUPY_CUB_PROD:
         return dtype_dispatcher(dtype_id, _cub_segmented_reduce_prod(),
-                   workspace, workspace_size, x, y, num_segments, itr, stream);
+                   workspace, workspace_size, x, y, num_segments,
+                   segment_size, itr, stream);
     default:
         throw std::runtime_error("Unsupported operation");
     }

--- a/tests/cupy_tests/core_tests/test_cub_reduction.py
+++ b/tests/cupy_tests/core_tests/test_cub_reduction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from itertools import combinations
 import sys
 
+import numpy
 import pytest
 
 import cupy
@@ -13,9 +14,20 @@ from cupy._core import _cub_reduction
 from cupy.cuda import memory
 
 
+def expected_cub_block_kernel_calls(shape, axis):
+    """Return how many generic CUB block-reduction kernels should launch."""
+    if len(axis) == len(shape):
+        return 2  # two-pass full reduction
+    contiguous_size = int(numpy.prod([shape[i] for i in axis]))
+    group_threads = _cub_reduction._get_cub_segment_group_threads(
+        contiguous_size, 512)
+    return 0 if group_threads == 0 else 1
+
 # This test class and its children below only test if CUB backend can be used
 # or not; they don't verify its correctness as it's already extensively covered
 # by existing tests
+
+
 class CubReductionTestBase:
     """
     Note: call self.can_use() when arrays are already allocated, otherwise
@@ -138,7 +150,7 @@ class TestSimpleCubReductionKernelMisc(CubReductionTestBase):
         old_routine_accelerators = _accelerator.get_routine_accelerators()
         _accelerator.set_routine_accelerators([])
 
-        a = cupy.random.random((10, 10))
+        a = cupy.random.random((10, 128))
         # this is the only function we can mock; the rest is cdef'd
         func_name = ''.join(('cupy._core._cub_reduction.',
                              '_SimpleCubReductionKernel_get_cached_function'))
@@ -150,7 +162,98 @@ class TestSimpleCubReductionKernelMisc(CubReductionTestBase):
                 func_name, wraps=func, times_called=1):  # one pass
             a.sum(axis=1)
         with testing.AssertFunctionIsCalled(
+                func_name, wraps=func, times_called=0):  # fallback
+            a[:, :1].sum(axis=1)
+        with testing.AssertFunctionIsCalled(
                 func_name, wraps=func, times_called=0):  # not used
             a.sum(axis=0)
 
         _accelerator.set_routine_accelerators(old_routine_accelerators)
+
+
+class TestSimpleCubReductionKernelSegmentMode(CubReductionTestBase):
+
+    @pytest.mark.parametrize('contiguous_size,expected', [
+        (1, 0),
+        (2, 0),
+        (4, 0),
+        (8, 0),
+        (16, 0),
+        (32, 0),
+        (64, 0),
+        (128, 16),
+        (256, 16),
+        (512, 16),
+        (2048, 16),
+        (4096, 512),
+    ])
+    def test_get_cub_segment_group_threads(
+            self, contiguous_size, expected):
+        result = _cub_reduction._get_cub_segment_group_threads(
+            contiguous_size, 512)
+        assert result == expected
+
+    @pytest.mark.parametrize('override,expected', [
+        ('fallback', 0),
+        ('block', 512),
+        ('16', 16),
+    ])
+    def test_get_cub_segment_group_threads_override(
+            self, monkeypatch, override, expected):
+        monkeypatch.setenv('CUPY_CUB_REDUCTION_GROUP_THREADS', override)
+        result = _cub_reduction._get_cub_segment_group_threads(64, 512)
+        assert result == expected
+
+
+class TestSimpleCubReductionKernelCorrectness(CubReductionTestBase):
+
+    @pytest.fixture(autouse=True)
+    def disable_routine_accelerators(self):
+        self.old_routine_accelerators = (
+            _accelerator.get_routine_accelerators())
+        _accelerator.set_routine_accelerators([])
+        yield
+        _accelerator.set_routine_accelerators(
+            self.old_routine_accelerators)
+
+    @pytest.mark.parametrize('shape', [
+        (32, 2),
+        (17, 33),
+        (9, 129),
+    ])
+    @pytest.mark.parametrize('op', [
+        'nansum',
+        'nanprod',
+        'all',
+        'any',
+        'argmin',
+        'argmax',
+    ])
+    def test_generic_cub_short_axis_correctness(self, shape, op):
+        if op in ('all', 'any'):
+            a = cupy.arange(numpy.prod(shape)).reshape(shape) % 3 == 0
+            expect = getattr(numpy, op)(cupy.asnumpy(a), axis=1)
+        else:
+            a = testing.shaped_arange(shape, cupy, dtype=cupy.float32)
+            if op in ('nansum', 'nanprod'):
+                a[:, 0] = cupy.nan
+            expect = getattr(numpy, op)(cupy.asnumpy(a), axis=1)
+
+        actual = getattr(cupy, op)(a, axis=1)
+        testing.assert_allclose(actual, expect)
+
+    @pytest.mark.parametrize('shape', [
+        (32, 2),
+        (17, 33),
+        (9, 129),
+    ])
+    def test_generic_user_reduction_kernel_correctness(self, shape):
+        kernel = cupy.ReductionKernel(
+            'float32 x', 'float32 y',
+            'x * x', 'a + b', 'y = a', '0',
+            'cupy_test_square_sum')
+        a = testing.shaped_arange(shape, cupy, dtype=cupy.float32)
+
+        actual = kernel(a, axis=1)
+        expect = (cupy.asnumpy(a) ** 2).sum(axis=1)
+        testing.assert_allclose(actual, expect)

--- a/tests/cupy_tests/core_tests/test_ndarray_reduction.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_reduction.py
@@ -9,6 +9,8 @@ import cupy
 import cupy._core._accelerator as _acc
 from cupy._core import _cub_reduction
 from cupy import testing
+from cupy_tests.core_tests.test_cub_reduction import (
+    expected_cub_block_kernel_calls)
 
 
 @pytest.mark.parametrize("order", ['C', 'F'])
@@ -389,10 +391,7 @@ class TestCubReduction:
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(shape):
-                times_called = 2  # two passes
-            else:
-                times_called = 1  # one pass
+            times_called = expected_cub_block_kernel_calls(a.shape, axis)
             if a.size == 0:
                 times_called = 0  # _reduction.pyx has an early return path
             with testing.AssertFunctionIsCalled(
@@ -436,10 +435,7 @@ class TestCubReduction:
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(shape):
-                times_called = 2  # two passes
-            else:
-                times_called = 1  # one pass
+            times_called = expected_cub_block_kernel_calls(a.shape, axis)
             if a.size == 0:
                 times_called = 0  # _reduction.pyx has an early return path
             with testing.AssertFunctionIsCalled(

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -13,6 +13,8 @@ import cupy.cuda.cutensor
 from cupy._core import _cub_reduction
 from cupy import testing
 from cupy.exceptions import AxisError
+from cupy_tests.core_tests.test_cub_reduction import (
+    expected_cub_block_kernel_calls)
 
 
 class TestSumprod:
@@ -265,10 +267,7 @@ class TestCubReduction:
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(shape):
-                times_called = 2  # two passes
-            else:
-                times_called = 1  # one pass
+            times_called = expected_cub_block_kernel_calls(a.shape, axis)
             with testing.AssertFunctionIsCalled(
                     func_name, wraps=func, times_called=times_called):
                 a.sum(axis=axis)
@@ -290,9 +289,17 @@ class TestCubReduction:
     @testing.for_contiguous_axes()
     # prod supports less dtypes; don't test float16 as it's not as accurate?
     @testing.for_dtypes('qQfdFD')
-    @testing.numpy_cupy_allclose(rtol=1E-5)
+    @testing.numpy_cupy_allclose(
+        rtol={'default': 1E-5, numpy.complex64: 3E-5})
     def test_cub_prod(self, xp, dtype, axis, shape, order, backend):
-        a = testing.shaped_random(shape, xp, dtype)
+        if numpy.dtype(dtype).kind == 'c':
+            # Keep the CUB backend route test away from overflow/invalid
+            # regions, where a different reduction tree can legitimately
+            # produce Inf before NumPy's order produces NaN.
+            a = testing.shaped_random(shape, xp, dtype, scale=0.0001)
+            a = a + xp.asarray(1, dtype=dtype)
+        else:
+            a = testing.shaped_random(shape, xp, dtype)
         if order in ('c', 'C'):
             a = xp.ascontiguousarray(a)
         elif order in ('f', 'F'):
@@ -316,10 +323,7 @@ class TestCubReduction:
             func_name = 'cupy._core._cub_reduction.'
             func_name += '_SimpleCubReductionKernel_get_cached_function'
             func = _cub_reduction._SimpleCubReductionKernel_get_cached_function
-            if len(axis) == len(shape):
-                times_called = 2  # two passes
-            else:
-                times_called = 1  # one pass
+            times_called = expected_cub_block_kernel_calls(a.shape, axis)
             with testing.AssertFunctionIsCalled(
                     func_name, wraps=func, times_called=times_called):
                 a.prod(axis=axis)


### PR DESCRIPTION
This is mostly vie coded, and I'll include a fully vibe coded benchmark script in the details below.

I'll open another PR that just focuses on not using the generic CUB paths for very short reductions (maybe mostly for the simplicity).
For intermediate sizes 1028-4096 (very rough), there are places where a WrapReduce should get 2x speedup.

(The main reason why I will do the other PR first is that (a) if we go here I should review it a bit more myself but mainly (b) I am wondering about using different approaches for the whole thing and the minimal thing is at least enough to not be a gigantic performance issue)

<details>

```
#!/usr/bin/env python3
"""Benchmark reductions while sweeping the last-axis size.

This script keeps the total input size roughly constant while varying the
last-axis reduction length.  It times:

* ``sum_device_cub``: ``cupy.sum(..., axis=-1)`` through the CUB routine path
* ``sum_generic_cub``: ``cupy.sum(..., axis=-1)`` through generic CUB reduction
  using the automatic group-size selector
* ``sum_generic_cub_warp<N>``: generic CUB with forced ``WarpReduce<N>``
* ``sum_generic_cub_block``: generic CUB with forced ``BlockReduce``
* ``sum_fallback``: ``cupy.sum(..., axis=-1)`` with CUB disabled
* ``vector_norm_generic_cub``: vector 2-norm through generic CUB reduction
  using the automatic group-size selector
* ``vector_norm_generic_cub_warp<N>``: vector 2-norm with forced
  ``WarpReduce<N>``
* ``vector_norm_generic_cub_block``: vector 2-norm with forced ``BlockReduce``
* ``vector_norm_fallback``: vector 2-norm with CUB disabled

Example:

    cd benchmarks
    python reduction_axis_scan.py --repeat 30 --warp-groups 2,4,8,16,32 \
      --cuda-profiler

For Nsight Systems, pair ``--cuda-profiler`` with:

    nsys profile -c cudaProfilerApi -o reduction_axis_scan \
      python reduction_axis_scan.py --cuda-profiler
"""

from __future__ import annotations

import argparse
import contextlib
import csv
import dataclasses
import math
import os
import pathlib
from typing import Callable


@dataclasses.dataclass(frozen=True)
class BenchCase:
    name: str
    op: str
    routine_accelerators: tuple[str, ...]
    reduction_accelerators: tuple[str, ...]
    cub_group_threads: str | None = None


def make_default_cases(warp_groups: tuple[int, ...]) -> tuple[BenchCase, ...]:
    cases = [
        BenchCase('sum_device_cub', 'sum', ('cub',), ()),
        BenchCase('sum_generic_cub', 'sum', (), ('cub',)),
        *(
            BenchCase(
                f'sum_generic_cub_warp{group}', 'sum', (), ('cub',),
                str(group))
            for group in warp_groups
        ),
        BenchCase('sum_generic_cub_block', 'sum', (), ('cub',), 'block'),
        BenchCase('sum_fallback', 'sum', (), ()),
        BenchCase('vector_norm_generic_cub', 'vector_norm', (), ('cub',)),
        *(
            BenchCase(
                f'vector_norm_generic_cub_warp{group}', 'vector_norm',
                (), ('cub',), str(group))
            for group in warp_groups
        ),
        BenchCase(
            'vector_norm_generic_cub_block', 'vector_norm', (), ('cub',),
            'block'),
        BenchCase('vector_norm_fallback', 'vector_norm', (), ()),
    ]
    return tuple(cases)


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument(
        '--total-elements', type=int, default=1 << 24,
        help='Approximate total input elements for each N.')
    parser.add_argument(
        '--max-n', type=int, default=100_000,
        help='Maximum last-axis reduction length in the default sweep.')
    parser.add_argument(
        '--n-values', default=None,
        help='Comma-separated explicit last-axis lengths.')
    parser.add_argument(
        '--dtype', default='float32',
        choices=('float16', 'float32', 'float64'),
        help='Input dtype.')
    parser.add_argument(
        '--repeat', type=int, default=10,
        help='Timed repeats per case.')
    parser.add_argument(
        '--warmup', type=int, default=3,
        help='Untimed warmup repeats per case.')
    parser.add_argument(
        '--max-duration', type=float, default=math.inf,
        help='Maximum benchmark duration per case, in seconds.')
    parser.add_argument(
        '--cases', default=None,
        help='Comma-separated case names. Defaults to all cases.')
    parser.add_argument(
        '--warp-groups', default='16',
        help='Comma-separated forced logical-warp group sizes to benchmark.')
    parser.add_argument(
        '--output-csv', default='reduction_axis_scan.csv',
        help='CSV output path.')
    parser.add_argument(
        '--output-plot', default='reduction_axis_scan.png',
        help='Plot output path.')
    parser.add_argument(
        '--no-plot', action='store_true',
        help='Skip matplotlib plot generation.')
    parser.add_argument(
        '--cuda-profiler', action='store_true',
        help='Bracket the benchmark loop with cudaProfilerStart/Stop.')
    return parser.parse_args()


def default_n_values(max_n: int) -> list[int]:
    values = []
    power = 1
    while power <= max_n:
        values.append(power)
        midpoint = power + power // 2
        if midpoint <= max_n:
            values.append(midpoint)
        power *= 2
    if max_n not in values:
        values.append(max_n)
    return sorted(set(values))


def parse_warp_groups(args: argparse.Namespace) -> tuple[int, ...]:
    if args.warp_groups.strip() == '':
        return ()
    groups = tuple(
        sorted({int(v.strip()) for v in args.warp_groups.split(',')}))
    if any(group <= 0 for group in groups):
        raise ValueError('--warp-groups must contain positive integers')
    return groups


def parse_n_values(args: argparse.Namespace) -> list[int]:
    if args.n_values is None:
        values = default_n_values(args.max_n)
    else:
        values = [int(v.strip()) for v in args.n_values.split(',')]
    values = [v for v in values if v > 0]
    if not values:
        raise ValueError('at least one positive N is required')
    return values


def select_cases(
        args: argparse.Namespace, cases: tuple[BenchCase, ...],
) -> list[BenchCase]:
    cases_by_name = {case.name: case for case in cases}
    if args.cases is None:
        return list(cases)
    selected = []
    for name in (v.strip() for v in args.cases.split(',')):
        if name not in cases_by_name:
            known = ', '.join(cases_by_name)
            raise ValueError(f'unknown case {name!r}; choices: {known}')
        selected.append(cases_by_name[name])
    return selected


@contextlib.contextmanager
def accelerator_state(cupy, routine: tuple[str, ...],
                      reduction: tuple[str, ...]):
    from cupy._core import _accelerator

    old_routine = _accelerator.get_routine_accelerators()
    old_reduction = _accelerator.get_reduction_accelerators()
    try:
        _accelerator.set_routine_accelerators(list(routine))
        _accelerator.set_reduction_accelerators(list(reduction))
        yield
    finally:
        _accelerator.set_routine_accelerators(old_routine)
        _accelerator.set_reduction_accelerators(old_reduction)


@contextlib.contextmanager
def cub_group_threads_state(group_threads: str | None):
    env_name = 'CUPY_CUB_REDUCTION_GROUP_THREADS'
    old_group_threads = os.environ.get(env_name)
    try:
        if group_threads is None:
            os.environ.pop(env_name, None)
        else:
            os.environ[env_name] = group_threads
        yield
    finally:
        if old_group_threads is None:
            os.environ.pop(env_name, None)
        else:
            os.environ[env_name] = old_group_threads


def make_input(cupy, shape: tuple[int, int], dtype_name: str):
    dtype = getattr(cupy, dtype_name)
    size = shape[0] * shape[1]
    a = cupy.arange(size, dtype=cupy.float32)
    a = (a % 17) * cupy.float32(0.25)
    return a.astype(dtype, copy=False).reshape(shape)


def make_operation(cupy, case: BenchCase) -> Callable:
    if case.op == 'sum':
        return lambda a: cupy.sum(a, axis=-1)

    if case.op == 'vector_norm':
        if hasattr(cupy.linalg, 'vector_norm'):
            return lambda a: cupy.linalg.vector_norm(a, axis=-1)
        return lambda a: cupy.linalg.norm(a, axis=-1)

    raise AssertionError(f'unhandled op: {case.op}')


def benchmark_case(cupy, profiler, case: BenchCase, a, args):
    op = make_operation(cupy, case)
    with accelerator_state(cupy, case.routine_accelerators,
                           case.reduction_accelerators), \
            cub_group_threads_state(case.cub_group_threads):
        # Compile and populate memory-pool state before timing.
        op(a)
        cupy.cuda.get_current_stream().synchronize()
        perf = profiler.benchmark(
            op, (a,), n_repeat=args.repeat, n_warmup=args.warmup,
            max_duration=args.max_duration, name=case.name)
    gpu_times = perf.gpu_times[0]
    return {
        'case': case.name,
        'op': case.op,
        'gpu_mean_us': float(gpu_times.mean() * 1e6),
        'gpu_std_us': float(gpu_times.std() * 1e6),
        'gpu_min_us': float(gpu_times.min() * 1e6),
        'gpu_max_us': float(gpu_times.max() * 1e6),
        'repeats': int(gpu_times.size),
        'cub_group_threads': case.cub_group_threads or 'auto',
    }


def write_csv(path: pathlib.Path, rows: list[dict]) -> None:
    if not rows:
        return
    fieldnames = list(rows[0])
    with path.open('w', newline='') as f:
        writer = csv.DictWriter(f, fieldnames=fieldnames)
        writer.writeheader()
        writer.writerows(rows)


def plot_results(path: pathlib.Path, rows: list[dict]) -> None:
    import matplotlib.pyplot as plt

    ops = sorted({row['op'] for row in rows})
    fig, axes = plt.subplots(
        len(ops), 1, figsize=(8, 3.8 * len(ops)), squeeze=False,
        sharex=True)
    for ax, op in zip(axes[:, 0], ops):
        op_rows = [row for row in rows if row['op'] == op]
        for case in sorted({row['case'] for row in op_rows}):
            case_rows = [row for row in op_rows if row['case'] == case]
            case_rows.sort(key=lambda row: row['N'])
            ax.plot(
                [row['N'] for row in case_rows],
                [row['gpu_mean_us'] for row in case_rows],
                marker='o', label=case)
        ax.set_xscale('log')
        ax.set_yscale('log')
        ax.set_ylabel('GPU time (us)')
        ax.set_title(op)
        ax.grid(True, which='both', alpha=0.3)
        ax.legend()
    axes[-1, 0].set_xlabel('last-axis reduction length N')
    fig.tight_layout()
    fig.savefig(path, dpi=160)

    plt.show()


def main() -> None:
    args = parse_args()

    import cupy
    from cupyx import profiler

    warp_groups = parse_warp_groups(args)
    all_cases = make_default_cases(warp_groups)
    n_values = parse_n_values(args)
    cases = select_cases(args, all_cases)
    rows = []

    profile_context = (
        profiler.profile() if args.cuda_profiler else contextlib.nullcontext())
    with profile_context:
        for n in n_values:
            outer = max(1, args.total_elements // n)
            shape = (outer, n)
            a = make_input(cupy, shape, args.dtype)
            actual_elements = shape[0] * shape[1]
            for case in cases:
                result = benchmark_case(cupy, profiler, case, a, args)
                result.update({
                    'N': n,
                    'outer': outer,
                    'elements': actual_elements,
                    'dtype': args.dtype,
                    'input_mib': a.nbytes / (1024 ** 2),
                })
                rows.append(result)
                print(
                    f"N={n:<5d} outer={outer:<7d} {case.name:<24s} "
                    f"{result['gpu_mean_us']:9.3f} us")

    csv_path = pathlib.Path(args.output_csv)
    write_csv(csv_path, rows)
    print(f'wrote {csv_path}')

    if not args.no_plot:
        plot_path = pathlib.Path(args.output_plot)
        plot_results(plot_path, rows)
        print(f'wrote {plot_path}')


if __name__ == '__main__':
    main()
```