### PR TITLE
Fix int64/uint64 corruption in separable min/max filters

### DIFF
--- a/cupyx/scipy/ndimage/_filters.py
+++ b/cupyx/scipy/ndimage/_filters.py
@@ -897,6 +897,21 @@ def maximum_filter(input, size=None, footprint=None, output=None,
                               cval, origin, 'max', axes)
 
 
+def _is_large_int_dtype(dtype):
+    # 64-bit integers cannot be represented exactly by a double intermediate
+    # (only a 53-bit mantissa), so the min/max filter kernels must use the
+    # native type for these. See AIOSS-5814.
+    return dtype.kind in 'iu' and dtype.itemsize > 4
+
+
+def _min_or_max_cval(cval, dtype):
+    # Embed the constant fill value using the native input type for integer
+    # inputs so that large 64-bit fill values are not truncated by float().
+    if dtype.kind in 'iu' and numpy.isfinite(cval):
+        return int(cval)
+    return float(cval)
+
+
 def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
                        origin, func, axes):
     # structure is used by morphology.grey_erosion() and grey_dilation()
@@ -937,10 +952,12 @@ def _min_or_max_filter(input, size, ftprnt, structure, output, mode, cval,
         )
 
     offsets = _filters_core._origins_to_offsets(origins, ftprnt.shape)
+    cval = _min_or_max_cval(cval, input.dtype)
     kernel = _get_min_or_max_kernel(modes, ftprnt.shape, func,
-                                    offsets, float(cval), int_type,
+                                    offsets, cval, int_type,
                                     has_structure=structure is not None,
-                                    has_central_value=bool(ftprnt[offsets]))
+                                    has_central_value=bool(ftprnt[offsets]),
+                                    large_int=_is_large_int_dtype(input.dtype))
     return _filters_core._call_kernel(kernel, input, ftprnt, output,
                                       structure, weights_dtype=bool)
 
@@ -1008,7 +1025,9 @@ def _min_or_max_1d(input, size, axis=-1, output=None, mode="reflect", cval=0.0,
         input, ftprnt, mode, origin, 'footprint', axes=None)
     offsets = _filters_core._origins_to_offsets(origins, ftprnt.shape)
     kernel = _get_min_or_max_kernel(modes, ftprnt.shape, func, offsets,
-                                    float(cval), int_type, has_weights=False)
+                                    _min_or_max_cval(cval, input.dtype),
+                                    int_type, has_weights=False,
+                                    large_int=_is_large_int_dtype(input.dtype))
     return _filters_core._call_kernel(kernel, input, None, output,
                                       weights_dtype=bool)
 
@@ -1016,13 +1035,20 @@ def _min_or_max_1d(input, size, axis=-1, output=None, mode="reflect", cval=0.0,
 @cupy._util.memoize(for_each_device=True)
 def _get_min_or_max_kernel(modes, w_shape, func, offsets, cval, int_type,
                            has_weights=True, has_structure=False,
-                           has_central_value=True):
+                           has_central_value=True, large_int=False):
     # When there are no 'weights' (the footprint, for the 1D variants) then
-    # we need to make sure intermediate results are stored as doubles for
-    # consistent results with scipy.
-    ctype = 'X' if has_weights else 'double'
+    # we normally store intermediate results as doubles for consistent results
+    # with scipy. However, for 64-bit integer inputs a double intermediate
+    # would silently corrupt values greater than 2**53 (and is undefined
+    # behavior at INT64_MAX) due to the limited 53-bit mantissa. In that case
+    # we keep the native input type ``X`` as the intermediate instead. Since
+    # min/max filters only ever select an existing element (no arithmetic on
+    # the values), using the native type is exact and does not change results
+    # for any other dtype. See AIOSS-5814.
+    use_double = not has_weights and not large_int
+    ctype = 'double' if use_double else 'X'
     value = '{value}'
-    if not has_weights:
+    if use_double:
         value = 'cast<double>({})'.format(value)
 
     # Having a non-flat structure biases the values

--- a/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
+++ b/tests/cupyx_tests/scipy_tests/ndimage_tests/test_filters.py
@@ -1103,3 +1103,93 @@ class TestOutputOverlapsInput:
         a_np = testing.shaped_random((5, 6), numpy, numpy.float64)
         expected = scipy.ndimage.generic_filter(a_np, numpy.mean, size=3)
         testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.int64, numpy.uint64],
+    'func': ['minimum', 'maximum'],
+}))
+class TestMinMaxFilterLargeInt:
+    # Regression tests for AIOSS-5814: the separable 1D min/max filter path
+    # used a ``double`` intermediate, which corrupts 64-bit integer values
+    # greater than 2**53 via an ``int64 -> double -> int64`` round-trip.
+    #
+    # NumPy (not SciPy) is used as the correctness oracle here: SciPy's own
+    # ndimage min/max filters share the same double-intermediate bug, so they
+    # cannot be used as a reference for int64/uint64.
+
+    def _values(self, xp):
+        info = numpy.iinfo(self.dtype)
+        # A value that is NOT exactly representable in float64 (> 2**53),
+        # plus the type extremes where the double round-trip is UB.
+        return [
+            self.dtype(2 ** 62 + 12345),
+            self.dtype(info.max),
+            self.dtype(info.min),
+            self.dtype(2 ** 53 + 1),
+        ]
+
+    def test_constant_array_is_identity_1d(self):
+        # A min/max filter over a constant array must return that constant.
+        for val in self._values(cupy):
+            a = cupy.full(8, val, dtype=self.dtype)
+            for size in (2, 3, 5):
+                out = getattr(cupyx.scipy.ndimage,
+                              self.func + '_filter')(a, size=size)
+                expected = numpy.full(8, val, dtype=self.dtype)
+                testing.assert_array_equal(out, expected)
+
+    def test_constant_array_is_identity_footprint(self):
+        # Non-separable (footprint) path must also be exact.
+        for val in self._values(cupy):
+            a = cupy.full((5, 5), val, dtype=self.dtype)
+            footprint = cupy.array(
+                [[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool)
+            out = getattr(cupyx.scipy.ndimage,
+                          self.func + '_filter')(a, footprint=footprint)
+            expected = numpy.full((5, 5), val, dtype=self.dtype)
+            testing.assert_array_equal(out, expected)
+
+    def test_matches_numpy_reference_1d(self):
+        # Compare against a brute-force NumPy reference (reflect mode).
+        rng = numpy.random.default_rng(0)
+        x = ((numpy.int64(1) << 60)
+             + rng.integers(0, 1 << 20, size=32)).astype(self.dtype)
+        r = 1  # size == 3
+        n = x.size
+        expected = numpy.empty_like(x)
+        red = numpy.minimum if self.func == 'minimum' else numpy.maximum
+        for i in range(n):
+            acc = None
+            for k in range(-r, r + 1):
+                j = i + k
+                if j < 0:
+                    j = -j - 1
+                elif j >= n:
+                    j = 2 * n - j - 1
+                acc = x[j] if acc is None else red(acc, x[j])
+            expected[i] = acc
+        func1d = getattr(cupyx.scipy.ndimage, self.func + '_filter1d')
+        out = func1d(cupy.asarray(x), size=3)
+        testing.assert_array_equal(out, expected)
+
+    def test_large_cval_not_truncated(self):
+        # mode='constant' fill value must not be truncated through float().
+        val = self.dtype(2 ** 62 + 12345)
+        cval = int(2 ** 61 + 777)
+        a = cupy.full(6, val, dtype=self.dtype)
+        n = a.size
+        r = 1
+        x = numpy.full(n, int(val), dtype=object)
+        red = min if self.func == 'minimum' else max
+        expected = numpy.empty(n, dtype=self.dtype)
+        for i in range(n):
+            acc = None
+            for k in range(-r, r + 1):
+                j = i + k
+                v = int(x[j]) if 0 <= j < n else cval
+                acc = v if acc is None else red(acc, v)
+            expected[i] = self.dtype(acc)
+        func1d = getattr(cupyx.scipy.ndimage, self.func + '_filter1d')
+        out = func1d(a, size=3, mode='constant', cval=cval)
+        testing.assert_array_equal(out, expected)


### PR DESCRIPTION
## Summary

`cupyx.scipy.ndimage.minimum_filter` / `maximum_filter` (and `minimum_filter1d` / `maximum_filter1d`) silently corrupt `int64`/`uint64` values greater than `2**53` when called with `size=` (the separable **1D kernel path**).

That path uses `double` as the kernel intermediate type, so every element goes through an `int64 -> double -> int64` round-trip. Because `double` has only a 53-bit mantissa, values above `2**53` lose their low-order bits, and at `INT64_MAX` the round-trip is undefined behavior, so the corruption is platform-dependent:

- **AMD HIP (gfx942 / gfx950):** `0x7FFFFFFF00000000` (lower 32 bits zeroed)
- **NVIDIA CUDA:** saturates to `INT64_MAX`
- **x86 CPU (SciPy):** `INT64_MIN`

`cval` (for `mode='constant'`) was additionally passed through `float()`, truncating 64-bit integer fill values.

### Reproducer

```python
import cupy as cp
import cupyx.scipy.ndimage as ndi
import numpy as np

val = 2**62 + 12345
a = cp.full(8, val, dtype=cp.int64)
out = ndi.minimum_filter(a, size=3)   # a min filter over a constant array must return the constant
np.testing.assert_array_equal(cp.asnumpy(out), np.full(8, val, dtype=np.int64))  # FAILS on current main
```

## Fix

Min/max filters only ever *select* an existing element (no arithmetic on the values), so the `double` intermediate was never required for correctness -- it merely matched SciPy, which shares the same bug. This PR:

- Uses the **native input type** as the kernel intermediate for 64-bit integer inputs (via a new `large_int` flag in `_get_min_or_max_kernel()`).
- Embeds `cval` as an integer for integer dtypes so large constant fill values are not truncated by `float()`.
- Leaves behavior for all other dtypes (int32, float32/64, etc.) **byte-for-byte unchanged** -- they continue to use the `double` intermediate.

## Tests

Adds `TestMinMaxFilterLargeInt` with **NumPy as the correctness oracle**. Note that SciPy's own `ndimage` min/max filters share the same double-intermediate bug, so SciPy cannot be used as the reference for `int64`/`uint64`.

Verified on AMD (gfx90a):
- The new tests fail on `main` and pass with this fix.
- The existing min/max filter suite continues to pass (no regressions).