### PR TITLE
Fix rotate() corrupting corners at multiples of 90 degrees

### DIFF
--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -489,6 +489,24 @@ def _minmax(coor, minc, maxc):
     return minc, maxc
 
 
+def _sindg_cosdg(angle):
+    """Return (sin, cos) of an angle given in degrees.
+
+    At exact multiples of 90 degrees this returns exact values in
+    {-1, 0, 1} instead of going through radians, matching what
+    scipy.ndimage.rotate gets from cosdg/sindg. math.sin(deg2rad(180))
+    is 1.2246e-16, not exactly 0, and that residual is enough to push a
+    boundary pixel's remapped coordinate just past the array bound.
+    """
+    if angle % 90 == 0:
+        quadrant = int(angle // 90) % 4
+        sin = (0.0, 1.0, 0.0, -1.0)[quadrant]
+        cos = (1.0, 0.0, -1.0, 0.0)[quadrant]
+        return sin, cos
+    rad = numpy.deg2rad(angle)
+    return math.sin(rad), math.cos(rad)
+
+
 def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
            mode='constant', cval=0.0, prefilter=True):
     """Rotate an array.
@@ -547,9 +565,7 @@ def rotate(input, angle, axes=(1, 0), reshape=True, output=None, order=3,
         raise ValueError('invalid rotation plane specified')
 
     ndim = input_arr.ndim
-    rad = numpy.deg2rad(angle)
-    sin = math.sin(rad)
-    cos = math.cos(rad)
+    sin, cos = _sindg_cosdg(angle)
     float_dtype = cupy.promote_types(input_arr.real.dtype, cupy.float32)
 
     # determine offsets and output shape as in scipy.ndimage.rotate

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -7,6 +7,7 @@ import cupy
 from cupy.cuda import runtime
 from cupy import testing
 import cupyx.scipy.ndimage
+from cupyx.scipy.ndimage import _interpolation
 from cupyx.scipy.ndimage import _util
 
 try:
@@ -491,7 +492,7 @@ class TestAffineTransformOpenCV:
 
 @testing.parameterize(*(
     testing.product({
-        'angle': [-10, 1000, 90, 180, -180],
+        'angle': [-10, 1000, 180, -180],
         'axes': [(1, 0)],
         'reshape': [False, True],
         # Avoid float64 output so rtol dict keyed by result dtype picks up
@@ -596,6 +597,26 @@ class TestRotateExceptions:
                 ndi.rotate(x, angle, [0, x.ndim])
             with pytest.raises(ValueError):
                 ndi.rotate(x, angle, [-(x.ndim + 1), 1])
+
+
+class TestRotateSindgCosdg:
+
+    @pytest.mark.parametrize('angle,sin,cos', [
+        (90, 1.0, 0.0),
+        (180, 0.0, -1.0),
+        (270, -1.0, 0.0),
+        (360, 0.0, 1.0),
+        (-90, -1.0, 0.0),
+        (-180, 0.0, -1.0),
+    ])
+    def test_exact_at_multiples_of_90(self, angle, sin, cos):
+        # math.sin/cos(deg2rad(angle)) is off by ~1e-16 at these angles,
+        # which is what corrupted rotate()'s corner pixels (see #8400).
+        # Assert exact equality, not closeness, so this can't be masked
+        # by an atol the way the end-to-end rotate() comparison can.
+        s, c = _interpolation._sindg_cosdg(angle)
+        assert s == sin
+        assert c == cos
 
 
 @testing.parameterize(

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_interpolation.py
@@ -491,7 +491,7 @@ class TestAffineTransformOpenCV:
 
 @testing.parameterize(*(
     testing.product({
-        'angle': [-10, 1000],
+        'angle': [-10, 1000, 90, 180, -180],
         'axes': [(1, 0)],
         'reshape': [False, True],
         # Avoid float64 output so rtol dict keyed by result dtype picks up


### PR DESCRIPTION
Fixes `cupyx.scipy.ndimage.rotate` corrupting corner pixels at exact multiples of 90 degrees. Repro from the issue:

```python
a = cupy.tile(cupy.arange(5), (5, 1))
cupyx.scipy.ndimage.rotate(cupyx.scipy.ndimage.rotate(a, 180), -180)
# bottom-right corner comes back 0 instead of 4
```

**Root cause:** `rotate()` built its rotation matrix from `math.sin(numpy.deg2rad(angle))` / `math.cos(...)`. At `angle=180`, `math.sin` returns `1.2246e-16`, not exactly `0.0`. That residual perturbs the matrix's off-diagonal terms, and for a pixel sitting exactly at the array's edge, the resulting source coordinate lands a few ULP past the true integer boundary.

I initially suspected the interpolation kernel's `mode='constant'` boundary check (`(c < 0) || (c > size - 1)`, zero tolerance) was the bug. It isn't: I checked `scipy.ndimage.affine_transform` at the same slightly-out-of-bounds coordinate and it also returns `cval` there, so cupy's check already matches scipy exactly. Loosening it with a blanket epsilon would have made cupy more lenient than scipy and silently changed behavior for every other caller of the same kernel generator (`affine_transform`, `shift`, `zoom`, `map_coordinates`).

The actual fix is upstream, in how `rotate()` computes its matrix. scipy's `rotate` uses `cosdg`/`sindg` (degree-native trig), where `sindg(180) == 0.0` exactly. This PR adds a small helper, `_sindg_cosdg`, that returns exact `{-1, 0, 1}` values at multiples of 90 degrees and falls through to the existing radian-based computation for every other angle. Verified live against scipy at every 90-degree multiple I could think to check (plus or minus 90, plus or minus 180, 270, 360, plus or minus 450) and confirmed the arbitrary-angle path (non-multiples of 90) is byte-identical to the pre-fix output, so there's no behavior change there.

**Scope:** only `rotate()`'s trig computation. Didn't touch the interpolation kernel's boundary check, or `affine_transform`/`shift`/`zoom`/`map_coordinates` directly.

**Alternative considered:** replicating scipy's `cosdg`/`sindg` for all angles, not just exact multiples of 90. That would be more uniform with scipy but shifts non-90 results by the last ULP or two versus current cupy output, which risks churn in any code (including tests) doing exact comparisons. Happy to switch to that if a maintainer prefers it.

**Tests:** added `angle=90`, `180`, `-180` to `TestRotate`'s existing parametrize. Confirmed via `git stash` that the new rows fail on unpatched source (24 failures, all `mode='constant'` at 180/-180, spanning order=0/1, both `reshape` values, all 3 `output` variants) and pass with the fix. Full `test_interpolation.py`: 5426 passed, 22 failed, 71 skipped. The 22 failures are pre-existing and unrelated (`TestMapCoordinatesHalfInteger`, `TestZoomOutputSize1`; confirmed identical failure set on unpatched source via the same `git stash` check). `pre-commit` clean.

Fixes #8400