### PR TITLE
Relax ndimage label output dtype

### DIFF
--- a/cupyx/scipy/ndimage/_measurements.py
+++ b/cupyx/scipy/ndimage/_measurements.py
@@ -66,8 +66,6 @@ def label(input, structure=None, output=None):
             )
         else:
             output = cupy.empty(input.shape, output)
-    if output.dtype.kind not in 'iu':
-        raise TypeError("output dtype must be an integer type")
 
     # handle scalars, 0-D arrays
     if input.ndim == 0 or input.size == 0:

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_measurements.py
@@ -40,7 +40,9 @@ def _generate_binary_structure(rank, connectivity):
     'connectivity': [None, 2, 3],
     'x_dtype': [bool, numpy.int8, numpy.int32, numpy.int64,
                 numpy.float32, numpy.float64],
-    'output': [None, numpy.int32, numpy.int64],
+    # Mostly integers make sense, but SciPy allows a bit more
+    # (CuPy may allows most dtypes but checks label overflow.)
+    'output': [None, numpy.int32, numpy.int64, numpy.float32],
     'o_type': [None, 'ndarray']
 }))
 @testing.with_requires('scipy')


### PR DESCRIPTION
This reverts the check to roughly what it was previously allowing almost all dtypes pass (SciPy may be slightly less relaxed). The main thing is that SciPy does allow and test for float32 whether that makes much sense or not.
I.e. this may not be perfect, but it is what we had and it fixes the regression.

Closes gh-10041