### PR TITLE
Work around compiler issue with volatile in bitcount

### DIFF
--- a/cupy/_core/_routines_binary.pyx
+++ b/cupy/_core/_routines_binary.pyx
@@ -84,7 +84,7 @@ cdef _bitwise_count = create_ufunc(
 template <typename T>
 __device__ inline int _cupy_bitcount(T x) {
     if constexpr (sizeof(T) <= 4) {
-        unsigned int ux = static_cast<unsigned int>(x);
+        volatile unsigned int ux = static_cast<unsigned int>(x);
         if constexpr (std::is_signed<T>::value) {
             if(x<0){
                 ux = ~ux + 1u;


### PR DESCRIPTION
I am not sure what is going on exactly, but locally the bitcount tests started failing and this is the "fix".
It seems the compiler is being too smart here a volatile fixes that although I am not sure if (when not memory bound) this might generate slightly slower code?

(We can not rush this, since I haven't figured out the _why_...)