### PR TITLE
Fix IndexError in eigsh/svds for matrices small relative to k

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -35,7 +35,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         v0 (ndarray): Starting vector for iteration. If ``None``, a random
             unit vector is used.
         ncv (int): The number of Lanczos vectors generated. Must be
-            ``k + 1 < ncv < n``. If ``None``, default value is used.
+            ``k + 1 < ncv <= n``. If ``None``, default value is used.
         maxiter (int): Maximum number of Lanczos update iterations.
             If ``None``, default value is used.
         tol (float): Tolerance for residuals ``||Ax - wx||``. If ``0``, machine
@@ -69,9 +69,9 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         raise ValueError('which must be \'LM\',\'LA\'or\'SA\' (actual: {})'
                          ''.format(which))
     if ncv is None:
-        ncv = min(max(2 * k, k + 32), n - 1)
+        ncv = min(max(2 * k, k + 32), n)
     else:
-        ncv = min(max(ncv, k + 2), n - 1)
+        ncv = min(max(ncv, k + 2), n)
     if maxiter is None:
         maxiter = 10 * n
     if tol == 0:
@@ -109,7 +109,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
     uu = cupy.empty((k,), dtype=a.dtype)
 
-    while res > tol and iter < maxiter:
+    while res > tol and iter < maxiter and k + 1 < ncv:
         # Setup for thick-restart
         beta[:k] = 0
         alpha[:k] = w
@@ -346,7 +346,7 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
         k (int): The number of singular values/vectors to compute. Must be
             ``1 <= k < min(m, n)``.
         ncv (int): The number of Lanczos vectors generated. Must be
-            ``k + 1 < ncv < min(m, n)``. If ``None``, default value is used.
+            ``k + 1 < ncv <= min(m, n)``. If ``None``, default value is used.
         tol (float): Tolerance for singular values. If ``0``, machine precision
             is used.
         which (str): Only 'LM' is supported. 'LM': finds ``k`` largest singular

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -325,6 +325,53 @@ class TestSvds:
             sp.linalg.svds(a, k=self.k, which='SM')
 
 
+@testing.with_requires('scipy')
+class TestEigshSvdsSmallNcv:
+    # Regression tests for gh-9278: eigsh's thick-restart step wrote past
+    # the end of the Lanczos basis (`V[k+1]`) whenever the default `ncv`
+    # ended up <= k + 1, which the old `min(..., n - 1)` cap allowed for
+    # matrices small relative to k.
+    tol = {numpy.float32: 1e-4, numpy.complex64: 1e-4, 'default': 1e-8}
+
+    @pytest.mark.parametrize('n,k', [(3, 1), (4, 2), (5, 3)])
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_eigsh(self, n, k, dtype, xp, sp):
+        aux = testing.shaped_random((n, n), xp, dtype=dtype, scale=1)
+        a = aux + aux.conj().T
+        w, _ = sp.linalg.eigsh(a, k=k)
+        return xp.sort(w)
+
+    @pytest.mark.parametrize(
+        'shape,k', [((4, 3), 1), ((5, 4), 2), ((6, 5), 3)])
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
+    def test_svds(self, shape, k, dtype, xp, sp):
+        a = testing.shaped_random(shape, xp, dtype=dtype, scale=1)
+        s = sp.linalg.svds(a, k=k, return_singular_vectors=False)
+        return xp.sort(s)
+
+    @testing.for_dtypes('fdFD')
+    def test_eigsh_k_equals_n_minus_1(self, dtype):
+        # k == n - 1 is the extreme case allowed by eigsh's own input
+        # validation (k < n). Even after capping ncv at n, the
+        # thick-restart step still has no room to restart (ncv == k + 1),
+        # so the fix also skips restarting once ncv == n, since that
+        # already spans the full Krylov space. scipy's own eigsh has an
+        # unrelated k >= N - 1 special case for complex Hermitian input
+        # (it falls back to a dense scipy.linalg.eig with a differently
+        # shaped result), so numpy.linalg.eigvalsh is the oracle here
+        # instead of scipy.
+        n, k = 3, 2
+        aux = testing.shaped_random((n, n), cupy, dtype=dtype, scale=1)
+        a = aux + aux.conj().T
+        w, _ = cupyx.scipy.sparse.linalg.eigsh(a, k=k, which='SA')
+        expected = numpy.sort(numpy.linalg.eigvalsh(cupy.asnumpy(a)))[:k]
+        tol = self.tol[dtype] if dtype in self.tol else self.tol['default']
+        testing.assert_allclose(
+            cupy.sort(w), expected, rtol=tol, atol=tol)
+
+
 @testing.parameterize(*testing.product({
     'x0': [None, 'ones'],
     'M': [None, 'jacobi'],


### PR DESCRIPTION
Fixes #9278.
Fixes #6863.

`cupyx.scipy.sparse.linalg.svds` (and the underlying `eigsh`) raised
`IndexError` for matrices whose size is small relative to `k`.

Root cause: the default number of Lanczos vectors was capped at `n - 1`
(`ncv = min(max(2*k, k+32), n - 1)`, and likewise for a user-supplied
`ncv`). For small `n`, this could leave `ncv <= k + 1`, and the
thick-restart step then wrote `V[k+1]`, indexing past the end of the
`(ncv, n)` Lanczos basis.

Fix has two parts:
- Widen the cap to `n`, so a full-space run can use `ncv == n`.
- Add a `k + 1 < ncv` guard to the thick-restart loop. At the extreme
  `k == n - 1` (the largest `k` the input validation allows), even
  `ncv == n` gives `ncv == k + 1`, one short of what the restart needs.
  With `ncv == n` the initial Lanczos pass already spans the full space,
  so the guard stops restarting and returns the exact result instead of
  crashing.

Docstrings for `eigsh` and `svds` updated to reflect the `ncv <= n`
(`<= min(m, n)`) bound.

Added regression tests (`TestEigshSvdsSmallNcv`) covering small `n`/`k`
for `eigsh` and `svds` across float/complex dtypes, checked against
SciPy, plus the `k == n - 1` edge checked against `numpy.linalg.eigvalsh`
(SciPy's ARPACK has an unrelated dense fallback at `k >= N - 1` for
complex Hermitian input). All seven new cases reproduce the reported
IndexError on the unpatched code and pass after the fix.

Related: #8636's comment thread reports the same `ncv` crash for `svds`
near `k = min(m, n)` (k=78/79 on an 80x100 matrix). That specific
IndexError is fixed here too. #8636's title-level ask, supporting
`k = min(m, n)` exactly via a PROPACK solver, is a separate,
unimplemented feature. `svds`'s own input validation still rejects
`k >= min(m, n)` regardless of this fix, so that issue is intentionally
left open rather than closed by this PR.
