### PR TITLE
Fix tests for NumPy 2.5 (take out= dtype, numpy.fix deprecation)

### DIFF
--- a/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
+++ b/tests/cupy_tests/core_tests/fusion_tests/test_routines.py
@@ -163,6 +163,10 @@ class TestFusionDegRad(FusionUnaryUfuncTestBase):
 )
 class TestFusionRounding(FusionUnaryUfuncTestBase):
 
+    # numpy.fix is deprecated starting NumPy 2.5 (use numpy.trunc); cupy.fix
+    # is still supported, so keep exercising it without failing on the warning.
+    @pytest.mark.filterwarnings(
+        'ignore:numpy.fix is deprecated:DeprecationWarning')
     @testing.for_all_dtypes(no_complex=True)
     @fusion_utils.check_fusion()
     def test_rounding(self, xp, dtype, func):

--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -514,8 +514,15 @@ class TestNdarrayTakeErrorTypeMismatch(unittest.TestCase):
             a = testing.shaped_arange(self.shape, xp, numpy.int32)
             i = testing.shaped_arange(self.indices, xp, numpy.int32) % 3
             o = testing.shaped_arange(self.out_shape, xp, numpy.float32)
-            with pytest.raises(TypeError):
+            if (xp is numpy
+                    and numpy.lib.NumpyVersion(numpy.__version__)
+                    >= '2.5.0'):
+                # numpy>=2.5 permits safe casting of the take() out= dtype,
+                # so it no longer raises; cupy still enforces a match.
                 wrap_take(a, i, out=o)
+            else:
+                with pytest.raises(TypeError):
+                    wrap_take(a, i, out=o)
 
 
 @testing.parameterize(


### PR DESCRIPTION
## Purpose

Fix two test failures that occur with **NumPy 2.5**. Both are test-only changes and are backwards compatible with older NumPy.

### 1. `TestNdarrayTakeErrorTypeMismatch::test_output_type_mismatch`

NumPy >= 2.5 permits safe casting of the `ndarray.take(out=)` output dtype (e.g. `int32` -> `float32`) and therefore no longer raises `TypeError`. The test iterates over `(numpy, cupy)` and expected both to raise, so it now fails on the NumPy side with `DID NOT RAISE`.

The assertion is now gated by NumPy version: for NumPy < 2.5 the `pytest.raises(TypeError)` behavior is unchanged, and **CuPy is still required to raise** `TypeError` in all cases (its behavior is unchanged).

### 2. `TestFusionRounding::test_rounding[fix]`

`numpy.fix` is deprecated starting NumPy 2.5 (in favor of `numpy.trunc`). Because the test config escalates `DeprecationWarning` to an error, the fusion rounding test fails. `cupy.fix` is still supported, so the test keeps exercising it and only ignores that specific deprecation warning.

## Backwards compatibility

- On NumPy < 2.5 the `take` test takes the same `pytest.raises(TypeError)` path as before.
- The `numpy.fix` deprecation filter is a no-op on NumPy versions that do not emit the warning.

Both changes follow existing patterns already used in the suite (`numpy.lib.NumpyVersion` gating and `@pytest.mark.filterwarnings` for NumPy 2.5 deprecations).
