### PR TITLE
feat: add `copy` keyword argument to reshape

### DIFF
--- a/cupy/_core/_routines_manipulation.pxd
+++ b/cupy/_core/_routines_manipulation.pxd
@@ -14,7 +14,8 @@ cdef class broadcast:
 
 
 cdef _ndarray_shape_setter(_ndarray_base self, newshape)
-cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order)
+cdef _ndarray_base _ndarray_reshape(
+    _ndarray_base self, tuple shape, order, copy)
 cdef _ndarray_base _ndarray_transpose(_ndarray_base self, tuple axes)
 cdef _ndarray_base _ndarray_swapaxes(
     _ndarray_base self, Py_ssize_t axis1, Py_ssize_t axis2)
@@ -30,7 +31,8 @@ cpdef _ndarray_base _move_single_axis(
 cpdef _ndarray_base rollaxis(
     _ndarray_base a, Py_ssize_t axis, Py_ssize_t start=*)
 cpdef _ndarray_base broadcast_to(_ndarray_base array, shape)
-cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec)
+cpdef _ndarray_base _reshape(
+    _ndarray_base self, const shape_t &shape_spec, copy=*)
 cpdef _ndarray_base _T(_ndarray_base self)
 cpdef _ndarray_base _transpose(
     _ndarray_base self, const vector.vector[Py_ssize_t] &axes)

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -370,10 +370,9 @@ cpdef _ndarray_base _reshape(
             return newarray.copy()
         return newarray
     if copy is False:
+        # Same message as NumPy (numpy/_core/src/multiarray/shape.c).
         raise ValueError(
-            f'Unable to avoid creating a copy while reshaping array of '
-            f'shape {tuple(self._shape)} and size {self.size} into shape '
-            f'{tuple(shape)}.')
+            'Unable to avoid creating a copy while reshaping.')
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)
 

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -24,12 +24,6 @@ from cupy._core._kernel cimport _check_peer_access, _preprocess_args
 from cupy.cuda import device
 
 
-cdef enum:
-    _COPY_IF_NEEDED = 0
-    _COPY_ALWAYS = 1
-    _COPY_NEVER = 2
-
-
 @cython.final
 cdef class broadcast:
     """Object that performs broadcasting.
@@ -76,22 +70,10 @@ cdef _ndarray_shape_setter(_ndarray_base self, newshape):
     self._set_shape_and_strides(shape, strides, False, True)
 
 
-cdef int _normalize_copy_mode(copy) except -1:
-    if copy is None:
-        return _COPY_IF_NEEDED
-    if isinstance(copy, str):
-        raise ValueError(
-            "strings are not allowed for 'copy' keyword. "
-            "Use True/False/None instead.")
-    if copy:
-        return _COPY_ALWAYS
-    return _COPY_NEVER
-
-
 cdef _ndarray_base _ndarray_reshape(
         _ndarray_base self, tuple shape, order, copy):
     cdef int order_char = internal._normalize_order(order, False)
-    cdef int copy_mode = _normalize_copy_mode(copy)
+    copy = internal._normalize_copy(copy)
 
     if len(shape) == 1 and cpython.PySequence_Check(shape[0]):
         shape = tuple(shape[0])
@@ -102,7 +84,7 @@ cdef _ndarray_base _ndarray_reshape(
         else:
             order_char = b'C'
     if order_char == b'C':
-        return _reshape(self, shape, copy_mode)
+        return _reshape(self, shape, copy)
     else:
         # TODO(grlee77): Support order within _reshape instead
 
@@ -110,7 +92,7 @@ cdef _ndarray_base _ndarray_reshape(
         #     1.) reverse the axes via transpose
         #     2.) C-ordered reshape using reversed shape
         #     3.) reverse the axes via transpose
-        return _T(_reshape(_T(self), shape[::-1], copy_mode))
+        return _T(_reshape(_T(self), shape[::-1], copy))
 
 
 cdef _ndarray_base _ndarray_transpose(_ndarray_base self, tuple axes):
@@ -370,27 +352,24 @@ cpdef _ndarray_base rollaxis(
 
 cpdef _ndarray_base _reshape(
         _ndarray_base self, const shape_t &shape_spec, copy=None):
+    # ``copy`` is a plain tri-state: None (copy only if needed), True (always
+    # copy) or False (never copy, raising if a copy is unavoidable).
     cdef shape_t shape
     cdef strides_t strides
     cdef _ndarray_base newarray
-    cdef int copy_mode
-    if copy is None:
-        copy_mode = _COPY_IF_NEEDED
-    else:
-        copy_mode = copy
     shape = internal.infer_unknown_dimension(shape_spec, self.size)
     if internal.vector_equal(shape, self._shape):
-        if copy_mode == _COPY_ALWAYS:
+        if copy is True:
             return self.copy()
         return self.view()
 
     _get_strides_for_nocopy_reshape(self, shape, strides)
     if strides.size() == shape.size():
         newarray = self._view(type(self), shape, strides, False, True, self)
-        if copy_mode == _COPY_ALWAYS:
+        if copy is True:
             return newarray.copy()
         return newarray
-    if copy_mode == _COPY_NEVER:
+    if copy is False:
         raise ValueError('Unable to avoid copy while reshaping.')
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -370,7 +370,10 @@ cpdef _ndarray_base _reshape(
             return newarray.copy()
         return newarray
     if copy is False:
-        raise ValueError('Unable to avoid copy while reshaping.')
+        raise ValueError(
+            f'Unable to avoid creating a copy while reshaping array of '
+            f'shape {tuple(self._shape)} and size {self.size} into shape '
+            f'{tuple(shape)}.')
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)
 

--- a/cupy/_core/_routines_manipulation.pyx
+++ b/cupy/_core/_routines_manipulation.pyx
@@ -24,6 +24,12 @@ from cupy._core._kernel cimport _check_peer_access, _preprocess_args
 from cupy.cuda import device
 
 
+cdef enum:
+    _COPY_IF_NEEDED = 0
+    _COPY_ALWAYS = 1
+    _COPY_NEVER = 2
+
+
 @cython.final
 cdef class broadcast:
     """Object that performs broadcasting.
@@ -70,8 +76,22 @@ cdef _ndarray_shape_setter(_ndarray_base self, newshape):
     self._set_shape_and_strides(shape, strides, False, True)
 
 
-cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order):
+cdef int _normalize_copy_mode(copy) except -1:
+    if copy is None:
+        return _COPY_IF_NEEDED
+    if isinstance(copy, str):
+        raise ValueError(
+            "strings are not allowed for 'copy' keyword. "
+            "Use True/False/None instead.")
+    if copy:
+        return _COPY_ALWAYS
+    return _COPY_NEVER
+
+
+cdef _ndarray_base _ndarray_reshape(
+        _ndarray_base self, tuple shape, order, copy):
     cdef int order_char = internal._normalize_order(order, False)
+    cdef int copy_mode = _normalize_copy_mode(copy)
 
     if len(shape) == 1 and cpython.PySequence_Check(shape[0]):
         shape = tuple(shape[0])
@@ -82,7 +102,7 @@ cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order):
         else:
             order_char = b'C'
     if order_char == b'C':
-        return _reshape(self, shape)
+        return _reshape(self, shape, copy_mode)
     else:
         # TODO(grlee77): Support order within _reshape instead
 
@@ -90,7 +110,7 @@ cdef _ndarray_base _ndarray_reshape(_ndarray_base self, tuple shape, order):
         #     1.) reverse the axes via transpose
         #     2.) C-ordered reshape using reversed shape
         #     3.) reverse the axes via transpose
-        return _T(_reshape(_T(self), shape[::-1]))
+        return _T(_reshape(_T(self), shape[::-1], copy_mode))
 
 
 cdef _ndarray_base _ndarray_transpose(_ndarray_base self, tuple axes):
@@ -348,17 +368,30 @@ cpdef _ndarray_base rollaxis(
     return _transpose(a, axes)
 
 
-cpdef _ndarray_base _reshape(_ndarray_base self, const shape_t &shape_spec):
+cpdef _ndarray_base _reshape(
+        _ndarray_base self, const shape_t &shape_spec, copy=None):
     cdef shape_t shape
     cdef strides_t strides
     cdef _ndarray_base newarray
+    cdef int copy_mode
+    if copy is None:
+        copy_mode = _COPY_IF_NEEDED
+    else:
+        copy_mode = copy
     shape = internal.infer_unknown_dimension(shape_spec, self.size)
     if internal.vector_equal(shape, self._shape):
+        if copy_mode == _COPY_ALWAYS:
+            return self.copy()
         return self.view()
 
     _get_strides_for_nocopy_reshape(self, shape, strides)
     if strides.size() == shape.size():
-        return self._view(type(self), shape, strides, False, True, self)
+        newarray = self._view(type(self), shape, strides, False, True, self)
+        if copy_mode == _COPY_ALWAYS:
+            return newarray.copy()
+        return newarray
+    if copy_mode == _COPY_NEVER:
+        raise ValueError('Unable to avoid copy while reshaping.')
     newarray = self.copy()
     _get_strides_for_nocopy_reshape(newarray, shape, strides)
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1014,7 +1014,7 @@ cdef class _ndarray_base:
     # -------------------------------------------------------------------------
     # Shape manipulation
     # -------------------------------------------------------------------------
-    def reshape(self, *shape, order='C'):
+    def reshape(self, *shape, order='C', copy=None):
         """Returns an array of a different shape and the same content.
 
         .. seealso::
@@ -1022,7 +1022,7 @@ cdef class _ndarray_base:
            :meth:`numpy.ndarray.reshape`
 
         """
-        return _manipulation._ndarray_reshape(self, shape, order)
+        return _manipulation._ndarray_reshape(self, shape, order, copy)
 
     # TODO(okuta): Implement resize
 

--- a/cupy/_core/internal.pxd
+++ b/cupy/_core/internal.pxd
@@ -44,6 +44,8 @@ cpdef size_t clp2(size_t x) noexcept
 
 cdef int _normalize_order(order, cpp_bool allow_k=*) except? 0
 
+cdef _normalize_copy(copy)
+
 cdef _broadcast_core(list arrays, shape_t& shape)
 
 cpdef bint _contig_axes(tuple axes) except -1

--- a/cupy/_core/internal.pyx
+++ b/cupy/_core/internal.pyx
@@ -317,6 +317,20 @@ cdef inline int _normalize_order(order, cpp_bool allow_k=True) except? 0:
     return order_char
 
 
+cdef inline _normalize_copy(copy):
+    # Validate the ``copy`` keyword for reshape/array-like APIs and return it
+    # as a plain tri-state: ``None`` (copy only if needed), ``True`` (always
+    # copy) or ``False`` (never copy). Strings are rejected explicitly so a
+    # stray ``copy='K'`` cannot be silently treated as truthy.
+    if isinstance(copy, str):
+        raise ValueError(
+            "strings are not allowed for 'copy' keyword. "
+            "Use True/False/None instead.")
+    if copy is None:
+        return None
+    return bool(copy)
+
+
 cdef _broadcast_core(list arrays, shape_t& shape):
     cdef Py_ssize_t i, j, s, a_ndim, a_sh, nd
     cdef strides_t strides

--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -22,7 +22,7 @@ def shape(a):
         return numpy.shape(a)
 
 
-def reshape(a, newshape, order='C'):
+def reshape(a, newshape, order='C', *, copy=None):
     """Returns an array with new shape and same elements.
 
     It tries to return a view if possible, otherwise returns a copy.
@@ -46,6 +46,10 @@ def reshape(a, newshape, order='C'):
             underlying array, and only refer to the order of indexing. 'A'
             means to read / write the elements in Fortran-like index order if
             a is Fortran contiguous in memory, C-like order otherwise.
+        copy (bool or None):
+            If ``True``, then the array data is copied. If ``None``, a copy is
+            made only if required. For ``False``, a ``ValueError`` is raised if
+            a copy cannot be avoided.
 
     Returns:
         cupy.ndarray: A reshaped view of ``a`` if possible, otherwise a copy.
@@ -54,7 +58,7 @@ def reshape(a, newshape, order='C'):
 
     """
     # TODO(okuta): check type
-    return a.reshape(newshape, order=order)
+    return a.reshape(newshape, order=order, copy=copy)
 
 
 def ravel(a, order='C'):

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -156,7 +156,10 @@ class TestReshape:
     def test_reshape_copy_false_noncontiguous_raises(self, external):
         a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
         with pytest.raises(
-                ValueError, match=r'Unable to avoid copy while reshaping\.'):
+                ValueError,
+                match=(r'Unable to avoid creating a copy while reshaping '
+                       r'array of shape \(4, 2, 3\) and size 24 into '
+                       r'shape \(2, 3, 4\)\.')):
             if external:
                 cupy.reshape(a, (2, 3, 4), copy=False)
             else:

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -157,9 +157,7 @@ class TestReshape:
         a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
         with pytest.raises(
                 ValueError,
-                match=(r'Unable to avoid creating a copy while reshaping '
-                       r'array of shape \(4, 2, 3\) and size 24 into '
-                       r'shape \(2, 3, 4\)\.')):
+                match=r'Unable to avoid creating a copy while reshaping\.'):
             if external:
                 cupy.reshape(a, (2, 3, 4), copy=False)
             else:

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -116,84 +116,68 @@ class TestReshape:
         a = xp.zeros((8,), dtype=xp.float32)
         return xp.reshape(a, (1, 1, 1, 4, 1, 2), order=order)
 
+    # ``external`` toggles between the bound (``a.reshape``) and functional
+    # (``xp.reshape(a, ...)``) call forms, which share a code path, so the
+    # copy behaviour is exercised once and parametrized rather than duplicated.
     @testing.with_requires('numpy>=2.1')
+    @pytest.mark.parametrize('external', [False, True])
     @pytest.mark.parametrize('copy', [None, True, False])
     @testing.for_orders('CFA')
     @testing.numpy_cupy_array_equal(
         accept_error=ValueError, strides_check=True)
-    def test_reshape_with_copy(self, xp, order, copy):
+    def test_reshape_with_copy(self, xp, order, copy, external):
         a = testing.shaped_arange((2, 3, 4), xp)
-        return a.reshape(3, -1, order=order, copy=copy)
+        if external:
+            return xp.reshape(a, (3, -1), order=order, copy=copy)
+        return a.reshape((3, -1), order=order, copy=copy)
 
-    @testing.with_requires('numpy>=2.1')
-    @pytest.mark.parametrize('copy', [None, True, False])
-    @testing.for_orders('CFA')
-    @testing.numpy_cupy_array_equal(
-        accept_error=ValueError, strides_check=True)
-    def test_external_reshape_with_copy(self, xp, order, copy):
-        a = testing.shaped_arange((2, 3, 4), xp)
-        return xp.reshape(a, (3, -1), order=order, copy=copy)
-
-    def test_reshape_copy_true_does_not_share_memory(self):
+    @pytest.mark.parametrize('external', [False, True])
+    def test_reshape_copy_true_forces_copy(self, external):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        b = a.reshape(3, -1, copy=True)
-
+        b = (cupy.reshape(a, (3, -1), copy=True) if external
+             else a.reshape((3, -1), copy=True))
         assert not cupy.shares_memory(a, b)
         testing.assert_array_equal(b, a.reshape(3, -1))
 
-    def test_external_reshape_copy_true_does_not_share_memory(self):
+    @pytest.mark.parametrize('order', ['C', 'F'])
+    @pytest.mark.parametrize('external', [False, True])
+    def test_reshape_copy_false_shares_memory(self, external, order):
         a = testing.shaped_arange((2, 3, 4), cupy)
-        b = cupy.reshape(a, (3, -1), copy=True)
-
-        assert not cupy.shares_memory(a, b)
-        testing.assert_array_equal(b, cupy.reshape(a, (3, -1)))
-
-    def test_reshape_copy_false_shares_memory(self):
-        a = testing.shaped_arange((2, 3, 4), cupy)
-        b = a.reshape(3, -1, copy=False)
-
+        if order == 'F':
+            a = cupy.asfortranarray(a)
+        b = (cupy.reshape(a, (3, -1), order=order, copy=False) if external
+             else a.reshape((3, -1), order=order, copy=False))
         assert cupy.shares_memory(a, b)
-        testing.assert_array_equal(b, a.reshape(3, -1))
+        if order == 'F':
+            assert b.flags.f_contiguous
+        testing.assert_array_equal(b, a.reshape(3, -1, order=order))
 
-    def test_reshape_copy_false_fortran_order_shares_memory(self):
-        a = cupy.asfortranarray(testing.shaped_arange((2, 3, 4), cupy))
-        b = a.reshape(3, -1, order='F', copy=False)
-
-        assert cupy.shares_memory(a, b)
-        assert b.flags.f_contiguous
-        testing.assert_array_equal(b, a.reshape(3, -1, order='F'))
-
-    def test_reshape_copy_false_noncontiguous_raises(self):
+    @pytest.mark.parametrize('external', [False, True])
+    def test_reshape_copy_false_noncontiguous_raises(self, external):
         a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
         with pytest.raises(
                 ValueError, match=r'Unable to avoid copy while reshaping\.'):
-            a.reshape(2, 3, 4, copy=False)
+            if external:
+                cupy.reshape(a, (2, 3, 4), copy=False)
+            else:
+                a.reshape((2, 3, 4), copy=False)
 
-    def test_external_reshape_copy_false_noncontiguous_raises(self):
-        a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
-        with pytest.raises(
-                ValueError, match=r'Unable to avoid copy while reshaping\.'):
-            cupy.reshape(a, (2, 3, 4), copy=False)
+    @pytest.mark.parametrize('shape', [(0,), (1,)])
+    def test_reshape_copy_false_zero_size_and_scalar(self, shape):
+        a = cupy.zeros((0,)) if shape == (0,) else cupy.array(1)
+        b = a.reshape(shape, copy=False)
+        assert b.base is a
+        testing.assert_array_equal(b, a.reshape(shape))
 
-    def test_reshape_copy_false_zero_size_and_scalar(self):
-        arrays_and_shapes = [
-            (cupy.zeros((0,)), (0,)),
-            (cupy.array(1), (1,)),
-        ]
-
-        for a, shape in arrays_and_shapes:
-            b = a.reshape(shape, copy=False)
-            assert b.base is a
-            testing.assert_array_equal(b, a.reshape(shape))
-
-    def test_reshape_invalid_copy(self):
+    @pytest.mark.parametrize('external', [False, True])
+    def test_reshape_invalid_copy(self, external):
         a = testing.shaped_arange((2, 3), cupy)
         with pytest.raises(
                 ValueError, match="strings are not allowed for 'copy'"):
-            a.reshape(3, 2, copy='invalid')
-        with pytest.raises(
-                ValueError, match="strings are not allowed for 'copy'"):
-            cupy.reshape(a, (3, 2), copy='invalid')
+            if external:
+                cupy.reshape(a, (3, 2), copy='invalid')
+            else:
+                a.reshape((3, 2), copy='invalid')
 
     def _test_ndim_limit(self, xp, ndim, dtype, order):
         idx = [1]*ndim

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -116,6 +116,85 @@ class TestReshape:
         a = xp.zeros((8,), dtype=xp.float32)
         return xp.reshape(a, (1, 1, 1, 4, 1, 2), order=order)
 
+    @testing.with_requires('numpy>=2.1')
+    @pytest.mark.parametrize('copy', [None, True, False])
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal(
+        accept_error=ValueError, strides_check=True)
+    def test_reshape_with_copy(self, xp, order, copy):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return a.reshape(3, -1, order=order, copy=copy)
+
+    @testing.with_requires('numpy>=2.1')
+    @pytest.mark.parametrize('copy', [None, True, False])
+    @testing.for_orders('CFA')
+    @testing.numpy_cupy_array_equal(
+        accept_error=ValueError, strides_check=True)
+    def test_external_reshape_with_copy(self, xp, order, copy):
+        a = testing.shaped_arange((2, 3, 4), xp)
+        return xp.reshape(a, (3, -1), order=order, copy=copy)
+
+    def test_reshape_copy_true_does_not_share_memory(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        b = a.reshape(3, -1, copy=True)
+
+        assert not cupy.shares_memory(a, b)
+        testing.assert_array_equal(b, a.reshape(3, -1))
+
+    def test_external_reshape_copy_true_does_not_share_memory(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        b = cupy.reshape(a, (3, -1), copy=True)
+
+        assert not cupy.shares_memory(a, b)
+        testing.assert_array_equal(b, cupy.reshape(a, (3, -1)))
+
+    def test_reshape_copy_false_shares_memory(self):
+        a = testing.shaped_arange((2, 3, 4), cupy)
+        b = a.reshape(3, -1, copy=False)
+
+        assert cupy.shares_memory(a, b)
+        testing.assert_array_equal(b, a.reshape(3, -1))
+
+    def test_reshape_copy_false_fortran_order_shares_memory(self):
+        a = cupy.asfortranarray(testing.shaped_arange((2, 3, 4), cupy))
+        b = a.reshape(3, -1, order='F', copy=False)
+
+        assert cupy.shares_memory(a, b)
+        assert b.flags.f_contiguous
+        testing.assert_array_equal(b, a.reshape(3, -1, order='F'))
+
+    def test_reshape_copy_false_noncontiguous_raises(self):
+        a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
+        with pytest.raises(
+                ValueError, match=r'Unable to avoid copy while reshaping\.'):
+            a.reshape(2, 3, 4, copy=False)
+
+    def test_external_reshape_copy_false_noncontiguous_raises(self):
+        a = testing.shaped_arange((2, 3, 4), cupy).transpose(2, 0, 1)
+        with pytest.raises(
+                ValueError, match=r'Unable to avoid copy while reshaping\.'):
+            cupy.reshape(a, (2, 3, 4), copy=False)
+
+    def test_reshape_copy_false_zero_size_and_scalar(self):
+        arrays_and_shapes = [
+            (cupy.zeros((0,)), (0,)),
+            (cupy.array(1), (1,)),
+        ]
+
+        for a, shape in arrays_and_shapes:
+            b = a.reshape(shape, copy=False)
+            assert b.base is a
+            testing.assert_array_equal(b, a.reshape(shape))
+
+    def test_reshape_invalid_copy(self):
+        a = testing.shaped_arange((2, 3), cupy)
+        with pytest.raises(
+                ValueError, match="strings are not allowed for 'copy'"):
+            a.reshape(3, 2, copy='invalid')
+        with pytest.raises(
+                ValueError, match="strings are not allowed for 'copy'"):
+            cupy.reshape(a, (3, 2), copy='invalid')
+
     def _test_ndim_limit(self, xp, ndim, dtype, order):
         idx = [1]*ndim
         idx[-1] = ndim


### PR DESCRIPTION
## Summary

Adds a `copy` keyword to `reshape` (`ndarray.reshape` and `cupy.reshape`), matching NumPy 2.x semantics: `copy=None` (default) copies only when a no-copy reshape is impossible, `copy=True` always copies, and `copy=False` raises a `ValueError` when a copy cannot be avoided.

Supersedes #10050, with @seberg's review incorporated:

- Dropped the `_COPY_*` cdef enum; the plain `True`/`False`/`None` tri-state is threaded straight into `_reshape`, which branches on `copy is True` / `copy is False`.
- Moved copy-argument validation into `cupy._core.internal` as `_normalize_copy`, alongside `_normalize_order`.
- Collapsed the copy tests: parametrized over the bound (`a.reshape`) vs functional (`cupy.reshape`) call forms instead of duplicating each, and folded the share-memory / raises cases into fewer parametrized tests.

Fixes #10039.