### PR TITLE
Fix int32 index overflow in cupyx.scipy.linalg LU decomposition kernels for large matrices

### DIFF
--- a/cupyx/scipy/linalg/_decomp_lu.py
+++ b/cupyx/scipy/linalg/_decomp_lu.py
@@ -162,8 +162,9 @@ def _cupy_split_lu(LU, order='C'):
 
 
 _device_get_index = '''
-__device__ inline int get_index(int row, int col, int num_rows, int num_cols,
-                                bool c_contiguous)
+__device__ inline ptrdiff_t get_index(ptrdiff_t row, ptrdiff_t col,
+                                      ptrdiff_t num_rows, ptrdiff_t num_cols,
+                                      bool c_contiguous)
 {
     if (c_contiguous) {
         return col + num_cols * row;
@@ -244,8 +245,8 @@ _kernel_cupy_laswp = cupy.ElementwiseKernel(
     while (1) {
         int row2 = IPIV[row1];
         if (row1 != row2) {
-            int idx1 = get_index(row1, col, M, N, C_CONTIGUOUS);
-            int idx2 = get_index(row2, col, M, N, C_CONTIGUOUS);
+            ptrdiff_t idx1 = get_index(row1, col, M, N, C_CONTIGUOUS);
+            ptrdiff_t idx2 = get_index(row2, col, M, N, C_CONTIGUOUS);
             T tmp       = ptr_A[idx1];
             ptr_A[idx1] = ptr_A[idx2];
             ptr_A[idx2] = tmp;

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_decomp_lu.py
@@ -155,3 +155,38 @@ class TestLUSolve(unittest.TestCase):
         with scipy.linalg.set_backend(backend):
             out = scipy.linalg.lu_solve(lu, b, trans=self.trans)
         return out
+
+
+class TestLUIndexOverflow(unittest.TestCase):
+
+    @testing.slow
+    def test_laswp_large_offset(self):
+        # _cupy_split_lu and _cupy_laswp share a get_index() device helper
+        # that used to compute flat offsets in 32-bit int, overflowing for
+        # any matrix with m * n > INT32_MAX (2,147,483,647). 46341 x 46341
+        # is the smallest square shape that crosses that threshold
+        # (46341**2 == 2,147,488,281). Using uint8 keeps the array at ~2GB
+        # instead of the 16GB+ a float64 matrix of this shape would need.
+        #
+        # Only _cupy_laswp is exercised directly here: _cupy_split_lu shares
+        # the same helper but needs three large buffers (LU, L, U) to run,
+        # which doesn't fit in this machine's VRAM budget.
+        from cupyx.scipy.linalg._decomp_lu import _cupy_laswp
+
+        m = n = 46341
+        assert m * n > 2**31 - 1
+        A = cupy.zeros((m, n), dtype=cupy.uint8)
+        A[0, :] = 1
+        A[m - 1, :] = 2
+
+        ipiv = cupy.arange(m, dtype=cupy.int32)
+        ipiv[m - 1] = 0
+
+        _cupy_laswp(A, m - 1, m - 1, ipiv, 1)
+
+        # The row-major flat offset for (row=m-1, col) crosses INT32_MAX
+        # partway through the row (around col == 41708), so checking the
+        # full row covers both the in-range and previously-overflowing
+        # columns.
+        assert bool(cupy.all(A[0, :] == 2))
+        assert bool(cupy.all(A[m - 1, :] == 1))


### PR DESCRIPTION
Fixes #10092.

`cupyx.scipy.linalg._decomp_lu` computes flat array offsets through a
`get_index()` device helper shared by the `_cupy_split_lu` and
`_cupy_laswp` kernels:

```c
__device__ inline int get_index(int row, int col, int num_rows, int num_cols,
                                bool c_contiguous)
{
    if (c_contiguous) {
        return col + num_cols * row;
    } else {
        return row + num_rows * col;
    }
}
```

`col + num_cols * row` is computed in 32-bit `int`, which overflows for
any matrix where `m * n > INT32_MAX` (2,147,483,647) and wraps to a
negative offset. Both kernels run on every `lu()`/`lu_factor()` call, so
this affects any matrix at or above roughly 46341x46341.

Fix: widen `get_index`'s parameters and return type to `ptrdiff_t`, and
widen the two `idx1`/`idx2` locals in `_cupy_laswp`'s body that hold its
result (they were still `int`, which would have re-truncated the widened
return and left the bug in place). `_cupy_split_lu` needed no change
beyond the shared helper: it consumes `get_index()`'s result directly as
a subscript with no truncating intermediate.

Individual dimensions (`M`, `N`, `K`) and the row/pivot locals stay
`int32`/`int` deliberately, not widened. They're bounded well under
`INT32_MAX` for any input `getrf` will accept in the first place (cuSOLVER
rejects `m`/`n >= INT32_MAX`), so only their product, the flat offset,
can overflow.

Also noticed while reading this code: `lu()`'s default (`permute_l=False`)
path allocates a full `(m, m)` permutation matrix in addition to the
factorized array and the `L`/`U` copies, roughly doubling peak memory.
That's a separate memory-efficiency question from this overflow fix, so
I've left it alone here and out of scope for this PR.

Added a regression test (`TestLUIndexOverflow`, marked `@testing.slow`)
that calls `_cupy_laswp` directly on a 46341x46341 `uint8` array (the
smallest square shape crossing `INT32_MAX`, kept to ~2GB by using a
1-byte dtype rather than the 16GB+ a float64 matrix this size would need)
and swaps its first and last rows. On the unpatched kernel this reliably
throws `CUDA_ERROR_ILLEGAL_ADDRESS`; with the fix it passes. `lu()`
itself isn't exercised at this scale directly, since the full pipeline
(factorization workspace plus the `L`/`U`/`P` copies) needs on the order
of 80GB for a matrix this size, well past what's available here. It
shares the same fixed `get_index()` helper, though.

Existing `test_decomp_lu.py` suite: 63 passed, 6 skipped, unchanged from
the pre-fix baseline.
