### PR TITLE
Fix eigsh/svds NaN on degenerate + zeros on rank-deficient inputs (Lanczos breakdown guard)

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -222,6 +222,11 @@ def _lanczos_fast(A, n, ncv):
             spmv_buff = cupy.empty(buff_size, cupy.int8)
 
         v[...] = V[i_start]
+        # Running ||A|| estimate and previous off-diagonal, for the
+        # lucky-breakdown test below.
+        anorm = 0.0
+        prev_beta = 0.0
+        break_rtol = float(numpy.sqrt(numpy.finfo(A.dtype).eps))
         for i in range(i_start, i_end):
             # Matrix-vector multiplication
             if cusparse_handle is None:
@@ -286,6 +291,21 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
 
+            # Lucky breakdown: beta[i] ~ 0 means A @ v landed in span(V), i.e.
+            # an invariant subspace was found. Normalizing by it (below) yields
+            # NaNs / wrong results on degenerate or rank-deficient spectra
+            # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
+            # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
+            # vector orthogonal to V[:i+1] so the iteration keeps exploring.
+            beta_i = float(beta[i])
+            anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
+            prev_beta = beta_i
+            if beta_i < break_rtol * anorm:
+                beta[i] = 0
+                v[...] = _restart_ortho(V, i + 1, n, u.dtype)
+                V[i + 1] = v
+                continue
+
             # Normalize
             _kernel_normalize(u, beta, i, n, v, V)
 
@@ -296,6 +316,16 @@ _kernel_normalize = cupy.ElementwiseKernel(
     'T u, raw S beta, int32 j, int32 n', 'T v, raw T V',
     'v = u / beta[j]; V[i + (j+1) * n] = v;', 'cupy_eigsh_normalize'
 )
+
+
+def _restart_ortho(V, m, n, dtype):
+    # Fresh unit vector orthogonal to V[:m], used to restart the Lanczos
+    # recurrence after a lucky breakdown (two classical Gram-Schmidt passes).
+    w = cupy.random.random((n,)).astype(dtype)
+    Vm = V[:m]
+    for _ in range(2):
+        w = w - Vm.T @ (Vm.conj() @ w)
+    return w / cupy.linalg.norm(w)
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -49,6 +49,20 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             where ``w`` is eigenvalues and ``x`` is eigenvectors. Otherwise,
             it returns only ``w``.
 
+    Raises:
+        RuntimeError: If the Lanczos basis loses numerical orthogonality
+            beyond repair, so that no correct answer can be produced. This
+            replaces silently wrong output (NaN or overflowed Ritz values)
+            on such inputs, and is raised from three places: the operator
+            norm estimate exceeding what an orthonormal basis can give, a
+            restart probe that grows when projected out of the basis, and
+            exhaustion of the restart candidate ladder. Degenerate or
+            rank-deficient spectra in single precision are the usual
+            cause; a smaller ``ncv``, a different ``v0``, or ``float64``
+            input is the usual remedy. Note that
+            :func:`scipy.sparse.linalg.eigsh` signals its own failure mode
+            differently, with ``ArpackNoConvergence``.
+
     .. seealso:: :func:`scipy.sparse.linalg.eigsh`
 
     .. note::
@@ -110,6 +124,13 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     # threshold can exceed legitimate small couplings in float32 and corrupt
     # the trailing Ritz values.)
     break_rtol = 64.0 * float(numpy.finfo(a.dtype).eps)
+    # Orthogonality tolerance, shared by the sweep-boundary check and the
+    # locked-block check: far above a healthy basis (~eps*ncv) and far
+    # below the failures it catches (O(1)).
+    ortho_rtol = float(numpy.sqrt(numpy.finfo(a.dtype).eps))
+    # True upper bound on ||A|| for the divergence guard (None for a
+    # LinearOperator, whose entries are not available).
+    norm_bound = _norm_upper_bound(a)
     # Restart-reseed bias (see _restart_ortho): pull reseeds out of the
     # operator's null space -- except for 'SA', where the smallest
     # (possibly zero) eigenvalues are the ones being sought.
@@ -123,10 +144,12 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha, beta,
                                                0, ncv, break_rtol, bias_op,
                                                la_shift,
-                                               anorm_ref=anorm_ref)
+                                               ortho_rtol=ortho_rtol,
+                                               anorm_ref=anorm_ref,
+                                               norm_bound=norm_bound)
 
     iter = work
-    w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
+    w, s, w_host = _eigsh_solve_ritz(alpha, beta, None, k, which)
     x = V.T @ s
 
     # Compute residual
@@ -140,6 +163,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         beta[:k] = 0
         alpha[:k] = w
         V[:k] = x.T
+        _repair_locked(a, V, alpha, k, n, ortho_rtol, bias_op,
+                       bias_shift, w_host=w_host)
 
         # u -= u.T @ V[:k].conj().T @ V[:k]
         cublas.gemv(_cublas.CUBLAS_OP_C, 1, V[:k].T, u, 0, uu)
@@ -180,12 +205,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
                                                    beta, k + 1, ncv,
                                                    break_rtol, bias_op,
                                                    la_shift,
-                                                   anorm_ref=anorm_ref)
+                                                   ortho_rtol=ortho_rtol,
+                                                   anorm_ref=anorm_ref,
+                                                   norm_bound=norm_bound)
 
         # +1 for the u = a @ V[k] above; equals the former ncv - k when no
         # repair re-sweep ran.
         iter += work + 1
-        w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
+        w, s, w_host = _eigsh_solve_ritz(alpha, beta, beta_k, k,
+                                         which)
         x = V.T @ s
 
         # Compute residual
@@ -363,15 +391,43 @@ _kernel_normalize = cupy.ElementwiseKernel(
 )
 
 
-# A healthy ||A|| estimate only creeps upward toward ||A||; anything past
-# this factor is divergence, not discovery (measured jump on a corrupted
-# basis: 1e5 in a single restart, then 1e40+ per restart).
-_DIVERGE_RTOL = 1e3
+# The row-sum estimate of ||T|| is bounded by 3 * ||T|| (a tridiagonal row
+# has at most three entries) and ||T|| <= ||A|| for orthonormal V, so a
+# healthy estimate can never exceed 3 * ||A||. Compared against a true
+# upper bound on ||A||, anything past this factor is therefore PROVABLE
+# corruption rather than a tuned threshold -- which matters because a
+# legitimate late discovery of ||A|| can be arbitrarily large: an operator
+# with wide dynamic range and a v0 orthogonal to its dominant eigenspace
+# (what deflation workflows produce) makes the first sweep honestly miss
+# ||A|| and a later reseed find it.
+_DIVERGE_RTOL = 8.0
+
+
+def _norm_upper_bound(a):
+    """Max absolute row sum of ``a``, an upper bound on ``||a||_2``.
+
+    Returns None when the operator's entries are not available (e.g. a
+    LinearOperator), in which case no absolute bound can be formed and the
+    caller falls back to checking only for non-finite estimates.
+    """
+    try:
+        if isinstance(a, cupy.ndarray):
+            return float(cupy.abs(a).sum(axis=1).max())
+        if _csr._is_csr(a) or getattr(a, 'format', None) in (
+                'csr', 'csc', 'coo'):
+            # |A| @ 1 gives the absolute row sums; A is Hermitian here, so
+            # a CSC/COO layout yields the same bound.
+            b = a.tocsr()
+            ones = cupy.ones(b.shape[1], dtype=b.dtype)
+            return float(cupy.abs(cupy.abs(b) @ ones).max())
+    except Exception:      # pragma: no cover - bound is optional
+        return None
+    return None
 
 
 def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
                      break_rtol, bias_op=None, la_shift=False,
-                     ortho_rtol=None, anorm_ref=None):
+                     ortho_rtol=None, anorm_ref=None, norm_bound=None):
     """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
     boundary.
 
@@ -491,20 +547,27 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         # which broke out at p and never looked further.
         end = m - 1 if p is None else p
         anorm = float(anorm_run[end])
-        # ||T|| <= ||A|| holds for any orthonormal V, so the estimate can
-        # only creep upward toward ||A|| as the subspace grows. A jump of
-        # orders of magnitude (or a non-finite row sum) means the
-        # recurrence itself diverged, and every value downstream -- Ritz
-        # pairs included -- is meaningless. Fail closed rather than return
-        # ghost eigenvalues that look like data.
-        if not numpy.isfinite(anorm) or (
-                anorm_ref[0] > 0.0
-                and anorm > _DIVERGE_RTOL * anorm_ref[0]):
+        # Fail closed on an estimate that cannot come from an orthonormal
+        # basis: with ||T|| <= ||A|| and the row-sum estimate <= 3 ||T||,
+        # exceeding 8x a true upper bound on ||A|| is impossible without
+        # corruption. A non-finite estimate is corrupt by inspection. When
+        # no bound is available (LinearOperator) only the latter applies --
+        # a relative test against the first sweep would misfire on the
+        # legitimate late-discovery case described at _DIVERGE_RTOL.
+        if not numpy.isfinite(anorm):
             raise RuntimeError(
-                'eigsh: Lanczos recurrence diverged (||A|| estimate went '
-                'from {:.3e} to {:.3e}). The Krylov basis is numerically '
+                'eigsh: Lanczos recurrence diverged (the ||A|| estimate is '
+                'not finite). The Krylov basis is numerically '
                 'rank-deficient; try a smaller ncv, a different v0, or '
-                'float64.'.format(anorm_ref[0], anorm))
+                'float64.')
+        if norm_bound is not None and anorm > _DIVERGE_RTOL * norm_bound:
+            raise RuntimeError(
+                'eigsh: Lanczos recurrence diverged (||A|| estimate {:.3e} '
+                'exceeds {:.0f}x the operator norm bound {:.3e}, which an '
+                'orthonormal basis cannot produce). The Krylov basis is '
+                'numerically rank-deficient; try a smaller ncv, a '
+                'different v0, or float64.'.format(
+                    anorm, _DIVERGE_RTOL, norm_bound))
         anorm_ref[0] = max(anorm_ref[0], anorm)
         shift = (anorm if (la_shift
                            and float(alpha_np[:end + 1].real.max()) <= 0.0)
@@ -515,6 +578,49 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op, shift)
         repaired.add(p)
         start = p + 1
+
+
+def _repair_locked(a, V, alpha, k, n, ortho_rtol, bias_op, bias_shift,
+                   w_host=None):
+    # The locked block V[:k] = (V.T @ s).T inherits orthonormality from V
+    # and from the Ritz basis s -- but only when BOTH are sound. On an
+    # eigenvalue of multiplicity > 1 the Ritz basis is degenerate by
+    # construction and several columns of s can name the same physical
+    # direction, so V[:k] can hold duplicate rows (measured: worst
+    # off-diagonal 4.0e-01 immediately after locking, where orthonormality
+    # demands ~1e-16). The sweep-boundary check cannot see this, because it
+    # only repairs positions at or after i_start - 1; a duplicate locked
+    # here would survive to poison every later reseed. So verify the block
+    # where it is created: one Gram of (k+1) x n per restart, far cheaper
+    # than the ncv x n check per sweep.
+    #
+    # A duplicated Ritz vector carries no information the block does not
+    # already have, so replacing it with a fresh orthogonal direction loses
+    # nothing. beta[:k] is zero here, i.e. T is block-decoupled, so each
+    # locked row is its own 1x1 block and alpha[j] must be updated to the
+    # new direction's Rayleigh quotient to keep T consistent.
+    #
+    # Gated on the Ritz values, which the driver already holds on the host:
+    # duplicate Ritz VECTORS can only arise from a degenerate Ritz basis,
+    # i.e. from (near-)repeated Ritz VALUES. That test is free -- k host
+    # floats -- whereas running the Gram unconditionally costs a device
+    # sync per restart, measured at +9-13% end to end on healthy problems.
+    if k < 2:
+        return
+    if w_host is not None:
+        ws = numpy.sort(numpy.abs(numpy.asarray(w_host, dtype=numpy.float64)))
+        scale = float(ws[-1]) if ws.size else 0.0
+        if scale == 0.0 or not numpy.any(
+                numpy.diff(ws) <= ortho_rtol * scale):
+            return
+    Vk = V[:k + 1]
+    gram = cupy.tril(cupy.abs(Vk @ Vk.conj().T), -1)
+    worst = cupy.asnumpy(gram.max(axis=1))
+    for j in numpy.flatnonzero(worst > ortho_rtol):
+        j = int(j)
+        V[j] = _restart_ortho(V, j, n, V.dtype, bias_op, bias_shift)
+        if j < k:
+            alpha[j] = cupy.inner(V[j].conj(), a @ V[j])
 
 
 def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
@@ -636,7 +742,9 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
     #   idx = cupy.argsort(abs(w))
     #   wk = w[idx[:k]]
     #   sk = s[:,idx[:k]]
-    return cupy.array(wk), cupy.array(sk)
+    # wk is already on the host here; handing it back lets the caller
+    # test for degeneracy without paying a device sync.
+    return cupy.array(wk), cupy.array(sk), wk
 
 
 def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -222,6 +222,11 @@ def _lanczos_fast(A, n, ncv):
             spmv_buff = cupy.empty(buff_size, cupy.int8)
 
         v[...] = V[i_start]
+        # Running ||A|| estimate and previous off-diagonal, for the
+        # lucky-breakdown test below.
+        anorm = 0.0
+        prev_beta = 0.0
+        break_rtol = float(numpy.sqrt(numpy.finfo(A.dtype).eps))
         for i in range(i_start, i_end):
             # Matrix-vector multiplication
             if cusparse_handle is None:
@@ -286,6 +291,21 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
 
+            # Lucky breakdown: beta[i] ~ 0 means A @ v landed in span(V), i.e.
+            # an invariant subspace was found. Normalizing by it (below) yields
+            # NaNs / wrong results on degenerate or rank-deficient spectra
+            # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
+            # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
+            # vector orthogonal to V[:i+1] so the iteration keeps exploring.
+            beta_i = float(beta[i])
+            anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
+            prev_beta = beta_i
+            if beta_i < break_rtol * anorm:
+                beta[i] = 0
+                v[...] = _restart_ortho(V, i + 1, n, u.dtype)
+                V[i + 1] = v
+                continue
+
             # Normalize
             _kernel_normalize(u, beta, i, n, v, V)
 
@@ -299,6 +319,16 @@ _kernel_normalize = cupy.ElementwiseKernel(
     'T u, raw S beta, int64 j, int64 n', 'T v, raw T V',
     'v = u / beta[j]; V[i + (j+1) * n] = v;', 'cupy_eigsh_normalize'
 )
+
+
+def _restart_ortho(V, m, n, dtype):
+    # Fresh unit vector orthogonal to V[:m], used to restart the Lanczos
+    # recurrence after a lucky breakdown (two classical Gram-Schmidt passes).
+    w = cupy.random.random((n,)).astype(dtype)
+    Vm = V[:m]
+    for _ in range(2):
+        w = w - Vm.T @ (Vm.conj() @ w)
+    return w / cupy.linalg.norm(w)
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -102,10 +102,14 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     # threshold can exceed legitimate small couplings in float32 and corrupt
     # the trailing Ritz values.)
     break_rtol = 64.0 * float(numpy.finfo(a.dtype).eps)
+    # Restart-reseed bias (see _restart_ortho): pull reseeds out of the
+    # operator's null space -- except for 'SA', where the smallest
+    # (possibly zero) eigenvalues are the ones being sought.
+    bias_op = a if which != 'SA' else None
 
     # Lanczos iteration
     anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0, ncv,
-                             break_rtol)
+                             break_rtol, bias_op)
 
     iter = ncv
     w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
@@ -135,7 +139,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         if nrm_u > break_rtol * anorm:
             V[k] = u / nrm_u
         else:
-            V[k] = _restart_ortho(V, k, n, V.dtype)
+            V[k] = _restart_ortho(V, k, n, V.dtype, bias_op)
 
         u[...] = a @ V[k]
         cublas.dotc(V[k], u, out=alpha[k])
@@ -150,7 +154,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
         # Lanczos iteration
         anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, k + 1, ncv,
-                                 break_rtol)
+                                 break_rtol, bias_op)
 
         iter += ncv - k
         w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
@@ -332,7 +336,7 @@ _kernel_normalize = cupy.ElementwiseKernel(
 
 
 def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
-                     break_rtol):
+                     break_rtol, bias_op=None):
     """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
     boundary.
 
@@ -372,19 +376,22 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         for i in range(i_end - 1):
             anorm = max(anorm, alpha_h[i] + beta_h[i]
                         + (beta_h[i - 1] if i else 0.0))
+            # Non-strict (<=) so an all-zero block (beta and anorm both 0,
+            # e.g. v0 in the null space of a singular A) is still caught
+            # and reseeded, not silently left as zero Ritz values.
             if (i >= max(i_start - 1, 0) and i not in repaired
-                    and beta_h[i] < break_rtol * anorm):
+                    and beta_h[i] <= break_rtol * anorm):
                 p = i
                 break
         if p is None:
             return anorm
         beta[p] = 0
-        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype)
+        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op)
         repaired.add(p)
         start = p + 1
 
 
-def _restart_ortho(V, m, n, dtype):
+def _restart_ortho(V, m, n, dtype, bias_op=None):
     # Deterministic fresh unit vector orthogonal to V[:m], used to restart
     # the Lanczos recurrence after a lucky breakdown. Start from the
     # canonical basis vector least represented in span(V[:m]) -- the rows of
@@ -392,12 +399,33 @@ def _restart_ortho(V, m, n, dtype):
     # 1 - ||V[:m, j]||^2 and its maximum over j is >= 1 - m/n > 0 -- then
     # orthogonalize with two classical Gram-Schmidt passes. No RNG: the
     # result depends only on V, keeping eigsh/svds output deterministic.
+    #
+    # bias_op: when the operator has a large null space (e.g. svds on a
+    # low-rank matrix works through A^H A whose null fraction is
+    # 1 - rank/n), a canonical basis vector is almost entirely null and the
+    # restart wastes Krylov slots exploring eigenvalue-0 directions
+    # (gh-8009's reproducer: 100x1000 rank 5). One application of the
+    # operator kills all null components, so seed with bias_op @ e_j
+    # instead (still deterministic); fall back to the unbiased e_j when the
+    # result lies in span(V[:m]) -- then the nonzero spectrum is exhausted
+    # and the null space is exactly what remains to explore.
     Vm = V[:m]
     j = int(cupy.argmin(cupy.sum(cupy.abs(Vm) ** 2, axis=0)))
-    w = cupy.zeros((n,), dtype=dtype)
-    w[j] = 1
-    for _ in range(2):
-        w = w - Vm.T @ (Vm.conj() @ w)
+    e = cupy.zeros((n,), dtype=dtype)
+    e[j] = 1
+    cands = (e,) if bias_op is None else (bias_op @ e, e)
+    for cand in cands:
+        nrm = float(cupy.linalg.norm(cand))
+        if nrm == 0.0:
+            continue
+        w = cand / nrm
+        for _ in range(2):
+            w = w - Vm.T @ (Vm.conj() @ w)
+        nrm = float(cupy.linalg.norm(w))
+        if nrm > 1e-6:
+            return w / nrm
+    # fully spanned candidates (can only happen transiently): keep e_j's
+    # orthogonalized remainder, however small -- never a zero vector
     return w / cupy.linalg.norm(w)
 
 

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -409,24 +409,42 @@ def _restart_ortho(V, m, n, dtype, bias_op=None):
     # instead (still deterministic); fall back to the unbiased e_j when the
     # result lies in span(V[:m]) -- then the nonzero spectrum is exhausted
     # and the null space is exactly what remains to explore.
+    # Robustness of the acceptance test: with orthonormal rows the argmin
+    # candidate's remainder is >= 1/sqrt(n) (sum of column norms^2 is
+    # m <= n-1), but transient repair states can hold zero or junk rows,
+    # for which CGS is not a projector and no lower bound exists -- a
+    # remainder can cancel arbitrarily small, and normalizing it would
+    # amplify CGS roundoff into a poorly-orthogonal noise direction (or
+    # 0/0 = NaN on exact cancellation). So: accept a remainder only above
+    # a dtype-aware floor (sqrt(eps), far above the CGS noise floor in
+    # both precisions), try a few canonical vectors in ascending
+    # column-norm order, and if all fail return the plain canonical
+    # vector: unit, finite and deterministic. Its lost orthogonality is
+    # absorbed by the sweep's own per-iteration reorthogonalization and
+    # the next boundary check -- always preferable to NaN or noise.
     Vm = V[:m]
-    j = int(cupy.argmin(cupy.sum(cupy.abs(Vm) ** 2, axis=0)))
+    colnorm = cupy.sum(cupy.abs(Vm) ** 2, axis=0)
+    order = [int(j) for j in cupy.asnumpy(cupy.argsort(colnorm)[:4])]
+    floor = float(numpy.sqrt(numpy.finfo(
+        numpy.dtype(dtype).char.lower()).eps))
     e = cupy.zeros((n,), dtype=dtype)
-    e[j] = 1
-    cands = (e,) if bias_op is None else (bias_op @ e, e)
-    for cand in cands:
-        nrm = float(cupy.linalg.norm(cand))
-        if nrm == 0.0:
-            continue
-        w = cand / nrm
-        for _ in range(2):
-            w = w - Vm.T @ (Vm.conj() @ w)
-        nrm = float(cupy.linalg.norm(w))
-        if nrm > 1e-6:
-            return w / nrm
-    # fully spanned candidates (can only happen transiently): keep e_j's
-    # orthogonalized remainder, however small -- never a zero vector
-    return w / cupy.linalg.norm(w)
+    for j in order:
+        e[...] = 0
+        e[j] = 1
+        cands = (e,) if bias_op is None else (bias_op @ e, e)
+        for cand in cands:
+            nrm = float(cupy.linalg.norm(cand))
+            if nrm == 0.0:
+                continue
+            w = cand / nrm
+            for _ in range(2):
+                w = w - Vm.T @ (Vm.conj() @ w)
+            nrm = float(cupy.linalg.norm(w))
+            if nrm > floor:
+                return w / nrm
+    e[...] = 0
+    e[order[0]] = 1
+    return e
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -106,10 +106,11 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     # operator's null space -- except for 'SA', where the smallest
     # (possibly zero) eigenvalues are the ones being sought.
     bias_op = a if which != 'SA' else None
+    la_shift = (which == 'LA')
 
     # Lanczos iteration
     anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0, ncv,
-                             break_rtol, bias_op)
+                             break_rtol, bias_op, la_shift)
 
     iter = ncv
     w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
@@ -139,7 +140,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         if nrm_u > break_rtol * anorm:
             V[k] = u / nrm_u
         else:
-            V[k] = _restart_ortho(V, k, n, V.dtype, bias_op)
+            V[k] = _restart_ortho(V, k, n, V.dtype, bias_op,
+                                  anorm if la_shift else 0.0)
 
         u[...] = a @ V[k]
         cublas.dotc(V[k], u, out=alpha[k])
@@ -154,7 +156,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
         # Lanczos iteration
         anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, k + 1, ncv,
-                                 break_rtol, bias_op)
+                                 break_rtol, bias_op, la_shift)
 
         iter += ncv - k
         w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
@@ -336,7 +338,7 @@ _kernel_normalize = cupy.ElementwiseKernel(
 
 
 def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
-                     break_rtol, bias_op=None):
+                     break_rtol, bias_op=None, la_shift=False):
     """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
     boundary.
 
@@ -386,12 +388,13 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         if p is None:
             return anorm
         beta[p] = 0
-        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op)
+        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op,
+                                  anorm if la_shift else 0.0)
         repaired.add(p)
         start = p + 1
 
 
-def _restart_ortho(V, m, n, dtype, bias_op=None):
+def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
     # Deterministic fresh unit vector orthogonal to V[:m], used to restart
     # the Lanczos recurrence after a lucky breakdown. Start from the
     # canonical basis vector least represented in span(V[:m]) -- the rows of
@@ -422,26 +425,60 @@ def _restart_ortho(V, m, n, dtype, bias_op=None):
     # vector: unit, finite and deterministic. Its lost orthogonality is
     # absorbed by the sweep's own per-iteration reorthogonalization and
     # the next boundary check -- always preferable to NaN or noise.
+    # Candidate ladder (all deterministic, first acceptable wins):
+    #   1. biased DENSE probe, varied with m -- a canonical e_j fails on
+    #      operators whose null space is coordinate-aligned (bias_op @ e_j
+    #      is then exactly 0: gh-8009's literal reproducer makes A^H A a
+    #      coordinate projector), and a FIXED dense probe is spanned after
+    #      its first acceptance, so the probe must change per reseed;
+    #   2. biased canonical walk over the least-represented columns;
+    #   3. unbiased canonical walk (correct once the operator's range is
+    #      exhausted: the null space is exactly what remains to explore);
+    #   4. plain canonical vector (unit, finite, deterministic; its lost
+    #      orthogonality is absorbed by the sweep's own per-iteration
+    #      reorthogonalization and the next boundary check).
+    # bias_shift: biasing by (bias_op + shift*I) instead of bias_op keeps
+    # zero eigenvalues alive when they are legitimate targets -- 'LA' on a
+    # negative-semidefinite operator has the null space at the TOP of the
+    # spectrum, so the driver passes shift ~ +||A|| there (null maps to
+    # shift != 0 while the anti-target bottom maps to ~0). 'LM' passes 0
+    # (plain bias_op preserves the |lambda| ordering exactly).
     Vm = V[:m]
     colnorm = cupy.sum(cupy.abs(Vm) ** 2, axis=0)
     order = [int(j) for j in cupy.asnumpy(cupy.argsort(colnorm)[:4])]
     floor = float(numpy.sqrt(numpy.finfo(
         numpy.dtype(dtype).char.lower()).eps))
+
+    def _accept(cand):
+        nrm = float(cupy.linalg.norm(cand))
+        if nrm == 0.0:
+            return None
+        w = cand / nrm
+        for _ in range(2):
+            w = w - Vm.T @ (Vm.conj() @ w)
+        nrm = float(cupy.linalg.norm(w))
+        return (w / nrm) if nrm > floor else None
+
+    if bias_op is not None:
+        d = cupy.cos((m + 1.0) * 0.7 * cupy.arange(1, n + 1)).astype(dtype)
+        d /= cupy.linalg.norm(d)
+        w = _accept(bias_op @ d + bias_shift * d)
+        if w is not None:
+            return w
     e = cupy.zeros((n,), dtype=dtype)
+    if bias_op is not None:
+        for j in order:
+            e[...] = 0
+            e[j] = 1
+            w = _accept(bias_op @ e + bias_shift * e)
+            if w is not None:
+                return w
     for j in order:
         e[...] = 0
         e[j] = 1
-        cands = (e,) if bias_op is None else (bias_op @ e, e)
-        for cand in cands:
-            nrm = float(cupy.linalg.norm(cand))
-            if nrm == 0.0:
-                continue
-            w = cand / nrm
-            for _ in range(2):
-                w = w - Vm.T @ (Vm.conj() @ w)
-            nrm = float(cupy.linalg.norm(w))
-            if nrm > floor:
-                return w / nrm
+        w = _accept(e)
+        if w is not None:
+            return w
     e[...] = 0
     e[order[0]] = 1
     return e

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -127,6 +127,20 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     # Orthogonality tolerance, shared by the sweep-boundary check and the
     # locked-block check: far above a healthy basis (~eps*ncv) and far
     # below the failures it catches (O(1)).
+    #
+    # Scale note: this margin and the two above (64*eps, and the 8x
+    # headroom on the norm bound) are n-INDEPENDENT, while the roundoff
+    # they discriminate against grows with n -- worst case ~eps*sqrt(n)
+    # for a length-n inner product. In float64 the crossover is around
+    # n ~ 1e15, unreachable. In float32 the worst-case model crosses
+    # sqrt(eps) near n ~ 1e7, though blocked GPU reductions keep the real
+    # error far below that bound (degenerate and late-norm-discovery
+    # cases were checked at n = 3e7 float32 during review). Every one of
+    # these margins fails in a safe direction: too loose degrades to the
+    # pre-guard behaviour, which the orthogonality check still backstops,
+    # and too tight raises the documented RuntimeError -- neither returns
+    # silent garbage. If float32 at n >> 1e7 ever needs support, the
+    # explicit form is max(sqrt(eps), c*eps*sqrt(n)).
     ortho_rtol = float(numpy.sqrt(numpy.finfo(a.dtype).eps))
     # True upper bound on ||A|| for the divergence guard (None for a
     # LinearOperator, whose entries are not available).
@@ -138,14 +152,10 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     la_shift = (which == 'LA')
 
     # Lanczos iteration
-    # Shared across sweeps so a later sweep is judged against the first,
-    # trusted ||A|| estimate rather than against its own corrupted one.
-    anorm_ref = [0.0]
     anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha, beta,
                                                0, ncv, break_rtol, bias_op,
                                                la_shift,
                                                ortho_rtol=ortho_rtol,
-                                               anorm_ref=anorm_ref,
                                                norm_bound=norm_bound)
 
     iter = work
@@ -206,7 +216,6 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
                                                    break_rtol, bias_op,
                                                    la_shift,
                                                    ortho_rtol=ortho_rtol,
-                                                   anorm_ref=anorm_ref,
                                                    norm_bound=norm_bound)
 
         # +1 for the u = a @ V[k] above; equals the former ncv - k when no
@@ -427,7 +436,7 @@ def _norm_upper_bound(a):
 
 def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
                      break_rtol, bias_op=None, la_shift=False,
-                     ortho_rtol=None, anorm_ref=None, norm_bound=None):
+                     ortho_rtol=None, norm_bound=None):
     """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
     boundary.
 
@@ -455,8 +464,6 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
     if ortho_rtol is None:
         ortho_rtol = float(numpy.sqrt(numpy.finfo(
             numpy.dtype(V.dtype).char.lower()).eps))
-    if anorm_ref is None:
-        anorm_ref = [0.0]
     start = i_start
     repaired = set()
     # Matvecs actually performed, including repair re-sweeps, so the driver's
@@ -568,7 +575,6 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
                 'numerically rank-deficient; try a smaller ncv, a '
                 'different v0, or float64.'.format(
                     anorm, _DIVERGE_RTOL, norm_bound))
-        anorm_ref[0] = max(anorm_ref[0], anorm)
         shift = (anorm if (la_shift
                            and float(alpha_np[:end + 1].real.max()) <= 0.0)
                  else 0.0)
@@ -608,19 +614,25 @@ def _repair_locked(a, V, alpha, k, n, ortho_rtol, bias_op, bias_shift,
     if k < 2:
         return
     if w_host is not None:
-        ws = numpy.sort(numpy.abs(numpy.asarray(w_host, dtype=numpy.float64)))
-        scale = float(ws[-1]) if ws.size else 0.0
+        wr = numpy.asarray(w_host, dtype=numpy.float64).real
+        scale = float(numpy.abs(wr).max()) if wr.size else 0.0
+        # Sort the SIGNED values: a +/-lambda pair is not degenerate, and
+        # sorting magnitudes would make an indefinite spectrum (common
+        # under 'LM') fire this gate for nothing.
         if scale == 0.0 or not numpy.any(
-                numpy.diff(ws) <= ortho_rtol * scale):
+                numpy.diff(numpy.sort(wr)) <= ortho_rtol * scale):
             return
-    Vk = V[:k + 1]
+    # Only the locked rows: the driver overwrites V[k] a few lines below,
+    # and its overlap with the locked block is |s[k, j]|, normally far
+    # above the tolerance -- including it would reseed a row that is about
+    # to be discarded, at the cost of a matvec and a sync.
+    Vk = V[:k]
     gram = cupy.tril(cupy.abs(Vk @ Vk.conj().T), -1)
     worst = cupy.asnumpy(gram.max(axis=1))
     for j in numpy.flatnonzero(worst > ortho_rtol):
         j = int(j)
         V[j] = _restart_ortho(V, j, n, V.dtype, bias_op, bias_shift)
-        if j < k:
-            alpha[j] = cupy.inner(V[j].conj(), a @ V[j])
+        alpha[j] = cupy.inner(V[j].conj(), a @ V[j])
 
 
 def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -96,8 +96,16 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     else:
         lanczos = _lanczos_asis
 
+    # Lucky-breakdown detection threshold (see _lanczos_checked): decoupling
+    # the tridiagonal at beta[i] perturbs the spectrum by at most beta[i], so
+    # an O(eps)*||A|| threshold is harmless by construction. (A sqrt(eps)
+    # threshold can exceed legitimate small couplings in float32 and corrupt
+    # the trailing Ritz values.)
+    break_rtol = 64.0 * float(numpy.finfo(a.dtype).eps)
+
     # Lanczos iteration
-    lanczos(a, V, u, alpha, beta, 0, ncv)
+    anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0, ncv,
+                             break_rtol)
 
     iter = ncv
     w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
@@ -118,17 +126,31 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         # u -= u.T @ V[:k].conj().T @ V[:k]
         cublas.gemv(_cublas.CUBLAS_OP_C, 1, V[:k].T, u, 0, uu)
         cublas.gemv(_cublas.CUBLAS_OP_N, -1, V[:k].T, uu, 1, u)
-        V[k] = u / cublas.nrm2(u)
+        # The deflation above can eat nearly all of u (residual almost inside
+        # the locked Ritz span, common in single precision): dividing by the
+        # collapsed norm would inject a huge junk vector and wild Ritz values.
+        # Reseed with a fresh direction orthogonal to V[:k] instead. (One
+        # host float per restart cycle; solve_ritz syncs here anyway.)
+        nrm_u = float(cublas.nrm2(u))
+        if nrm_u > break_rtol * anorm:
+            V[k] = u / nrm_u
+        else:
+            V[k] = _restart_ortho(V, k, n, V.dtype)
 
         u[...] = a @ V[k]
         cublas.dotc(V[k], u, out=alpha[k])
         u -= alpha[k] * V[k]
         u -= V[:k].T @ beta_k
         cublas.nrm2(u, out=beta[k])
-        V[k+1] = u / beta[k]
+        # NaN-proof normalization: beta[k] = ||u||, so the division is finite
+        # for beta[k] > 0; an exact zero (restart subspace invariant) yields a
+        # zero column, then _lanczos_checked's boundary check (which covers
+        # index k) decouples and reseeds it.
+        V[k+1] = cupy.where(beta[k] > 0, u / beta[k], u * 0)
 
         # Lanczos iteration
-        lanczos(a, V, u, alpha, beta, k + 1, ncv)
+        anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, k + 1, ncv,
+                                 break_rtol)
 
         iter += ncv - k
         w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
@@ -222,13 +244,6 @@ def _lanczos_fast(A, n, ncv):
             spmv_buff = cupy.empty(buff_size, cupy.int8)
 
         v[...] = V[i_start]
-        # Running ||A|| estimate and previous off-diagonal, for the
-        # lucky-breakdown test below. Kept on device so the healthy path
-        # syncs a single bool per iteration (this loop is otherwise built
-        # to avoid device->host syncs).
-        anorm = cupy.zeros((), dtype=beta.dtype)
-        prev_beta = cupy.zeros((), dtype=beta.dtype)
-        break_rtol = float(numpy.sqrt(numpy.finfo(A.dtype).eps))
         for i in range(i_start, i_end):
             # Matrix-vector multiplication
             if cusparse_handle is None:
@@ -293,22 +308,10 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
 
-            # Lucky breakdown: beta[i] ~ 0 means A @ v landed in span(V), i.e.
-            # an invariant subspace was found. Normalizing by it (below) yields
-            # NaNs / wrong results on degenerate or rank-deficient spectra
-            # (gh-6446, gh-7495, gh-8009). Instead decouple the tridiagonal
-            # (beta[i] = 0) and restart V[i+1] with a fresh unit vector
-            # orthogonal to V[:i+1] so the iteration keeps exploring.
-            anorm = cupy.maximum(
-                anorm, cupy.abs(alpha[i]) + beta[i] + prev_beta)
-            prev_beta = beta[i]
-            if bool((beta[i] < break_rtol * anorm).item()):
-                beta[i] = 0
-                v[...] = _restart_ortho(V, i + 1, n, u.dtype)
-                V[i + 1] = v
-                continue
-
-            # Normalize
+            # Normalize. beta[i] = ||u||, so u/beta[i] stays finite for any
+            # beta[i] > 0; the kernel emits 0 instead of dividing when
+            # beta[i] == 0 (exact lucky breakdown), so the sweep completes
+            # NaN-free and _lanczos_checked repairs it at the sweep boundary.
             _kernel_normalize(u, beta, i, n, v, V)
 
     return aux
@@ -319,8 +322,66 @@ _kernel_normalize = cupy.ElementwiseKernel(
     # in 64-bit; an int32 product wraps for n * ncv >= 2**31 (e.g. dim
     # 2**28 with the default ncv) and corrupts memory.
     'T u, raw S beta, int64 j, int64 n', 'T v, raw T V',
-    'v = u / beta[j]; V[i + (j+1) * n] = v;', 'cupy_eigsh_normalize'
+    # beta[j] = ||u||, so u/beta[j] is finite whenever beta[j] > 0; on an
+    # EXACT lucky breakdown (beta[j] == 0) emit 0 instead of 0/0 = NaN --
+    # the zero column is detected and repaired at the sweep boundary
+    # (_lanczos_checked), keeping this inner loop free of host syncs.
+    'S b = beta[j]; v = (b > (S)0) ? (u / b) : (u * (S)0);'
+    ' V[i + (j+1) * n] = v;', 'cupy_eigsh_normalize'
 )
+
+
+def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
+                     break_rtol):
+    """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
+    boundary.
+
+    beta[i] ~ 0 means A @ v landed in span(V), i.e. an invariant subspace was
+    found; normalizing by it yields NaNs / wrong results on degenerate or
+    rank-deficient spectra (gh-6446, gh-7495, gh-8009). The inner loop stays
+    completely free of host syncs (its device-pointer-mode design): an exact
+    breakdown produces a zero column (see _kernel_normalize) and a near
+    breakdown a finite junk-but-orthonormalized column, both harmless within
+    the sweep. HERE, on the host copy of (alpha, beta) that the Ritz solve
+    needs anyway, positions with beta[i] < break_rtol * ||A||_est are
+    decoupled (beta[i] = 0 -- a spectrum perturbation of at most beta[i],
+    machine-level by the threshold choice) and V[i+1] is reseeded with a
+    deterministic fresh vector orthogonal to V[:i+1]; the sweep re-runs from
+    there so the iteration keeps exploring. Healthy problems detect nothing
+    and pay zero overhead; a fully degenerate spectrum costs at most
+    O(i_end - i_start) partial re-sweeps.
+
+    The check range starts at i_start - 1, so it also covers the thick
+    restart's own normalization V[k+1] = u / beta[k] (repaired the same way).
+    Returns the ||A|| estimate for the driver's own guard on V[k].
+    """
+    n = V.shape[1]
+    start = i_start
+    repaired = set()
+    while True:
+        lanczos(a, V, u, alpha, beta, start, i_end)
+        alpha_h = numpy.abs(cupy.asnumpy(alpha))
+        beta_h = numpy.abs(cupy.asnumpy(beta))
+        # Gershgorin-style row-sum estimate of ||T|| ~ ||A||, built by
+        # walking the rows IN ORDER and stopping at the first breakdown:
+        # rows past an exhausted subspace hold roundoff junk whose magnitude
+        # can dwarf ||A|| -- folding them into the estimate would inflate
+        # the threshold and misfire on legitimate large couplings.
+        anorm = 0.0
+        p = None
+        for i in range(i_end - 1):
+            anorm = max(anorm, alpha_h[i] + beta_h[i]
+                        + (beta_h[i - 1] if i else 0.0))
+            if (i >= max(i_start - 1, 0) and i not in repaired
+                    and beta_h[i] < break_rtol * anorm):
+                p = i
+                break
+        if p is None:
+            return anorm
+        beta[p] = 0
+        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype)
+        repaired.add(p)
+        start = p + 1
 
 
 def _restart_ortho(V, m, n, dtype):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -223,9 +223,11 @@ def _lanczos_fast(A, n, ncv):
 
         v[...] = V[i_start]
         # Running ||A|| estimate and previous off-diagonal, for the
-        # lucky-breakdown test below.
-        anorm = 0.0
-        prev_beta = 0.0
+        # lucky-breakdown test below. Kept on device so the healthy path
+        # syncs a single bool per iteration (this loop is otherwise built
+        # to avoid device->host syncs).
+        anorm = cupy.zeros((), dtype=beta.dtype)
+        prev_beta = cupy.zeros((), dtype=beta.dtype)
         break_rtol = float(numpy.sqrt(numpy.finfo(A.dtype).eps))
         for i in range(i_start, i_end):
             # Matrix-vector multiplication
@@ -294,13 +296,13 @@ def _lanczos_fast(A, n, ncv):
             # Lucky breakdown: beta[i] ~ 0 means A @ v landed in span(V), i.e.
             # an invariant subspace was found. Normalizing by it (below) yields
             # NaNs / wrong results on degenerate or rank-deficient spectra
-            # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
-            # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
-            # vector orthogonal to V[:i+1] so the iteration keeps exploring.
-            beta_i = float(beta[i])
-            anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
-            prev_beta = beta_i
-            if beta_i < break_rtol * anorm:
+            # (gh-6446, gh-7495, gh-8009). Instead decouple the tridiagonal
+            # (beta[i] = 0) and restart V[i+1] with a fresh unit vector
+            # orthogonal to V[:i+1] so the iteration keeps exploring.
+            anorm = cupy.maximum(
+                anorm, cupy.abs(alpha[i]) + beta[i] + prev_beta)
+            prev_beta = beta[i]
+            if bool((beta[i] < break_rtol * anorm).item()):
                 beta[i] = 0
                 v[...] = _restart_ortho(V, i + 1, n, u.dtype)
                 V[i + 1] = v
@@ -322,10 +324,17 @@ _kernel_normalize = cupy.ElementwiseKernel(
 
 
 def _restart_ortho(V, m, n, dtype):
-    # Fresh unit vector orthogonal to V[:m], used to restart the Lanczos
-    # recurrence after a lucky breakdown (two classical Gram-Schmidt passes).
-    w = cupy.random.random((n,)).astype(dtype)
+    # Deterministic fresh unit vector orthogonal to V[:m], used to restart
+    # the Lanczos recurrence after a lucky breakdown. Start from the
+    # canonical basis vector least represented in span(V[:m]) -- the rows of
+    # V[:m] are orthonormal, so the residual ||(I - P) e_j||^2 is
+    # 1 - ||V[:m, j]||^2 and its maximum over j is >= 1 - m/n > 0 -- then
+    # orthogonalize with two classical Gram-Schmidt passes. No RNG: the
+    # result depends only on V, keeping eigsh/svds output deterministic.
     Vm = V[:m]
+    j = int(cupy.argmin(cupy.sum(cupy.abs(Vm) ** 2, axis=0)))
+    w = cupy.zeros((n,), dtype=dtype)
+    w[j] = 1
     for _ in range(2):
         w = w - Vm.T @ (Vm.conj() @ w)
     return w / cupy.linalg.norm(w)

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -109,8 +109,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     la_shift = (which == 'LA')
 
     # Lanczos iteration
-    anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0, ncv,
-                             break_rtol, bias_op, la_shift)
+    anorm, bias_shift = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0,
+                                         ncv, break_rtol, bias_op, la_shift)
 
     iter = ncv
     w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
@@ -140,8 +140,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         if nrm_u > break_rtol * anorm:
             V[k] = u / nrm_u
         else:
-            V[k] = _restart_ortho(V, k, n, V.dtype, bias_op,
-                                  anorm if la_shift else 0.0)
+            V[k] = _restart_ortho(V, k, n, V.dtype, bias_op, bias_shift)
 
         u[...] = a @ V[k]
         cublas.dotc(V[k], u, out=alpha[k])
@@ -155,8 +154,9 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         V[k+1] = cupy.where(beta[k] > 0, u / beta[k], u * 0)
 
         # Lanczos iteration
-        anorm = _lanczos_checked(a, lanczos, V, u, alpha, beta, k + 1, ncv,
-                                 break_rtol, bias_op, la_shift)
+        anorm, bias_shift = _lanczos_checked(a, lanczos, V, u, alpha, beta,
+                                             k + 1, ncv, break_rtol, bias_op,
+                                             la_shift)
 
         iter += ncv - k
         w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
@@ -366,30 +366,56 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
     repaired = set()
     while True:
         lanczos(a, V, u, alpha, beta, start, i_end)
-        alpha_h = numpy.abs(cupy.asnumpy(alpha))
+        alpha_np = cupy.asnumpy(alpha)
+        alpha_h = numpy.abs(alpha_np)
         beta_h = numpy.abs(cupy.asnumpy(beta))
         # Gershgorin-style row-sum estimate of ||T|| ~ ||A||, built by
         # walking the rows IN ORDER and stopping at the first breakdown:
         # rows past an exhausted subspace hold roundoff junk whose magnitude
         # can dwarf ||A|| -- folding them into the estimate would inflate
         # the threshold and misfire on legitimate large couplings.
-        anorm = 0.0
+        # Vectorized: the running max IS a cumulative maximum, so the whole
+        # ordered walk is one numpy pass -- no per-ncv Python loop on the
+        # healthy path (which produces no candidates at all).
+        m = i_end - 1
+        # float64 accumulation: alpha/beta past an exhausted subspace can be
+        # huge in float32 (the junk this walk exists to exclude) and the
+        # row sums would overflow to inf before we ever get to ignore them.
+        rows = alpha_h[:m].astype(numpy.float64) + beta_h[:m]
+        rows[1:] += beta_h[:m - 1]
+        anorm_run = numpy.maximum.accumulate(rows)
+        # Non-strict (<=) so an all-zero block (beta and anorm both 0, e.g.
+        # v0 in the null space of a singular A) is still caught and
+        # reseeded, not silently left as zero Ritz values.
+        # LA reseed shift: bias by (A + anorm*I) ONLY when zero may itself
+        # be an LA target, i.e. no positive Rayleigh quotient has been seen
+        # (v^H A v <= 0 for every Lanczos vector so far, so A looks negative
+        # semidefinite and its null space sits at the TOP of the spectrum).
+        # On a positive-semidefinite or indefinite operator the shift would
+        # instead let null-space candidates pass _accept and waste Krylov
+        # slots on eigenvalue-0 directions that are not targets, while the
+        # plain bias correctly annihilates them.
+        hits = numpy.flatnonzero(beta_h[:m] <= break_rtol * anorm_run)
+        lo = max(i_start - 1, 0)
         p = None
-        for i in range(i_end - 1):
-            anorm = max(anorm, alpha_h[i] + beta_h[i]
-                        + (beta_h[i - 1] if i else 0.0))
-            # Non-strict (<=) so an all-zero block (beta and anorm both 0,
-            # e.g. v0 in the null space of a singular A) is still caught
-            # and reseeded, not silently left as zero Ritz values.
-            if (i >= max(i_start - 1, 0) and i not in repaired
-                    and beta_h[i] <= break_rtol * anorm):
+        for i in hits:                       # typically empty
+            i = int(i)
+            if i >= lo and i not in repaired:
                 p = i
                 break
+        # ||A|| estimate and the shift decision must use only the PREFIX up
+        # to the breakdown -- rows after it hold roundoff junk (this is the
+        # same reason the walk is ordered). Equivalent to the scalar loop,
+        # which broke out at p and never looked further.
+        end = m - 1 if p is None else p
+        anorm = float(anorm_run[end])
+        shift = (anorm if (la_shift
+                           and float(alpha_np[:end + 1].real.max()) <= 0.0)
+                 else 0.0)
         if p is None:
-            return anorm
+            return anorm, shift
         beta[p] = 0
-        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op,
-                                  anorm if la_shift else 0.0)
+        V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op, shift)
         repaired.add(p)
         start = p + 1
 
@@ -434,9 +460,8 @@ def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
     #   2. biased canonical walk over the least-represented columns;
     #   3. unbiased canonical walk (correct once the operator's range is
     #      exhausted: the null space is exactly what remains to explore);
-    #   4. plain canonical vector (unit, finite, deterministic; its lost
-    #      orthogonality is absorbed by the sweep's own per-iteration
-    #      reorthogonalization and the next boundary check).
+    #   4. nothing acceptable -> raise (fail closed) rather than store a
+    #      vector that is not numerically orthogonal to V[:m].
     # bias_shift: biasing by (bias_op + shift*I) instead of bias_op keeps
     # zero eigenvalues alive when they are legitimate targets -- 'LA' on a
     # negative-semidefinite operator has the null space at the TOP of the
@@ -479,9 +504,19 @@ def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
         w = _accept(e)
         if w is not None:
             return w
-    e[...] = 0
-    e[order[0]] = 1
-    return e
+    # Fail closed. Reaching here means no candidate produced a remainder
+    # above the sqrt(eps) floor, i.e. we cannot supply a vector that is
+    # numerically orthogonal to V[:m]. Returning a raw (unprojected) e_j
+    # would satisfy "unit, finite and deterministic" but not "safe to store
+    # in V": the caller would continue under an orthonormality invariant
+    # that no longer holds, producing silently wrong Ritz values. With
+    # orthonormal rows this is unreachable (the argmin-column remainder is
+    # >= sqrt(1 - m/n)), so it only fires from an already-corrupted basis.
+    raise RuntimeError(
+        'eigsh: Lanczos restart failed -- no direction orthogonal to the '
+        'current basis exceeds the {:.1e} floor after {} candidates. The '
+        'basis is numerically rank-deficient; try a smaller ncv or a '
+        'different v0.'.format(floor, 2 * len(order) + 1))
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -55,6 +55,14 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         This function uses the thick-restart Lanczos methods
         (https://sdm.lbl.gov/~kewu/ps/trlan.html).
 
+    .. note::
+        Degenerate and tightly clustered spectra exhaust the Krylov space
+        early (a lucky breakdown). Those breakdowns are detected and
+        repaired, which keeps the result correct but costs extra sweeps:
+        healthy problems pay a few percent, while a strongly degenerate
+        spectrum (e.g. one with only two distinct eigenvalues) can take
+        several times longer than the nominal iteration count suggests.
+
     """
     n = a.shape[0]
     if a.ndim != 2 or a.shape[0] != a.shape[1]:
@@ -109,10 +117,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     la_shift = (which == 'LA')
 
     # Lanczos iteration
-    anorm, bias_shift = _lanczos_checked(a, lanczos, V, u, alpha, beta, 0,
-                                         ncv, break_rtol, bias_op, la_shift)
+    # Shared across sweeps so a later sweep is judged against the first,
+    # trusted ||A|| estimate rather than against its own corrupted one.
+    anorm_ref = [0.0]
+    anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha, beta,
+                                               0, ncv, break_rtol, bias_op,
+                                               la_shift,
+                                               anorm_ref=anorm_ref)
 
-    iter = ncv
+    iter = work
     w, s = _eigsh_solve_ritz(alpha, beta, None, k, which)
     x = V.T @ s
 
@@ -141,6 +154,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             V[k] = u / nrm_u
         else:
             V[k] = _restart_ortho(V, k, n, V.dtype, bias_op, bias_shift)
+            # V[k] is now a fresh direction, not the old residual, so the
+            # coupling row beta_k no longer describes it (it is used just
+            # below and as the Ritz arrowhead). This branch fires only when
+            # the residual collapsed into span(V[:k]), i.e. that span is
+            # already numerically invariant, so the true coupling to any
+            # direction outside it is at threshold scale. Zero it: T is then
+            # exactly block-decoupled -- the same repair _lanczos_checked
+            # makes with beta[p] = 0.
+            beta_k[...] = 0
 
         u[...] = a @ V[k]
         cublas.dotc(V[k], u, out=alpha[k])
@@ -154,11 +176,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         V[k+1] = cupy.where(beta[k] > 0, u / beta[k], u * 0)
 
         # Lanczos iteration
-        anorm, bias_shift = _lanczos_checked(a, lanczos, V, u, alpha, beta,
-                                             k + 1, ncv, break_rtol, bias_op,
-                                             la_shift)
+        anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha,
+                                                   beta, k + 1, ncv,
+                                                   break_rtol, bias_op,
+                                                   la_shift,
+                                                   anorm_ref=anorm_ref)
 
-        iter += ncv - k
+        # +1 for the u = a @ V[k] above; equals the former ncv - k when no
+        # repair re-sweep ran.
+        iter += work + 1
         w, s = _eigsh_solve_ritz(alpha, beta, beta_k, k, which)
         x = V.T @ s
 
@@ -337,34 +363,52 @@ _kernel_normalize = cupy.ElementwiseKernel(
 )
 
 
+# A healthy ||A|| estimate only creeps upward toward ||A||; anything past
+# this factor is divergence, not discovery (measured jump on a corrupted
+# basis: 1e5 in a single restart, then 1e40+ per restart).
+_DIVERGE_RTOL = 1e3
+
+
 def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
-                     break_rtol, bias_op=None, la_shift=False):
+                     break_rtol, bias_op=None, la_shift=False,
+                     ortho_rtol=None, anorm_ref=None):
     """Run a Lanczos sweep; detect and repair lucky breakdowns at the sweep
     boundary.
 
-    beta[i] ~ 0 means A @ v landed in span(V), i.e. an invariant subspace was
-    found; normalizing by it yields NaNs / wrong results on degenerate or
+    beta[i] ~ 0 means A @ v landed in span(V) -- an invariant subspace -- and
+    normalizing by it yields NaNs or wrong results on degenerate and
     rank-deficient spectra (gh-6446, gh-7495, gh-8009). The inner loop stays
-    completely free of host syncs (its device-pointer-mode design): an exact
-    breakdown produces a zero column (see _kernel_normalize) and a near
-    breakdown a finite junk-but-orthonormalized column, both harmless within
-    the sweep. HERE, on the host copy of (alpha, beta) that the Ritz solve
-    needs anyway, positions with beta[i] < break_rtol * ||A||_est are
-    decoupled (beta[i] = 0 -- a spectrum perturbation of at most beta[i],
-    machine-level by the threshold choice) and V[i+1] is reseeded with a
-    deterministic fresh vector orthogonal to V[:i+1]; the sweep re-runs from
-    there so the iteration keeps exploring. Healthy problems detect nothing
-    and pay zero overhead; a fully degenerate spectrum costs at most
-    O(i_end - i_start) partial re-sweeps.
+    free of host syncs: an exact breakdown emits a zero column
+    (_kernel_normalize), a near one a finite column, both harmless within the
+    sweep. Here, on the host copy of (alpha, beta) the Ritz solve needs
+    anyway, positions with beta[i] < break_rtol * ||A||_est are decoupled
+    (beta[i] = 0, perturbing the spectrum by at most beta[i]) and V[i+1] is
+    reseeded orthogonal to V[:i+1]; the sweep re-runs from there. The range
+    starts at i_start - 1, so it also covers the thick restart's own
+    V[k+1] = u / beta[k].
 
-    The check range starts at i_start - 1, so it also covers the thick
-    restart's own normalization V[k+1] = u / beta[k] (repaired the same way).
-    Returns the ||A|| estimate for the driver's own guard on V[k].
+    Cost: detection is a few host ops per sweep (2-6% end to end on healthy
+    problems, measured); a degenerate spectrum can trigger up to
+    O(i_end - i_start) partial re-sweeps, which is why the matvec count is
+    returned rather than assumed.
+
+    Returns (||A|| estimate for the driver's guard on V[k], LA reseed shift,
+    matvecs performed including re-sweeps).
     """
     n = V.shape[1]
+    if ortho_rtol is None:
+        ortho_rtol = float(numpy.sqrt(numpy.finfo(
+            numpy.dtype(V.dtype).char.lower()).eps))
+    if anorm_ref is None:
+        anorm_ref = [0.0]
     start = i_start
     repaired = set()
+    # Matvecs actually performed, including repair re-sweeps, so the driver's
+    # maxiter still bounds work on degenerate spectra (where a sweep can be
+    # re-run up to O(i_end - i_start) times).
+    work = 0
     while True:
+        work += i_end - start
         lanczos(a, V, u, alpha, beta, start, i_end)
         alpha_np = cupy.asnumpy(alpha)
         alpha_h = numpy.abs(alpha_np)
@@ -378,6 +422,16 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         # ordered walk is one numpy pass -- no per-ncv Python loop on the
         # healthy path (which produces no candidates at all).
         m = i_end - 1
+        if m == 0:
+            # ncv == 1, reachable only at n == 2: no beta[i] has both
+            # neighbours in range, so there is nothing to check or repair
+            # (position 0 is covered by the driver's own nrm_u guard).
+            # Estimate ||A|| from the single row; the cumulative walk below
+            # would index an empty array.
+            anorm = float(alpha_h[0] + beta_h[0])
+            shift = (anorm if (la_shift and float(alpha_np[0].real) <= 0.0)
+                     else 0.0)
+            return anorm, shift, work
         # float64 accumulation: alpha/beta past an exhausted subspace can be
         # huge in float32 (the junk this walk exists to exclude) and the
         # row sums would overflow to inf before we ever get to ignore them.
@@ -403,17 +457,60 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
             if i >= lo and i not in repaired:
                 p = i
                 break
+        # The absolute test above catches a breakdown only while the
+        # residual is still AT the roundoff floor. On a spectrum whose
+        # Krylov dimension is far below ncv (e.g. two distinct
+        # eigenvalues) the floor itself grows as roundoff is amplified --
+        # measured 5e-14 -> 5e-8 over twenty steps -- so after the first
+        # couple of repairs no fixed multiple of eps*||A|| fires again,
+        # and the basis quietly fills with amplified noise. What does not
+        # drift is the invariant the method actually rests on: every
+        # stored row must be numerically orthogonal to the rows before
+        # it. Verify it directly with one Gram matrix (a single BLAS3
+        # call on the ncv x n basis), gated on a cheap host-side trigger
+        # so a healthy sweep -- which never produces a coupling far below
+        # the operator scale -- pays nothing.
+        # Trigger on the ACTIVE range only: the thick restart deliberately
+        # sets beta[:k] = 0, so scanning from 0 would fire this check on
+        # every restart of a perfectly healthy problem (measured: up to
+        # +23% on an FP64-limited card, where the Gram is a float64 GEMM).
+        if bool((beta_h[lo:m] <= ortho_rtol * anorm_run[lo:m]).any()):
+            Vm = V[:i_end]
+            gram = cupy.tril(cupy.abs(Vm @ Vm.conj().T), -1)
+            worst = cupy.asnumpy(gram.max(axis=1))
+            # Row j lost orthogonality => V[j] was produced by normalizing
+            # a collapsed residual at step j-1: that is the breakdown.
+            for j in numpy.flatnonzero(worst > ortho_rtol):
+                q = int(j) - 1
+                if q >= lo and q not in repaired and (p is None or q < p):
+                    p = q
+                    break
         # ||A|| estimate and the shift decision must use only the PREFIX up
         # to the breakdown -- rows after it hold roundoff junk (this is the
         # same reason the walk is ordered). Equivalent to the scalar loop,
         # which broke out at p and never looked further.
         end = m - 1 if p is None else p
         anorm = float(anorm_run[end])
+        # ||T|| <= ||A|| holds for any orthonormal V, so the estimate can
+        # only creep upward toward ||A|| as the subspace grows. A jump of
+        # orders of magnitude (or a non-finite row sum) means the
+        # recurrence itself diverged, and every value downstream -- Ritz
+        # pairs included -- is meaningless. Fail closed rather than return
+        # ghost eigenvalues that look like data.
+        if not numpy.isfinite(anorm) or (
+                anorm_ref[0] > 0.0
+                and anorm > _DIVERGE_RTOL * anorm_ref[0]):
+            raise RuntimeError(
+                'eigsh: Lanczos recurrence diverged (||A|| estimate went '
+                'from {:.3e} to {:.3e}). The Krylov basis is numerically '
+                'rank-deficient; try a smaller ncv, a different v0, or '
+                'float64.'.format(anorm_ref[0], anorm))
+        anorm_ref[0] = max(anorm_ref[0], anorm)
         shift = (anorm if (la_shift
                            and float(alpha_np[:end + 1].real.max()) <= 0.0)
                  else 0.0)
         if p is None:
-            return anorm, shift
+            return anorm, shift, work
         beta[p] = 0
         V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op, shift)
         repaired.add(p)
@@ -421,53 +518,33 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
 
 
 def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
-    # Deterministic fresh unit vector orthogonal to V[:m], used to restart
-    # the Lanczos recurrence after a lucky breakdown. Start from the
-    # canonical basis vector least represented in span(V[:m]) -- the rows of
-    # V[:m] are orthonormal, so the residual ||(I - P) e_j||^2 is
-    # 1 - ||V[:m, j]||^2 and its maximum over j is >= 1 - m/n > 0 -- then
-    # orthogonalize with two classical Gram-Schmidt passes. No RNG: the
-    # result depends only on V, keeping eigsh/svds output deterministic.
+    # Deterministic unit vector orthogonal to V[:m], used to restart the
+    # recurrence after a lucky breakdown.
     #
-    # bias_op: when the operator has a large null space (e.g. svds on a
-    # low-rank matrix works through A^H A whose null fraction is
-    # 1 - rank/n), a canonical basis vector is almost entirely null and the
-    # restart wastes Krylov slots exploring eigenvalue-0 directions
-    # (gh-8009's reproducer: 100x1000 rank 5). One application of the
-    # operator kills all null components, so seed with bias_op @ e_j
-    # instead (still deterministic); fall back to the unbiased e_j when the
-    # result lies in span(V[:m]) -- then the nonzero spectrum is exhausted
-    # and the null space is exactly what remains to explore.
-    # Robustness of the acceptance test: with orthonormal rows the argmin
-    # candidate's remainder is >= 1/sqrt(n) (sum of column norms^2 is
-    # m <= n-1), but transient repair states can hold zero or junk rows,
-    # for which CGS is not a projector and no lower bound exists -- a
-    # remainder can cancel arbitrarily small, and normalizing it would
-    # amplify CGS roundoff into a poorly-orthogonal noise direction (or
-    # 0/0 = NaN on exact cancellation). So: accept a remainder only above
-    # a dtype-aware floor (sqrt(eps), far above the CGS noise floor in
-    # both precisions), try a few canonical vectors in ascending
-    # column-norm order, and if all fail return the plain canonical
-    # vector: unit, finite and deterministic. Its lost orthogonality is
-    # absorbed by the sweep's own per-iteration reorthogonalization and
-    # the next boundary check -- always preferable to NaN or noise.
-    # Candidate ladder (all deterministic, first acceptable wins):
-    #   1. biased DENSE probe, varied with m -- a canonical e_j fails on
-    #      operators whose null space is coordinate-aligned (bias_op @ e_j
-    #      is then exactly 0: gh-8009's literal reproducer makes A^H A a
-    #      coordinate projector), and a FIXED dense probe is spanned after
-    #      its first acceptance, so the probe must change per reseed;
+    # INVARIANT: what this returns is numerically orthogonal to V[:m], or it
+    # raises. Nothing else may be stored in V.
+    #
+    # No RNG -- the result depends only on V, keeping eigsh/svds output
+    # deterministic. A candidate is accepted only if two classical
+    # Gram-Schmidt passes leave a remainder above a sqrt(eps) floor: a
+    # transient repair state can hold zero or junk rows, for which CGS is not
+    # a projector and a remainder can cancel to noise (or 0/0 = NaN).
+    #
+    # bias_op (the operator; None for 'SA'): one application annihilates
+    # null-space components, which a canonical e_j is mostly made of when the
+    # operator has a large null space (svds on a low-rank matrix, gh-8009).
+    # bias_shift: bias by (bias_op + shift*I) so zero eigenvalues survive when
+    # they are legitimate targets -- 'LA' on a negative-semidefinite operator
+    # has the null space at the TOP of the spectrum; 'LM' passes 0.
+    #
+    # Ladder, first acceptable candidate wins:
+    #   1. biased dense probe, varied with m -- a canonical e_j fails when the
+    #      null space is coordinate-aligned (bias_op @ e_j is then exactly 0),
+    #      and a fixed probe is spanned after its first acceptance;
     #   2. biased canonical walk over the least-represented columns;
-    #   3. unbiased canonical walk (correct once the operator's range is
-    #      exhausted: the null space is exactly what remains to explore);
-    #   4. nothing acceptable -> raise (fail closed) rather than store a
-    #      vector that is not numerically orthogonal to V[:m].
-    # bias_shift: biasing by (bias_op + shift*I) instead of bias_op keeps
-    # zero eigenvalues alive when they are legitimate targets -- 'LA' on a
-    # negative-semidefinite operator has the null space at the TOP of the
-    # spectrum, so the driver passes shift ~ +||A|| there (null maps to
-    # shift != 0 while the anti-target bottom maps to ~0). 'LM' passes 0
-    # (plain bias_op preserves the |lambda| ordering exactly).
+    #   3. unbiased canonical walk -- correct once the operator's range is
+    #      exhausted, since the null space is then what remains to explore;
+    #   4. nothing acceptable -> raise (fail closed).
     Vm = V[:m]
     colnorm = cupy.sum(cupy.abs(Vm) ** 2, axis=0)
     order = [int(j) for j in cupy.asnumpy(cupy.argsort(colnorm)[:4])]
@@ -482,6 +559,18 @@ def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
         for _ in range(2):
             w = w - Vm.T @ (Vm.conj() @ w)
         nrm = float(cupy.linalg.norm(w))
+        if nrm > 1.0 + floor:
+            # Projecting a unit vector out of an orthonormal V[:m] cannot
+            # lengthen it. A remainder above 1 therefore proves V is no
+            # longer orthonormal, so no reseed drawn from it can restore
+            # the invariant -- fail closed instead of amplifying roundoff
+            # into the basis (measured remainders of 9-60 immediately
+            # before runaway Ritz values).
+            raise RuntimeError(
+                'eigsh: Lanczos basis lost orthogonality (a unit probe '
+                'grew to {:.3e} when projected out of the first {} '
+                'rows). The recurrence cannot be restarted safely; try a '
+                'smaller ncv, a different v0, or float64.'.format(nrm, m))
         return (w / nrm) if nrm > floor else None
 
     if bias_op is not None:
@@ -504,14 +593,9 @@ def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
         w = _accept(e)
         if w is not None:
             return w
-    # Fail closed. Reaching here means no candidate produced a remainder
-    # above the sqrt(eps) floor, i.e. we cannot supply a vector that is
-    # numerically orthogonal to V[:m]. Returning a raw (unprojected) e_j
-    # would satisfy "unit, finite and deterministic" but not "safe to store
-    # in V": the caller would continue under an orthonormality invariant
-    # that no longer holds, producing silently wrong Ritz values. With
-    # orthonormal rows this is unreachable (the argmin-column remainder is
-    # >= sqrt(1 - m/n)), so it only fires from an already-corrupted basis.
+    # Fail closed: no candidate cleared the floor, so the invariant above
+    # cannot be met. Unreachable from orthonormal rows (the argmin-column
+    # remainder is >= sqrt(1 - m/n)); it only fires from a corrupted basis.
     raise RuntimeError(
         'eigsh: Lanczos restart failed -- no direction orthogonal to the '
         'current basis exceeds the {:.1e} floor after {} candidates. The '

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -182,6 +182,19 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
+    def test_degenerate(self):
+        # A degenerate spectrum exhausts the Krylov space (beta -> 0).
+        # Without a breakdown guard this normalized by ~0 and returned NaN
+        # (gh-6446, gh-7495). Check the identity yields all-ones, no NaN.
+        if self.use_linear_operator:
+            pytest.skip()
+        a = sparse.identity(self.n, dtype='d', format='csr')
+        w = sparse.linalg.eigsh(a, k=self.k, which=self.which,
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        cupy.testing.assert_allclose(
+            cupy.sort(w), cupy.ones(self.k, dtype='d'), atol=1e-8)
+
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
@@ -289,6 +302,22 @@ class TestSvds:
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
+
+    def test_rank_deficient(self):
+        # A rank-deficient matrix gives A^H A a large null space, exhausting
+        # the Krylov space; without a breakdown guard svds collapsed to all
+        # zeros (gh-8009, gh-7157). Check it recovers the true top-k values.
+        if self.use_linear_operator:
+            pytest.skip()
+        m, n = self.shape
+        rank = min(m, n) // 2
+        a = (testing.shaped_random((m, rank), cupy, dtype='d')
+             @ testing.shaped_random((rank, n), cupy, dtype='d'))
+        s = sparse.linalg.svds(sparse.csr_matrix(a), k=self.k,
+                               return_singular_vectors=False)
+        assert not bool(cupy.isnan(s).any())
+        ref = cupy.sort(cupy.linalg.svd(a, compute_uv=False)[:self.k])
+        cupy.testing.assert_allclose(cupy.sort(s), ref, rtol=1e-4, atol=1e-6)
 
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -377,6 +377,31 @@ class TestEigsh:
 
 
 @testing.with_requires('scipy')
+class TestEigshLateNormDiscovery:
+    # An operator with wide dynamic range and a v0 orthogonal to its
+    # dominant eigenspace -- what a deflation workflow produces -- makes
+    # the first sweep honestly underestimate ||A||, and a later reseed
+    # legitimately discovers it. A divergence guard measured against the
+    # first sweep's own estimate mistakes that for corruption; one
+    # measured against a true bound on ||A|| cannot.
+    @testing.for_dtypes('fdFD')
+    @pytest.mark.parametrize('big', [1e4, 1e6])
+    def test_dominant_eigenvalue_hidden_from_v0(self, dtype, big):
+        n = 400
+        d = numpy.ones(n)
+        d[0] = big
+        a = sparse.diags(cupy.asarray(d.astype(
+            numpy.dtype(dtype).char.lower()))).tocsr().astype(dtype)
+        v0 = numpy.random.default_rng(0).random(n)
+        v0[0] = 0.0                        # exactly orthogonal to e_0
+        v0 = cupy.asarray((v0 / numpy.linalg.norm(v0)).astype(dtype))
+        w = sparse.linalg.eigsh(a, k=6, which='LA', v0=v0,
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        assert bool((cupy.abs(w) <= 8 * big).all())
+
+
+@testing.with_requires('scipy')
 class TestEigshTinyN:
     # n = 2 forces ncv = n - 1 = 1, so the sweep yields a single row and the
     # breakdown walk has no interior beta to inspect. Regression guard: the

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -225,9 +225,37 @@ class TestEigsh:
         cupy.testing.assert_allclose(
             cupy.sort(w), cupy.full(k, 50.0), rtol=tol, atol=tol)
 
+    @testing.for_dtypes('fdFD')
+    def test_null_space_start(self, dtype):
+        # v0 exactly in the null space of a singular A: beta and the norm
+        # estimate both start at 0, so the breakdown test must be
+        # non-strict (<=) for the reseed to fire -- with strict < the
+        # whole Krylov space silently stays zero and eigsh returns zeros.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n = 10
+        a = sparse.diags(cupy.arange(n).astype(dtype)).tocsr()
+        v0 = cupy.zeros(n, dtype=dtype)
+        v0[0] = 1                      # eigenvector of eigenvalue 0
+        w = sparse.linalg.eigsh(a, k=2, which='LA', v0=v0,
+                                return_eigenvectors=False)
+        # with '<' this returned [0, 0]; with '<=' the reseeds explore true
+        # eigendirections. (A dead v0 plus ncv = n - 1 leaves one dimension
+        # unexplored and the exact-invariant res = 0 stop ends there, so the
+        # result is genuine nonzero eigenvalues, not necessarily the
+        # extremal pair -- inherited Lanczos semantics.)
+        w = cupy.sort(w.real)
+        assert not bool(cupy.isnan(w).any())
+        assert float(w.min()) > 0.5
+        cupy.testing.assert_allclose(w, cupy.around(w), atol=1e-4)
+
+    # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
+    # a run-dependent subset of these instances, so they XPASS
+    # intermittently; keep non-strict until gh-5001 is closed end-to-end.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
+        strict=False,
     )
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')
@@ -359,9 +387,40 @@ class TestSvds:
         cupy.testing.assert_allclose(
             cupy.sort(s), ref, rtol=cmp_tol, atol=cmp_tol * float(ref.max()))
 
+    low_rank_wide_tol = {'f': 1e-2, 'd': 1e-6}
+
+    @testing.for_dtypes('fdFD')
+    def test_low_rank_wide(self, dtype):
+        # gh-8009's exact regime: rank 5 in a 100x1000 matrix, so A^H A has
+        # a 95% null space. The breakdown reseed must be biased out of the
+        # null space (one application of the operator, see _restart_ortho)
+        # -- an unbiased canonical reseed wastes the Krylov slots on
+        # eigenvalue-0 directions and default ncv recovers only 1-3 of the
+        # 5 true values. Runs once (not per class parameter).
+        if (self.use_linear_operator or self.return_vectors
+                or self.shape != (30, 29) or self.k != 6):
+            pytest.skip()
+        rank = 5
+        a = (testing.shaped_random((100, rank), cupy, dtype=dtype, seed=0)
+             @ testing.shaped_random((rank, 1000), cupy, dtype=dtype,
+                                     seed=1))
+        s = cupy.sort(sparse.linalg.svds(sparse.csr_matrix(a), k=6,
+                      return_singular_vectors=False))
+        assert not bool(cupy.isnan(s).any())
+        ref = cupy.linalg.svd(a, compute_uv=False)[:rank]
+        tol = self.low_rank_wide_tol[numpy.dtype(dtype).char.lower()]
+        cupy.testing.assert_allclose(
+            cupy.sort(s[1:]), cupy.sort(ref), rtol=tol,
+            atol=tol * float(ref.max()))
+        assert float(s[0]) < 1e-3 * float(ref.max())   # the rank-6 value ~ 0
+
+    # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
+    # a run-dependent subset of these instances, so they XPASS
+    # intermittently; keep non-strict until gh-5001 is closed end-to-end.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
+        strict=False,
     )
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=tol, atol=tol, sp_name='sp')

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -215,7 +215,7 @@ class TestEigsh:
             [cupy.ones(n // 2, dtype='d'),
              50.0 * cupy.ones(n // 2, dtype='d')])
         q, _ = cupy.linalg.qr(testing.shaped_random((n, n), cupy,
-                                                    dtype=dtype))
+                                                    dtype=dtype, seed=0))
         a = ((q * evals) @ q.conj().T).astype(dtype)
         w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
                                 return_eigenvectors=False)
@@ -224,6 +224,33 @@ class TestEigsh:
         tol = self.clustered_tol[numpy.dtype(dtype).char.lower()]
         cupy.testing.assert_allclose(
             cupy.sort(w), cupy.full(k, 50.0), rtol=tol, atol=tol)
+
+    @testing.for_dtypes('fdFD')
+    def test_clustered_large_k_gaussian(self, dtype):
+        # The same two-value spectrum under a gaussian-QR rotation, with a
+        # pinned start vector. Reported in review: this rotation returns
+        # ghost Ritz values up to ~1e307 (NaN on stock) where the rotation
+        # above happens to converge, because the restart locks duplicate
+        # rows into the basis once an eigenvalue is degenerate. Both the
+        # rotation and v0 are built on the host with seeded numpy, so the
+        # input does not depend on GPU RNG.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n, k = 200, 20
+        rng = numpy.random.default_rng(1)
+        q, _ = numpy.linalg.qr(rng.standard_normal((n, n)))
+        evals = numpy.concatenate(
+            [numpy.ones(n // 2), 50.0 * numpy.ones(n // 2)])
+        a = cupy.asarray((q * evals) @ q.T).astype(dtype)
+        v0 = cupy.asarray(
+            numpy.random.default_rng(1).random(n)).astype(dtype)
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                v0=v0, return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        assert bool((cupy.abs(w) < 1e3).all())      # no ghost / overflow
+        tol = self.clustered_tol[numpy.dtype(dtype).char.lower()]
+        cupy.testing.assert_allclose(
+            cupy.sort(w.real), cupy.full(k, 50.0), rtol=tol, atol=tol)
 
     @testing.for_dtypes('fdFD')
     def test_null_space_start(self, dtype):
@@ -286,7 +313,9 @@ class TestEigsh:
 
     # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
     # a run-dependent subset of these instances, so they XPASS
-    # intermittently; keep non-strict until gh-5001 is closed end-to-end.
+    # intermittently. The blocker is not gh-5001 itself but the unseeded
+    # default v0 (see the gh-5001 analysis in #10098): non-strict until the
+    # default v0 is seeded, after which these markers can go.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
@@ -345,6 +374,82 @@ class TestEigsh:
         v_v0 = cupy.copysign(ev_v0[:, 0], v)
 
         assert cupy.linalg.norm(v - v_v0) < cupy.linalg.norm(v - v_aux)
+
+
+@testing.with_requires('scipy')
+class TestEigshTinyN:
+    # n = 2 forces ncv = n - 1 = 1, so the sweep yields a single row and the
+    # breakdown walk has no interior beta to inspect. Regression guard: the
+    # running-max array is empty there, and indexing it raised IndexError
+    # before the first Ritz solve. With v0 an exact eigenvector the first
+    # sweep converges (res = 0), which is the path that must keep working;
+    # a non-converging n = 2 input still hits the separate V[k+1] bound
+    # issue tracked in #10220.
+    @testing.for_dtypes('fdFD')
+    def test_n2_exact_v0(self, dtype):
+        a = cupy.array([[2, 0], [0, 1]], dtype=dtype)
+        v0 = cupy.array([1, 0], dtype=dtype)
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=1, which='LM',
+                                v0=v0, return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        cupy.testing.assert_allclose(w.real, cupy.array([2.0]),
+                                     rtol=1e-5, atol=1e-5)
+
+
+@testing.parameterize(*testing.product({
+    'which': ['LM', 'SA'],
+    'shift': [0.0, 0.5],
+}))
+@testing.with_requires('scipy')
+class TestEigshDegenerateHermitian:
+    # Hermitian, well-posed, and silently wrong on stock: B @ B^H with
+    # rank 5 << n has an eigenvalue of multiplicity n - 5, so the Krylov
+    # space is exhausted after ~5 steps and stock normalizes by ~0 --
+    # returning NaN, or ghost Ritz values, depending on the draw. The
+    # +0.5*I variant moves the degenerate block off zero, so a failure
+    # cannot be dismissed as a null-space artifact.
+    #
+    # The exact spectrum is known analytically, which matters here: a
+    # dense eigvalsh of the n x n matrix is LESS accurate than eigsh on
+    # the degenerate block (measured 1.9e-3 vs 3e-4 in float32), so it is
+    # not a usable reference. B^H B is only rank x rank and carries the
+    # nonzero eigenvalues exactly; everything else is the shift.
+    n = 100
+    rank = 5
+    k = 6
+
+    @testing.for_dtypes('fdFD')
+    def test_low_rank_gram(self, dtype):
+        b = testing.shaped_random((self.n, self.rank), cupy, dtype=dtype,
+                                  seed=0)
+        a = b @ b.conj().T
+        a = (a + a.conj().T) / 2              # exactly Hermitian
+        if self.shift:
+            a = a + self.shift * cupy.eye(self.n, dtype=dtype)
+
+        # Exact spectrum: rank nonzero eigenvalues from the small Gram,
+        # the rest are the shift (multiplicity n - rank).
+        nonzero = cupy.linalg.eigvalsh(b.conj().T @ b) + self.shift
+        if self.which == 'LM':
+            expected = cupy.sort(cupy.concatenate(
+                [nonzero, cupy.asarray([self.shift], dtype=nonzero.dtype)]))
+        else:                                  # 'SA': the degenerate block
+            expected = cupy.full((self.k,), self.shift,
+                                 dtype=nonzero.dtype)
+
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=self.k,
+                                which=self.which,
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        assert bool(cupy.isfinite(w).all())
+        # Absolute tolerance must scale with ||A||: the degenerate block
+        # sits at the roundoff floor of the largest eigenvalue, not at an
+        # absolute one. Same 64*eps*||A|| scale the solver itself uses.
+        anorm = float(cupy.abs(nonzero).max())
+        eps = float(numpy.finfo(numpy.dtype(dtype).char.lower()).eps)
+        cupy.testing.assert_allclose(
+            cupy.sort(w.real), cupy.sort(expected.real),
+            rtol=1e-4, atol=64 * eps * anorm)
 
 
 @testing.parameterize(*testing.product({
@@ -467,7 +572,9 @@ class TestSvds:
 
     # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
     # a run-dependent subset of these instances, so they XPASS
-    # intermittently; keep non-strict until gh-5001 is closed end-to-end.
+    # intermittently. The blocker is not gh-5001 itself but the unseeded
+    # default v0 (see the gh-5001 analysis in #10098): non-strict until the
+    # default v0 is seeded, after which these markers can go.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -182,18 +182,22 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
-    def test_degenerate(self):
+    degenerate_tol = {'f': 1e-5, 'd': 1e-10}
+
+    @testing.for_dtypes('fdFD')
+    def test_degenerate(self, dtype):
         # A degenerate spectrum exhausts the Krylov space (beta -> 0).
         # Without a breakdown guard this normalized by ~0 and returned NaN
         # (gh-6446, gh-7495). Check the identity yields all-ones, no NaN.
         if self.use_linear_operator:
             pytest.skip()
-        a = sparse.identity(self.n, dtype='d', format='csr')
+        a = sparse.identity(self.n, dtype=dtype, format='csr')
         w = sparse.linalg.eigsh(a, k=self.k, which=self.which,
                                 return_eigenvectors=False)
         assert not bool(cupy.isnan(w).any())
+        tol = self.degenerate_tol[numpy.dtype(dtype).char.lower()]
         cupy.testing.assert_allclose(
-            cupy.sort(w), cupy.ones(self.k, dtype='d'), atol=1e-8)
+            cupy.sort(w), cupy.ones(self.k), rtol=tol, atol=tol)
 
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
@@ -303,21 +307,26 @@ class TestSvds:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
 
-    def test_rank_deficient(self):
+    rank_deficient_tol = {'f': 1e-2, 'd': 1e-4}
+
+    @testing.for_dtypes('fdFD')
+    def test_rank_deficient(self, dtype):
         # A rank-deficient matrix gives A^H A a large null space, exhausting
         # the Krylov space; without a breakdown guard svds collapsed to all
-        # zeros (gh-8009, gh-7157). Check it recovers the true top-k values.
+        # zeros (gh-8009). Check it recovers the true top-k values.
         if self.use_linear_operator:
             pytest.skip()
         m, n = self.shape
         rank = min(m, n) // 2
-        a = (testing.shaped_random((m, rank), cupy, dtype='d')
-             @ testing.shaped_random((rank, n), cupy, dtype='d'))
+        a = (testing.shaped_random((m, rank), cupy, dtype=dtype, seed=0)
+             @ testing.shaped_random((rank, n), cupy, dtype=dtype, seed=1))
         s = sparse.linalg.svds(sparse.csr_matrix(a), k=self.k,
                                return_singular_vectors=False)
         assert not bool(cupy.isnan(s).any())
         ref = cupy.sort(cupy.linalg.svd(a, compute_uv=False)[:self.k])
-        cupy.testing.assert_allclose(cupy.sort(s), ref, rtol=1e-4, atol=1e-6)
+        tol = self.rank_deficient_tol[numpy.dtype(dtype).char.lower()]
+        cupy.testing.assert_allclose(
+            cupy.sort(s), ref, rtol=tol, atol=tol * float(ref.max()))
 
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -264,6 +264,26 @@ class TestEigsh:
                                 return_eigenvectors=False)
         cupy.testing.assert_allclose(w.real, cupy.zeros(5), atol=1e-5)
 
+    @testing.for_dtypes('fdFD')
+    def test_semidefinite_la_null_not_targeted(self, dtype):
+        # The mirror image of the test above: on a POSITIVE-semidefinite (or
+        # indefinite) operator with a null space, zero is NOT an LA target,
+        # so the reseed must keep annihilating null candidates rather than
+        # spending Krylov slots on them. The shift is therefore applied only
+        # when no positive Rayleigh quotient has been observed.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        for vals in ([1.0, 2.0, 3.0] + [0.0] * 7,
+                     [2.0, -3.0] + [0.0] * 8):
+            a = sparse.diags(
+                cupy.asarray(vals).astype(dtype)).tocsr()
+            w = sparse.linalg.eigsh(a, k=3, which='LA',
+                                    return_eigenvectors=False)
+            ref = cupy.sort(cupy.asarray(vals).astype(
+                cupy.asarray(vals).real.dtype))[-3:]
+            cupy.testing.assert_allclose(
+                cupy.sort(w.real), ref, atol=1e-4)
+
     # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
     # a run-dependent subset of these instances, so they XPASS
     # intermittently; keep non-strict until gh-5001 is closed end-to-end.

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -199,6 +199,32 @@ class TestEigsh:
         cupy.testing.assert_allclose(
             cupy.sort(w), cupy.ones(self.k), rtol=tol, atol=tol)
 
+    clustered_tol = {'f': 1e-4, 'd': 1e-6}
+
+    @testing.for_dtypes('fdFD')
+    def test_clustered_large_k(self, dtype):
+        # A spectrum with only a few distinct eigenvalues exhausts its
+        # Krylov space almost immediately (a 2-value spectrum has Krylov
+        # dimension ~2): without the breakdown guard this returned NaN or
+        # ghost/overflow Ritz values (~1e+217) at larger k (gh-7168,
+        # gh-6769). The top-k eigenvalues are k exact copies of 50.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n, k = 200, 20
+        evals = cupy.concatenate(
+            [cupy.ones(n // 2, dtype='d'),
+             50.0 * cupy.ones(n // 2, dtype='d')])
+        q, _ = cupy.linalg.qr(testing.shaped_random((n, n), cupy,
+                                                    dtype=dtype))
+        a = ((q * evals) @ q.conj().T).astype(dtype)
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        assert bool((cupy.abs(w) < 1e3).all())      # no ghost / overflow
+        tol = self.clustered_tol[numpy.dtype(dtype).char.lower()]
+        cupy.testing.assert_allclose(
+            cupy.sort(w), cupy.full(k, 50.0), rtol=tol, atol=tol)
+
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -307,26 +307,31 @@ class TestSvds:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
 
-    rank_deficient_tol = {'f': 1e-2, 'd': 1e-4}
-
     @testing.for_dtypes('fdFD')
     def test_rank_deficient(self, dtype):
         # A rank-deficient matrix gives A^H A a large null space, exhausting
         # the Krylov space; without a breakdown guard svds collapsed to all
-        # zeros (gh-8009). Check it recovers the true top-k values.
+        # zeros (gh-8009). Check it recovers the true top-k values: to
+        # machine precision in d/D, and to ~1% in f/F GIVEN AN ACHIEVABLE
+        # tol -- the default tol = eps is an absolute residual that single
+        # precision cannot reach for a matrix of this norm, so the solve
+        # would run to maxiter and return a partially converged tail.
         if self.use_linear_operator:
             pytest.skip()
         m, n = self.shape
         rank = min(m, n) // 2
         a = (testing.shaped_random((m, rank), cupy, dtype=dtype, seed=0)
              @ testing.shaped_random((rank, n), cupy, dtype=dtype, seed=1))
-        s = sparse.linalg.svds(sparse.csr_matrix(a), k=self.k,
+        if numpy.dtype(dtype).char.lower() == 'd':
+            svds_tol, cmp_tol = 0, 1e-4
+        else:
+            svds_tol, cmp_tol = 1e-6 * float(cupy.linalg.norm(a)) ** 2, 5e-2
+        s = sparse.linalg.svds(sparse.csr_matrix(a), k=self.k, tol=svds_tol,
                                return_singular_vectors=False)
         assert not bool(cupy.isnan(s).any())
         ref = cupy.sort(cupy.linalg.svd(a, compute_uv=False)[:self.k])
-        tol = self.rank_deficient_tol[numpy.dtype(dtype).char.lower()]
         cupy.testing.assert_allclose(
-            cupy.sort(s), ref, rtol=tol, atol=tol * float(ref.max()))
+            cupy.sort(s), ref, rtol=cmp_tol, atol=cmp_tol * float(ref.max()))
 
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -249,6 +249,21 @@ class TestEigsh:
         assert float(w.min()) > 0.5
         cupy.testing.assert_allclose(w, cupy.around(w), atol=1e-4)
 
+    @testing.for_dtypes('fdFD')
+    def test_negative_semidefinite_la(self, dtype):
+        # 'LA' on a negative-semidefinite operator with nullity >= k: the
+        # zero eigenvalues ARE the largest algebraic targets, so the reseed
+        # bias must not steer away from the null space -- 'LA' biases by
+        # (A + anorm*I), which keeps the null space alive (see
+        # _restart_ortho).
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        a = sparse.diags(cupy.concatenate(
+            [cupy.zeros(5), -cupy.ones(5)]).astype(dtype)).tocsr()
+        w = sparse.linalg.eigsh(a, k=5, which='LA',
+                                return_eigenvectors=False)
+        cupy.testing.assert_allclose(w.real, cupy.zeros(5), atol=1e-5)
+
     # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
     # a run-dependent subset of these instances, so they XPASS
     # intermittently; keep non-strict until gh-5001 is closed end-to-end.
@@ -413,6 +428,22 @@ class TestSvds:
             cupy.sort(s[1:]), cupy.sort(ref), rtol=tol,
             atol=tol * float(ref.max()))
         assert float(s[0]) < 1e-3 * float(ref.max())   # the rank-6 value ~ 0
+
+    def test_low_rank_coordinate_null(self):
+        # gh-8009's literal reproducer: eye(100, 1000) with rows 5+ zeroed
+        # makes A^H A a COORDINATE projector, so every canonical reseed
+        # lands exactly in the null space (bias_op @ e_j == 0); the varied
+        # dense probe in _restart_ortho is what recovers all five values.
+        if (self.use_linear_operator or self.return_vectors
+                or self.shape != (30, 29) or self.k != 6):
+            pytest.skip()
+        a = cupy.eye(100, 1000, dtype='d')
+        a[5:] = 0
+        s = cupy.sort(sparse.linalg.svds(sparse.csr_matrix(a), k=6,
+                      return_singular_vectors=False))
+        assert not bool(cupy.isnan(s).any())
+        cupy.testing.assert_allclose(s[1:], cupy.ones(5), atol=1e-8)
+        assert float(s[0]) < 1e-6
 
     # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
     # a run-dependent subset of these instances, so they XPASS


### PR DESCRIPTION
## Summary
`eigsh` returns NaN and `svds` returns all-zeros on degenerate or
rank-deficient inputs, because the Lanczos normalization `V[i+1] = u/beta[i]`
has no guard when `beta[i] -> 0` (invariant subspace found early).

## Fix (redesigned after A100 measurements — see review thread)
Two findings from validating on hardware reshaped the mechanism:
1. Any per-iteration host sync in the inner loop — even the single bool of the
   first review round — costs **+57–62% wall time** on healthy problems
   (measured, sparse 1e5×1e5, k=6/64): one `.item()` per iteration serializes
   the launch pipeline the loop was designed to keep full.
2. A `sqrt(eps)·||A||` breakdown threshold sits **inside the legitimate beta
   range in float32** (`sqrt(eps_f) ≈ 3e-4`), firing on real couplings and
   corrupting trailing Ritz values. Since zeroing a coupling of size `beta`
   perturbs the spectrum by at most `beta`, the threshold must be
   `O(eps)·||A||` (64·eps here) — harmless by construction.

Mechanism now:
- **`_kernel_normalize` is NaN-proof**: `beta = ||u||`, so `u/beta` is finite
  for any `beta > 0`; an exact breakdown emits a zero column instead of 0/0.
  The inner loop has **zero host syncs** (measured overhead now **+4–5%**).
- **Detection/repair at the sweep boundary** (`_lanczos_checked`), using the
  host copy of `(alpha, beta)` the Ritz solve makes anyway: fire positions
  (non-strict `<=`, so an all-zero block is caught too) are decoupled
  (`beta = 0`) and `V[p+1]` reseeded with a **deterministic** fresh vector
  orthogonal to `V[:p+1]` — the canonical basis vector least represented in
  the span, **biased out of the operator's null space** by one application of
  the operator (fallback to unbiased when the range is exhausted; disabled
  for `which='SA'`). No RNG. Healthy problems detect nothing and pay only
  the boundary checks (**+1.3–5.0%** end to end, measured on three GPU
  generations; see Cost below). The bias is what makes #8009's exact reproducer (100×1000 rank 5,
  `svds(k=6)`, default `ncv`) recover all 5 values.
- The `||A||` estimate **walks rows in order and stops at the first
  breakdown** — rows past an exhausted subspace hold roundoff junk that would
  otherwise inflate the threshold (observed misfires in float32).
- The same machinery guards **both thick-restart normalizations**
  (`V[k+1] = u/beta[k]` via the boundary check; `V[k] = u/nrm2(u)` via a
  reseed when deflation collapses the residual) — closing the scope gap
  flagged in review; the latter produced wild `>>||A||` Ritz values in single
  precision when unguarded.

- **Basis-orthogonality check at the sweep boundary.** The absolute
  `beta` test only catches a breakdown while the residual is still at the
  roundoff floor; on a degenerate spectrum that floor GROWS as roundoff is
  amplified, and the thick restart can lock duplicate rows into the basis
  when an eigenvalue has multiplicity > 1 (Gram off-diagonal of exactly
  1.0). One Gram matrix per sweep boundary, gated on the active range,
  verifies the invariant directly; `_restart_ortho` and the `||A||`
  estimate additionally fail closed on the unrecoverable cases.

## Cost, including the degenerate path

Correct-but-slower on the inputs this PR targets, stated explicitly:

| input class | cost vs stock |
|---|---|
| healthy / breakdown-free | **+1.3–5.0%** (A100 / H200 / L40S) |
| rank-60 diagonal (reseed fires) | +34% A100 / +72% A5000 / −14% L40S |
| two-value spectrum (fully degenerate) | **+1600–2292%** |

The last row is the honest worst case: a spectrum with only two distinct
eigenvalues exhausts its Krylov space almost immediately, so nearly every
sweep boundary triggers a repair re-sweep. Stock is faster there only
because it returns NaN or ~1e+264 ghost values instead of an answer. The
`eigsh` docstring now carries the same warning, and `_lanczos_checked`
returns the matvecs it actually performed (repairs included) so `maxiter`
still bounds the work.

## Validation (A100, cupy 14.1.1 wheel + this patch)
- `test_degenerate` / `test_rank_deficient` parametrized over `fdFD`:
  72/72 across 4 consecutive runs; full `TestEigsh`/`TestSvds`: 432 passed,
  0 failed. A 540-solve sweep (dtypes × shapes × k × 30 reps) has **zero**
  failures; k=3/6 recover to ~2e-7, k=12 to ~1e-2 in single precision.
- Healthy-path A/B vs stock: +5.0% (k=6), +4.3% (k=64); outputs match.
- The breakdown path is deterministic by construction (no RNG anywhere in
  the reseed); repeated runs reproduce to ~1e-17, the residual variation
  being cuBLAS parallel-reduction nondeterminism in `nrm2`/`dotc` rather
  than the reseed logic. Stock reproduces the NaN on the same inputs.
- Side effect: **23 previously-xfailed gh-5001 eigsh cases now xpass**.
- The clustered-spectrum case of #7168/#6769 (a 2-value spectrum, n=200,
  k=20 -> NaN / ~1e+217 ghost values) is a breakdown case in disguise (two
  distinct eigenvalues -> Krylov dimension ~2) and is fixed by this guard
  alone: 1.4e-14 (double) / 9.5e-7 (single) vs dense, with a
  dtype-parametrized regression test (`test_clustered_large_k`, ported
  from #10099). An extensive A/B hunt found no case where a second
  reorthogonalization pass changes results on top of this PR.
- `test_rank_deficient` passes an achievable `tol` for f/F: the default
  `tol = eps` is an absolute residual single precision cannot reach at this
  matrix norm, so the solve would run to `maxiter` and return a partially
  converged tail. d/D assert at 1e-4 (measured ~1e-15); f/F at 5e-2
  (measured ≤1.2e-2).
- A numpy mirror of the full thick-restart algorithm passes 28 checks
  (identity × all `which` × all dtypes, rank-deficient vs LAPACK real+complex,
  determinism, healthy-path invariance) and reproduces the NaN with the guard
  removed.

Note: a second reorthogonalization pass was explored in #10099 and
withdrawn after an A100 A/B across clusters, geometric decay, exact
multiplicities, k=n/2, maxiter-bound f32 and large sparse long runs found no
case where it changes results on top of this PR (the loop reorthogonalizes
against all of V every iteration, and the tiny-beta cancellation events that
defeat a single CGS pass are exactly the ones this guard intercepts).
#9019's literal reproducer is eigsh applied to a NON-symmetric matrix --
an input-contract issue handled in a separate follow-up (a cheap Hermitian
probe + UserWarning).

Fixes #8486 — its reproducer is the classic breakdown signature (beta collapses
to 6e-13, blows up to 1e23, returns NaN). On A100 with the issue's own 32x32
input: stock 14.1.1 gives `[-2.2081223e+10, nan]`, this PR gives
`[-103.83952, -37.784576]` against a scipy reference of
`[-103.83951, -37.78458]` (rel err 1.5e-07).
Fixes #6446
Fixes #7168
Fixes #6769
Fixes #7495
Fixes #8009
Fixes #5000 — the `TypeError` reported there was already fixed in 2cab873a
(v9.1); this completes the underlying rank-deficient `svds` case end-to-end.
Re #7157: its reproducer (random binary 1000x1000, f32, svds k=40) was
re-run on A100 against current main — it no longer reproduces (stock returns
the exact dense-reference values, stably, across repeated calls; the full
reorthogonalization pass added to _lanczos_fast since v11 evidently fixed
it), so that issue can simply be closed as already resolved on main.
Partially addresses #5001 (23 of its xfailed cases pass with this change).





