### PR TITLE
FIX: Fix free-threaded global safety with `cached_object` helper

### DIFF
--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -1,3 +1,5 @@
+# distutils: language = c++
+
 from libc.stdint cimport intptr_t
 
 cimport cpython
@@ -9,6 +11,7 @@ import numpy
 
 import cupy
 from cupy._core cimport _dtype
+from cupy._core.internal cimport cached_object
 
 
 cdef dict _typenames_base = {
@@ -144,7 +147,7 @@ cdef dict _cuda_alignments = {
     numpy.dtype('complex64'): 8,
     numpy.dtype('complex128'): 16,
 }
-cdef object _alignment_kernel = None
+cdef cached_object _alignment_kernel
 
 
 cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
@@ -152,7 +155,8 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
     uses an ElementwiseKernel to compile and get the actual alignment.
     (Although, normally that should just be the itemsize.)
     """
-    global _cuda_alignments, _alignment_kernel
+    global _cuda_alignments
+    cdef object kernel
 
     alignment = _cuda_alignments.get(dtype)
     if alignment is not None:
@@ -176,15 +180,16 @@ cdef Py_ssize_t get_cuda_alignment(cnp.dtype dtype) except -1:
             # Alignment is inherited from the field dtype
             return get_cuda_alignment(dtype.base)
 
-    if _alignment_kernel is None:
-        _alignment_kernel = cupy.ElementwiseKernel(
+    kernel = _alignment_kernel.get()
+    if kernel is None:
+        kernel = _alignment_kernel.setdefault(cupy.ElementwiseKernel(
             "T in", "int64 out",
             "using in_t = decltype(in); out = alignof(in_t);",
             "_cupy_get_cuda_alignment",
-        )
+        ))
 
     # synchronize!
-    alignment = int(_alignment_kernel(cupy.empty((), dtype=dtype))[()])
+    alignment = int(kernel(cupy.empty((), dtype=dtype))[()])
     _cuda_alignments[dtype] = alignment
     return alignment
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2449,13 +2449,13 @@ cdef list _cupy_extra_header_list = [
 ]
 
 
-cpdef str _init_header_dir_path():
+cpdef str _get_header_dir_path():
     # Cython cannot use __file__ in global scope
     return os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'include'))
 
 
-cdef str _header_dir_path = _init_header_dir_path()
+cdef str _header_dir_path = _get_header_dir_path()
 cdef cached_object _header_source_cache
 cdef dict _header_source_map = {}
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -27,6 +27,7 @@ cimport cython  # NOQA
 cimport cpython
 from libc.stdint cimport int64_t, intptr_t, INT32_MAX
 from libc cimport stdlib
+from libcpp cimport bool as cpp_bool
 from cpython cimport Py_buffer
 
 cimport numpy as cnp
@@ -48,6 +49,7 @@ from cupy._core cimport _routines_statistics as _statistics
 from cupy._core cimport _scalar
 from cupy._core cimport dlpack
 from cupy._core cimport internal
+from cupy._core.internal cimport cached_object
 from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.cuda cimport pinned_memory
@@ -80,9 +82,8 @@ cdef tuple _HANDLED_TYPES
 cdef object _null_context = contextlib.nullcontext()
 
 # Supported index types for mdspan - initialized at runtime to avoid
-# circular import
-cdef tuple _MDSPAN_SUPPORTED_INDEX_TYPES = None
-cdef dict _MDSPAN_INDEX_TYPE_TO_ITEMSIZE = None
+# circular import.  Maps index type -> itemsize in bytes.
+cdef cached_object _MDSPAN_SUPPORTED_INDEX_TYPES
 
 
 # If rop of cupy.ndarray is called, cupy's op is the last chance.
@@ -2350,25 +2351,26 @@ cdef inline _carray.mdspan _mdspan_from_ndarray(
     # Creates mdspan from ndarray.
     # Note that this function cannot be defined in _carray.pxd because that
     # would cause cyclic cimport dependencies.
-    global _MDSPAN_SUPPORTED_INDEX_TYPES, _MDSPAN_INDEX_TYPE_TO_ITEMSIZE
-
     cdef _carray.mdspan carr
     cdef int index_itemsize
+    cdef dict supported_index_types
 
     # Initialize cached constants on first use (avoid circular import)
-    if _MDSPAN_SUPPORTED_INDEX_TYPES is None:
-        _MDSPAN_SUPPORTED_INDEX_TYPES = (cupy.int32, cupy.int64)
-        _MDSPAN_INDEX_TYPE_TO_ITEMSIZE = {cupy.int32: 4, cupy.int64: 8}
+    supported_index_types = _MDSPAN_SUPPORTED_INDEX_TYPES.get()
+    if supported_index_types is None:
+        supported_index_types = _MDSPAN_SUPPORTED_INDEX_TYPES.setdefault({
+            cupy.int32: 4,
+            cupy.int64: 8,
+        })
 
     carr = _carray.mdspan.__new__(_carray.mdspan)
 
-    # Use dict lookup with membership check for validation
-    if index_type not in _MDSPAN_SUPPORTED_INDEX_TYPES:
+    index_itemsize = supported_index_types.get(index_type, -1)
+    if index_itemsize == -1:
         raise ValueError(
             f"Unsupported index_type: {index_type}. "
             "Must be cupy.int32 or cupy.int64."
         )
-    index_itemsize = _MDSPAN_INDEX_TYPE_TO_ITEMSIZE[index_type]
 
     # Validate that array size fits in index_type
     if index_type == cupy.int32 and arr.size > INT32_MAX:
@@ -2402,8 +2404,9 @@ _HANDLED_TYPES = (ndarray, numpy.ndarray)
 # TODO(niboshi): Move it out of core.pyx
 
 cdef bint _is_hip = runtime._is_hip_environment
-cdef str _cuda_include_dir = ''  # '' for uninitialized, None for non-existing
-cdef str _rocm_include_dir = ''  # '' for uninitialized, None for non-existing
+# Lazily resolved include dirs.
+cdef cached_object _cuda_include_dir
+cdef cached_object _rocm_include_dir
 
 cdef list cupy_header_list = [
     'cupy/complex.cuh',
@@ -2445,44 +2448,42 @@ cdef list _cupy_extra_header_list = [
     'cupy/complex/catrigf.h',
 ]
 
-cdef str _header_path_cache = None
-cdef str _header_source = None
-cdef dict _header_source_map = {}
 
-
-cpdef str _get_header_dir_path():
-    global _header_path_cache
-    if _header_path_cache is None:
-        # Cython cannot use __file__ in global scope
-        _header_path_cache = os.path.abspath(
+cpdef str _init_header_dir_path():
+    # Cython cannot use __file__ in global scope
+    return os.path.abspath(
             os.path.join(os.path.dirname(__file__), 'include'))
-    return _header_path_cache
+
+
+cdef str _header_dir_path = _init_header_dir_path()
+cdef cached_object _header_source_cache
+cdef dict _header_source_map = {}
 
 
 cpdef tuple _get_cccl_include_options():
     # the search paths are made such that they resemble the layout in CTK
-    return (f"-I{_get_header_dir_path()}/cupy/_cccl/cub",
-            f"-I{_get_header_dir_path()}/cupy/_cccl/thrust",
-            f"-I{_get_header_dir_path()}/cupy/_cccl/libcudacxx")
+    return (f"-I{_header_dir_path}/cupy/_cccl/cub",
+            f"-I{_header_dir_path}/cupy/_cccl/thrust",
+            f"-I{_header_dir_path}/cupy/_cccl/libcudacxx")
 
 
 cpdef str _get_header_source():
-    global _header_source
     global _header_source_map
     cdef str header_path, base_path, file_path, header
     cdef list source
+    cdef object header_source = _header_source_cache.get()
 
-    if _header_source is None or not _header_source_map:
+    if header_source is None or not _header_source_map:
         source = []
-        base_path = _get_header_dir_path()
+        base_path = _header_dir_path
         for file_path in _cupy_extra_header_list + cupy_header_list:
             header_path = os.path.join(base_path, file_path)
             with open(header_path) as header_file:
                 header = header_file.read()
             source.append(header)
             _header_source_map[file_path.encode()] = header.encode()
-        _header_source = '\n'.join(source)
-    return _header_source
+        header_source = _header_source_cache.setdefault('\n'.join(source))
+    return header_source
 
 
 cpdef dict _get_header_source_map():
@@ -2532,6 +2533,8 @@ cpdef warn_on_unsupported_std(tuple options):
 
 
 cpdef tuple assemble_cupy_compiler_options(tuple options):
+    cdef cpp_bool initialized
+
     if use_default_std(options):
         options += ('--std=c++17',)
     else:
@@ -2541,32 +2544,36 @@ cpdef tuple assemble_cupy_compiler_options(tuple options):
         # make sure bundled CCCL is searched first
         options = (_get_cccl_include_options() + options)
 
-    options += ('-I%s' % _get_header_dir_path(),)
+    options += ('-I%s' % _header_dir_path,)
 
     if not _is_hip:
-        global _cuda_include_dir
-        if _cuda_include_dir == '':
+        cuda_include_dir = _cuda_include_dir.get(&initialized)
+        if not initialized:
             from cuda.pathfinder import find_nvidia_header_directory
-            _cuda_include_dir = find_nvidia_header_directory('cudart')
-        if _cuda_include_dir is None:
+            cuda_include_dir = _cuda_include_dir.setdefault(
+                find_nvidia_header_directory('cudart'))
+
+        if cuda_include_dir is None:
             raise RuntimeError(
                 'Failed to find CUDA headers. Please install CUDA toolkit '
                 'headers (e.g., pip install cupy-cuda12x[ctk]) or specify '
                 'CUDA_PATH environment variable.')
-        options += ('-I' + _cuda_include_dir,)
+        options += ('-I' + cuda_include_dir,)
     else:
-        global _rocm_include_dir
-        if _rocm_include_dir == '':
+        rocm_include_dir = _rocm_include_dir.get(&initialized)
+        if not initialized:
             _rocm_path = cuda.get_rocm_path()
             if _rocm_path is not None:
-                _rocm_include_dir = os.path.join(_rocm_path, 'include')
+                rocm_include_dir = os.path.join(_rocm_path, 'include')
             else:
-                _rocm_include_dir = None
-        if _rocm_include_dir is None:
+                rocm_include_dir = None
+            rocm_include_dir = _rocm_include_dir.setdefault(rocm_include_dir)
+
+        if rocm_include_dir is None:
             raise RuntimeError(
                 'Failed to auto-detect ROCm root directory. '
                 'Please specify `ROCM_HOME` environment variable.')
-        options += ('-I' + _rocm_include_dir,)
+        options += ('-I' + rocm_include_dir,)
 
     return options
 

--- a/cupy/_core/fusion.pyx
+++ b/cupy/_core/fusion.pyx
@@ -1,6 +1,9 @@
+# distutils: language = c++
+
 from cupy._core cimport _accelerator
 from cupy._core._accelerator cimport ACCELERATOR_CUB
 from cupy._core._scalar cimport get_typename, _get_cuda_scalar_repr
+from cupy._core.internal cimport cached_object
 
 import functools
 import string
@@ -971,13 +974,13 @@ def _create_astype_ufunc(dtype):
     return core.create_ufunc(name, rules, command)
 
 
-_dtype_to_astype_dict = None
+cdef cached_object _dtype_to_astype_dict
 
 
 def _dtype_to_astype(dtype):
-    global _dtype_to_astype_dict
-    if _dtype_to_astype_dict is None:
-        _dtype_to_astype_dict = dict([
+    cdef object astype_dict = _dtype_to_astype_dict.get()
+    if astype_dict is None:
+        astype_dict = _dtype_to_astype_dict.setdefault(dict([
             (dt, _create_astype_ufunc(dt))
-            for dt in _dtype_list])
-    return _dtype_to_astype_dict[dtype]
+            for dt in _dtype_list]))
+    return astype_dict[dtype]

--- a/cupy/_core/internal.pxd
+++ b/cupy/_core/internal.pxd
@@ -7,6 +7,71 @@ from cupy._core._carray cimport strides_t
 from cupy._core.core cimport _ndarray_base
 
 
+cdef extern from *:
+    """
+    #include <atomic>
+
+    class cached_object {
+    private:
+        std::atomic<PyObject*> ptr;
+
+    public:
+        cached_object() : ptr(nullptr) {}
+        cached_object(const cached_object&) = delete;
+        cached_object& operator=(const cached_object&) = delete;
+        ~cached_object() {
+            PyObject *val = ptr.exchange(nullptr, std::memory_order_relaxed);
+            if (val && Py_IsInitialized()) {
+                Py_DECREF(val);
+            }
+        }
+
+        PyObject* get(bool *initialized = nullptr) const {
+            PyObject* o = ptr.load(std::memory_order_acquire);
+            if (initialized) {
+                *initialized = (o != nullptr);
+            }
+            if (o != nullptr) {
+                Py_INCREF(o);
+                return o;
+            }
+            Py_RETURN_NONE;
+        }
+
+        bool initialized() const {
+            // NOTE: Using memory_order_acquire so that true means it is fully
+            // initialized with all side-effects.
+            return ptr.load(std::memory_order_acquire) != nullptr;
+        }
+
+        // Install ``value`` iff nothing is stored yet; always return the
+        // stored value (with a new strong reference for the caller).
+        PyObject* setdefault(PyObject* value) {
+            Py_INCREF(value);
+            PyObject* expected = nullptr;
+            if (!ptr.compare_exchange_strong(
+                    expected, value,
+                    std::memory_order_release,  // wrote value: release
+                    std::memory_order_acquire)  // read value: acquire
+                ) {
+                Py_DECREF(value);
+                value = expected;
+            }
+            Py_INCREF(value);
+            return value;
+        }
+    };
+    """
+    cppclass cached_object:
+        cached_object() except +
+        # Get the stored value or None.
+        object get()
+        # Also return if already initialized (useful if None is valid).
+        object get(cpp_bool *initialized)
+        cpp_bool initialized() const
+        object setdefault(object value)
+
+
 cpdef Py_ssize_t prod(const vector.vector[Py_ssize_t]& args) noexcept
 
 cpdef Py_ssize_t prod_sequence(object args)

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -314,6 +314,7 @@ def _jitify_prep(source, options, cu_path):
     global _jitify_header_source_map_populated
     if not _jitify_header_source_map_populated:
         from cupy._core import core
+        jitify._init_module()
         jitify._add_sources(core._get_header_source_map())
         _jitify_header_source_map_populated = True
 

--- a/cupy/cuda/compiler.py
+++ b/cupy/cuda/compiler.py
@@ -314,7 +314,6 @@ def _jitify_prep(source, options, cu_path):
     global _jitify_header_source_map_populated
     if not _jitify_header_source_map_populated:
         from cupy._core import core
-        jitify._init_module()
         jitify._add_sources(core._get_header_source_map())
         _jitify_header_source_map_populated = True
 

--- a/cupy/cuda/cufft.pyx
+++ b/cupy/cuda/cufft.pyx
@@ -1,3 +1,5 @@
+# distutils: language = c++
+
 cimport cython  # NOQA
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.string cimport memset as c_memset
@@ -25,27 +27,30 @@ cdef F_cufftXtSetJITCallback _cufftXtSetJITCallback
 
 # ****************** SoftLink utilities ******************
 
+# NOTE: Need a mutex to safely init the callback and the owner _L
+cdef cython.pymutex _init_mutex
 cdef SoftLink _L = None
 
 cdef inline void initialize() except *:
     global _L
-    if _L is not None:
-        return
-    _L = _initialize()
+    with _init_mutex:
+        if _L is not None:
+            return
+        _L = _initialize_locked()
 
-cdef SoftLink _initialize():
-    _L = _get_softlink()
-
+cdef SoftLink _initialize_locked() except *:
     global _cufftXtSetJITCallback
+    cdef SoftLink L = _get_softlink()
+
     if CUPY_CUDA_VERSION < 13000:
         # __cufftXtSetJITCallback_12_7
-        _cufftXtSetJITCallback = <F_cufftXtSetJITCallback>_L.get(
+        _cufftXtSetJITCallback = <F_cufftXtSetJITCallback>L.get(
             'XtSetJITCallback_12_7')
     else:
-        _cufftXtSetJITCallback = <F_cufftXtSetJITCallback>_L.get(
+        _cufftXtSetJITCallback = <F_cufftXtSetJITCallback>L.get(
             'XtSetJITCallback')
 
-    return _L
+    return L
 
 cdef SoftLink _get_softlink():
     cdef int runtime_version

--- a/cupy/cuda/jitify.pyx
+++ b/cupy/cuda/jitify.pyx
@@ -7,6 +7,8 @@ from libcpp.map cimport map as cpp_map
 from libcpp.string cimport string as cpp_str
 from libcpp.vector cimport vector
 
+cimport cython
+
 import json
 import os
 import re
@@ -92,6 +94,7 @@ cpdef str get_cuda_version():
 cdef cpp_map[cpp_str, cpp_str] cupy_headers
 
 # Module-level constants
+cdef cython.pymutex _jitify_init_mutex
 cdef bint _jitify_init = False
 cdef str _jitify_cache_dir = None
 cdef str _jitify_cache_versions = None
@@ -218,7 +221,7 @@ cdef inline void _init_cupy_headers() except*:
     _init_cupy_headers_from_scratch()
 
 
-cpdef void _init_module() except*:
+cpdef void _init_module_locked() except*:
     if _jitify_init:
         return
 
@@ -243,6 +246,11 @@ cpdef void _init_module() except*:
             f"{get_cuda_version()}_{build_num}_{cupy_cache_key.decode()}")
 
     _init_cupy_headers()
+
+
+cpdef void _init_module() except*:
+    with _jitify_init_mutex:
+        _init_module_locked()
 
 
 # Use Jitify's internal mechanism to search all included headers, and return

--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -1,9 +1,12 @@
+# distutils: language = c++
+
 from libc.stdint cimport intptr_t, uint64_t, int32_t, int64_t, uint32_t
 from libc.string cimport memcpy
 
 import numpy
 
 import cupy
+from cupy._core.internal cimport cached_object
 from cupy import _core
 from cupy.cuda cimport stream
 from cupy.cuda.function cimport CPointer
@@ -1092,7 +1095,7 @@ cdef class _FeistelBijectionParam(CPointer):
         self.ptr = <intptr_t>(&self.struct)
 
 
-cdef object _feistel_bijection_with_cutoff_kernel = None
+cdef cached_object _feistel_bijection_with_cutoff_kernel
 
 
 cdef inline uint64_t get_cipher_bits(uint64_t m) nogil noexcept:
@@ -1162,9 +1165,10 @@ cdef class FeistelBijection:
         Returns:
             cupy.RawKernel: The compiled CUDA kernel for the bijection
         """
-        global _feistel_bijection_with_cutoff_kernel
-        if _feistel_bijection_with_cutoff_kernel is None:
-            _feistel_bijection_with_cutoff_kernel = cupy.RawKernel(rf'''
+        kernel = _feistel_bijection_with_cutoff_kernel.get()
+        if kernel is None:
+            kernel = _feistel_bijection_with_cutoff_kernel.setdefault(
+                cupy.RawKernel(rf'''
             #if defined(__HIPCC_RTC__) || defined(__HIPCC__)
             #include <stdint.h>
             #else
@@ -1219,8 +1223,8 @@ cdef class FeistelBijection:
                 }}
             }}
             '''  # noqa: E501
-            , 'feistel_bijection_choice')
-        return _feistel_bijection_with_cutoff_kernel
+            , 'feistel_bijection_choice'))
+        return kernel
 
     def __call__(self, size):
         kernel = self.get_kernel()


### PR DESCRIPTION
Fix most occurances with a `cached_object` helper.  We could also just use a global in principle, but maybe this is fine (honestly, I don't think it will be measurable in practice speed wise).

Cython really needs to have atomicity guarantees for globals probably (which I guess will require some form of critical section, but...)

The alternative is to just use plain Python exposed definitions, those will go to the module dict and thus be safe.

Closes gh-10080

**NOTE: This is a maximalist solution with a new helper.  Perfectly fine, but a bit over-engineered.  So happy to replace this with just using Python globals which are "safe enough" (but not `setdefault()` safe). -- the mutex is a real fix, though.**

CC @yangcal in case you want to have a look.  I couldn't actually reproduce your failure locally, but there are more anyway...