### PR TITLE
Fix AxisError not raised for out-of-range axis in nanmedian

### DIFF
--- a/cupy/_core/_routines_statistics.pyx
+++ b/cupy/_core/_routines_statistics.pyx
@@ -471,22 +471,9 @@ cpdef _ndarray_base _median(
 cpdef _ndarray_base _nanmedian(
         _ndarray_base a, axis, out, overwrite_input, keepdims):
 
-    if axis is None:
-        axis = tuple(range(a.ndim))
-    if not sequence.PySequence_Check(axis):
-        axis = (axis,)
-
-    reduce_axis = []
-    reduce_shape = []
-    out_axis = []
-    out_shape = []
-    for i in range(a.ndim):
-        if axis is None or i in axis or i - a.ndim in axis:
-            reduce_axis.append(i)
-            reduce_shape.append(a.shape[i])
-        else:
-            out_axis.append(i)
-            out_shape.append(a.shape[i])
+    reduce_axis, out_axis = _reduction._get_axis(axis, a.ndim)
+    reduce_shape = [a.shape[i] for i in reduce_axis]
+    out_shape = [a.shape[i] for i in out_axis]
 
     a_data_ptr = a.data.ptr
     a = a.transpose(out_axis + reduce_axis)

--- a/tests/cupy_tests/statistics_tests/test_meanvar.py
+++ b/tests/cupy_tests/statistics_tests/test_meanvar.py
@@ -78,6 +78,24 @@ class TestMedian:
         return xp.median(a, axis=1)
 
 
+class TestNanMedianInvalidAxis:
+
+    def test_nanmedian_invalid_axis(self):
+        for xp in [numpy, cupy]:
+            a = testing.shaped_random((3, 4, 5), xp)
+            with pytest.raises(AxisError):
+                return xp.nanmedian(a, -a.ndim - 1, keepdims=False)
+
+            with pytest.raises(AxisError):
+                return xp.nanmedian(a, a.ndim, keepdims=False)
+
+            with pytest.raises(AxisError):
+                return xp.nanmedian(a, (-a.ndim - 1, 1), keepdims=False)
+
+            with pytest.raises(AxisError):
+                return xp.nanmedian(a, (0, a.ndim,), keepdims=False)
+
+
 @testing.parameterize(
     *testing.product({
         'shape': [(3, 4, 5)],


### PR DESCRIPTION
Fixes #9332

## What

`cupy.nanmedian(a, axis=...)` didn't validate that `axis` was actually a
valid dimension of `a`. Out-of-range axis values were silently dropped
instead of raising, so the function fell through into an unrelated
`reshape` call and raised a confusing `ValueError` instead of the
`AxisError` NumPy raises in the same situation:

```py
>>> import cupy as cp
>>> cp.nanmedian(cp.array([]), axis=1)
ValueError: cannot reshape array of size 0 into shape (0, -1)
```

```py
>>> import numpy as np
>>> np.nanmedian(np.array([]), axis=1)
numpy.exceptions.AxisError: axis 1 is out of bounds for array of dimension 1
```

(The linked issue's title says "zero dim arrays", but the actual repro is
a 1-D array with an out-of-bounds `axis` — the array's zero *size* isn't
what triggers the bug, the invalid axis is.)

## How

`_nanmedian` (`cupy/_core/_routines_statistics.pyx`) had its own
hand-rolled loop for splitting `axis` into `reduce_axis`/`out_axis` that
never checked whether the axis values the caller passed actually
corresponded to real dimensions. The sibling function `_median` in the
same file already delegates this to `_reduction._get_axis`, which
normalizes/validates axis via `internal._normalize_axis_index` and raises
`AxisError` for out-of-range values (and `ValueError` for duplicates) —
exactly NumPy's behavior. This PR makes `_nanmedian` use the same helper
instead of duplicating (buggily) what `_median` already does correctly.

Net change: -13/+3 lines, no new abstractions, no changes to the
transpose/reduce logic that follows.

## Tests

Added `TestNanMedianInvalidAxis.test_nanmedian_invalid_axis`, mirroring
the existing `TestMedian.test_median_invalid_axis` for the sibling
function, covering out-of-range scalar and sequence axis values (both
positive and negative).

## Note on verification

`pre-commit run -a` passes clean on both changed files. I wasn't able to
get cupy building from source locally (an unrelated pre-existing
`nvcc`/CUB build issue on my machine), so I haven't run the new test
against a real GPU build myself — I verified the logic by tracing
`_get_axis`'s use in the sibling `_median` function instead. Flagging
this rather than claiming a run that didn't happen.
