### PR TITLE
Second Lanczos reorthogonalization pass: fix eigsh ghost/overflow on degenerate spectra

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -222,6 +222,11 @@ def _lanczos_fast(A, n, ncv):
             spmv_buff = cupy.empty(buff_size, cupy.int8)
 
         v[...] = V[i_start]
+        # Running ||A|| estimate and previous off-diagonal, for the
+        # lucky-breakdown test below.
+        anorm = 0.0
+        prev_beta = 0.0
+        break_rtol = float(numpy.sqrt(numpy.finfo(A.dtype).eps))
         for i in range(i_start, i_end):
             # Matrix-vector multiplication
             if cusparse_handle is None:
@@ -286,6 +291,21 @@ def _lanczos_fast(A, n, ncv):
             if i >= i_end - 1:
                 break
 
+            # Lucky breakdown: beta[i] ~ 0 means A @ v landed in span(V), i.e.
+            # an invariant subspace was found. Normalizing by it (below) yields
+            # NaNs / wrong results on degenerate or rank-deficient spectra
+            # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
+            # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
+            # vector orthogonal to V[:i+1] so the iteration keeps exploring.
+            beta_i = float(beta[i])
+            anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
+            prev_beta = beta_i
+            if beta_i < break_rtol * anorm:
+                beta[i] = 0
+                v[...] = _restart_ortho(V, i + 1, n, u.dtype)
+                V[i + 1] = v
+                continue
+
             # Normalize
             _kernel_normalize(u, beta, i, n, v, V)
 
@@ -296,6 +316,16 @@ _kernel_normalize = cupy.ElementwiseKernel(
     'T u, raw S beta, int32 j, int32 n', 'T v, raw T V',
     'v = u / beta[j]; V[i + (j+1) * n] = v;', 'cupy_eigsh_normalize'
 )
+
+
+def _restart_ortho(V, m, n, dtype):
+    # Fresh unit vector orthogonal to V[:m], used to restart the Lanczos
+    # recurrence after a lucky breakdown (two classical Gram-Schmidt passes).
+    w = cupy.random.random((n,)).astype(dtype)
+    Vm = V[:m]
+    for _ in range(2):
+        w = w - Vm.T @ (Vm.conj() @ w)
+    return w / cupy.linalg.norm(w)
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -313,10 +313,13 @@ def _lanczos_fast(A, n, ncv):
             # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
             # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
             # vector orthogonal to V[:i+1] so the iteration keeps exploring.
+            # The test is non-strict (<=) so an all-zero spectrum -- where anorm
+            # stays 0 and the relative threshold collapses to 0 -- is still
+            # caught instead of dividing by ~0.
             beta_i = float(beta[i])
             anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
             prev_beta = beta_i
-            if beta_i < break_rtol * anorm:
+            if beta_i <= break_rtol * anorm:
                 beta[i] = 0
                 v[...] = _restart_ortho(V, i + 1, n, u.dtype)
                 V[i + 1] = v
@@ -337,11 +340,19 @@ _kernel_normalize = cupy.ElementwiseKernel(
 def _restart_ortho(V, m, n, dtype):
     # Fresh unit vector orthogonal to V[:m], used to restart the Lanczos
     # recurrence after a lucky breakdown (two classical Gram-Schmidt passes).
+    # The projection conjugates V (Vm.conj()) so it is correct for complex
+    # Hermitian A; the reconstruction (Vm.T) is intentionally not conjugated.
     w = cupy.random.random((n,)).astype(dtype)
     Vm = V[:m]
     for _ in range(2):
         w = w - Vm.T @ (Vm.conj() @ w)
-    return w / cupy.linalg.norm(w)
+    nrm = cupy.linalg.norm(w)
+    # If V[:m] already spans the space (m >= n, e.g. an all-zero spectrum that
+    # keeps breaking down until the Krylov basis is full), no orthogonal
+    # direction remains -- return zeros so the tridiagonal stays decoupled
+    # rather than normalizing by ~0 and producing NaNs.
+    tol = numpy.sqrt(numpy.finfo(dtype).eps)
+    return w / nrm if float(nrm) > tol else cupy.zeros_like(w)
 
 
 def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -313,9 +313,8 @@ def _lanczos_fast(A, n, ncv):
             # (gh-6446, gh-7495, gh-8009, gh-7157). Instead decouple the
             # tridiagonal (beta[i] = 0) and restart V[i+1] with a fresh unit
             # vector orthogonal to V[:i+1] so the iteration keeps exploring.
-            # The test is non-strict (<=) so an all-zero spectrum -- where anorm
-            # stays 0 and the relative threshold collapses to 0 -- is still
-            # caught instead of dividing by ~0.
+            # Non-strict (<=) so an all-zero spectrum (anorm stays 0, so the
+            # threshold collapses to 0) is still caught, not divided by ~0.
             beta_i = float(beta[i])
             anorm = max(anorm, float(abs(alpha[i])) + beta_i + prev_beta)
             prev_beta = beta_i

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -278,6 +278,22 @@ def _lanczos_fast(A, n, ncv):
                  one.ctypes.data, u.data.ptr, 1)
             alpha[i] += uu[i]
 
+            # Second reorthogonalization pass ("twice is enough"): a single
+            # classical Gram-Schmidt pass leaves residual non-orthogonality on
+            # clustered / degenerate spectra, which grows into spurious
+            # ("ghost") Ritz values and overflow at large k (gh-7168, gh-6769,
+            # gh-9019). A second pass restores orthogonality.
+            gemv(cublas_handle, _cublas.CUBLAS_OP_C,
+                 n, i + 1,
+                 one.ctypes.data, V.data.ptr, n,
+                 u.data.ptr, 1,
+                 zero.ctypes.data, uu.data.ptr, 1)
+            gemv(cublas_handle, _cublas.CUBLAS_OP_N,
+                 n, i + 1,
+                 mone.ctypes.data, V.data.ptr, n,
+                 uu.data.ptr, 1,
+                 one.ctypes.data, u.data.ptr, 1)
+
             # Call nrm2
             _cublas.setPointerMode(
                 cublas_handle, _cublas.CUBLAS_POINTER_MODE_DEVICE)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -214,6 +214,64 @@ class TestEigsh:
         ref = cupy.sort(cupy.linalg.eigvalsh(a))[-k:]
         cupy.testing.assert_allclose(cupy.sort(w), ref, rtol=1e-6, atol=1e-6)
 
+    def test_complex_degenerate(self):
+        # Exercises the COMPLEX lucky-breakdown restart (_restart_ortho, whose
+        # projection conjugates V): a complex Hermitian matrix with repeated
+        # eigenvalues exhausts the Krylov space, forcing restarts on complex
+        # data. A wrong conjugation there gives non-orthogonal restarts and
+        # ghost / NaN Ritz values.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n, k = 60, 6
+        for dtype in ('F', 'D'):
+            rdt = numpy.dtype(dtype).char.lower()
+            evals = cupy.concatenate([5.0 * cupy.ones(4, dtype=rdt),
+                                      2.0 * cupy.ones(4, dtype=rdt),
+                                      cupy.zeros(n - 8, dtype=rdt)])
+            q, _ = cupy.linalg.qr(
+                testing.shaped_random((n, n), cupy, dtype=dtype, scale=1))
+            a = (q * evals) @ q.conj().T                 # complex Hermitian
+            w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                    return_eigenvectors=False)
+            assert not bool(cupy.isnan(w).any())
+            ref = cupy.sort(cupy.linalg.eigvalsh(a))[-k:]
+            cupy.testing.assert_allclose(
+                cupy.sort(w), ref, rtol=1e-4, atol=1e-4)
+
+    def test_zero_matrix(self):
+        # All-zero spectrum: anorm stays 0 so the relative breakdown threshold
+        # collapses to 0; the non-strict (<=) guard must still catch it instead
+        # of normalizing by ~0 and returning NaN. Expect k zeros.
+        if self.use_linear_operator:
+            pytest.skip()
+        idx = cupy.arange(self.n)
+        a = sparse.csr_matrix(                           # n explicit zeros
+            (cupy.zeros(self.n, dtype='d'), (idx, idx)),
+            shape=(self.n, self.n))
+        w = sparse.linalg.eigsh(a, k=self.k, which=self.which,
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        cupy.testing.assert_allclose(
+            cupy.sort(w), cupy.zeros(self.k, dtype='d'), atol=1e-8)
+
+    def test_multiple_breakdowns(self):
+        # A low-rank, high-multiplicity spectrum forces SEVERAL lucky
+        # breakdowns/restarts in one run; the tridiagonal must stay decoupled
+        # and recover the correct multiset (no ghosts, no NaN).
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n, k = 60, 6
+        evals = cupy.concatenate([cupy.ones(3, dtype='d'),
+                                   cupy.zeros(n - 3, dtype='d')])
+        q, _ = cupy.linalg.qr(
+            testing.shaped_random((n, n), cupy, dtype='d'))
+        a = (q * evals) @ q.T
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        ref = cupy.sort(cupy.linalg.eigvalsh(a))[-k:]    # [0,0,0,1,1,1]
+        cupy.testing.assert_allclose(cupy.sort(w), ref, atol=1e-6)
+
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -261,8 +261,8 @@ class TestEigsh:
         if self.use_linear_operator or self.which != 'LA':
             pytest.skip()
         n, k = 60, 6
-        evals = cupy.concatenate([cupy.ones(3, dtype='d'),
-                                   cupy.zeros(n - 3, dtype='d')])
+        evals = cupy.concatenate(
+            [cupy.ones(3, dtype='d'), cupy.zeros(n - 3, dtype='d')])
         q, _ = cupy.linalg.qr(
             testing.shaped_random((n, n), cupy, dtype='d'))
         a = (q * evals) @ q.T

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -182,6 +182,19 @@ class TestEigsh:
             a = sp.linalg.aslinearoperator(a)
         return self._test_eigsh(a, xp, sp)
 
+    def test_degenerate(self):
+        # A degenerate spectrum exhausts the Krylov space (beta -> 0).
+        # Without a breakdown guard this normalized by ~0 and returned NaN
+        # (gh-6446, gh-7495). Check the identity yields all-ones, no NaN.
+        if self.use_linear_operator:
+            pytest.skip()
+        a = sparse.identity(self.n, dtype='d', format='csr')
+        w = sparse.linalg.eigsh(a, k=self.k, which=self.which,
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        cupy.testing.assert_allclose(
+            cupy.sort(w), cupy.ones(self.k, dtype='d'), atol=1e-8)
+
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
@@ -289,6 +302,22 @@ class TestSvds:
         if self.use_linear_operator:
             a = sp.linalg.aslinearoperator(a)
         return self._test_svds(a, xp, sp)
+
+    def test_rank_deficient(self):
+        # A rank-deficient matrix gives A^H A a large null space, exhausting
+        # the Krylov space; without a breakdown guard svds collapsed to all
+        # zeros (gh-8009, gh-7157). Check it recovers the true top-k values.
+        if self.use_linear_operator:
+            pytest.skip()
+        m, n = self.shape
+        rank = min(m, n) // 2
+        a = (testing.shaped_random((m, rank), cupy, dtype='d')
+             @ testing.shaped_random((rank, n), cupy, dtype='d'))
+        s = sparse.linalg.svds(sparse.csr_matrix(a), k=self.k,
+                               return_singular_vectors=False)
+        assert not bool(cupy.isnan(s).any())
+        ref = cupy.sort(cupy.linalg.svd(a, compute_uv=False)[:self.k])
+        cupy.testing.assert_allclose(cupy.sort(s), ref, rtol=1e-4, atol=1e-6)
 
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -195,6 +195,25 @@ class TestEigsh:
         cupy.testing.assert_allclose(
             cupy.sort(w), cupy.ones(self.k, dtype='d'), atol=1e-8)
 
+    def test_clustered_large_k(self):
+        # A degenerate spectrum loses orthogonality after a single reorth pass,
+        # giving ghost / overflow Ritz values at larger k (gh-7168, gh-6769); a
+        # second reorthogonalization pass restores it. Checked once, vs dense.
+        if self.use_linear_operator or self.which != 'LA':
+            pytest.skip()
+        n, k = 200, 20
+        evals = cupy.concatenate(
+            [cupy.ones(n // 2, dtype='d'),
+             50.0 * cupy.ones(n // 2, dtype='d')])
+        q, _ = cupy.linalg.qr(testing.shaped_random((n, n), cupy, dtype='d'))
+        a = (q * evals) @ q.T
+        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                return_eigenvectors=False)
+        assert not bool(cupy.isnan(w).any())
+        assert bool((cupy.abs(w) < 1e3).all())      # no ghost / overflow
+        ref = cupy.sort(cupy.linalg.eigvalsh(a))[-k:]
+        cupy.testing.assert_allclose(cupy.sort(w), ref, rtol=1e-6, atol=1e-6)
+
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,


### PR DESCRIPTION
## Summary
Builds on #10098. A single Gram-Schmidt reorth pass leaves residual
non-orthogonality on clustered/degenerate spectra, producing spurious Ritz
values and overflow once `k` is a sizable fraction of `n`
(e.g. `eigsh(A, k=20, which='LA')` on a 2-value, n=200 spectrum -> NaN/1e+217).

## Fix
Add a second Gram-Schmidt pass ("twice is enough") to restore orthogonality
to machine precision.

## Validation
On A100, the previously-NaN/overflowing case above now matches a dense
reference to ~1e-13; well-separated spectra unchanged. Adds
`test_clustered_large_k`.

Depends on #10098 — first commit here is that PR's guard; will rebase once
#10098 merges.

Fixes #7168
Fixes #6769