### PR TITLE
Fix libcufft_static.a lookup when the CUDA path is a targets directory

### DIFF
--- a/cupy/fft/_callback.pyx
+++ b/cupy/fft/_callback.pyx
@@ -223,9 +223,26 @@ cdef dict _cc_major_map = {
 
 cdef inline str _prune(str temp_dir, str cache_dir, str _cufft_ver, str arch):
     cdef str cufft_lib_full, cufft_lib_pruned, cufft_lib_temp, cufft_lib_cached
+    cdef str libdir, candidate
 
     if _nvprune:
-        cufft_lib_full = os.path.join(_cuda_path, 'lib64/libcufft_static.a')
+        # _cuda_path may point to either the CUDA Toolkit root (which has
+        # lib64/ on Linux) or a targets/<arch> directory (which has lib/
+        # only; e.g. conda, or a system CTK located via cuda.pathfinder),
+        # so probe both layouts.
+        cufft_lib_full = None
+        for libdir in ('lib64', 'lib'):
+            candidate = os.path.join(_cuda_path, libdir, 'libcufft_static.a')
+            if os.path.isfile(candidate):
+                cufft_lib_full = candidate
+                break
+        if cufft_lib_full is None:
+            # cannot locate the static library; fall back to linking the
+            # full one via nvcc's default library search paths
+            warnings.warn(
+                'libcufft_static.a not found under ' + _cuda_path,
+                RuntimeWarning)
+            return None
         cufft_lib_pruned = f'cufft_static_{_cufft_ver}_sm{arch[0]}'
         cufft_lib_temp = os.path.join(temp_dir,
                                       'lib' + cufft_lib_pruned + '.a')


### PR DESCRIPTION
Fix #10133.

Since #9853, `get_cuda_path()` may return a `targets/<arch>` directory — a system CTK resolved via `cuda.pathfinder`, or conda — which contains `lib/` but no `lib64/`. `_prune()` composed the cuFFT static library path as `_cuda_path + 'lib64/libcufft_static.a'`, which only exists under a toolkit root.

The bug stayed dormant because `find_nvidia_binary_utility("nvprune")` returned `None` in such environments, so pruning was skipped with a `RuntimeWarning`. cuda-pathfinder 1.6.0 (released 2026-07-21) added a CTK-root canary fallback to the binary finder (NVIDIA/cuda-python#2196): nvprune is now found, `_prune()` runs, and every test in `tests/cupy_tests/fft_tests/test_callback.py` fails with

    nvprune fatal   : Could not open input file '/usr/local/cuda-12.0/targets/x86_64-linux/lib64/libcufft_static.a'

Since the `cuda-pathfinder==1.*,>=1.3.4` requirement floats, CI picked up 1.6.0 with no repo change — per-PR pipelines on `main` and `v14` have been red since 2026-07-21 (e.g. [cupy.linux.cuda120/223030](https://ci.preferred.jp/cupy.linux.cuda120/223030/), [cupy.linux.cuda129/223039](https://ci.preferred.jp/cupy.linux.cuda129/223039/)).

**Fix:** probe `lib64/` then `lib/` under `_cuda_path`; if `libcufft_static.a` is not found, warn and fall back to linking the full static library through nvcc's default search paths — the same behavior CI ran green with while pruning was inactive (cf. `RuntimeWarning: nvprune is not found` in [green logs](https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/222720/log.txt) up to Jul 20).

**Validation** in the `cupy.linux.cuda120` CI image (built locally via `.pfnci/linux/run.sh cuda120 build`; RTX A6000; `-k test_fft_load_aux` subset of `test_callback.py`):

| build | cuda-pathfinder | result |
|---|---|---|
| v14 unpatched | 1.6.0 | 1 failed (`CalledProcessError` above) |
| v14 unpatched | 1.5.6 | 48 passed (pruning skipped + `RuntimeWarning`) |
| v14 + this patch | 1.6.0 | 48 passed, pruning active (`libcufft_static_11001_sm8.a` generated in the callback cache) |

The patch applies cleanly to `v14` (backport needed — both branches are affected).