### PR TITLE
Add thread safety marker for test_spmm_large_n in TestSpmmLargeColumns

### DIFF
--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -759,6 +759,10 @@ class TestSpmm:
 class TestSpmmLargeColumns:
     """cuSPARSE SpMM gridDim.y overflow (#9850)."""
 
+    @pytest.mark.thread_unsafe(
+        reason="sparse.random -> cupy.random.choice lazily compiles a "
+               "RawKernel into a module global (FeistelBijection.get_kernel), "
+               "which races and can crash under free-threading.")
     @testing.slow
     def test_spmm_large_n(self):
         if not cusparse.check_availability('spmm'):


### PR DESCRIPTION
### Summary
This change introduces a thread_unsafe marker to the `test_spmm_large_n` method, addressing potential race conditions due to lazy compilation of `RawKernel` in `cupy.random.choice`. 

### Root cause
The test builds its sparse operand via `cupyx.scipy.sparse.random(...)`, which
samples indices without replacement using `Generator.choice(..., replace=False)`.
That path drives `FeistelBijection`, which **lazily compiles a `RawKernel` into
a module-global on first use**:

```python
cdef object _feistel_bijection_with_cutoff_kernel = None

cdef get_kernel(self):
    global _feistel_bijection_with_cutoff_kernel
    if _feistel_bijection_with_cutoff_kernel is None:
        _feistel_bijection_with_cutoff_kernel = cupy.RawKernel(...)  # first-time compile
    return _feistel_bijection_with_cutoff_kernel
```