### PR TITLE
Fix cuBLAS pointer mode in solve_triangular

### DIFF
--- a/cupyx/scipy/linalg/_solve_triangular.py
+++ b/cupyx/scipy/linalg/_solve_triangular.py
@@ -155,32 +155,43 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     else:
         diag = cublas.CUBLAS_DIAG_NON_UNIT
 
-    if batch_count:
-        if dtype == 'f':
-            trsm = cublas.strsmBatched
-        elif dtype == 'd':
-            trsm = cublas.dtrsmBatched
-        elif dtype == 'F':
-            trsm = cublas.ctrsmBatched
-        else:  # dtype == 'D'
-            trsm = cublas.ztrsmBatched
-        trsm(
-            cublas_handle, cublas.CUBLAS_SIDE_LEFT, uplo,
-            trans, diag,
-            m, n, one.ctypes.data, a_array.data.ptr, m,
-            b_array.data.ptr, m, batch_count)
-        return b.transpose(0, 2, 1).reshape(b_shape)
-    else:
-        if dtype == 'f':
-            trsm = cublas.strsm
-        elif dtype == 'd':
-            trsm = cublas.dtrsm
-        elif dtype == 'F':
-            trsm = cublas.ctrsm
-        else:  # dtype == 'D'
-            trsm = cublas.ztrsm
-        trsm(
-            cublas_handle, cublas.CUBLAS_SIDE_LEFT, uplo,
-            trans, diag,
-            m, n, one.ctypes.data, a.data.ptr, m, b.data.ptr, m)
-        return b
+    # ?trsm passes the scalar ``one`` by host pointer, so the cuBLAS handle must
+    # be in HOST pointer mode.  The handle returned by ``get_cublas_handle()`` is
+    # shared and may have been left in DEVICE pointer mode by another routine; in
+    # that case the host pointer is interpreted as a device pointer -- silently
+    # tolerated by CUDA cuBLAS, but rejected with an error by ROCm/hipBLAS.  Force
+    # HOST mode around the call and restore the previous mode afterwards.
+    pointer_mode = cublas.getPointerMode(cublas_handle)
+    cublas.setPointerMode(cublas_handle, cublas.CUBLAS_POINTER_MODE_HOST)
+    try:
+        if batch_count:
+            if dtype == 'f':
+                trsm = cublas.strsmBatched
+            elif dtype == 'd':
+                trsm = cublas.dtrsmBatched
+            elif dtype == 'F':
+                trsm = cublas.ctrsmBatched
+            else:  # dtype == 'D'
+                trsm = cublas.ztrsmBatched
+            trsm(
+                cublas_handle, cublas.CUBLAS_SIDE_LEFT, uplo,
+                trans, diag,
+                m, n, one.ctypes.data, a_array.data.ptr, m,
+                b_array.data.ptr, m, batch_count)
+            return b.transpose(0, 2, 1).reshape(b_shape)
+        else:
+            if dtype == 'f':
+                trsm = cublas.strsm
+            elif dtype == 'd':
+                trsm = cublas.dtrsm
+            elif dtype == 'F':
+                trsm = cublas.ctrsm
+            else:  # dtype == 'D'
+                trsm = cublas.ztrsm
+            trsm(
+                cublas_handle, cublas.CUBLAS_SIDE_LEFT, uplo,
+                trans, diag,
+                m, n, one.ctypes.data, a.data.ptr, m, b.data.ptr, m)
+            return b
+    finally:
+        cublas.setPointerMode(cublas_handle, pointer_mode)

--- a/cupyx/scipy/linalg/_solve_triangular.py
+++ b/cupyx/scipy/linalg/_solve_triangular.py
@@ -155,12 +155,13 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
     else:
         diag = cublas.CUBLAS_DIAG_NON_UNIT
 
-    # ?trsm passes the scalar ``one`` by host pointer, so the cuBLAS handle must
-    # be in HOST pointer mode.  The handle returned by ``get_cublas_handle()`` is
-    # shared and may have been left in DEVICE pointer mode by another routine; in
-    # that case the host pointer is interpreted as a device pointer -- silently
-    # tolerated by CUDA cuBLAS, but rejected with an error by ROCm/hipBLAS.  Force
-    # HOST mode around the call and restore the previous mode afterwards.
+    # ?trsm passes the scalar ``one`` by host pointer, so the cuBLAS
+    # handle must be in HOST pointer mode.  The handle returned by
+    # ``get_cublas_handle()`` is shared and may have been left in DEVICE
+    # pointer mode by another routine; in that case the host pointer is
+    # interpreted as a device pointer -- silently tolerated by CUDA
+    # cuBLAS, but rejected with an error by ROCm/hipBLAS.  Force HOST
+    # mode around the call and restore the previous mode afterwards.
     pointer_mode = cublas.getPointerMode(cublas_handle)
     cublas.setPointerMode(cublas_handle, cublas.CUBLAS_POINTER_MODE_HOST)
     try:

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
@@ -147,3 +147,38 @@ class TestSolveTriangular(unittest.TestCase):
         self.check_batched((4, 4, 4), (4, 4))
         self.check_batched((5, 5, 5), (5, 5, 2))
         self.check_batched((5, 5, 5), (5, 5, 5))
+
+
+@testing.with_requires('scipy')
+class TestSolveTriangularPointerMode(unittest.TestCase):
+    # Regression test for the cuBLAS pointer-mode handling of solve_triangular.
+    # The routine passes the scalar alpha by host pointer, so it must force HOST
+    # pointer mode on the shared cuBLAS handle.  If another routine left the handle
+    # in DEVICE pointer mode, the host pointer would be misread as device memory --
+    # tolerated by CUDA cuBLAS but rejected by ROCm/hipBLAS.  solve_triangular must
+    # both compute correctly and leave the handle's pointer mode unchanged.
+
+    @testing.for_dtypes('fdFD')
+    def test_solve_with_device_pointer_mode(self, dtype):
+        from cupy.cuda import cublas
+        from cupy.cuda import device
+
+        a_cpu = (numpy.tril(numpy.random.rand(5, 5))
+                 + 5 * numpy.eye(5)).astype(dtype)
+        b_cpu = numpy.random.rand(5, 3).astype(dtype)
+        a = cupy.asarray(a_cpu)
+        b = cupy.asarray(b_cpu)
+
+        handle = device.get_cublas_handle()
+        orig_mode = cublas.getPointerMode(handle)
+        cublas.setPointerMode(handle, cublas.CUBLAS_POINTER_MODE_DEVICE)
+        try:
+            result = cupyx.scipy.linalg.solve_triangular(a, b, lower=True)
+            mode_after = cublas.getPointerMode(handle)
+        finally:
+            cublas.setPointerMode(handle, orig_mode)
+
+        expected = scipy.linalg.solve_triangular(a_cpu, b_cpu, lower=True)
+        testing.assert_allclose(result, expected, atol=1e-5)
+        # solve_triangular must restore the handle's pointer mode on exit.
+        assert mode_after == cublas.CUBLAS_POINTER_MODE_DEVICE

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_solve_triangular.py
@@ -151,12 +151,14 @@ class TestSolveTriangular(unittest.TestCase):
 
 @testing.with_requires('scipy')
 class TestSolveTriangularPointerMode(unittest.TestCase):
-    # Regression test for the cuBLAS pointer-mode handling of solve_triangular.
-    # The routine passes the scalar alpha by host pointer, so it must force HOST
-    # pointer mode on the shared cuBLAS handle.  If another routine left the handle
-    # in DEVICE pointer mode, the host pointer would be misread as device memory --
-    # tolerated by CUDA cuBLAS but rejected by ROCm/hipBLAS.  solve_triangular must
-    # both compute correctly and leave the handle's pointer mode unchanged.
+    # Regression test for the cuBLAS pointer-mode handling of
+    # solve_triangular.  The routine passes the scalar alpha by host
+    # pointer, so it must force HOST pointer mode on the shared cuBLAS
+    # handle.  If another routine left the handle in DEVICE pointer mode,
+    # the host pointer would be misread as device memory -- tolerated by
+    # CUDA cuBLAS but rejected by ROCm/hipBLAS.  solve_triangular must
+    # both compute correctly and leave the handle's pointer mode
+    # unchanged.
 
     @testing.for_dtypes('fdFD')
     def test_solve_with_device_pointer_mode(self, dtype):


### PR DESCRIPTION
# Fix cuBLAS pointer mode in `solve_triangular`

## Problem

`cupyx.scipy.linalg.solve_triangular` builds the scalar `alpha` (`one`) as a
host NumPy value and passes `one.ctypes.data` (a **host** pointer) to
`cublas.?trsm` / `?trsmBatched`, but it never sets the cuBLAS handle's pointer
mode to `HOST`. It therefore relies on the shared handle returned by
`device.get_cublas_handle()` already being in `HOST` pointer mode.

If that shared handle is in `DEVICE` pointer mode when `solve_triangular` is
called, the host `alpha` pointer is interpreted as device memory:

- On **CUDA**, cuBLAS tolerates the mismatch and the result is still correct, so
  the latent bug is masked.
- On **ROCm/hipBLAS** (tested gfx1100), the call fails with
  `CUBLASError: HIPBLAS_STATUS_INTERNAL_ERROR`.

Every scalar-taking routine in `cupy/cublas.py` already saves/sets/restores the
pointer mode (`_setup_scalar_ptr`, `getPointerMode`/`setPointerMode`);
`solve_triangular` is the outlier that does not.

## Fix

Force `CUBLAS_POINTER_MODE_HOST` around both the batched and non-batched trsm
calls and restore the previous mode in a `finally`, matching the existing
`cupy/cublas.py` idiom. One `getPointerMode` + two `setPointerMode` calls; no
behavior change when the handle is already in HOST mode (the common case).

## Reproducer

```python
import numpy as np, cupy as cp
import cupyx.scipy.linalg as cpx_linalg
from cupy.cuda import cublas

n, k = 256, 512
rng = np.random.default_rng(0)
q, _ = np.linalg.qr(rng.standard_normal((n, n)))
L_h = np.linalg.cholesky((q * np.geomspace(1, 1e-8, n)) @ q.T + np.eye(n) * 1e-10)
T_h = L_h @ rng.standard_normal((n, k))
L, T = cp.asarray(L_h), cp.asarray(T_h)
handle = cp.cuda.get_cublas_handle()

cublas.setPointerMode(handle, cublas.CUBLAS_POINTER_MODE_DEVICE)   # left DEVICE by other code
B = cpx_linalg.solve_triangular(L, T, lower=True)                  # <-- raises on ROCm before this fix
cp.cuda.Stream.null.synchronize()
```

Before the fix (ROCm gfx1100): `CUBLASError: HIPBLAS_STATUS_INTERNAL_ERROR`.
After the fix: residual `7.5e-16`, and the handle's pointer mode is restored.

## Tests

Added `TestSolveTriangularPointerMode.test_solve_with_device_pointer_mode`
(dtypes `fdFD`), which runs `solve_triangular` with the shared handle set to
`DEVICE` mode and checks (a) the result matches SciPy and (b) the handle's
pointer mode is restored on exit.

- New test **fails** on the current code on ROCm (`CUBLASError`) and **passes**
  with this fix.
- Full existing `test_solve_triangular.py` suite: **385 passed, 96 xfailed**
  (unchanged) with the fix applied.

## Environment where reproduced / verified

cupy 14.1.1 · AMD Radeon RX 7900 XT (gfx1100) · HIP 7.1.52801 · rocBLAS 5.1.0 ·
hipBLAS 3.1.0 · Ubuntu 26.04. Cross-checked on NVIDIA RTX 5070 (CUDA), where the
bug is masked and the fix is a no-op.

## Note

The underlying BLAS is not at fault: a pure hipBLAS C++ check shows
`hipblasDtrsm` returns a clean `INTERNAL_ERROR` for the invalid
DEVICE-mode + host-`alpha` combination and does not corrupt the context — the
missing guard is on the cupy side.
