### PR TITLE
Support cuSPARSE SpGEAM types in CUDA 13.4

### DIFF
--- a/cupy_backends/cuda/cupy_cusparse.h
+++ b/cupy_backends/cuda/cupy_cusparse.h
@@ -4,6 +4,15 @@
 #include <cuda.h>
 #include <cusparse.h>
 
+// SpGEAM is public in cuSPARSE 12.8.5. CuPy loads the functions with
+// SoftLink, so older toolkits only need opaque fallback types.
+#if CUSPARSE_VERSION < 12805
+typedef void* cusparseSpGEAMDescr_t;
+typedef int cusparseSpGEAMAlg_t;
+#define CUSPARSE_SPGEAM_ALG_DEFAULT 0
+#define CUSPARSE_SPGEAM_ALG1 1
+#endif
+
 // Functions deleted in cuSparse 11.0
 
 // cuSPARSE Level2 Function

--- a/cupy_backends/cuda/libs/cusparse.pxd
+++ b/cupy_backends/cuda/libs/cusparse.pxd
@@ -81,21 +81,17 @@ ELSE:
 # Types removed in CUDA 12.0+
 IF CUPY_CUDA_VERSION == 0:
     cdef extern from *:
+        """
+        /* SpGEAM is unavailable in HIP and stub builds. */
+        typedef void* cusparseSpGEAMDescr_t;
+        typedef int cusparseSpGEAMAlg_t;
+        #define CUSPARSE_SPGEAM_ALG_DEFAULT 0
+        #define CUSPARSE_SPGEAM_ALG1 1
+        """
         ctypedef void* csrsv2Info_t
         ctypedef void* csrsm2Info_t
         ctypedef void* csrgemm2Info_t
-# TODO(eriknw): cuSPARSE--remove stubs when SpGEAM ships in a public release.
-# The #ifndef guard auto-deactivates when the real header defines these.
 cdef extern from *:
-    """
-    #ifndef CUSPARSE_SPGEAM_ALG_DEFAULT
-    /* SpGEAM not in this cuSPARSE; provide opaque forward decls. */
-    typedef void* cusparseSpGEAMDescr_t;
-    typedef int cusparseSpGEAMAlg_t;
-    #define CUSPARSE_SPGEAM_ALG_DEFAULT 0
-    #define CUSPARSE_SPGEAM_ALG1 1
-    #endif
-    """
     ctypedef void* SpGEAMDescr 'cusparseSpGEAMDescr_t'
     ctypedef int SpGEAMAlg 'cusparseSpGEAMAlg_t'
 


### PR DESCRIPTION
## Summary

- use the cuSPARSE version macro to provide SpGEAM fallback types only before cuSPARSE 12.8.5
- use the public SpGEAM types supplied by newer cuSPARSE headers
- retain fallback declarations for HIP and stub builds

## Root cause

The previous fallback used `#ifndef CUSPARSE_SPGEAM_ALG_DEFAULT`, but
`CUSPARSE_SPGEAM_ALG_DEFAULT` is an enum member rather than a preprocessor
macro. With the cuSPARSE headers shipped in CUDA 13.4, the guard still
activated and redeclared `cusparseSpGEAMAlg_t` and
`cusparseSpGEAMDescr_t`, causing compilation to fail.

This was discovered while validating Windows ARM64 support in #10135, but
the issue is specific to the newer CUDA/cuSPARSE headers and is independent
of the host architecture.

## Testing

- compiled a native ARM64 MSVC translation unit including
  `cupy_backends/cuda/cupy_cusparse.h` against CUDA 13.4
- completed a native Windows ARM64 editable CuPy build with CUDA 13.4 when
  this patch and #10135 were applied together
- exercised the complete 108,390-node test collection with the two patches
  applied together; all executed tests passed with expected skips and xfails
