### PR TITLE
Fix cupy.pad mode='wrap' producing incorrect results when pad width exceeds data length

### DIFF
--- a/cupy/_padding/pad.py
+++ b/cupy/_padding/pad.py
@@ -281,7 +281,7 @@ def _set_reflect_both(padded, axis, width_pair, method, include_edge=False):
     return left_pad, right_pad
 
 
-def _set_wrap_both(padded, axis, width_pair):
+def _set_wrap_both(padded, axis, width_pair, original_period):
     """Pads an `axis` of `arr` with wrapped values.
 
     Args:
@@ -289,9 +289,13 @@ def _set_wrap_both(padded, axis, width_pair):
       axis(int): Axis along which to pad `arr`.
       width_pair((int, int)): Pair of widths that mark the pad area on both
           sides in the given dimension.
+      original_period(int): Original length of data on `axis` of `arr`.
     """
     left_pad, right_pad = width_pair
     period = padded.shape[axis] - right_pad - left_pad
+    # Avoid wrapping with only a subset of the original area by ensuring
+    # period can only be a multiple of the original area's length.
+    period = period // original_period * original_period
 
     # If the current dimension of `arr` doesn't contain enough valid values
     # (not part of the undefined pad area) we need to pad multiple times.
@@ -302,16 +306,12 @@ def _set_wrap_both(padded, axis, width_pair):
 
     if left_pad > 0:
         # Pad with wrapped values on left side
-        # First slice chunk from right side of the non-pad area.
+        # First slice chunk from left side of the non-pad area.
         # Use min(period, left_pad) to ensure that chunk is not larger than
         # pad area
-        right_slice = _slice_at_axis(
-            slice(
-                -right_pad - min(period, left_pad),
-                -right_pad if right_pad != 0 else None,
-            ),
-            axis,
-        )
+        slice_end = left_pad + period
+        slice_start = slice_end - min(period, left_pad)
+        right_slice = _slice_at_axis(slice(slice_start, slice_end), axis)
         right_chunk = padded[right_slice]
 
         if left_pad > period:
@@ -325,12 +325,12 @@ def _set_wrap_both(padded, axis, width_pair):
 
     if right_pad > 0:
         # Pad with wrapped values on right side
-        # First slice chunk from left side of the non-pad area.
+        # First slice chunk from right side of the non-pad area.
         # Use min(period, right_pad) to ensure that chunk is not larger than
         # pad area
-        left_slice = _slice_at_axis(
-            slice(left_pad, left_pad + min(period, right_pad)), axis
-        )
+        slice_start = -right_pad - period
+        slice_end = slice_start + min(period, right_pad)
+        left_slice = _slice_at_axis(slice(slice_start, slice_end), axis)
         left_chunk = padded[left_slice]
 
         if right_pad > period:
@@ -742,12 +742,13 @@ def pad(array, pad_width, mode='constant', **kwargs):
     elif mode == 'wrap':
         for axis, (left_index, right_index) in zip(axes, pad_width):
             roi = _view_roi(padded, original_area_slice, axis)
+            original_period = padded.shape[axis] - right_index - left_index
             while left_index > 0 or right_index > 0:
                 # Iteratively pad until dimension is filled with wrapped
                 # values. This is necessary if the pad area is larger than
                 # the length of the original values in the current dimension.
                 left_index, right_index = _set_wrap_both(
-                    roi, axis, (left_index, right_index)
+                    roi, axis, (left_index, right_index), original_period
                 )
 
     return padded

--- a/tests/cupy_tests/padding_tests/test_pad.py
+++ b/tests/cupy_tests/padding_tests/test_pad.py
@@ -201,6 +201,24 @@ class TestPadNumpybug(unittest.TestCase):
         return a
 
 
+@testing.parameterize(
+    # Issue #9123: when 'wrap' padding needs multiple iterations to fill
+    # the pad area, the wrapped region must be a strict repeat of the
+    # original data, not a partial/duplicated cycle.
+    {'array': numpy.arange(4).reshape(2, 2), 'pad_width': [(1, 4), (2, 1)]},
+    {'array': numpy.arange(4).reshape(2, 2), 'pad_width': [(2, 3), (2, 3)]},
+    {'array': numpy.arange(4).reshape(2, 2), 'pad_width': [(0, 4), (0, 0)]},
+    {'array': numpy.arange(3), 'pad_width': (7, 3)},
+)
+class TestPadWrapMultiIteration(unittest.TestCase):
+
+    @testing.for_all_dtypes(no_bool=True)
+    @testing.numpy_cupy_array_equal()
+    def test_pad_wrap(self, xp, dtype):
+        array = xp.array(self.array, dtype=dtype)
+        return xp.pad(array, self.pad_width, mode='wrap')
+
+
 class TestPadEmpty(unittest.TestCase):
 
     @testing.with_requires('numpy>=1.17')


### PR DESCRIPTION
Fixes #9123.

## Root cause
cupy/_padding/pad.py is a historical port of numpy's arraypad.py. It
inherited a bug (issue #9123) in `_set_wrap_both`: when a 'wrap' pad
region is larger than the data along an axis and requires multiple
fill iterations, `period` could take a value that is not a whole
multiple of the original data length, so the wrapped region became a
partial/misaligned cycle instead of a strict repeat of the input.

Example from the issue:
    np.pad(np.arange(4).reshape(2, 2), ((1, 4), (2, 1)), mode='wrap')
cupy and numpy disagreed on the result.

## Fix
This ports numpy's upstream fix for the same bug, numpy/numpy#22575,
into cupy's equivalent code:
- `_set_wrap_both` gains an `original_period` parameter.
- `period` is capped to a multiple of the original length:
  `period = period // original_period * original_period`.
- Both chunk-slice computations are rewritten to the position-based
  `slice_start`/`slice_end` form matching numpy.
- The 'wrap' branch of `pad()` computes `original_period` before the
  iteration loop and threads it through.

The change is a verbatim port of numpy/numpy#22575; credit for the
fix logic belongs to that PR.

## Scope
Only the 'wrap' mode path is touched. reflect/symmetric/edge/constant
modes are unchanged.

## Tests
Adds TestPadWrapMultiIteration to tests/cupy_tests/padding_tests/test_pad.py:
the issue's exact repro, an exact-multiple-of-period case, a
non-reproducing over-correction guard, and a 1-D asymmetric case.
Verified the repro case fails before the fix and all pass after;
full test_pad.py (79 tests) passes with no regressions.