### PR TITLE
Maintain F-contiguity in round-trip pickle

### DIFF
--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -1747,7 +1747,7 @@ cdef class _ndarray_base:
             runtime.setDevice(prev_device)
 
     def __reduce__(self):
-        return array, (self.get(),)
+        return array, (self.get(order="A"),)
 
     # Basic customization:
 

--- a/tests/cupy_tests/io_tests/test_npz.py
+++ b/tests/cupy_tests/io_tests/test_npz.py
@@ -81,10 +81,13 @@ class TestNpz(unittest.TestCase):
 
     @testing.for_all_dtypes()
     def test_pickle(self, dtype):
-        a = testing.shaped_arange((2, 3, 4), dtype=dtype)
-        s = pickle.dumps(a)
-        b = pickle.loads(s)
-        testing.assert_array_equal(a, b)
+        for order in ["C", "F"]:
+            a = testing.shaped_arange((2, 3, 4), dtype=dtype, order=order)
+            s = pickle.dumps(a)
+            b = pickle.loads(s)
+            testing.assert_array_equal(a, b)
+            assert a.flags.c_contiguous == b.flags.c_contiguous
+            assert a.flags.f_contiguous == b.flags.f_contiguous
 
     @testing.for_all_dtypes()
     def test_dump(self, dtype):


### PR DESCRIPTION
Previously all arrays roundtrip serialized with `pickle` would end up as C-contiguous. We now maintain F-contiguity when serializing an F-contiguous array, more closely matching numpy's behavior.

Fixes #10084