### PR TITLE
ENH: Add complex output to cupyx.scipy.signal.chirp

### DIFF
--- a/cupyx/scipy/signal/_waveforms.py
+++ b/cupyx/scipy/signal/_waveforms.py
@@ -392,11 +392,10 @@ _chirp_phase_lin_kernel_cplx = cupy.ElementwiseKernel(
     "Y phase",
     """
     const T beta { (f1 - f0) / t1 };
-    const T temp { 2 * M_PI * (f0 * t + 0.5 * beta * t * t) };
-    // Convert  phi to radians.
-    phase = Y(cos(temp + phi), cos(temp + phi + M_PI/2) * -1);
+    const T temp { 2 * M_PI * (f0 * t + 0.5 * beta * t * t) + phi };
+    phase = Y(cos(temp), sin(temp));
     """,
-    "_chirp_phase_lin_kernel",
+    "_chirp_phase_lin_kernel_cplx",
 )
 
 _chirp_phase_quad_kernel = cupy.ElementwiseKernel(
@@ -418,6 +417,25 @@ _chirp_phase_quad_kernel = cupy.ElementwiseKernel(
     "_chirp_phase_quad_kernel",
 )
 
+_chirp_phase_quad_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi, bool vertex_zero",
+    "Y phase",
+    """
+    T temp {};
+    const T beta { (f1 - f0) / (t1 * t1) };
+    if ( vertex_zero ) {
+        temp = 2 * M_PI * (f0 * t + beta * (t * t * t) / 3);
+    } else {
+        temp = 2 * M_PI *
+            ( f1 * t + beta *
+            ( ( (t1 - t) * (t1 - t) * (t1 - t) ) - (t1 * t1 * t1)) / 3);
+    }
+    temp += phi;
+    phase = Y(cos(temp), sin(temp));
+    """,
+    "_chirp_phase_quad_kernel_cplx",
+)
+
 _chirp_phase_log_kernel = cupy.ElementwiseKernel(
     "T t, T f0, T t1, T f1, T phi",
     "T phase",
@@ -433,6 +451,23 @@ _chirp_phase_log_kernel = cupy.ElementwiseKernel(
     phase = cos(temp + phi);
     """,
     "_chirp_phase_log_kernel",
+)
+
+_chirp_phase_log_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi",
+    "Y phase",
+    """
+    T temp {};
+    if ( f0 == f1 ) {
+        temp = 2 * M_PI * f0 * t;
+    } else {
+        T beta { t1 / log(f1 / f0) };
+        temp = 2 * M_PI * beta * f0 * ( pow(f1 / f0, t / t1) - 1.0 );
+    }
+    temp += phi;
+    phase = Y(cos(temp), sin(temp));
+    """,
+    "_chirp_phase_log_kernel_cplx",
 )
 
 _chirp_phase_hyp_kernel = cupy.ElementwiseKernel(
@@ -452,8 +487,33 @@ _chirp_phase_hyp_kernel = cupy.ElementwiseKernel(
     "_chirp_phase_hyp_kernel",
 )
 
+_chirp_phase_hyp_kernel_cplx = cupy.ElementwiseKernel(
+    "T t, T f0, T t1, T f1, T phi",
+    "Y phase",
+    """
+    T temp {};
+    if ( f0 == f1 ) {
+        temp = 2 * M_PI * f0 * t;
+    } else {
+        T sing { -f1 * t1 / (f0 - f1) };
+        temp = 2 * M_PI * ( -sing * f0 ) * log( abs( 1 - t / sing ) );
+    }
+    temp += phi;
+    phase = Y(cos(temp), sin(temp));
+    """,
+    "_chirp_phase_hyp_kernel_cplx",
+)
 
-def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
+
+def _run_chirp_complex_kernel(kernel, t, *args):
+    dtype = cupy.result_type(t.dtype, cupy.complex64)
+    out = cupy.empty(t.shape, dtype=dtype)
+    kernel(t, *args, out)
+    return out
+
+
+def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True, *,
+          complex=False):
     """Frequency-swept cosine generator.
 
     In the following, 'Hz' should be interpreted as 'cycles per unit';
@@ -480,13 +540,17 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
         This parameter is only used when `method` is 'quadratic'.
         It determines whether the vertex of the parabola that is the graph
         of the frequency is at t=0 or t=t1.
+    complex : bool, optional
+        If True, return a complex-valued analytic signal instead of a
+        real-valued signal. Default is False.
 
     Returns
     -------
     y : ndarray
-        A numpy array containing the signal evaluated at `t` with the
-        requested time-varying frequency.  More precisely, the function
-        returns ``cos(phase + (pi/180)*phi)`` where `phase` is the integral
+        An array containing the signal evaluated at `t` with the requested
+        time-varying frequency. More precisely, the function returns
+        ``exp(1j * (phase + (pi/180)*phi))`` if `complex` is True and
+        ``cos(phase + (pi/180)*phi)`` otherwise, where `phase` is the integral
         (from 0 to `t`) of ``2*pi*f(t)``. ``f(t)`` is defined below.
 
     Examples
@@ -535,23 +599,18 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
         t = t.astype(cupy.float64)
 
     phi *= np.pi / 180
-    type = 'real'
 
     if method in ["linear", "lin", "li"]:
-        if type == "real":
-            return _chirp_phase_lin_kernel_real(t, f0, t1, f1, phi)
-        elif type == "complex":
-            # type hard-coded to 'real' above, so this code path is never used
-            if t.real.dtype.kind == 'f' and t.dtype.itemsize == 8:
-                phase = cupy.empty(t.shape, dtype=cupy.complex128)
-            else:
-                phase = cupy.empty(t.shape, dtype=cupy.complex64)
-            _chirp_phase_lin_kernel_cplx(t, f0, t1, f1, phi, phase)
-            return phase
-        else:
-            raise NotImplementedError("No kernel for type {}".format(type))
+        if complex:
+            return _run_chirp_complex_kernel(
+                _chirp_phase_lin_kernel_cplx, t, f0, t1, f1, phi)
+        return _chirp_phase_lin_kernel_real(t, f0, t1, f1, phi)
 
     elif method in ["quadratic", "quad", "q"]:
+        if complex:
+            return _run_chirp_complex_kernel(
+                _chirp_phase_quad_kernel_cplx,
+                t, f0, t1, f1, phi, vertex_zero)
         return _chirp_phase_quad_kernel(t, f0, t1, f1, phi, vertex_zero)
 
     elif method in ["logarithmic", "log", "lo"]:
@@ -560,12 +619,18 @@ def chirp(t, f0, t1, f1, method="linear", phi=0, vertex_zero=True):
                 "For a logarithmic chirp, f0 and f1 must be "
                 "nonzero and have the same sign."
             )
+        if complex:
+            return _run_chirp_complex_kernel(
+                _chirp_phase_log_kernel_cplx, t, f0, t1, f1, phi)
         return _chirp_phase_log_kernel(t, f0, t1, f1, phi)
 
     elif method in ["hyperbolic", "hyp"]:
         if f0 == 0 or f1 == 0:
             raise ValueError(
                 "For a hyperbolic chirp, f0 and f1 must be " "nonzero.")
+        if complex:
+            return _run_chirp_complex_kernel(
+                _chirp_phase_hyp_kernel_cplx, t, f0, t1, f1, phi)
         return _chirp_phase_hyp_kernel(t, f0, t1, f1, phi)
 
     else:

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py
@@ -48,6 +48,67 @@ class TestChirp:
             t=0, f0=10.0, f1=1.0, t1=1.0, method='hyperbolic')
         return w
 
+    @pytest.mark.parametrize('method, f0, f1, vertex_zero', [
+        ('linear', -3.0, 3.0, True),
+        ('lin', -3.0, 3.0, True),
+        ('li', -3.0, 3.0, True),
+        ('quadratic', 1.0, 3.0, True),
+        ('quadratic', 1.0, 3.0, False),
+        ('quad', 1.0, 3.0, True),
+        ('q', 1.0, 3.0, True),
+        ('logarithmic', 1.0, 3.0, True),
+        ('log', 1.0, 3.0, True),
+        ('lo', 1.0, 3.0, True),
+        ('hyperbolic', 3.0, 1.0, True),
+        ('hyp', 3.0, 1.0, True),
+    ])
+    @testing.with_requires('scipy>=1.15.0')
+    @testing.numpy_cupy_allclose(
+        scipy_name='scp', rtol=1e-6, atol=1e-6)
+    def test_complex(
+            self, method, f0, f1, vertex_zero, xp, scp):
+        t = xp.linspace(-0.25, 1.0, 101)
+        return scp.signal.chirp(
+            t, f0, 1.0, f1, method=method, phi=37.0,
+            vertex_zero=vertex_zero, complex=True)
+
+    @pytest.mark.parametrize('dtype, expected_dtype, tol', [
+        (cupy.float32, cupy.complex64, 1e-5),
+        (cupy.float64, cupy.complex128, 1e-12),
+    ])
+    def test_complex_properties(self, dtype, expected_dtype, tol):
+        t = cupy.linspace(0.0, 1.0, 101, dtype=dtype)
+        actual = cupyx.scipy.signal.chirp(
+            t, 1.0, 1.0, 3.0, complex=True)
+        expected_real = cupyx.scipy.signal.chirp(t, 1.0, 1.0, 3.0)
+
+        assert actual.dtype == expected_dtype
+        testing.assert_allclose(
+            actual.real, expected_real, rtol=tol, atol=tol)
+        testing.assert_allclose(
+            cupy.abs(actual), cupy.ones_like(expected_real),
+            rtol=tol, atol=tol)
+
+    @pytest.mark.parametrize('method, f0, f1', [
+        ('logarithmic', 0.0, 1.0),
+        ('hyperbolic', 0.0, 1.0),
+    ])
+    @testing.with_requires('scipy>=1.15.0')
+    def test_complex_invalid_frequency(self, method, f0, f1):
+        for xp, scp in [(cupy, cupyx.scipy), (np, scipy)]:
+            t = xp.linspace(0.0, 1.0, 5)
+            with pytest.raises(ValueError):
+                scp.signal.chirp(
+                    t, f0, 1.0, f1, method=method, complex=True)
+
+    @testing.with_requires('scipy>=1.15.0')
+    def test_complex_keyword_only(self):
+        for xp, scp in [(cupy, cupyx.scipy), (np, scipy)]:
+            t = xp.linspace(0.0, 1.0, 5)
+            with pytest.raises(TypeError):
+                scp.signal.chirp(
+                    t, 1.0, 1.0, 3.0, 'linear', 0.0, True, True)
+
     def test_hyperbolic_zero_freq(self):
         # f0=0 or f1=0 must raise a ValueError.
         method = 'hyperbolic'


### PR DESCRIPTION
## Summary

- add the keyword-only `complex=False` argument to `cupyx.scipy.signal.chirp`
- return an analytic complex exponential for all sweep methods when enabled
- preserve the existing real-valued kernels and default behavior
- add SciPy compatibility and regression coverage

Dedicated complex elementwise kernels keep each complex path to one output allocation and one kernel launch.

Fixes #10029.

## Prior work

This follows #10051. When that PR was closed, @seberg explicitly said the chirp work was a good starting point and could be picked up by another contributor. Relative to that patch, this version uses a shared complex-output helper, gives every new kernel a unique name, and expands coverage to method aliases, negative frequencies, keyword-only behavior, and invalid-frequency inputs.

## Validation

- `python -m pytest tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py -k "TestChirp and complex" -q`: 17 passed
- `python -m pytest tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py -k "TestChirp" -q`: 28 passed
- `python -m pytest tests/cupyx_tests/scipy_tests/signal_tests/test_waveforms.py -q`: 59 passed
- changed-file pre-commit hooks: passed

Test environment:

- NVIDIA RTX 5000 Ada Generation
- driver 560.35.03
- CUDA 12.6 / NVCC 12.6.85
- Linux 6.8.0-78-generic x86_64, glibc 2.39
- Python 3.12.3
- CuPy 15.0.0a1
- NumPy 2.3.5
- SciPy 1.16.3

ROCm was not tested locally.