### PR TITLE
fix build incompatibility with cuda-python + cu13

### DIFF
--- a/cupy_backends/cuda/api/driver.pyx
+++ b/cupy_backends/cuda/api/driver.pyx
@@ -145,7 +145,10 @@ cpdef intptr_t ctxCreate(Device dev) except? 0:
     cdef Context ctx
     cdef unsigned int flags = 0
     with nogil:
-        status = cuCtxCreate(&ctx, flags, dev)
+        IF CUPY_USE_CUDA_PYTHON and CUPY_CUDA_VERSION >= 13000:
+            status = cuCtxCreate(&ctx, NULL, flags, dev)
+        ELSE:
+            status = cuCtxCreate(&ctx, flags, dev)
     check_status(status)
     return <intptr_t>ctx
 

--- a/cupy_backends/cuda/api/runtime.pxd
+++ b/cupy_backends/cuda/api/runtime.pxd
@@ -89,6 +89,7 @@ IF CUPY_USE_CUDA_PYTHON:
     ctypedef cudaMemAllocationType MemAllocationType
     ctypedef cudaMemAllocationHandleType MemAllocationHandleType
     ctypedef cudaMemLocationType MemLocationType
+    ctypedef cudaMemLocation _MemLocation
 
 ELSE:
     include "_runtime_typedef.pxi"


### PR DESCRIPTION
This PR addresses a bug uncovered by https://github.com/cupy/cupy/pull/10126 and add CUDA Python build compatibility for CUDA13.


## Changes

- Use CUDA 13's `cuCtxCreate_v4` signature when building with CUDA Python:
  - CUDA 13: `cuCtxCreate(&ctx, NULL, flags, dev)`
  - CUDA 12: retain the three-argument call
- Add the missing `cudaMemLocation` type alias required by CUDA Python 13
