### PR TITLE
Document cupy.lib.stride_tricks.sliding_window_view in API reference

### DIFF
--- a/docs/source/reference/indexing.rst
+++ b/docs/source/reference/indexing.rst
@@ -43,6 +43,7 @@ Indexing-like operations
    select
    # TODO(kmaehashi): create a dedicated page for cupy.lib namespace
    lib.stride_tricks.as_strided
+   lib.stride_tricks.sliding_window_view
 
 Inserting data into arrays
 --------------------------


### PR DESCRIPTION
## What
Adds `lib.stride_tricks.sliding_window_view` to the Sphinx API reference (`docs/source/reference/indexing.rst`), right alongside its sibling `lib.stride_tricks.as_strided`.

## Why
Addresses one item from #4902 (Minor Documentation Issues): `cupy.lib.stride_tricks.sliding_window_view` has a complete docstring in `cupy/lib/stride_tricks.py`, but was never added to the reference, so it doesn't render in the docs or the [comparison table](https://docs.cupy.dev/en/latest/reference/comparison.html).

I checked the rest of #4902's "Missing API Reference" checklist (`cupy.max`, `cupy.min`, `cupy.ndim`, `cupy.round`, `cupy.size`, and the `cupyx.scipy.linalg`/`cupyx.scipy.special` items) against current `main`, and all of those are already documented — this appears to be the one remaining gap, so I'm scoping this PR to just that.

## How validated
- [x] `pre-commit run` on the changed file passes (docs-only change, no build required to author)
- [ ] No CUDA available locally to build the full docs/verify Sphinx rendering; the entry mirrors the existing `as_strided` line directly above it in the same autosummary block, so the directive format matches a working example exactly.

## Notes
Small, single-line, self-contained fix — no other changes.