### PR TITLE
Fix incorrect output for ndimage filters when output aliases input

### DIFF
--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -177,13 +177,13 @@ def _call_kernel(kernel, input, weights, output, structure=None,
     output = _util._get_output(output, input, None, complex_output)
     needs_temp = cupy.shares_memory(output, input, 'MAY_SHARE_BOUNDS')
     if needs_temp:
-        output, temp = _util._get_output(output.dtype, input, None,
-                                         complex_output), output
+        output, orig_out = _util._get_output(output.dtype, input, None,
+                                             complex_output), output
     args.append(output)
     kernel(*args)
     if needs_temp:
-        _core.elementwise_copy(output, temp)
-        output = temp
+        _core.elementwise_copy(output, orig_out)
+        output = orig_out
     return output
 
 

--- a/cupyx/scipy/ndimage/_filters_core.py
+++ b/cupyx/scipy/ndimage/_filters_core.py
@@ -182,7 +182,7 @@ def _call_kernel(kernel, input, weights, output, structure=None,
     args.append(output)
     kernel(*args)
     if needs_temp:
-        _core.elementwise_copy(temp, output)
+        _core.elementwise_copy(output, temp)
         output = temp
     return output
 

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1056,6 +1056,19 @@ class TestInvalidOrigin(FilterTestCaseBase):
         return self._filter(xp, scp)
 
 
+# RawKernel/pyfunc pair for TestOutputOverlapsInput.test_generic_filter.
+mean_raw = cupy.RawKernel('''extern "C" __global__
+void mean_filter(const double* x, int filter_size, double* y) {
+    double s = 0;
+    for (int i = 0; i < filter_size; ++i) { s += x[i]; }
+    y[0] = s / filter_size;
+}''', 'mean_filter')
+
+
+def mean_pyfunc(x):
+    return x.sum() / len(x)
+
+
 # Tests that `output` aliasing `input` still produces the filtered result
 # instead of the unmodified input. See cupy/cupy#8406.
 @testing.with_requires('scipy')
@@ -1070,15 +1083,30 @@ class TestOutputOverlapsInput:
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_minimum_filter(self, xp, scp):
         a = testing.shaped_random((5, 6), xp, numpy.float64)
-        return scp.ndimage.minimum_filter(a, size=3, output=a)
+        # A rectangular (all-True) footprint is separable into independent
+        # 1D passes and takes a fast path that bypasses the aliasing guard
+        # entirely, so it wouldn't exercise the bug this test targets. A
+        # non-rectangular footprint forces the non-separable _call_kernel
+        # path instead.
+        footprint = xp.array(
+            [[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool)
+        return scp.ndimage.minimum_filter(a, footprint=footprint, output=a)
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_rank_filter(self, xp, scp):
         a = testing.shaped_random((5, 6), xp, numpy.int32, scale=100)
         return scp.ndimage.rank_filter(a, 1, size=[2, 3], output=a)
 
-    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
-    def test_generic_filter(self, xp, scp):
-        a = testing.shaped_random((5, 6), xp, numpy.float64)
-        func = rms_pyfunc if xp is numpy else rms_raw
-        return scp.ndimage.generic_filter(a, func, size=3, output=a)
+    def test_generic_filter(self):
+        # SciPy's generic_filter does not protect the Python-callback path
+        # against read-after-write when output aliases input (it processes
+        # cells sequentially with no double-buffering), so its own aliased
+        # output does not equal its own clean (non-aliased) output. CuPy's
+        # aliasing guard means CuPy's aliased result should equal SciPy's
+        # *clean* result instead, so that is what this compares against.
+        a = testing.shaped_random((5, 6), cupy, numpy.float64)
+        actual = cupyx.scipy.ndimage.generic_filter(
+            a, mean_raw, size=3, output=a)
+        a_np = testing.shaped_random((5, 6), numpy, numpy.float64)
+        expected = scipy.ndimage.generic_filter(a_np, mean_pyfunc, size=3)
+        testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1054,3 +1054,31 @@ class TestInvalidOrigin(FilterTestCaseBase):
     def test_invalid_origin_pos(self, xp, scp):
         self.origin = self.ksize - self.ksize // 2
         return self._filter(xp, scp)
+
+
+# Tests that `output` aliasing `input` still produces the filtered result
+# instead of the unmodified input. See cupy/cupy#8406.
+@testing.with_requires('scipy')
+class TestOutputOverlapsInput:
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_correlate(self, xp, scp):
+        a = testing.shaped_random((5, 6), xp, numpy.float64)
+        weights = testing.shaped_random((3, 3), xp, numpy.float64, seed=1)
+        return scp.ndimage.correlate(a, weights, output=a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_minimum_filter(self, xp, scp):
+        a = testing.shaped_random((5, 6), xp, numpy.float64)
+        return scp.ndimage.minimum_filter(a, size=3, output=a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_rank_filter(self, xp, scp):
+        a = testing.shaped_random((5, 6), xp, numpy.int32, scale=100)
+        return scp.ndimage.rank_filter(a, 1, size=[2, 3], output=a)
+
+    @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
+    def test_generic_filter(self, xp, scp):
+        a = testing.shaped_random((5, 6), xp, numpy.float64)
+        func = rms_pyfunc if xp is numpy else rms_raw
+        return scp.ndimage.generic_filter(a, func, size=3, output=a)

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1056,23 +1056,16 @@ class TestInvalidOrigin(FilterTestCaseBase):
         return self._filter(xp, scp)
 
 
-# RawKernel/pyfunc pair for TestOutputOverlapsInput.test_generic_filter.
-mean_raw = cupy.RawKernel('''extern "C" __global__
-void mean_filter(const double* x, int filter_size, double* y) {
-    double s = 0;
-    for (int i = 0; i < filter_size; ++i) { s += x[i]; }
-    y[0] = s / filter_size;
-}''', 'mean_filter')
+# ReductionKernel for TestOutputOverlapsInput.test_generic_filter.
+mean_red = cupy.ReductionKernel('X x', 'Y y', 'x',
+                                'a + b', 'y = a / _in_ind.size()', '0',
+                                'mean')
 
 
-def mean_pyfunc(x):
-    return x.sum() / len(x)
-
-
-# Tests that `output` aliasing `input` still produces the filtered result
-# instead of the unmodified input. See cupy/cupy#8406.
 @testing.with_requires('scipy')
 class TestOutputOverlapsInput:
+    # Tests that `output` aliasing `input` still produces the filtered
+    # result instead of the unmodified input. See cupy/cupy#8406.
 
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp')
     def test_correlate(self, xp, scp):
@@ -1106,7 +1099,7 @@ class TestOutputOverlapsInput:
         # *clean* result instead, so that is what this compares against.
         a = testing.shaped_random((5, 6), cupy, numpy.float64)
         actual = cupyx.scipy.ndimage.generic_filter(
-            a, mean_raw, size=3, output=a)
+            a, mean_red, size=3, output=a)
         a_np = testing.shaped_random((5, 6), numpy, numpy.float64)
-        expected = scipy.ndimage.generic_filter(a_np, mean_pyfunc, size=3)
+        expected = scipy.ndimage.generic_filter(a_np, numpy.mean, size=3)
         testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Fixes #8406.

In `_call_kernel`, when the user passes an `output` array that shares
memory with `input`, the result is computed into a temporary buffer and
then copied back. The copy arguments were reversed: `elementwise_copy`
takes (source, destination), so `elementwise_copy(temp, output)` copied
the original input over the freshly computed result, causing the filter
to return the unmodified input.

Swapping to `elementwise_copy(output, temp)` copies the computed result
into the user's array, matching SciPy's behavior. This affects all
ndimage filters routed through `_call_kernel` (correlate, minimum/maximum
filter, rank_filter, generic_filter, etc.).

Adds regression tests in test_filters.py covering the output-aliases-input
case for correlate, minimum_filter, rank_filter, and generic_filter.