### PR TITLE
sparse: accept bool, integer, and 16-bit-float value dtypes

### DIFF
--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools as _functools
-
 import numpy as _numpy
 import platform as _platform
 
@@ -65,8 +63,13 @@ class MatDescriptor:
 
 
 def _cast_common_type(*xs):
+    # ``promote_data_types`` falls back to dense CuPy's ufunc promotion for
+    # pairs numpy cannot promote abstractly (bfloat16 with a >= 16-bit int);
+    # only the elementwise callers hit that -- matmul rejects the mix at its
+    # routing gate first.
+    from cupyx.scipy.sparse import _sputils
     dtypes = [x.dtype for x in xs if x is not None]
-    dtype = _functools.reduce(_numpy.promote_types, dtypes)
+    dtype = _sputils.promote_data_types(*dtypes)
     return [x.astype(dtype) if x is not None and x.dtype != dtype else x
             for x in xs]
 
@@ -141,6 +144,43 @@ def _build_indptr(row_indices, n_rows, dtype):
     _cupy.add.at(indptr[1:], row_indices, 1)
     _cupy.cumsum(indptr, out=indptr)
     return indptr
+
+
+def _argsort_major_minor(major, minor, major_count, minor_range):
+    """Return the permutation that sorts entries by ``(major, minor)``.
+
+    Encodes the two coordinates into a single ``major * minor_range + minor``
+    key and radix ``argsort``s it -- one sort instead of the two stable passes
+    ``lexsort`` runs, roughly an order of magnitude faster on millions of
+    entries.  ``minor`` must lie in ``[0, minor_range)`` so the key is
+    order-isomorphic to the ``(major, minor)`` pair.
+
+    ``major`` is cast to int64 before the multiply so an int32 ``major`` does
+    not wrap.  Falls back to a two-key ``lexsort`` when the largest possible
+    key ``major_count * minor_range`` could exceed int64 -- reachable in the
+    int64-index regime, where a sparse matrix may have a logical shape whose
+    product overflows even though it holds few entries.
+
+    Args:
+        major: Per-entry primary sort coordinate (values in
+            ``[0, major_count)``).
+        minor: Per-entry secondary sort coordinate (values in
+            ``[0, minor_range)``).
+        major_count (int): Exclusive upper bound on ``major``; with
+            ``minor_range`` it bounds the composite key.
+        minor_range (int): Exclusive upper bound on ``minor``; the key
+            multiplier.
+
+    Returns:
+        cupy.ndarray: Indices that sort the entries into canonical order.
+    """
+    # Coerce the bounds to Python ints so the overflow check runs in exact
+    # arbitrary precision: a numpy scalar would wrap the product mod 2**64 and
+    # could pass a guard that should have failed, silently corrupting the sort.
+    if int(major_count) * int(minor_range) < (1 << 63):
+        return _cupy.argsort(
+            major.astype(_cupy.int64, copy=False) * minor_range + minor)
+    return _cupy.lexsort(_cupy.stack([minor, major]))
 
 
 def _with_indices_dtype(m, dtype):
@@ -565,6 +605,34 @@ def csrgeam(a, b, alpha=1, beta=1):
         has_canonical_format=True)
 
 
+def _scale_geam_operand(data, coeff):
+    """Scale a geam/gemm operand's ``data`` by ``coeff``.
+
+    The ``+``/``-`` operators only ever pass ``coeff`` of +1 or -1; other
+    values reach here solely via the low-level ``spgemm``/``csrgeam2`` entry
+    points.  Negation wraps for signed and unsigned integers, so ``-data``
+    handles the -1 case.  A general coefficient multiplies through numpy
+    promotion so a fractional coefficient on integer data is not silently
+    truncated (``int64(0.5) == 0``).  ``coeff == 1`` is a no-op returned
+    up front, so it is safe for any dtype including bool (bool SpGEMM keeps
+    its operands as bool -- products are logical AND, sum_duplicates ORs --
+    and only reaches here with the default ``alpha == 1``).
+    """
+    if coeff == 1:
+        return data
+    if data.dtype.kind == 'b':
+        # bool has no negation/scaling; callers scaling bool by a non-unit
+        # coefficient must convert to int8 first.  Raise (rather than assert,
+        # which ``python -O`` strips) so a forgetful caller cannot silently
+        # get an int64 result or cupy's raw "boolean negative" error.
+        raise TypeError(
+            'bool operands must be cast to int8 before scaling by a '
+            'non-unit coefficient')
+    if coeff == -1:
+        return -data
+    return data * coeff
+
+
 def _cupy_csrgeam_int64(a, b, alpha, beta):
     # TODO(eriknw): cuSPARSE--remove once SpGEAM ships across all
     # supported CUDA versions.
@@ -577,11 +645,26 @@ def _cupy_csrgeam_int64(a, b, alpha, beta):
     # a.shape) instead of raising for incompatible operands.
     if a.shape != b.shape:
         raise ValueError('inconsistent shapes')
+    if a.dtype == _numpy.bool_ and b.dtype == _numpy.bool_:
+        # Compute bool +/- in int8 so subtraction follows C-style bool
+        # arithmetic like scipy (True - True -> 0 -> False), then cast back.
+        # The bool ``sum_duplicates`` kernel would instead OR the coalesced
+        # operands, which is wrong for subtraction.  Restage only ``data``:
+        # the coordinate arrays are read, never mutated, so a full ``astype``
+        # would copy them for nothing.
+        c = _cupy_csrgeam_int64(
+            a._with_data(a.data.astype(_numpy.int8), copy=False),
+            b._with_data(b.data.astype(_numpy.int8), copy=False),
+            alpha, beta)
+        return c._with_data(c.data.astype(_numpy.bool_), copy=False)
     idx_dtype = _numpy.result_type(a.indices.dtype, b.indices.dtype)
-    # ``dtype.type(alpha)`` returns a numpy scalar; a 0-d ndarray
-    # (e.g. from ``_numpy.array(alpha)``) would be rejected by CuPy's ufunc.
-    a_data = a.data * a.dtype.type(alpha) if alpha != 1 else a.data
-    b_data = b.data * b.dtype.type(beta) if beta != 1 else b.data
+    # ``alpha``/``beta`` are +1 or -1 (from ``+``/``-``).  Scale by negation
+    # rather than ``data * dtype.type(alpha)``: negating wraps correctly for
+    # every integer dtype (matching scipy), whereas ``uint8(-1)`` etc. raises
+    # an OverflowError.  ``dtype.type`` keeps a numpy scalar for other alphas
+    # (a 0-d ndarray would be rejected by CuPy's ufunc).
+    a_data = _scale_geam_operand(a.data, alpha)
+    b_data = _scale_geam_operand(b.data, beta)
 
     a_rows = _indptr_to_coo(a.indptr, idx_dtype, nnz=a.nnz)
     b_rows = _indptr_to_coo(b.indptr, idx_dtype, nnz=b.nnz)
@@ -616,6 +699,29 @@ def csrgeam2(a, b, alpha=1, beta=1):
         raise TypeError(f'unsupported type (actual: {type(a)})')
     if not _is_csr_type(b):
         raise TypeError(f'unsupported type (actual: {type(b)})')
+
+    from cupyx.scipy.sparse import _sputils
+    # bfloat16 mixed with a >= 16-bit integer has no numpy abstract promotion
+    # (ml_dtypes never registered it), but this is an elementwise op so it
+    # follows dense cupy/numpy, which resolve it through ufunc loops
+    # (-> float32/float64 by width); promote_data_types reproduces that.
+    result_dtype = _sputils.promote_data_types(a.dtype, b.dtype)
+    if _sputils.is_16bit_float(result_dtype):
+        # 16-bit float: upcast to float32, use native cuSPARSE, downcast
+        # (float32 is a lossless widening; keeps the sum in float32).
+        # Restage only ``data`` -- the coordinate arrays are read, never
+        # mutated, so a full ``astype`` would copy them for nothing.
+        c = csrgeam2(a._with_data(a.data.astype(_cupy.float32), copy=False),
+                     b._with_data(b.data.astype(_cupy.float32), copy=False),
+                     alpha, beta)
+        return c._with_data(c.data.astype(result_dtype), copy=False)
+    # Route through the pure-CuPy COO-concatenate fallback only when the
+    # *promoted* result is non-float (bool/integer): a mixed int x float pair
+    # promotes to a cuSPARSE-capable float, so it stays on the fast native
+    # path.  Integer add wraps on overflow, matching numpy/scipy.
+    if _needs_cupy_fallback(result_dtype):
+        a, b = _cast_common_type(a, b)
+        return _cupy_csrgeam_int64(a, b, alpha, beta)
 
     # TODO(eriknw): cuSPARSE--route int32 through spgeam() too when it
     # ships in a public release (see 'spgeam' in _available_cusparse_version).
@@ -1057,10 +1163,14 @@ def csrsort(x):
         return
     m, n = x.shape
 
-    if x.indices.dtype == _cupy.int64:
-        # TODO(eriknw): cuSPARSE--remove when xcsrsort supports int64
+    if x.indices.dtype == _cupy.int64 or _needs_cupy_fallback(x.dtype):
+        # TODO(eriknw): cuSPARSE--remove when xcsrsort supports int64.  The
+        # data-reorder gather (gthr/Gather) is also float/complex-only, so
+        # non-float data takes this pure-CuPy path too.
         row = _indptr_to_coo(x.indptr, nnz=nnz)
-        order = _cupy.lexsort(_cupy.stack([x.indices, row]))
+        # Canonical order sorts by (row, col); col (x.indices) is the minor
+        # coordinate, so its range is n.
+        order = _argsort_major_minor(row, x.indices, m, n)
         x.indices[:] = x.indices[order]
         x.data[:] = x.data[order]
         x.has_sorted_indices = True
@@ -1103,10 +1213,14 @@ def cscsort(x):
         return
     m, n = x.shape
 
-    if x.indices.dtype == _cupy.int64:
-        # TODO(eriknw): cuSPARSE--remove when xcscsort supports int64
+    if x.indices.dtype == _cupy.int64 or _needs_cupy_fallback(x.dtype):
+        # TODO(eriknw): cuSPARSE--remove when xcscsort supports int64.  The
+        # data-reorder gather is also float/complex-only, so non-float data
+        # takes this pure-CuPy path too.
         col = _indptr_to_coo(x.indptr, nnz=nnz)
-        order = _cupy.lexsort(_cupy.stack([x.indices, col]))
+        # Canonical order sorts by (col, row); row (x.indices) is the minor
+        # coordinate, so its range is m.
+        order = _argsort_major_minor(col, x.indices, n, m)
         x.indices[:] = x.indices[order]
         x.data[:] = x.data[order]
         x.has_sorted_indices = True
@@ -1152,16 +1266,20 @@ def coosort(x, sort_by='r'):
         return
     m, n = x.shape
 
-    if x.row.dtype == _cupy.int64:
-        # TODO(eriknw): cuSPARSE--remove when xcoosort supports int64
+    if x.row.dtype == _cupy.int64 or _needs_cupy_fallback(x.dtype):
+        # TODO(eriknw): cuSPARSE--remove when xcoosort supports int64.  The
+        # cuSPARSE data-reorder gather is float/complex + int32-index only,
+        # so bool/integer/16-bit-float data (and int64 indices) permute the
+        # data in pure CuPy here instead.
         if sort_by == 'r':
-            # Sort by (row, col): primary=row, secondary=col
-            order = _cupy.lexsort(_cupy.stack([x.col, x.row]))
+            # (row, col): minor is col, whose range is n.
+            major, minor, major_count, minor_range = x.row, x.col, m, n
         elif sort_by == 'c':
-            # Sort by (col, row): primary=col, secondary=row
-            order = _cupy.lexsort(_cupy.stack([x.row, x.col]))
+            # (col, row): minor is row, whose range is m.
+            major, minor, major_count, minor_range = x.col, x.row, n, m
         else:
             raise ValueError("sort_by must be either 'r' or 'c'")
+        order = _argsort_major_minor(major, minor, major_count, minor_range)
         x.row[:] = x.row[order]
         x.col[:] = x.col[order]
         x.data[:] = x.data[order]
@@ -1189,16 +1307,17 @@ def coosort(x, sort_by='r'):
     else:
         raise ValueError("sort_by must be either 'r' or 'c'")
 
-    if x.dtype.char != '?':
-        if check_availability('gthr'):
-            _call_cusparse(
-                'gthr', x.dtype,
-                handle, nnz, data_orig.data.ptr, x.data.data.ptr,
-                P.data.ptr, _cusparse.CUSPARSE_INDEX_BASE_ZERO)
-        else:
-            desc_x = SpVecDescriptor.create(P, x.data)
-            desc_y = DnVecDescriptor.create(data_orig)
-            _cusparse.gather(handle, desc_y.desc, desc_x.desc)
+    # Only float/complex data reaches here (bool and the other non-'fdFD'
+    # dtypes took the pure-CuPy branch above), so the gather always runs.
+    if check_availability('gthr'):
+        _call_cusparse(
+            'gthr', x.dtype,
+            handle, nnz, data_orig.data.ptr, x.data.data.ptr,
+            P.data.ptr, _cusparse.CUSPARSE_INDEX_BASE_ZERO)
+    else:
+        desc_x = SpVecDescriptor.create(P, x.data)
+        desc_y = DnVecDescriptor.create(data_orig)
+        _cusparse.gather(handle, desc_y.desc, desc_x.desc)
 
     if sort_by == 'c':  # coo canonical order is row-major
         x.has_canonical_format = False
@@ -1281,28 +1400,41 @@ def csr2coo(x, data, indices):
     return A
 
 
+def _needs_cupy_fallback(dtype):
+    """Whether cuSPARSE cannot compute on this *data* dtype.
+
+    cuSPARSE operates only on float32/float64/complex64/complex128
+    (``dtype.char in 'fdFD'``); bool and every integer dtype must route
+    through a pure-CuPy fallback.  This is the value-dtype axis only; int64
+    *indices* are a separate routing axis (``_check_int32_indices`` /
+    ``indices.dtype == int64``).  Some ops need the fallback when either
+    axis applies (see :func:`_transpose_needs_cupy`).
+    """
+    return _numpy.dtype(dtype).char not in 'fdFD'
+
+
 def _transpose_needs_cupy(x):
     """Whether a CSR<->CSC transpose must use the pure-CuPy fallback.
 
     cuSPARSE's ``Csr2cscEx2`` (and legacy ``csr2csc``) support only
     float/complex data with int32 indices, so both int64 indices and a
-    non-float (e.g. ``bool``) data dtype must route through the
+    non-float (e.g. ``bool`` or integer) data dtype must route through the
     dtype-agnostic :func:`_cupy_transpose_compressed`.
     """
-    return x.indices.dtype == _cupy.int64 or x.dtype.char not in 'fdFD'
+    return x.indices.dtype == _cupy.int64 or _needs_cupy_fallback(x.dtype)
 
 
 def _cupy_transpose_compressed(x, output_cls, out_dim):
     """Pure-CuPy CSR<->CSC transpose (int64 indices or non-float data).
 
-    Uses ``_build_indptr`` + ``lexsort`` -- O(nnz log nnz) time, and is
+    Uses ``_build_indptr`` plus a single composite-key radix argsort and is
     dtype-agnostic (it only gathers/reorders the data, never operating on
     the value dtype).  It is the fallback whenever cuSPARSE's float-only,
     int32-only ``Csr2cscEx2`` cannot be used: no Generic API CSR<->CSC
     transpose accepts 64-bit indices (newer sparse Generic APIs such as
     SpGEAM are addition, not transpose), and cuSPARSE has no bool support
-    at all.  For int64 this runs roughly an order of magnitude slower than
-    the int32 ``cusparseCsr2cscEx2`` path.
+    at all.  For int64 this runs a few times slower than the int32
+    ``cusparseCsr2cscEx2`` path.
 
     Args:
         x: Input compressed sparse matrix.
@@ -1325,13 +1457,16 @@ def _cupy_transpose_compressed(x, output_cls, out_dim):
     out_indptr = _build_indptr(x.indices, out_dim, idx_dtype)
     expanded = _indptr_to_coo(x.indptr, nnz=x.nnz)
 
-    # Sort by (output major, output minor) for canonical order.
-    order = _cupy.lexsort(_cupy.stack([expanded, x.indices]))
+    # Canonical order sorts by (output major, output minor): x.indices is the
+    # output major and ``expanded`` (the input's major per entry) is the
+    # output minor, so the input's major count is the output's minor range.
+    in_major = x.indptr.size - 1
+    order = _argsort_major_minor(x.indices, expanded, out_dim, in_major)
 
     # Propagate has_canonical_format only when known True: a canonical
-    # input transposes to a canonical output (lexsort guarantees sort;
+    # input transposes to a canonical output (the sort guarantees ordering;
     # output has duplicates iff input did).  False/None are not
-    # propagated -- the lexsort may make a non-canonical input canonical
+    # propagated -- the sort may make a non-canonical input canonical
     # in the output, so we let the lazy getter recompute.  Read the
     # private attr to avoid triggering ``x``'s lazy kernel ourselves.
     canonical = getattr(x, '_has_canonical_format', None)
@@ -1656,12 +1791,13 @@ class BaseDescriptor:
 class SpMatDescriptor(BaseDescriptor):
 
     @classmethod
-    def create(cls, a):
+    def create(cls, a, is_half_allowed=False):
         if not cupyx.scipy.sparse.issparse(a):
             raise TypeError('expected sparse matrix')
         rows, cols = a.shape
         idx_base = _cusparse.CUSPARSE_INDEX_BASE_ZERO
-        cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
+        cuda_dtype = _dtype.to_cuda_dtype(
+            a.dtype, is_half_allowed=is_half_allowed)
         if a.format == 'csr':
             desc = _cusparse.createCsr(
                 rows, cols, a.nnz, a.indptr.data.ptr, a.indices.data.ptr,
@@ -1708,8 +1844,9 @@ class SpVecDescriptor(BaseDescriptor):
 class DnVecDescriptor(BaseDescriptor):
 
     @classmethod
-    def create(cls, x):
-        cuda_dtype = _dtype.to_cuda_dtype(x.dtype)
+    def create(cls, x, is_half_allowed=False):
+        cuda_dtype = _dtype.to_cuda_dtype(
+            x.dtype, is_half_allowed=is_half_allowed)
         desc = _cusparse.createDnVec(x.size, x.data.ptr, cuda_dtype)
         get = _cusparse.dnVecGet
         destroy = _cusparse.destroyDnVec
@@ -1719,14 +1856,15 @@ class DnVecDescriptor(BaseDescriptor):
 class DnMatDescriptor(BaseDescriptor):
 
     @classmethod
-    def create(cls, a):
+    def create(cls, a, is_half_allowed=False):
         if a.ndim != 2:
             raise ValueError('expected 2-D matrix')
         if not a.flags.f_contiguous:
             raise ValueError('expected F-contiguous array')
         rows, cols = a.shape
         ld = rows
-        cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
+        cuda_dtype = _dtype.to_cuda_dtype(
+            a.dtype, is_half_allowed=is_half_allowed)
         desc = _cusparse.createDnMat(rows, cols, ld, a.data.ptr, cuda_dtype,
                                      _cusparse.CUSPARSE_ORDER_COL)
         get = _cusparse.dnMatGet
@@ -1781,15 +1919,30 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
         y.fill(0)
         return y
 
-    desc_a = SpMatDescriptor.create(a)
-    desc_x = DnVecDescriptor.create(x)
-    desc_y = DnVecDescriptor.create(y)
+    desc_a = SpMatDescriptor.create(a, is_half_allowed=True)
+    desc_x = DnVecDescriptor.create(x, is_half_allowed=True)
+
+    # float16 has no native cuSPARSE accumulate type -- only the mixed
+    # hf16_hf16_f32 mode (data float16, compute float32) -- so stage y in
+    # float32 and downcast, keeping the sparse matrix and x in float16 (no
+    # float32 copy of the potentially large operand).  bfloat16 is not routed
+    # here: CUDA_R_16BF needs compute capability >= 8.0, so bfloat16 matmul
+    # upcasts to float32 upstream instead.
+    half = a.dtype.char == 'e'
+    if half:
+        y_f32 = y.astype(_cupy.float32)
+        desc_y = DnVecDescriptor.create(y_f32)
+        cuda_dtype = _runtime.CUDA_R_32F
+        alpha = _numpy.array(alpha, _numpy.float32).ctypes
+        beta = _numpy.array(beta, _numpy.float32).ctypes
+    else:
+        desc_y = DnVecDescriptor.create(y)
+        cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
+        alpha = _numpy.array(alpha, a.dtype).ctypes
+        beta = _numpy.array(beta, a.dtype).ctypes
 
     handle = _device.get_cusparse_handle()
     op_a = _transpose_flag(transa)
-    alpha = _numpy.array(alpha, a.dtype).ctypes
-    beta = _numpy.array(beta, a.dtype).ctypes
-    cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
     alg = _cusparse.CUSPARSE_MV_ALG_DEFAULT
     buff_size = _cusparse.spMV_bufferSize(handle, op_a, alpha.data,
                                           desc_a.desc, desc_x.desc, beta.data,
@@ -1798,6 +1951,8 @@ def spmv(a, x, y=None, alpha=1, beta=0, transa=False):
     _cusparse.spMV(handle, op_a, alpha.data, desc_a.desc, desc_x.desc,
                    beta.data, desc_y.desc, cuda_dtype, alg, buff.data.ptr)
 
+    if half:
+        y[...] = y_f32.astype(y.dtype)
     return y
 
 
@@ -1879,16 +2034,28 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
                  transa=transa, transb=transb)
         return c
 
-    desc_a = SpMatDescriptor.create(a)
-    desc_b = DnMatDescriptor.create(b)
-    desc_c = DnMatDescriptor.create(c)
+    desc_a = SpMatDescriptor.create(a, is_half_allowed=True)
+    desc_b = DnMatDescriptor.create(b, is_half_allowed=True)
+
+    # float16 mixed precision: hf16_hf16_f32 (see spmv).  Stage c in float32
+    # and downcast, keeping the sparse matrix and b in float16.  bfloat16
+    # upcasts to float32 upstream instead (CUDA_R_16BF needs cc >= 8.0).
+    half = a.dtype.char == 'e'
+    if half:
+        c_f32 = c.astype(_cupy.float32)
+        desc_c = DnMatDescriptor.create(c_f32)
+        cuda_dtype = _runtime.CUDA_R_32F
+        alpha = _numpy.array(alpha, _numpy.float32).ctypes
+        beta = _numpy.array(beta, _numpy.float32).ctypes
+    else:
+        desc_c = DnMatDescriptor.create(c)
+        cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
+        alpha = _numpy.array(alpha, a.dtype).ctypes
+        beta = _numpy.array(beta, a.dtype).ctypes
 
     handle = _device.get_cusparse_handle()
     op_a = _transpose_flag(transa)
     op_b = _transpose_flag(transb)
-    alpha = _numpy.array(alpha, a.dtype).ctypes
-    beta = _numpy.array(beta, a.dtype).ctypes
-    cuda_dtype = _dtype.to_cuda_dtype(a.dtype)
     alg = _cusparse.CUSPARSE_MM_ALG_DEFAULT
     buff_size = _cusparse.spMM_bufferSize(handle, op_a, op_b, alpha.data,
                                           desc_a.desc, desc_b.desc, beta.data,
@@ -1898,6 +2065,8 @@ def spmm(a, b, c=None, alpha=1, beta=0, transa=False, transb=False):
                                desc_b.desc, beta.data, desc_c.desc,
                                cuda_dtype, alg, buff.data.ptr)
 
+    if half:
+        c[...] = c_f32.astype(c.dtype)
     return c
 
 
@@ -2153,7 +2322,18 @@ def denseToSparse(x, format='csr'):
     if x.ndim != 2:
         raise ValueError('expected 2-D matrix')
     if x.dtype.char not in 'fdFD':
-        raise ValueError('unsupported dtype')
+        # TODO(eriknw): cuSPARSE--remove when cusparseDenseToSparse
+        #   supports non-float value types.  The pure-CuPy CSR builder
+        #   and format conversions are dtype-agnostic.
+        from cupyx.scipy.sparse import _csr
+        y = _csr.dense2csr(x)
+        if format == 'csr':
+            return y
+        elif format == 'csc':
+            return y.tocsc()
+        elif format == 'coo':
+            return y.tocoo()
+        raise TypeError('unsupported format (actual: {})'.format(format))
     x = _cupy.asfortranarray(x)
     desc_x = DnMatDescriptor.create(x)
     if format == 'csr':
@@ -2418,6 +2598,16 @@ def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
         _cusparse.spSM_destroyDescr(spsm_descr)
 
 
+def _needs_cupy_spgemm(a, b):
+    # int64 indices or a non-float value dtype must route through the
+    # pure-CuPy SpGEMM fallbacks: cuSPARSE csrgemm/csrgemm2 are
+    # int32/float-only and native SpGEMM lacks integer compute types.
+    return (
+        a.indices.dtype == _cupy.int64
+        or b.indices.dtype == _cupy.int64
+        or _numpy.promote_types(a.dtype, b.dtype).char not in 'fdFD')
+
+
 def _cupy_spgemm_int64(a, b, alpha):
     # TODO(eriknw): cuSPARSE--removable once all supported CUDA versions have
     # native int64 SpGEMM.  Verified working on CUDA 13.0+ (native is
@@ -2428,7 +2618,16 @@ def _cupy_spgemm_int64(a, b, alpha):
     Expands all (i,j,a*b) products into COO, then sum_duplicates.
     O(P log P) time, O(P + nnz_C) space, where P = total products.
     """
+    # Bool operands stay bool: the product ``a*b`` is a logical AND and the
+    # bool ``sum_duplicates`` ORs coincident products, so a cell is True iff
+    # any product is -- exact for any overlap count.  (Casting to int8 like
+    # csrgeam does would overflow: 256 True products wrap to int8(0) -> a
+    # spurious False; csrgeam is safe only because add sums at most 2 values.)
     idx_dtype = _cupy.int64
+    # The int64 expand below is internal; the output should keep the
+    # operands' index dtype (a int32-indexed product stays int32 like the
+    # native path) unless the result is too large to fit.
+    out_idx_dtype = _numpy.result_type(a.indices.dtype, b.indices.dtype)
     # Normalise both operands to int64 (no copy if already int64).
     a_indices = a.indices.astype(idx_dtype, copy=False)
     a_indptr = a.indptr.astype(idx_dtype, copy=False)
@@ -2446,8 +2645,8 @@ def _cupy_spgemm_int64(a, b, alpha):
     if total_products == 0:
         return cupyx.scipy.sparse.csr_matrix._from_parts(
             _cupy.empty(0, a.dtype),
-            _cupy.empty(0, idx_dtype),
-            _cupy.zeros(m + 1, idx_dtype),
+            _cupy.empty(0, out_idx_dtype),
+            _cupy.zeros(m + 1, out_idx_dtype),
             (m, n))
 
     a_src = _cupy.repeat(
@@ -2470,14 +2669,108 @@ def _cupy_spgemm_int64(a, b, alpha):
     c_rows = a_rows[a_src]
     c_vals = a.data[a_src] * b.data[b_col_pos]
     del a_src, b_offset, b_col_pos, a_rows, a_col_k  # free P-sized temporaries
-    if alpha != 1:
-        c_vals = c_vals * a.dtype.type(alpha)
+    # Uint-safe scaling: ``a.dtype.type(-1)`` would raise OverflowError.
+    c_vals = _scale_geam_operand(c_vals, alpha)
 
     # Merge products with the same (row, col) position.
     coo = cupyx.scipy.sparse.coo_matrix._from_parts(
         c_vals, c_rows, c_cols, shape=(m, n))
     coo.sum_duplicates()
-    return coo.tocsr()
+    c = coo.tocsr()
+    # Narrow the indices back to the operands' dtype when the result fits.
+    # ``nnz <= m*n`` and m, n are Python ints, so the cheap m*n bound settles
+    # the usual ``m*n < 2**31`` case without inspecting the result at all.
+    max_idx = _numpy.iinfo(out_idx_dtype).max
+    if c.indptr.dtype != out_idx_dtype and (
+            m * n <= max_idx or int(c.nnz) <= max_idx):
+        c = _with_indices_dtype(c, out_idx_dtype)
+    return c
+
+
+def _cupy_csr_dense_matmul(a, x):
+    """``A @ X`` for value dtypes cuSPARSE ``spmv``/``spmm`` cannot multiply.
+
+    ``a`` is CSR; ``x`` is a dense ``(K,)`` or ``(K, N)`` array.  A 16-bit
+    float result upcasts to float32, multiplies with native cuSPARSE, then
+    downcasts (float32 is a lossless widening) -- faster and lower-memory than
+    the scatter used for bool/integer results.  In practice only bfloat16
+    reaches this branch: float16 has its own native cuSPARSE mixed-precision
+    (f16 data, f32 compute) spmv/spmm path and never falls back here.
+
+    For a bool/integer result each nonzero ``a[i, k]`` scatters
+    ``a[i, k] * x[k]`` into output row ``i``; overlapping rows accumulate.
+    Narrow integers (and bool) accumulate in a 64-bit carrier and wrap on the
+    down-cast, matching numpy/scipy integer matmul (mod ``2**bits``); a bool
+    result becomes True where any product is nonzero.  This exact integer
+    path is why the result is not simply upcast to a float compute type,
+    which would lose precision past 2**53.  Duplicate entries in ``a`` sum
+    naturally, so no ``sum_duplicates`` is required.
+    """
+    from cupyx.scipy.sparse import _sputils
+    # cupy fancy-indexing does not bounds-check the ``x2[a.indices]`` gather
+    # (it clamps), so an unchecked mismatch would return a silently wrong
+    # result where the float path and scipy both raise.
+    if a.shape[1] != x.shape[0]:
+        raise ValueError('dimension mismatch')
+    res_dtype = _numpy.promote_types(a.dtype, x.dtype)
+    if _sputils.is_16bit_float(res_dtype):
+        # 16-bit floats: upcast to float32 and reuse the native cuSPARSE
+        # spmv/spmm path (via ``@``), then downcast.  float32 is a lossless
+        # widening and accumulates the products in float32 exactly like the
+        # scatter, but is faster and uses less peak memory (no nnz x N
+        # products array).  float16 normally uses cuSPARSE's native f16/f32
+        # mixed mode directly; bfloat16 reaches here because its native
+        # CUDA_R_16BF path needs compute capability >= 8.0.
+        return (a.astype(_cupy.float32)
+                @ x.astype(_cupy.float32)).astype(res_dtype)
+    x2 = x[:, None] if x.ndim == 1 else x
+    # cupy.add.at cannot target bool, narrow ints, or bfloat16; accumulate in
+    # a compatible carrier (bool -> int64, so "any product nonzero"; else the
+    # shared int/bfloat16 carrier) and cast back.  Widen the K x N source
+    # before the gather, not the larger nnz x N result of it.
+    acc_dtype = _sputils.add_at_accumulator_dtype(res_dtype)
+    rows = _indptr_to_coo(a.indptr, nnz=a.nnz)
+    n = x2.shape[1]
+    data_acc = a.data[:, None].astype(acc_dtype, copy=False)
+    # The per-nonzero products ``contrib`` are (nnz, block) -- up to
+    # ``nnz / m`` times larger than the (m, block) result -- so materialising
+    # them whole OOMs for a wide dense operand.  Split the dense columns into
+    # blocks sized to free memory; the scatter stays exact (no float64
+    # round-off) at any width.  Within a block ``contrib`` and its gather
+    # source are each (nnz, block) of ``acc_dtype`` and coexist during the
+    # multiply, so budget for 2x that with a safety margin (factor 4).
+    # ``contrib`` is passed straight into ``add.at`` (never name-bound), so it
+    # frees each pass and the peak stays one block.  Count the pool's free
+    # blocks as available -- ``memGetInfo`` alone reports them used and would
+    # over-chunk.  A single dense column cannot be split, so skip the probe
+    # (a host-blocking driver call) entirely for the matvec case.
+    if n == 1:
+        block = 1
+    else:
+        per_col = max(a.nnz * acc_dtype.itemsize, 1)
+        free = (int(_cupy.cuda.runtime.memGetInfo()[0])
+                + int(_cupy.get_default_memory_pool().free_bytes()))
+        block = max(1, min(n, free // (4 * per_col)))
+    if block >= n:
+        # Single block: accumulate straight into the wide carrier, then cast.
+        y = _cupy.zeros((a.shape[0], n), dtype=acc_dtype)
+        _cupy.add.at(y, rows,
+                     data_acc * x2.astype(acc_dtype, copy=False)[a.indices])
+        y = y.astype(res_dtype, copy=False)
+    else:
+        # Near-OOM: keep the (m, n) output in the narrow res_dtype and widen
+        # only each block slice of the operand, casting the block back on
+        # store -- avoids a full-width (m, n) accumulator and a full-width copy
+        # of the dense operand.  Each output column is fully accumulated within
+        # its block, so the per-block cast is exact.
+        y = _cupy.zeros((a.shape[0], n), dtype=res_dtype)
+        for j0 in range(0, n, block):
+            j1 = min(j0 + block, n)
+            yb = _cupy.zeros((a.shape[0], j1 - j0), dtype=acc_dtype)
+            xb = x2[:, j0:j1].astype(acc_dtype, copy=False)[a.indices]
+            _cupy.add.at(yb, rows, data_acc * xb)
+            y[:, j0:j1] = yb.astype(res_dtype, copy=False)
+    return y.ravel() if x.ndim == 1 else y
 
 
 def spgemm(a, b, alpha=1):
@@ -2502,6 +2795,34 @@ def spgemm(a, b, alpha=1):
     if not _is_csr_type(b):
         raise TypeError(f'unsupported type (actual: {type(b)})')
 
+    if a.shape[1] != b.shape[0]:
+        raise ValueError('mismatched shape')
+
+    from cupyx.scipy.sparse import _sputils
+    # See csrgeam2: bfloat16 mixed with a >= 16-bit integer raises
+    # DTypePromotionError here (an accepted ml_dtypes limitation) though dense
+    # computes it; cast one operand explicitly to work around it.
+    result_dtype = _numpy.result_type(a.dtype, b.dtype)
+    if _sputils.is_16bit_float(result_dtype):
+        # 16-bit float: upcast to float32, use native cuSPARSE spgemm, then
+        # downcast.  This accumulates the contraction in float32 (more
+        # accurate than rounding each product to 16 bits) and is faster than
+        # the pure-CuPy sort-merge; float32 is a lossless widening.
+        # Restage only ``data`` (spgemm reads indices/indptr without mutating,
+        # like spmv/spmm), so ``astype`` would needlessly copy them.
+        a32 = a._with_data(a.data.astype(_cupy.float32), copy=False)
+        b32 = b._with_data(b.data.astype(_cupy.float32), copy=False)
+        r = spgemm(a32, b32, alpha)
+        return r._with_data(r.data.astype(result_dtype), copy=False)
+    # Route through the pure-CuPy sort-merge fallback only when the
+    # *promoted* result is non-float (bool/integer), regardless of index
+    # dtype: a mixed int x float pair promotes to a cuSPARSE-capable float and
+    # stays native.  Integer products/sums use ordinary integer arithmetic
+    # (wrapping on overflow, matching numpy/scipy).
+    if _needs_cupy_fallback(result_dtype):
+        a, b = _cast_common_type(a, b)
+        return _cupy_spgemm_int64(a, b, alpha)
+
     # TODO(eriknw): cuSPARSE--remove pure-CuPy fallback when all supported CUDA
     # versions have native int64 SpGEMM.  Native int64 SpGEMM is ~14x
     # faster and within 1.6x of int32 (verified on CUDA 13.0+).
@@ -2510,8 +2831,6 @@ def spgemm(a, b, alpha=1):
     # the CUDA runtime version rather than check_availability().
     # Mixed int32/int64 inputs: upcast to int64, prefer cuSPARSE.
     if a.indices.dtype == _cupy.int64 or b.indices.dtype == _cupy.int64:
-        if a.shape[1] != b.shape[0]:
-            raise ValueError('mismatched shape')
         _native_int64 = (
             not _runtime.is_hip
             and _runtime.runtimeGetVersion() >= 13000
@@ -2534,8 +2853,6 @@ def spgemm(a, b, alpha=1):
         raise ValueError('expected canonical format for a')
     if not b.has_canonical_format:
         raise ValueError('expected canonical format for b')
-    if a.shape[1] != b.shape[0]:
-        raise ValueError('mismatched shape')
 
     m, k = a.shape
     _, n = b.shape

--- a/cupyx/linalg/sparse/_solve.py
+++ b/cupyx/linalg/sparse/_solve.py
@@ -36,11 +36,19 @@ def lschol(A, b):
     if b.ndim != 1 or len(b) != m:
         raise ValueError('b must be 1-d array whose size is same as A')
 
-    # Cast to float32 or float64
-    if A.dtype == 'f' or A.dtype == 'd':
+    # Cast to float32 or float64.  cuSOLVER reads ``A.data``/``b`` through raw
+    # pointers, so the operands must actually be converted -- picking the
+    # kernel from a promoted dtype while leaving a narrower buffer in place
+    # makes it read past the end and return garbage.
+    if A.dtype.char in 'fd':
         dtype = A.dtype
     else:
         dtype = numpy.promote_types(A.dtype, 'f')
+        if dtype.char not in 'fd':
+            # ``scsrlsvchol``/``dcsrlsvchol`` are real-only.
+            raise TypeError('Invalid dtype (actual: {})'.format(A.dtype))
+        A = A.astype(dtype)
+    b = b.astype(dtype, copy=False)
 
     handle = device.get_cusolver_sp_handle()
     nnz = A.nnz

--- a/cupyx/scipy/sparse/_base.py
+++ b/cupyx/scipy/sparse/_base.py
@@ -89,10 +89,11 @@ class _spbase:
         # Delegate to scipy via ``self.get()`` so the output (including
         # version-specific quirks like DIA's "(N diagonals)" annotation)
         # tracks the installed scipy.  Fall back to ``repr`` only when
-        # ``get()`` is unavailable.
+        # ``get()`` is unavailable or scipy cannot represent the dtype
+        # (``ValueError`` for float16/bfloat16, which scipy.sparse rejects).
         try:
             return str(self.get())
-        except (RuntimeError, NotImplementedError):
+        except (RuntimeError, NotImplementedError, ValueError):
             return repr(self)
 
     def __iter__(self):
@@ -644,14 +645,18 @@ class _spbase:
 
         if self.ndim == 1:
             # The only axis reduces everything to a scalar.  Implicit zeros
-            # contribute nothing, so summing the stored data suffices;
-            # duplicates of a non-bool dtype already sum to the right total,
-            # so no dedup (or in-place mutation) is needed here.  ``out=`` is
-            # forwarded to the reduction (which validates its shape and writes
-            # the result in place) and then returned explicitly: the cuTENSOR
-            # reduction backend returns a fresh 0-D array from a 1-D reduction
-            # even when ``out`` is given, which breaks numpy's out-identity
-            # contract (``a.sum(out=b) is b``).
+            # contribute nothing, so summing the stored data suffices.  This
+            # equals numpy/scipy for a canonical matrix (the common case); a
+            # non-canonical *integer* matrix is the one divergence -- when
+            # its duplicates overflow the storage width scipy coalesces at
+            # that width first while this widens the accumulator -- accepted
+            # rather than force a copy+sort (or a canonical-format D2H sync)
+            # onto every reduction.  ``out=`` is forwarded to the reduction
+            # (which validates its shape and writes the result in place) and
+            # then returned explicitly: the cuTENSOR reduction backend
+            # returns a fresh 0-D array from a 1-D reduction even when
+            # ``out`` is given, which breaks numpy's out-identity contract
+            # (``a.sum(out=b) is b``).
             _sputils.validate_axis_1d(axis)
             result = self.data.sum(dtype=dtype, out=out)
             return out if out is not None else result
@@ -666,17 +671,67 @@ class _spbase:
         _sputils.validateaxis(axis)
 
         if axis is None:
-            # ``ones``-vector matmul gives a 1-D vector; its final reduction
-            # to a scalar must return ``out`` explicitly (see the 1-D branch:
-            # cuTENSOR returns a fresh 0-D array from a 1-D reduction).
-            result = self.dot(cupy.ones(n, dtype=self.dtype)).sum(
-                dtype=dtype, out=out)
+            # Both branches end in a 1-D reduction to a scalar whose ``out``
+            # must be returned explicitly: the cuTENSOR reduction backend
+            # returns a fresh 0-D array from a 1-D reduction even when ``out``
+            # is given (see the 1-D branch), which breaks numpy's out-identity
+            # contract (``a.sum(out=b) is b``).
+            if self.dtype.kind in 'iu':
+                # cuSPARSE has no integer ones-vector matmul; summing the
+                # stored values widens the accumulator to int64/uint64 like
+                # numpy/scipy, with the same non-canonical-duplicate
+                # divergence the 1-D branch documents.  DIA's ``data`` holds
+                # off-matrix padding, so take the coalesced COO values there.
+                values = (self.data if self.format in ('csr', 'csc', 'coo')
+                          else self.tocoo().data)
+                result = values.sum(dtype=dtype, out=out)
+            else:
+                result = self.dot(cupy.ones(n, dtype=self.dtype)).sum(
+                    dtype=dtype, out=out)
             return out if out is not None else result
 
         if axis < 0:
             axis += 2
 
-        if isinstance(self, sparray):
+        if self.dtype.kind in 'iu':
+            # cuSPARSE has no integer arithmetic; reduce exactly into the
+            # numpy/scipy sum accumulator (int64/uint64 -- exact even past
+            # 2**53, unlike a float64 carrier) instead of the ones-vector
+            # matmul; duplicates accumulate there too, with the divergence
+            # the 1-D branch documents.  When the reduction axis is the
+            # format's already *contiguous* axis (CSR rows / CSC columns),
+            # sum each ``indptr`` segment with a contention-free cumsum -- no
+            # conversion, and it avoids the atomic pile-up a dense row/column
+            # would cause when scattered.  Otherwise scatter-add from COO:
+            # the cross axis would need a costly CSR<->CSC to make its groups
+            # contiguous, while its scatter has only light contention.
+            acc_dtype = _sputils.get_sum_dtype(self.dtype)
+            fmt = self.format
+            if (fmt == 'csr' and axis == 1) or (fmt == 'csc' and axis == 0):
+                csum = cupy.empty(self.data.size + 1, dtype=acc_dtype)
+                csum[0] = 0
+                cupy.cumsum(self.data, dtype=acc_dtype, out=csum[1:])
+                acc = csum[self.indptr[1:]] - csum[self.indptr[:-1]]
+            else:
+                if fmt in ('csr', 'csc'):
+                    # Reducing over the format's *minor* axis: ``indices``
+                    # already holds each entry's coordinate on it, so the
+                    # COO conversion (whose only extra output is the major
+                    # coordinate this branch never reads) is skipped.
+                    coord, data = self.indices, self.data
+                else:
+                    coo = self.tocoo()
+                    coord = coo.col if axis == 0 else coo.row
+                    data = coo.data
+                dim = n if axis == 0 else m
+                acc = cupy.zeros(dim, dtype=acc_dtype)
+                cupy.add.at(
+                    acc, coord, data.astype(acc_dtype, copy=False))
+            if isinstance(self, sparray):
+                ret = acc
+            else:
+                ret = acc.reshape(1, n) if axis == 0 else acc.reshape(m, 1)
+        elif isinstance(self, sparray):
             # Arrays: reduction along an axis returns 1D
             if axis == 0:
                 ret = self.T.dot(cupy.ones(m, dtype=self.dtype))
@@ -881,7 +936,7 @@ class spmatrix:
         Returns:
             cupyx.scipy.sparse.spmatrix: A matrix with float type.
         """
-        if self.dtype.kind == 'f':
+        if _sputils.is_float_dtype(self.dtype):
             return self
         typ = numpy.promote_types(self.dtype, 'f')
         return self.astype(typ)

--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -23,14 +23,21 @@ from cupyx.scipy.sparse import _util
 
 from cupyx.scipy.sparse import _index
 
+# CUDA typename of the index dtype ``_arg_minor_reduce`` returns.  SciPy makes
+# the outcome dtype platform dependent, so it is derived from ``numpy.dtype(
+# int)`` (what the output array is allocated with) rather than hardcoded.
+# Module level so the class-body comprehensions below can see it: a class
+# attribute is out of scope in every loop of a comprehension but the first.
+_ARG_REDUCTION_OUT_TYPENAME = _scalar.get_typename(numpy.dtype(int))
+
 
 class _compressed_sparse_matrix(sparse_data._data_matrix,
                                 sparse_data._minmax_mixin,
                                 _index.IndexMixin):
 
     _max_min_reduction_code = r'''
-        template<typename TI> __global__
-        void ${func}(double* data, TI* x, TI* y, TI length, double* z) {
+        template<typename T, typename TI> __global__
+        void ${func}(T* data, TI* x, TI* y, TI length, T* z) {
             // Get the index of the block
             int tid = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -38,7 +45,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             TI block_length = y[tid] - x[tid];
 
             // Select initial value based on the block density
-            double running_value = 0;
+            T running_value = 0;
             if (${cond}){
                 running_value = data[x[tid]];
             } else {
@@ -63,38 +70,54 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             z[tid] = running_value;
         }'''
 
-    # Index type specializations: int (int32) and long long (int64).
+    # Index type specializations: int (int32) and long long (int64).  Usable
+    # only as the *first* iterable of a class-body comprehension -- Python
+    # evaluates the remaining loops in a scope that skips the class body --
+    # so the inner loops below spell the same tuple literally.
     _idx_types = ('int', 'long long')
+
+    # Value type specializations for min/max.  ``double`` is exact for every
+    # supported dtype except the 64-bit integers (their magnitudes can exceed
+    # 2**53), so only those get a native reduction; complex reduces on its
+    # real part via the double path (comparison on complex is ill-defined).
+    _minmax_value_types = ('double', 'long long', 'unsigned long long')
 
     _max_reduction_mod = _core.RawModule(
         code=string.Template(_max_min_reduction_code).substitute(
             func='max_reduction', op='>', cond='block_length == length'),
         name_expressions=[
-            f'max_reduction<{t}>' for t in _idx_types])
+            f'max_reduction<{v}, {t}>'
+            for v in _minmax_value_types
+            for t in ('int', 'long long')])
 
     _max_nonzero_reduction_mod = _core.RawModule(
         code=string.Template(_max_min_reduction_code).substitute(
             func='max_nonzero_reduction', op='>',
             cond='block_length > 0'),
         name_expressions=[
-            f'max_nonzero_reduction<{t}>' for t in _idx_types])
+            f'max_nonzero_reduction<{v}, {t}>'
+            for v in _minmax_value_types
+            for t in ('int', 'long long')])
 
     _min_reduction_mod = _core.RawModule(
         code=string.Template(_max_min_reduction_code).substitute(
             func='min_reduction', op='<', cond='block_length == length'),
         name_expressions=[
-            f'min_reduction<{t}>' for t in _idx_types])
+            f'min_reduction<{v}, {t}>'
+            for v in _minmax_value_types
+            for t in ('int', 'long long')])
 
     _min_nonzero_reduction_mod = _core.RawModule(
         code=string.Template(_max_min_reduction_code).substitute(
             func='min_nonzero_reduction', op='<',
             cond='block_length > 0'),
         name_expressions=[
-            f'min_nonzero_reduction<{t}>' for t in _idx_types])
+            f'min_nonzero_reduction<{v}, {t}>'
+            for v in _minmax_value_types
+            for t in ('int', 'long long')])
 
     # For _max_arg_reduction_mod and _min_arg_reduction_mod below, we pick
     # the right template specialization according to input dtypes at runtime.
-    # The distinction in int types (T2) is important for portability in OS.
 
     _argmax_argmin_code = r'''
         template<typename T1, typename T2, typename TI> __global__ void
@@ -108,7 +131,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
 
             // Select initial value based on the block density
             TI data_index = 0;
-            double data_value = 0;
+            T1 data_value = 0;
 
             if (block_length == length){
                 // Block is dense. Fill the first value
@@ -150,11 +173,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             z[tid] = (T2)data_index;
         }'''
 
-    # T1=data type, T2=output type, TI=index type
+    # T1=data type, T2=output type, TI=index type.  T1 spans every supported
+    # value dtype (bool, all integer widths, float, double); the NaN guard in
+    # the kernel is dead code for the non-floating types.
+    _value_typenames = (
+        'bool', 'signed char', 'short', 'int', 'long long',
+        'unsigned char', 'unsigned short', 'unsigned int',
+        'unsigned long long', 'float', 'double',
+    )
     _arg_reduction_types = [
         f'{{func}}_arg_reduction<{t1}, {t2}, {ti}>'
-        for t1 in ('float', 'double')
-        for t2 in ('int', 'long long')
+        for t1 in _value_typenames
+        for t2 in (_ARG_REDUCTION_OUT_TYPENAME,)
         for ti in ('int', 'long long')
     ]
 
@@ -429,10 +459,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         else:
             dtype = numpy.dtype(dtype)
 
-        if not _sputils.is_sparse_data_dtype(dtype):
-            raise ValueError(
-                'Only bool, float32, float64, complex64 and complex128 '
-                'are supported')
+        _sputils.check_data_dtype(dtype)
 
         data = data.astype(dtype, copy=copy)
         sparse_data._data_matrix.__init__(self, data)
@@ -698,12 +725,17 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             _index._compress_getitem_complex_kern(
                 data.real, data.imag, indices, minor, res.real, res.imag)
             return res
-        if dtype.kind == 'b':
-            # ``atomicAdd`` has no bool overload; accumulate the matching
-            # entries as int, then a non-zero count means a stored True.
-            res = cupy.zeros((), dtype=cupy.int32)
+        if dtype.kind in 'biu' and dtype.itemsize < 4:
+            # ``atomicAdd`` has no bool / 8- / 16-bit integer overload, so
+            # accumulate the matching entries in a 32-bit integer of the same
+            # signedness (bool -> uint32) and cast back: a nonzero count is a
+            # stored True, and duplicate integers sum then wrap on the
+            # down-cast (matching scipy).  int32/int64 use ``atomicAdd``
+            # directly below.
+            acc_dtype = cupy.int32 if dtype.kind == 'i' else cupy.uint32
+            res = cupy.zeros((), dtype=acc_dtype)
             _index._compress_getitem_kern(
-                data.astype(cupy.int32), indices, minor, res)
+                data.astype(acc_dtype), indices, minor, res)
             return res.astype(dtype)
         res = cupy.zeros((), dtype=dtype)
         _index._compress_getitem_kern(data, indices, minor, res)
@@ -899,9 +931,9 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         options=('-std=c++17',),
         name_expressions=[
             f'fill_B<{dt}, {it}>'
-            # ``bool`` is a supported data dtype; ``fill_B`` only copies
-            # values (no arithmetic on ``T``), so it instantiates safely.
-            for dt in ('bool', 'float', 'double')
+            # ``fill_B`` only copies values (no arithmetic on ``T``), so it
+            # instantiates safely for every supported data dtype.
+            for dt in _value_typenames
             for it in ('int', 'long long')
         ],
     )
@@ -968,14 +1000,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         if self.nnz == 0 or n_idx == 0:
             return self._empty_like(new_shape)
 
-        # Histogram path uses int32 counters internally; fall back to
-        # the sort-based path when either ``N`` (count-buffer size) or
-        # ``n_idx`` (cumulative-sum end value) overflows int32.  The
-        # ``n_idx`` arm needs an idx array > 8 GB to trigger, so it has
-        # no direct unit test -- correctness rests on the existing
+        # The histogram path uses int32 counters internally and launches one
+        # block per major-axis entry, so fall back to the sort-based path
+        # when ``N`` (count-buffer size), ``n_idx`` (cumulative-sum end
+        # value) or ``M`` overflows int32.  Past int32 ``M`` exceeds the CUDA
+        # ``gridDim.x`` limit, and the kernels' ``const int n_row`` / ``int
+        # row = blockIdx.x`` would both wrap, so their bounds check could not
+        # filter correctly even if the launch were accepted.  The ``n_idx``
+        # arm needs an idx array > 8 GB to trigger, so it has no direct unit
+        # test -- correctness rests on the existing
         # ``_minor_index_fancy_sorted`` coverage.
         int32_max = numpy.iinfo(numpy.int32).max
-        if N > int32_max or n_idx > int32_max:
+        if N > int32_max or n_idx > int32_max or M > int32_max:
             return self._minor_index_fancy_sorted(
                 idx, M, n_idx, new_shape)
 
@@ -1019,40 +1055,48 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         nnzB = int(Bp[-1])  # synchronize!
 
         Bj = cupy.empty(nnzB, dtype=idx_dtype)
-        Bx = cupy.empty(nnzB, dtype=self.data.dtype)
 
-        # Compute Bj and Bx
+        # Compute Bj and Bx.  ``fill_B`` only copies values, so for the
+        # 16-bit floats (not instantiated) it runs in float32 (lossless) and
+        # Bx is cast back afterwards.
+        data = self.data
         if self.dtype.kind == 'c':
             tname = _scalar.get_typename(self.data.real.dtype)
             ker_name = f'fill_B_complex<{tname}, {idx_tname}>'
             fillB = self._fill_B_complex.get_function(ker_name)
         else:
-            tname = _scalar.get_typename(self.data.dtype)
+            if _sputils.is_16bit_float(data.dtype):
+                data = data.astype(cupy.float32)
+            tname = _scalar.get_typename(data.dtype)
             ker_name = f'fill_B<{tname}, {idx_tname}>'
             fillB = self._fill_B.get_function(ker_name)
+        Bx = cupy.empty(nnzB, dtype=data.dtype)
         threads = 32
         fillB((M,),
               (threads,),
               (M,
                self.indptr,
                self.indices,
-               self.data,
+               data,
                col_offset,
                col_order,
                Bp,
                Bj,
                Bx),
               )
+        if Bx.dtype != self.data.dtype:
+            Bx = Bx.astype(self.data.dtype)
 
         return self.__class__._from_parts(
             Bx, Bj, Bp, new_shape)
 
     def _minor_index_fancy_sorted(self, idx, M, n_idx, new_shape):
-        """Sort-based fancy minor-axis indexing for large minor axis.
+        """Sort-based fancy minor-axis indexing for large axes.
 
-        O(nnz + n_idx) space instead of O(N). Used when N > INT32_MAX
-        where the histogram-based path would require a prohibitive
-        O(N) allocation.
+        O(nnz + n_idx) space instead of O(N).  Used when ``N`` exceeds
+        INT32_MAX (the histogram path would need a prohibitive O(N)
+        allocation) and when ``M`` does (the histogram path's one-block-
+        per-row launch would exceed the CUDA grid limit).
         """
         idx_dtype = self.indices.dtype
         idx = cupy.asarray(idx, dtype=idx_dtype)
@@ -1084,7 +1128,11 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             self.indptr, nnz=self.nnz)
         out_major = major_of_each[out_src]
 
-        sort_key = cupy.lexsort(cupy.stack([out_minor, out_major]))
+        # Canonical (major, minor) order; out_minor is a position within the
+        # selection, so its range is the selection size.
+        n_selected = idx.size
+        sort_key = _cusparse_mod._argsort_major_minor(
+            out_major, out_minor, self.indptr.size - 1, n_selected)
         out_major = out_major[sort_key]
         out_minor = out_minor[sort_key]
         out_data = out_data[sort_key]
@@ -1588,7 +1636,17 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         # int64 indptr.
         idx_dtype = self.indptr.dtype
         tname = _scalar.get_typename(idx_dtype)
-        out = cupy.zeros(out_shape, dtype=cupy.float64)
+        # ``double`` is exact for every supported dtype except 64-bit
+        # integers, whose magnitudes can exceed 2**53; reduce those in their
+        # native type to avoid precision loss.  Everything else reduces on
+        # the double path -- complex on its real part (``astype`` drops the
+        # imaginary part), the 16-bit floats widened losslessly.
+        if self.data.dtype in (cupy.int64, cupy.uint64):
+            compute_dtype = self.data.dtype
+        else:
+            compute_dtype = cupy.dtype(cupy.float64)
+        vname = _scalar.get_typename(compute_dtype)
+        out = cupy.zeros(out_shape, dtype=compute_dtype)
         if ufunc is cupy.amax:
             if nonzero:
                 mod, fname = (self._max_nonzero_reduction_mod,
@@ -1605,9 +1663,9 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             # Only min/max reductions have kernels; guard against a future
             # caller silently getting a min result for another ufunc.
             raise ValueError(f'unsupported reduction ufunc: {ufunc}')
-        ker = mod.get_function(f'{fname}<{tname}>')
+        ker = mod.get_function(f'{fname}<{vname}, {tname}>')
         ker((out_shape,), (1,),
-            (self.data.astype(cupy.float64),
+            (self.data.astype(compute_dtype, copy=False),
              self.indptr[:-1], self.indptr[1:],
              idx_dtype.type(self.shape[axis]),
              out))
@@ -1645,7 +1703,18 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
         indptr_x = self.indptr[:len(self.indptr) - 1].astype(idx_dtype,
                                                              copy=False)
         indptr_y = self.indptr[1:].astype(idx_dtype, copy=False)
-        data_t = _scalar.get_typename(self.data.dtype)
+        # The kernel is instantiated only for the real value types.  Complex
+        # reduces on its real part (as ``_minor_reduce`` does for min/max);
+        # the 16-bit floats widen to float32 (lossless, order-preserving).
+        # Only the comparison depends on the values -- the result is the
+        # winning index -- and the raw kernel indexes ``data`` contiguously,
+        # so make the real part contiguous.
+        data = self.data
+        if data.dtype.kind == 'c':
+            data = cupy.ascontiguousarray(data.real)
+        elif _sputils.is_16bit_float(data.dtype):
+            data = data.astype(cupy.float32)
+        data_t = _scalar.get_typename(data.dtype)
         out_t = _scalar.get_typename(out.dtype)
         idx_t = _scalar.get_typename(idx_dtype)
         ker_name = f'_arg_reduction<{data_t}, {out_t}, {idx_t}>'
@@ -1656,7 +1725,7 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
             ker = self._min_arg_reduction_mod.get_function('min' + ker_name)
 
         ker((out_shape,), (1,),
-            (self.data, self.indices,
+            (data, self.indices,
              indptr_x, indptr_y,
              idx_dtype.type(self.shape[axis]),
              out))

--- a/cupyx/scipy/sparse/_construct.py
+++ b/cupyx/scipy/sparse/_construct.py
@@ -473,8 +473,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     if density < 0 or density > 1:
         raise ValueError('density expected to be 0 <= density <= 1')
     dtype = cupy.dtype(dtype)
-    if dtype.char not in 'fd':
-        raise NotImplementedError('type %s not supported' % dtype)
+    _sputils.check_data_dtype(dtype)
 
     k = int(density * m * n)
 
@@ -484,7 +483,25 @@ def random(m, n, density=0.01, format='coo', dtype=None,
         random_state = cupy.random.RandomState(random_state)
 
     if data_rvs is None:
-        data_rvs = random_state.rand
+        if dtype.kind in 'iu':
+            # Sample uniformly across the whole integer range, like scipy;
+            # the default float sampler below would give [0, 1) values that
+            # truncate to all zeros.
+            info = numpy.iinfo(dtype)
+            lo, hi = int(info.min), int(info.max)
+
+            def data_rvs(size):
+                return random_state.randint(lo, hi + 1, size=size,
+                                            dtype=dtype)
+        elif dtype.kind == 'c':
+            # Give the imaginary part its own [0, 1) sample so complex
+            # results are not purely real.
+            def data_rvs(size):
+                return random_state.rand(size) + 1j * random_state.rand(size)
+        else:
+            # float32/float64 (and bool: [0, 1) samples are all nonzero, so
+            # the ``astype(bool)`` below yields all-True, matching scipy).
+            data_rvs = random_state.rand
 
     mn = m * n
 
@@ -849,10 +866,9 @@ def block_diag(mats, format=None, dtype=None):
         """Promote a dense input (list/tuple/scalar/ndarray) to a 2-D
         ``cupy.ndarray`` with a sparse-supported dtype.
 
-        Integer-typed dense input is upcast to float64 since cuSPARSE
-        won't store it.  This matches scipy's behaviour for integer
-        ``diags`` input -- the upstream FutureWarning is filtered out
-        in ``pyproject.toml``.
+        A dtype cupyx.scipy.sparse cannot store (e.g. longdouble) is
+        upcast to float64; every supported dtype -- including the
+        integer widths -- is preserved as-is.
         """
         a = cupy.atleast_2d(cupy.asarray(a))
         if not _sputils.is_sparse_data_dtype(a.dtype):

--- a/cupyx/scipy/sparse/_coo.py
+++ b/cupyx/scipy/sparse/_coo.py
@@ -226,10 +226,7 @@ class _coo_base(sparse_data._data_matrix):
         else:
             dtype = numpy.dtype(dtype)
 
-        if not _sputils.is_sparse_data_dtype(dtype):
-            raise ValueError(
-                'Only bool, float32, float64, complex64 and complex128'
-                ' are supported')
+        _sputils.check_data_dtype(dtype)
 
         data = data.astype(dtype, copy=copy)
         # Choose index dtype: int32 when values fit, int64 when they don't.
@@ -437,10 +434,12 @@ class _coo_base(sparse_data._data_matrix):
             mask = ((self.row == _normalize_index(key[0], m, 'row'))
                     & (self.col == _normalize_index(key[1], n, 'column')))
         # Sum the stored values at the coordinate (duplicates included,
-        # like scipy); absent entries contribute nothing.  ``sum`` upcasts
-        # bool to int, so restore the bool dtype to match the CSR path.
-        s = self.data[mask].sum()
-        return s.astype(self.dtype) if self.dtype.kind == 'b' else s
+        # like scipy); absent entries contribute nothing.  Accumulate in the
+        # matrix's own dtype: a bare ``sum`` widens bool and every narrow
+        # integer to the platform int, which both changes the result dtype
+        # and lets duplicates that should wrap (``int8`` 100 + 100 -> -56,
+        # what ``toarray`` and the CSR path give) survive at 64-bit width.
+        return self.data[mask].sum(dtype=self.dtype)
 
     def diagonal(self, k=0):
         """Returns the k-th diagonal of the matrix.
@@ -700,8 +699,24 @@ class _coo_base(sparse_data._data_matrix):
         # the cuSPARSE functions such as cusparseSpMV() assume this sorting
         # order.
         # See https://docs.nvidia.com/cuda/cusparse/index.html#coo-format
-        keys = cupy.stack([self.col, self.row])
-        order = cupy.lexsort(keys)
+        #
+        # Only the (row, col) order matters here; within-duplicate order is
+        # irrelevant to the sum below.  A 1-D array's backing COO keeps ``row``
+        # all-zero, so ``nrow == 1`` and the composite key reduces to ``col``.
+        #
+        # That key is injective only for in-bounds coordinates (``col <
+        # ncol``), which every valid matrix and every internal ``_from_parts``
+        # caller guarantees.  A malformed matrix with out-of-bounds indices --
+        # already undefined for toarray/matmul, since the CSR ``(data,
+        # indices, indptr)`` constructor does not validate bounds -- could
+        # collide two distinct pairs onto one key and fail to coalesce them
+        # (the lexsort fallback is robust to it).  Not guarded here: detecting
+        # it would cost a D2H sync (``col.max()``) on this hot path, and the
+        # matrix is garbage regardless.
+        from cupyx import cusparse
+        ncol = self.shape[-1]
+        nrow = self.shape[0] if self.ndim > 1 else 1
+        order = cusparse._argsort_major_minor(self.row, self.col, nrow, ncol)
         src_data = self.data[order]
         src_row = self.row[order]
         src_col = self.col[order]
@@ -721,10 +736,10 @@ class _coo_base(sparse_data._data_matrix):
             idx_dtype = self.row.dtype
             index = cupy.cumsum(diff, dtype=idx_dtype)
             size = int(index[-1]) + 1  # synchronize!
-            data = cupy.zeros(size, dtype=self.data.dtype)
             row = cupy.empty(size, dtype=idx_dtype)
             col = cupy.empty(size, dtype=idx_dtype)
             if self.data.dtype.kind == 'b':
+                data = cupy.zeros(size, dtype=self.data.dtype)
                 cupy.ElementwiseKernel(
                     'T src_data, I src_row, I src_col, I index',
                     'raw T data, raw I row, raw I col',
@@ -735,7 +750,11 @@ class _coo_base(sparse_data._data_matrix):
                     ''',
                     'cupyx_scipy_sparse_coo_sum_duplicates_assign'
                 )(src_data, src_row, src_col, index, data, row, col)
-            elif self.data.dtype.kind == 'f':
+            elif (self.data.dtype.kind == 'f'
+                  and self.data.dtype.itemsize >= 4):
+                # float32/float64: atomicAdd handles these directly.  The
+                # 16-bit floats fall through to the carrier branch below.
+                data = cupy.zeros(size, dtype=self.data.dtype)
                 cupy.ElementwiseKernel(
                     'T src_data, I src_row, I src_col, I index',
                     'raw T data, raw I row, raw I col',
@@ -747,6 +766,7 @@ class _coo_base(sparse_data._data_matrix):
                     'cupyx_scipy_sparse_coo_sum_duplicates_assign'
                 )(src_data, src_row, src_col, index, data, row, col)
             elif self.data.dtype.kind == 'c':
+                data = cupy.zeros(size, dtype=self.data.dtype)
                 cupy.ElementwiseKernel(
                     'T src_real, T src_imag, I src_row, I src_col, '
                     'I index',
@@ -760,6 +780,21 @@ class _coo_base(sparse_data._data_matrix):
                     'cupyx_scipy_sparse_coo_sum_duplicates_assign_complex'
                 )(src_data.real, src_data.imag, src_row, src_col, index,
                   data.real, data.imag, row, col)
+            else:
+                # Integer or 16-bit-float data: cuSPARSE-free segment sum.
+                # ``atomicAdd``/``add.at`` cannot target int8/int16/int64 or
+                # the 16-bit floats, so accumulate in an ``add.at``-compatible
+                # carrier (a 64-bit integer for the narrow ints, float32 for
+                # float16/bfloat16), then cast back -- integer casts wrap
+                # modulo 2**n like numpy/scipy (e.g. int8 100+100+100 -> 44),
+                # the floats round.  Duplicate coordinates share a segment
+                # index, so the plain ``row``/``col`` scatter is unambiguous.
+                acc_dtype = _sputils.add_at_accumulator_dtype(self.data.dtype)
+                acc = cupy.zeros(size, dtype=acc_dtype)
+                cupy.add.at(acc, index, src_data.astype(acc_dtype, copy=False))
+                data = acc.astype(self.data.dtype, copy=False)
+                row[index] = src_row
+                col[index] = src_col
 
         self.data = data
         self.row = row

--- a/cupyx/scipy/sparse/_csc.py
+++ b/cupyx/scipy/sparse/_csc.py
@@ -12,6 +12,7 @@ from cupy_backends.cuda.api import runtime
 import cupyx.scipy.sparse
 from cupyx.scipy.sparse import _base
 from cupyx.scipy.sparse import _compressed
+from cupyx.scipy.sparse import _sputils
 
 
 class _csc_base(_compressed._compressed_sparse_matrix):
@@ -108,9 +109,8 @@ class _csc_base(_compressed._compressed_sparse_matrix):
         if _base.issparse(other) and other.format == 'csr':
             self.sum_duplicates()
             other.sum_duplicates()
-            is_int64 = (self.indices.dtype == cupy.int64
-                        or other.indices.dtype == cupy.int64)
-            if is_int64 or cusparse.check_availability('spgemm'):
+            needs_spgemm = cusparse._needs_cupy_spgemm(self, other)
+            if needs_spgemm or cusparse.check_availability('spgemm'):
                 a = self.tocsr()
                 a.sum_duplicates()
                 return self._as_csr_type(cusparse.spgemm(a, other))
@@ -128,11 +128,10 @@ class _csc_base(_compressed._compressed_sparse_matrix):
         elif _base.issparse(other) and other.format == 'csc':
             self.sum_duplicates()
             other.sum_duplicates()
-            is_int64 = (self.indices.dtype == cupy.int64
-                        or other.indices.dtype == cupy.int64)
-            if is_int64:
-                # csrgemm/csrgemm2 are int32-only; route via spgemm,
-                # which has a pure-CuPy fallback for older cuSPARSE.
+            needs_spgemm = cusparse._needs_cupy_spgemm(self, other)
+            if needs_spgemm:
+                # csrgemm/csrgemm2 are int32/float-only; route via
+                # spgemm, which has pure-CuPy fallbacks.
                 a = self.tocsr()
                 b = other.tocsr()
                 a.sum_duplicates()
@@ -164,10 +163,40 @@ class _csc_base(_compressed._compressed_sparse_matrix):
             if other.ndim == 0:
                 self.sum_duplicates()
                 return self._with_data(self.data * other)
-            elif other.ndim == 1:
+            native_f16 = False
+            if other.ndim in (1, 2):
+                # cuSPARSE spmv/spmm accept float/complex plus a native
+                # float16 mixed mode (f16 data, f32 compute).  bfloat16 and
+                # bool/integer results have no cuSPARSE path and route through
+                # the pure-CuPy scatter.  float16 must NOT: it has to reach the
+                # native spmv/spmm via ``self.T`` (transa), because routing it
+                # through ``_cupy_csr_dense_matmul(self.tocsr())`` would pay a
+                # full CSC->CSR conversion (~25x slower).  The transa path is
+                # buggy on HIP, so keep the fallback there.
+                result_dtype = cupy.promote_types(self.dtype, other.dtype)
+                native_f16 = (
+                    result_dtype.char == 'e' and not runtime.is_hip
+                    and cusparse.check_availability(
+                        'spmv' if other.ndim == 1 else 'spmm'))
+                if (_sputils.is_16bit_float(result_dtype)
+                        and not native_f16 and not runtime.is_hip):
+                    # bfloat16 has no native cuSPARSE type (and float16 lands
+                    # here only if the native path is unavailable): upcast to
+                    # float32 and reuse the native CSC spmv/spmm, which is
+                    # cheap via ``self.T``, then downcast.  Routing through
+                    # ``_cupy_csr_dense_matmul(self.tocsr())`` would pay a full
+                    # CSC->CSR conversion (~25x slower) first.
+                    return (self.astype(cupy.float32)
+                            @ other.astype(cupy.float32)).astype(result_dtype)
+                if (cusparse._needs_cupy_fallback(result_dtype)
+                        and not native_f16):
+                    return cusparse._cupy_csr_dense_matmul(
+                        self.tocsr(), other)
+            if other.ndim == 1:
                 self.sum_duplicates()
                 if (
-                    cusparse.check_availability('csrmv')
+                    not native_f16
+                    and cusparse.check_availability('csrmv')
                     and (
                         not runtime.is_hip
                         or driver.get_build_version() >= 5_00_00000
@@ -186,7 +215,8 @@ class _csc_base(_compressed._compressed_sparse_matrix):
             elif other.ndim == 2:
                 self.sum_duplicates()
                 if (
-                    cusparse.check_availability('csrmm2')
+                    not native_f16
+                    and cusparse.check_availability('csrmm2')
                     and (
                         not runtime.is_hip
                         or driver.get_build_version() >= 5_00_00000

--- a/cupyx/scipy/sparse/_csr.py
+++ b/cupyx/scipy/sparse/_csr.py
@@ -79,8 +79,17 @@ class _csr_base(_compressed._compressed_sparse_matrix):
                 other, lambda a, o: a._comparison(o, op, op_name))
         cls = type(self)
         if _util.isscalarlike(other):
-            data = cupy.asarray(other, dtype=self.dtype).reshape(1)
-            if numpy.isnan(data[0]):
+            if self.dtype.kind in 'biu':
+                # Keep the scalar's own dtype: casting it into a narrow
+                # bool/integer matrix dtype would overflow (``int8 > 300``
+                # raises) or truncate (``int8 == 2.5`` matches the 2s),
+                # diverging from scipy, which compares in the promoted type.
+                data = cupy.asarray(other).reshape(1)
+            else:
+                data = cupy.asarray(other, dtype=self.dtype).reshape(1)
+            # ``isnan`` only applies to (and only accepts) float/complex
+            # scalars; an integer scalar kept above cannot be NaN.
+            if data.dtype.kind in 'fc' and numpy.isnan(data[0]):
                 if op_name == '_ne_':
                     return cls(cupy.ones(self.shape, dtype=numpy.bool_))
                 else:
@@ -198,11 +207,11 @@ class _csr_base(_compressed._compressed_sparse_matrix):
         if _is_csr(other):
             self.sum_duplicates()
             other.sum_duplicates()
-            # int64: always route through cusparse.spgemm, which has a
-            # pure-CuPy fallback when cuSPARSE lacks int64 SpGEMM.
-            is_int64 = (self.indices.dtype == cupy.int64
-                        or other.indices.dtype == cupy.int64)
-            if is_int64 or cusparse.check_availability('spgemm'):
+            # int64 indices and non-float value dtypes: always route
+            # through cusparse.spgemm, which has pure-CuPy fallbacks
+            # when cuSPARSE lacks the required SpGEMM support.
+            needs_spgemm = cusparse._needs_cupy_spgemm(self, other)
+            if needs_spgemm or cusparse.check_availability('spgemm'):
                 return self._as_csr_type(cusparse.spgemm(self, other))
             elif cusparse.check_availability('csrgemm2'):
                 return self._as_csr_type(cusparse.csrgemm2(self, other))
@@ -213,11 +222,10 @@ class _csr_base(_compressed._compressed_sparse_matrix):
         elif _is_csc(other):
             self.sum_duplicates()
             other.sum_duplicates()
-            is_int64 = (self.indices.dtype == cupy.int64
-                        or other.indices.dtype == cupy.int64)
-            if is_int64:
-                # csrgemm/csrgemm2 are int32-only; route via spgemm,
-                # which has a pure-CuPy fallback for older cuSPARSE.
+            needs_spgemm = cusparse._needs_cupy_spgemm(self, other)
+            if needs_spgemm:
+                # csrgemm/csrgemm2 are int32/float-only; route via
+                # spgemm, which has pure-CuPy fallbacks.
                 b = other.tocsr()
                 b.sum_duplicates()
                 return self._as_csr_type(cusparse.spgemm(self, b))
@@ -241,10 +249,30 @@ class _csr_base(_compressed._compressed_sparse_matrix):
             if other.ndim == 0:
                 self.sum_duplicates()
                 return self._with_data(self.data * other)
-            elif other.ndim == 1:
+            native_f16 = False
+            if other.ndim in (1, 2):
+                # cuSPARSE spmv/spmm accept float/complex plus a native
+                # float16 mixed mode (f16 data, f32 compute) that keeps the
+                # operand in float16 -- lower memory than upcasting.  bfloat16
+                # (native CUDA_R_16BF needs cc >= 8.0) and bool/integer
+                # results have no cuSPARSE path, so route them through a
+                # pure-CuPy scatter matmul instead.  Gated off HIP (like the
+                # CSC path): hipSPARSE float16 mixed-mode support is
+                # unverified, so fall back to the f32-upcast scatter there.
+                result_dtype = cupy.promote_types(self.dtype, other.dtype)
+                native_f16 = (
+                    result_dtype.char == 'e' and not runtime.is_hip
+                    and cusparse.check_availability(
+                        'spmv' if other.ndim == 1 else 'spmm'))
+                if (cusparse._needs_cupy_fallback(result_dtype)
+                        and not native_f16):
+                    return cusparse._cupy_csr_dense_matmul(self, other)
+            if other.ndim == 1:
                 self.sum_duplicates()
                 other = cupy.asfortranarray(other)
-                if cusparse.check_availability('csrmv'):
+                # csrmv (legacy) is float/complex-only; float16 must use the
+                # generic spmv, which carries the mixed-precision path.
+                if not native_f16 and cusparse.check_availability('csrmv'):
                     csrmv = cusparse.csrmv
                 elif cusparse.check_availability('spmv'):
                     csrmv = cusparse.spmv
@@ -253,7 +281,9 @@ class _csr_base(_compressed._compressed_sparse_matrix):
                 return csrmv(self, other)
             elif other.ndim == 2:
                 self.sum_duplicates()
-                if cusparse.check_availability('csrmm2'):
+                # csrmm2 (legacy) is float/complex-only; float16 must use the
+                # generic spmm, which carries the mixed-precision path.
+                if not native_f16 and cusparse.check_availability('csrmm2'):
                     csrmm = cusparse.csrmm2
                 elif cusparse.check_availability('spmm'):
                     csrmm = cusparse.spmm
@@ -274,19 +304,33 @@ class _csr_base(_compressed._compressed_sparse_matrix):
     def __truediv__(self, other):
         """Point-wise division by another matrix, vector or scalar"""
         if _util.isscalarlike(other):
-            # Pick the result dtype.  scipy upcasts any dtype that's
-            # castable to float64 (bool/int*/float16/float32/...) before
-            # dividing; mirror that behaviour, and additionally fall
-            # back to float64 for any non-cuSPARSE-supported dtype so
-            # the result remains usable with cuSPARSE-backed ops.
-            # Real-vs-complex follows numpy's natural promotion
-            # (``result_type(float64, complex64) -> complex128``).
+            # Division always yields a float/complex result.
             dtype = self.dtype
-            if dtype == numpy.float32:
-                dtype = numpy.float64
-            dtype = cupy.result_type(dtype, other)
+            if _sputils.is_16bit_float(dtype):
+                # scipy rejects the 16-bit floats, so cupy dense is the oracle.
+                # Probe the actual dense ufunc result: numpy's ``result_type``
+                # is inconsistent for bfloat16 (``result_type(bf16, 2.0)`` is
+                # float64 but ``bf16-array / 2.0`` is float32), so key off the
+                # division ufunc itself, not result_type.
+                dtype = (cupy.zeros(0, dtype) / other).dtype
+            else:
+                # scipy upcasts any dtype castable to float64 before dividing;
+                # mirror that by promoting bool/every integer width/float32 to
+                # float64 first -- otherwise ``reciprocal(2, dtype=int)`` is 0
+                # and an integer matrix divides to all zeros.  Real-vs-complex
+                # then follows numpy's natural promotion.
+                if dtype.kind in 'biu' or dtype == numpy.float32:
+                    dtype = numpy.dtype(numpy.float64)
+                dtype = cupy.result_type(dtype, other)
             if not _sputils.is_sparse_data_dtype(dtype):
-                dtype = numpy.dtype(numpy.float64)
+                # An exotic scalar (e.g. numpy.longdouble/clongdouble)
+                # can promote to a dtype the GPU cannot store
+                # (float128/complex256); fall back to the widest
+                # storable dtype of the same kind so a complex divisor
+                # keeps its imaginary part instead of collapsing to
+                # float64.
+                dtype = numpy.dtype(numpy.complex128 if dtype.kind == 'c'
+                                    else numpy.float64)
             d = cupy.reciprocal(other, dtype=dtype)
             return multiply_by_scalar(self, d)
         if self.ndim != 2:
@@ -295,12 +339,27 @@ class _csr_base(_compressed._compressed_sparse_matrix):
             return self._run_1d_backing_op(
                 other, lambda a, o: a.__truediv__(o))
         if _util.isdense(other):
-            other = cupy.atleast_2d(other)
+            # Division yields a float/complex result; the kernel shares one
+            # dtype ``T`` for the sparse data and the dense divisor, so
+            # promote both (int/bool -> float64, like the scalar path) before
+            # dividing -- otherwise the kernel rejects mismatched int/float
+            # operands and integer data would truncate.  promote_data_types
+            # (not numpy.promote_types) so a bfloat16 sparse / float16 dense
+            # pair resolves to dense's ufunc result (float32) instead of
+            # raising DTypePromotionError.
+            dtype = _sputils.promote_data_types(self.dtype, other.dtype)
+            if dtype.kind in 'biu':
+                dtype = numpy.promote_types(numpy.float64, dtype)
+            other = cupy.atleast_2d(other).astype(dtype, copy=False)
             other = cupy.broadcast_to(other, self.shape)
             check_shape_for_pointwise_op(self.shape, other.shape)
+            # Only ``data`` has to be restaged in ``dtype`` (the kernel writes
+            # a fresh output array); casting the whole matrix would copy the
+            # coordinate arrays too.
             ret = self.tocoo()
             ret.data = _cupy_divide_by_dense()(
-                ret.data, ret.row, ret.col, ret.shape[1], other)
+                ret.data.astype(dtype, copy=False),
+                ret.row, ret.col, ret.shape[1], other)
             return ret
         elif _base.issparse(other):
             # Note: If broadcasting is needed, an exception is raised here for
@@ -308,7 +367,10 @@ class _csr_base(_compressed._compressed_sparse_matrix):
             # in the "sparse / sparse" case.
             check_shape_for_pointwise_op(self.shape, other.shape,
                                          allow_broadcasting=False)
-            dtype = numpy.promote_types(self.dtype, other.dtype)
+            # promote_data_types so a bfloat16/float16 pair does not raise
+            # DTypePromotionError (this path densifies and divides, so the
+            # dense ufunc is the reference).
+            dtype = _sputils.promote_data_types(self.dtype, other.dtype)
             if dtype.char not in 'FD':
                 dtype = numpy.promote_types(numpy.float64, dtype)
             # Note: The following implementation converts two sparse matrices
@@ -339,49 +401,45 @@ class _csr_base(_compressed._compressed_sparse_matrix):
 
     def eliminate_zeros(self):
         """Removes zero entries in place."""
-        from cupyx import cusparse
-
         if self.ndim == 1:
             # Route through the (1, N) backing (rebuilds indptr as
             # [0, nnz]); the direct paths below assume a 2-D shape.
             return self._apply_2d_inplace(lambda m: m.eliminate_zeros())
 
-        if self.indices.dtype == cupy.int64:
-            # TODO(eriknw): cuSPARSE--csr2csr_compress doesn't support int64
-            mask = self.data != 0
-            if mask.all():  # synchronize!
-                return
-            new_data = self.data[mask]
-            new_indices = self.indices[mask]
-            nrows = self.shape[0]
-            idx_dtype = self.indptr.dtype
-            if len(new_data) == 0:
-                self.data = new_data
-                self.indices = new_indices
-                self.indptr = cupy.zeros(nrows + 1, dtype=idx_dtype)
-                return
-            row_of_each = cusparse._indptr_to_coo(
-                self.indptr, nnz=self.nnz)
-            kept_rows = row_of_each[mask]
-            new_indptr = cusparse._build_indptr(
-                kept_rows, nrows, idx_dtype)
-            self.data = new_data
-            self.indices = new_indices
-            self.indptr = new_indptr
+        # Pure-CuPy mask-and-rebuild for every dtype.  cuSPARSE's
+        # csr2csr_compress prunes by ``value > tol`` (a signed threshold), so
+        # at tol=0 it silently drops *negative* stored values, not just the
+        # zeros -- wrong for any signed data.  ``data != 0`` is the exact test
+        # and is also int64-index safe (csr2csr_compress is int32 only).
+        mask = self.data != 0
+        if mask.all():  # synchronize!
             return
-
-        compress = cusparse.csr2csr_compress(self, 0)
-        self.data = compress.data
-        self.indices = compress.indices
-        self.indptr = compress.indptr
+        idx_dtype = self.indptr.dtype
+        # New indptr = running count of survivors sampled at the old row
+        # boundaries (entries are grouped by row in CSR order): one cumsum
+        # plus a gather, no atomic histogram.  ``kept[k]`` is the number of
+        # survivors in ``data[:k]``, so ``kept[indptr]`` is the new indptr;
+        # an all-zero matrix falls out as an all-zero indptr automatically.
+        kept = cupy.empty(self.data.size + 1, dtype=idx_dtype)
+        kept[0] = 0
+        cupy.cumsum(mask, dtype=idx_dtype, out=kept[1:])
+        new_indptr = kept[self.indptr]
+        self.data = self.data[mask]
+        self.indices = self.indices[mask]
+        self.indptr = new_indptr
 
     def _maximum_minimum(self, other, cupy_op, op_name, dense_check):
         cls = type(self)
         if _util.isscalarlike(other):
-            dtype = cupy.result_type(self.dtype, other)
-            other = cupy.asarray(other)
+            dtype = _sputils.promote_scalar_data_type(self.dtype, other)
+            # Build the scalar array *in* the promoted dtype rather than
+            # casting afterwards.  Promotion against a Python scalar is
+            # value-based, so ``result_type(int8, 300)`` is still ``int8``;
+            # ``asarray(300).astype(int8)`` would then wrap to 44, while
+            # ``asarray(300, dtype=int8)`` raises OverflowError like numpy
+            # and scipy.
+            other = cupy.asarray(other, dtype=dtype)
             if dense_check(other):
-                other = other.astype(dtype, copy=False)
                 new_array = cupy_op(self.todense(), other)
                 return cls(new_array)
             else:
@@ -830,7 +888,16 @@ def multiply_by_dense(sp, dn):
     dn_m, dn_n = dn.shape
     m, n = max(sp_m, dn_m), max(sp_n, dn_n)
     nnz = sp.nnz * (m // sp_m) * (n // sp_n)
-    dtype = numpy.promote_types(sp.dtype, dn.dtype)
+    # promote_data_types (not numpy.promote_types) so a bfloat16 sparse
+    # mixed with a >= 16-bit int/float dense resolves to dense's ufunc
+    # result (e.g. float64) instead of raising DTypePromotionError.
+    dtype = _sputils.promote_data_types(sp.dtype, dn.dtype)
+    # The kernel multiplies the sparse and dense values through independent
+    # template parameters, and CUDA has no ``integer * thrust::complex``
+    # operator, so cast both operands to the promoted dtype first (mirrors
+    # ``binopt_csr``).
+    sp_data = sp.data.astype(dtype, copy=False)
+    dn = dn.astype(dtype, copy=False)
     data = cupy.empty(nnz, dtype=dtype)
     indices = cupy.empty(nnz, dtype=sp.indices.dtype)
     if m > sp_m:
@@ -847,7 +914,7 @@ def multiply_by_dense(sp, dn):
     idx_dtype = sp.indptr.dtype
     it = idx_dtype.type
     cupy_multiply_by_dense()(
-        sp.data, sp.indptr, sp.indices, it(sp_m), it(sp_n),
+        sp_data, sp.indptr, sp.indices, it(sp_m), it(sp_n),
         dn, it(dn_m), it(dn_n), indptr, it(m), it(n),
         data, indices)
 
@@ -971,7 +1038,15 @@ def multiply_by_csr(a, b, *, out_cls=None):
     b_indices = b.indices.astype(idx_dtype, copy=False)
     b_indptr = b.indptr.astype(idx_dtype, copy=False)
     c_nnz = a_nnz
-    dtype = numpy.promote_types(a.dtype, b.dtype)
+    # promote_data_types (not numpy.promote_types) so bfloat16 mixed with a
+    # >= 16-bit int resolves to dense's ufunc result instead of raising.
+    dtype = _sputils.promote_data_types(a.dtype, b.dtype)
+    # The kernel multiplies ``A_DATA * B_DATA`` through independent template
+    # parameters, and CUDA has no ``integer * thrust::complex`` (or
+    # ``complex<float> * complex<double>``) operator, so cast both operands
+    # to the promoted dtype first -- mirrors ``binopt_csr``.
+    a_data = a.data.astype(dtype, copy=False)
+    b_data = b.data.astype(dtype, copy=False)
     c_data = cupy.empty(c_nnz, dtype=dtype)
     c_indices = cupy.empty(c_nnz, dtype=idx_dtype)
     if m > a_m:
@@ -989,8 +1064,8 @@ def multiply_by_csr(a, b, *, out_cls=None):
     # compute c = a * b where necessary and get sparsity pattern of matrix d
     it = idx_dtype.type
     cupy_multiply_by_csr_step1()(
-        a.data, a_indptr, a_indices, it(a_m), it(a_n),
-        b.data, b_indptr, b_indices, it(b_m), it(b_n),
+        a_data, a_indptr, a_indices, it(a_m), it(a_n),
+        b_data, b_indptr, b_indices, it(b_m), it(b_n),
         c_indptr, it(m), it(n), c_data, c_indices, flags, nnz_each_row)
 
     flags = cupy.cumsum(flags, dtype=idx_dtype)
@@ -1128,7 +1203,9 @@ def binopt_csr(a, b, op_name):
     a_valid = cupy.zeros(a_nnz, dtype=numpy.int8)
     b_valid = cupy.zeros(b_nnz, dtype=numpy.int8)
     c_indptr = cupy.zeros(m + 1, dtype=idx_dtype)
-    in_dtype = numpy.promote_types(a.dtype, b.dtype)
+    # promote_data_types (not numpy.promote_types) so bfloat16 mixed with a
+    # >= 16-bit int resolves to dense's ufunc result instead of raising.
+    in_dtype = _sputils.promote_data_types(a.dtype, b.dtype)
     a_data = a.data.astype(in_dtype, copy=False)
     b_data = b.data.astype(in_dtype, copy=False)
     funcs = _GET_ROW_ID_
@@ -1368,6 +1445,18 @@ def cupy_binopt_csr_step2(op_name):
 
 
 def csr2dense(a, order):
+    if a.dtype.char in 'bBhH':
+        # 8/16-bit integers have no atomicAdd overload, so the kernel writes
+        # each entry directly -- correct only when duplicate coordinates have
+        # already been summed.  Force a canonicalization (clearing a
+        # possibly-stale ``has_canonical_format`` so ``sum_duplicates`` cannot
+        # no-op on it) so duplicates always sum, matching scipy and the
+        # atomicAdd dtypes.  The O(nnz log nnz) dedup is dominated by the
+        # O(M*N) densify, so this narrow path stays cheap (unlike an
+        # always-canonicalize densify for every dtype).
+        a = a.copy()
+        a.has_canonical_format = False
+        a.sum_duplicates()
     out = cupy.zeros(a.shape, dtype=a.dtype, order=order)
     m, n = a.shape
     idx_dtype = a.indptr.dtype
@@ -1380,8 +1469,20 @@ def csr2dense(a, order):
 @cupy._util.memoize(for_each_device=True)
 def _cupy_csr2dense(dtype):
     if dtype == '?':
+        # Idempotent store: any stored True (also from duplicates) wins.
         op = "if (DATA) OUT[index] = true;"
+    elif dtype.char in 'bBhH':
+        # int8/16 and uint8/16 have no atomicAdd overload.  Direct write
+        # is safe because ``csr2dense`` canonicalizes these dtypes first
+        # (each (row, col) then appears at most once).
+        op = "OUT[index] = DATA;"
     else:
+        # Everything routed here has an atomicAdd overload: int32/int64,
+        # uint32/uint64, and float16/bfloat16 (CuPy adds the int64/uint64/
+        # float16/bfloat16 ones in atomics.cuh).  float32/64 and complex go
+        # through cuSPARSE instead, never this path.  So duplicates sum
+        # correctly without the O(nnz log nnz) pre-canonicalization the
+        # narrow ints need.
         op = "atomicAdd(&OUT[index], DATA);"
 
     return cupy.ElementwiseKernel(

--- a/cupyx/scipy/sparse/_data.py
+++ b/cupyx/scipy/sparse/_data.py
@@ -68,12 +68,11 @@ class _data_matrix(_base._spbase):
     def _scalar_op_dtype(self_dtype, other):
         """Pick the dtype for ``self.data * other`` / ``... / other``.
 
-        numpy's natural promotion can land outside the cuSPARSE-supported
-        set (e.g. ``bool * int -> int64``).  Upcast to ``float64`` in
-        that case so the result remains usable.  Mirrors scipy which
-        promotes bool / int sparse to float on division.
+        numpy's natural promotion can land on a dtype sparse cannot store
+        (e.g. ``float64 * numpy.longdouble -> longdouble``).  Upcast to
+        ``float64`` in that case so the result remains usable.
         """
-        out = np.result_type(self_dtype, other)
+        out = _sputils.promote_scalar_data_type(self_dtype, other)
         if not _sputils.is_sparse_data_dtype(out):
             out = np.dtype(np.float64)
         return out
@@ -124,6 +123,9 @@ class _data_matrix(_base._spbase):
             Sparse object with the requested dtype and the same format.
         """
         dtype = np.dtype(dtype)
+        # Reject targets the GPU cannot store (float8, extended precision) so
+        # ``astype`` cannot bypass the construction-time dtype policy.
+        _sputils.check_data_dtype(dtype)
         if self.dtype != dtype:
             return self._with_data(self.data.astype(dtype, copy=copy))
         if copy:
@@ -214,19 +216,27 @@ class _data_matrix(_base._spbase):
             # empty axis, like scipy.
             _sputils.validate_axis_1d(axis)
             total = self.data.sum() * (1.0 / self.shape[0])
-            return total.sum(dtype=dtype, out=out)
-
-        axis = _sputils.collapse_2d_axis(axis)
-        _sputils.validateaxis(axis)
-        nRow, nCol = self.shape
-        if axis is None:
-            n = nRow * nCol
-        elif axis in (0, -2):
-            n = nRow
+            result = total.sum(dtype=dtype, out=out)
         else:
-            n = nCol
+            axis = _sputils.collapse_2d_axis(axis)
+            _sputils.validateaxis(axis)
+            nRow, nCol = self.shape
+            if axis is None:
+                n = nRow * nCol
+            elif axis in (0, -2):
+                n = nRow
+            else:
+                n = nCol
+            result = self._with_data(self.data * (1.0 / n)).sum(
+                axis, dtype, out)
 
-        return self._with_data(self.data * (1.0 / n)).sum(axis, dtype, out)
+        if (dtype is None and out is None
+                and _sputils.is_extra_float_dtype(self.dtype)):
+            # dense bfloat16.mean() stays bfloat16, but scaling by the
+            # float64 ``1/n`` promoted the data to float32; round back so the
+            # result dtype matches the dense array (float16 already does).
+            result = result.astype(self.dtype)
+        return result
 
     def power(self, n, dtype=None):
         """Elementwise power function.
@@ -245,12 +255,23 @@ class _data_matrix(_base._spbase):
                 'zero power is not supported as it would densify the '
                 'matrix.\n'
                 'Use cupy.ones(A.shape, dtype=A.dtype) for this case.')
-        if dtype is None:
-            data = self.data.copy()
-        else:
-            data = self.data.astype(dtype, copy=True)
-        data **= n
-        return self._with_data(data)
+        # Out-of-place so the result can widen (the in-place ``**=`` could not
+        # cast a promoted result back into a narrow buffer).  Integer/float/
+        # complex keep their own dtype.
+        data = self.data if dtype is None else self.data.astype(
+            dtype, copy=False)
+        if data.dtype.kind == 'b':
+            # scipy/numpy give ``bool ** n`` a per-exponent dtype -- int8 at
+            # n == 2 but int64 for n >= 3 (a numpy promotion quirk).  cupy's
+            # own ``bool ** n`` would give int64 for every n; as a
+            # scipy-compatible sparse type, derive the exact carrier from
+            # numpy so a scipy port sees identical result dtypes.  ``n`` is
+            # scalar-like but may be a 0-D cupy array (e.g. ``coef[0]``);
+            # read it to host for the host-side numpy power, which rejects
+            # a device array.
+            n_host = n.get() if isinstance(n, cupy.ndarray) else n
+            data = data.astype((np.ones(1, np.bool_) ** n_host).dtype)
+        return self._with_data(data ** n)
 
 
 def _find_missing_index(ind, n):
@@ -325,6 +346,10 @@ class _minmax_mixin:
             _sputils.validate_axis_1d(axis)
             axis = None
         else:
+            # scipy accepts a tuple axis for a 2-D reduction (a length-2
+            # tuple spanning both axes is a full reduction); collapse it to
+            # a plain int / None first, matching sum/mean.
+            axis = _sputils.collapse_2d_axis(axis)
             _sputils.validateaxis(axis)
 
         if axis is None:
@@ -383,6 +408,9 @@ class _minmax_mixin:
             _sputils.validate_axis_1d(axis)
             axis = None
         else:
+            # scipy accepts a tuple axis for a 2-D reduction (see
+            # _min_or_max); collapse it to a plain int / None first.
+            axis = _sputils.collapse_2d_axis(axis)
             _sputils.validateaxis(axis)
 
         if axis is None:
@@ -493,7 +521,8 @@ class _minmax_mixin:
         Implicit zero elements are taken into account. If there are several
         maximum values, the index of the first occurrence is returned. If
         ``NaN`` values occur in the matrix, the output defaults to a zero entry
-        for the row/column in which the NaN occurs.
+        for the row/column in which the NaN occurs. Complex inputs are
+        compared by their real part (like the ``min``/``max`` reductions).
 
         Args:
             axis (int): {-2, -1, 0, 1, ``None``} (optional)
@@ -518,7 +547,8 @@ class _minmax_mixin:
         Implicit zero elements are taken into account. If there are several
         minimum values, the index of the first occurrence is returned. If
         ``NaN`` values occur in the matrix, the output defaults to a zero entry
-        for the row/column in which the NaN occurs.
+        for the row/column in which the NaN occurs. Complex inputs are
+        compared by their real part (like the ``min``/``max`` reductions).
 
         Args:
             axis (int): {-2, -1, 0, 1, ``None``} (optional)

--- a/cupyx/scipy/sparse/_sputils.py
+++ b/cupyx/scipy/sparse/_sputils.py
@@ -6,21 +6,190 @@ import numpy
 
 from cupy._core._dtype import get_dtype
 
-supported_dtypes = [get_dtype(x) for x in
-                    ('single', 'double', 'csingle', 'cdouble')]
+# Extra floating dtypes beyond numpy's own that CuPy can store and compute
+# on.  Today this is only ``ml_dtypes.bfloat16`` (an optional dependency):
+# CuPy has no float8 support.  These have no scipy.sparse equivalent (scipy
+# rejects them), so their semantics follow CuPy's dense arrays.  Detected by
+# identity, not dtype ``kind`` (bfloat16's kind is the opaque ``'V'``).
+#
+# CuPy only registers the bfloat16 kernel typename when ml_dtypes is present
+# AND numpy >= 2.1.2; on older numpy the bfloat16 loops are silently a no-op
+# (see cupy/_core/_scalar.pyx, dlpack.pyx and _util.pyx).  Match that guard --
+# without the version check the gate would admit bfloat16 sparse data whose
+# kernels do not exist, and every operation on it would miscompile.
+if numpy.lib.NumpyVersion(numpy.__version__) >= '2.1.2':
+    try:
+        import ml_dtypes as _ml_dtypes
+        _extra_float_dtypes = frozenset([numpy.dtype(_ml_dtypes.bfloat16)])
+    except ImportError:
+        _extra_float_dtypes = frozenset()
+else:
+    _extra_float_dtypes = frozenset()
 
-# dtype kind chars that cuSPARSE accepts for sparse ``data`` arrays:
-#   '?' bool, 'f' float32, 'd' float64, 'F' complex64, 'D' complex128.
-_SPARSE_DATA_KINDS = frozenset('?fdFD')
+# Dtypes ``upcast`` may promote to, widest last.  Mirrors scipy minus the
+# extended-precision types the GPU cannot store (longdouble/clongdouble):
+# without the integer entries ``upcast`` would promote every int/bool
+# combination to float (e.g. hstack/bmat/kronsum of int blocks -> float32).
+# The 16-bit floats (float16, then bfloat16 if available) sit just before
+# float32 so a same-dtype upcast stays 16-bit rather than widening.
+supported_dtypes = (
+    [get_dtype(x) for x in ('bool_', 'int8', 'uint8', 'int16', 'uint16',
+                            'int32', 'uint32', 'int64', 'uint64')]
+    + [get_dtype('float16')]
+    + sorted(_extra_float_dtypes, key=lambda d: d.itemsize)
+    + [get_dtype(x) for x in ('single', 'double', 'csingle', 'cdouble')])
+
+
+def is_extra_float_dtype(dtype):
+    """Whether ``dtype`` is a supported non-numpy float (e.g. bfloat16)."""
+    return numpy.dtype(dtype) in _extra_float_dtypes
+
+
+def is_16bit_float(dtype):
+    """Whether ``dtype`` is a 16-bit float (float16 or bfloat16).
+
+    These widen losslessly to float32, which the pure-CuPy fallbacks use for
+    accumulation and for the value-templated kernels: ``add.at``/``atomicAdd``
+    and the kernel instantiations do not cover the 16-bit floats uniformly.
+    """
+    dtype = numpy.dtype(dtype)
+    return dtype in _extra_float_dtypes or (
+        dtype.kind == 'f' and dtype.itemsize == 2)
+
+
+def is_float_dtype(dtype):
+    """True for real floating-point dtypes, *including* bfloat16.
+
+    A bare ``dtype.kind == 'f'`` test excludes bfloat16 (whose kind is the
+    opaque ``'V'``); use this where a float-vs-non-float decision must treat
+    bfloat16 as the float it is (e.g. ``asfptype``).
+    """
+    return numpy.dtype(dtype).kind == 'f' or is_extra_float_dtype(dtype)
+
+
+def promote_data_types(*dtypes):
+    """``numpy.promote_types`` reduction with a dense-parity fallback.
+
+    bfloat16 mixed with a >= 16-bit int (or with float16) has no numpy
+    abstract promotion -- ml_dtypes never registered it -- so
+    ``numpy.promote_types`` raises ``DTypePromotionError``.  Dense CuPy still
+    resolves the pair through its ufunc loops (e.g. ``bfloat16 + int32 ->
+    float64``); reproduce that by promoting through an actual (empty) add so
+    the elementwise sparse ops (add, multiply, maximum, comparison) match
+    dense.  Only the rare unpromotable mix reaches the fallback -- every other
+    combination takes the plain ``promote_types`` fast path.
+    """
+    try:
+        result = numpy.dtype(dtypes[0])
+        for dt in dtypes[1:]:
+            result = numpy.promote_types(result, dt)
+        return result
+    except TypeError:  # numpy's DTypePromotionError subclasses TypeError
+        acc = cupy.empty(0, numpy.dtype(dtypes[0]))
+        for dt in dtypes[1:]:
+            acc = acc + cupy.empty(0, numpy.dtype(dt))
+        return acc.dtype
+
+
+def promote_scalar_data_type(sparse_dtype, scalar):
+    """Dtype of an elementwise sparse-data op against a *scalar*, like dense.
+
+    For every dtype but the extra floats (bfloat16) this is value-based
+    ``numpy.result_type`` -- so a Python ``int``/``float`` promotes weakly.
+    ``numpy.result_type`` mishandles bfloat16, though: it *raises* for a typed
+    numpy scalar (e.g. ``numpy.int16(1)`` has no abstract promotion) and
+    *over-promotes* a Python float (``result_type(bfloat16, 2.0)`` -> float64
+    where the ufunc gives float32).  Reproduce dense CuPy's actual promotion
+    with a zero-length add so scalar ``maximum``/``minimum``/``*``/``*=`` on a
+    bfloat16 matrix match dense instead of raising or widening.
+    ``maximum``/``minimum``/``multiply`` share ``add``'s operand promotion;
+    division forces a float through its own path.
+    """
+    sparse_dtype = numpy.dtype(sparse_dtype)
+    if not is_extra_float_dtype(sparse_dtype):
+        return numpy.result_type(sparse_dtype, scalar)
+    return (cupy.empty(0, sparse_dtype) + scalar).dtype
+
+
+def get_sum_dtype(dtype):
+    """The dtype ``sum`` accumulates in, mirroring numpy/scipy.
+
+    The counterpart of ``scipy.sparse._sputils.get_sum_dtype``: bool and
+    signed integers widen to the platform int (int64 on the 64-bit builds
+    CuPy targets), unsigned integers to the platform uint; float and complex
+    are unchanged.  Used by the integer axis reductions, which accumulate in
+    an explicit wide type.
+    """
+    dtype = numpy.dtype(dtype)
+    if dtype.kind == 'u' and numpy.can_cast(dtype, numpy.uint):
+        return numpy.dtype(numpy.uint)
+    if numpy.can_cast(dtype, numpy.int_):
+        return numpy.dtype(numpy.int_)
+    return dtype
+
+
+def add_at_accumulator_dtype(dtype):
+    """Return an ``add.at``-compatible accumulator dtype for ``dtype``.
+
+    ``cupy.add.at`` targets only int32/int64/uint32/uint64 and
+    float16/32/64.  bool and narrow signed integers widen to int64 (bool via
+    "any nonzero"); narrow unsigned integers to uint64 (exact; the cast back
+    wraps like numpy); the 16-bit floats accumulate in float32 and round back
+    on the cast (lossless widening).  Every other (already-accepted) dtype is
+    returned unchanged, so the result is always a valid ``add.at`` target.
+    """
+    dtype = numpy.dtype(dtype)
+    if dtype.kind == 'b' or (dtype.kind == 'i' and dtype.itemsize < 4):
+        return numpy.dtype(numpy.int64)
+    if dtype.kind == 'u' and dtype.itemsize < 4:
+        return numpy.dtype(numpy.uint64)
+    if is_16bit_float(dtype):
+        return numpy.dtype(numpy.float32)
+    return dtype
 
 
 def is_sparse_data_dtype(dtype):
     """Return True if ``dtype`` can be stored in a sparse ``data`` array.
 
-    cuSPARSE-backed ops accept only bool, float32, float64, complex64,
-    and complex128 for ``data``.
+    Accepts every dtype CuPy dense arrays support: bool, every signed/
+    unsigned integer width, float16/32/64, complex64/128, and (if installed)
+    bfloat16.  cuSPARSE itself accepts only float32/64 and complex64/128;
+    bool, integers and the 16-bit floats route through pure-CuPy fallbacks.
+    This is a superset of scipy (which rejects float16 and bfloat16).
+    Rejected: extended precision (longdouble/clongdouble) and float8, which
+    the GPU cannot represent.  numpy pins the ``char`` of every fixed-width
+    float/complex ('e'/'f'/'d' and 'F'/'D') and gives longdouble its own
+    'g'/'G', so the char is the platform-independent test here -- the
+    *width* is not (MSVC's ``long double`` is 8 bytes, so longdouble would
+    pass an itemsize check).
     """
-    return numpy.dtype(dtype).char in _SPARSE_DATA_KINDS
+    dtype = numpy.dtype(dtype)
+    if dtype in _extra_float_dtypes:
+        return True
+    if dtype.kind in 'biu':          # bool, signed int, unsigned int
+        return True
+    if dtype.kind == 'f':            # float16/32/64 (not float8/longdouble)
+        return dtype.char in 'efd'
+    if dtype.kind == 'c':            # complex64/complex128 (not clongdouble)
+        return dtype.char in 'FD'
+    return False
+
+
+def check_data_dtype(dtype):
+    """Raise ``ValueError`` if ``dtype`` cannot back a sparse ``data`` array.
+
+    Shared by the constructors and :meth:`astype` so an unsupported dtype
+    (float8 or extended precision the GPU cannot store) is rejected the same
+    way everywhere.  The supported list is built from ``supported_dtypes``,
+    so bfloat16 appears only when ``ml_dtypes`` is installed, and the wording
+    mirrors scipy's ``getdtype`` rejection.
+    """
+    dtype = numpy.dtype(dtype)
+    if not is_sparse_data_dtype(dtype):
+        names = ', '.join(d.name for d in supported_dtypes)
+        raise ValueError(
+            f'cupyx.scipy.sparse does not support dtype {dtype.name}. '
+            f'The only supported types are: {names}.')
 
 
 _upcast_memo: dict = {}

--- a/cupyx/scipy/sparse/linalg/_norm.py
+++ b/cupyx/scipy/sparse/linalg/_norm.py
@@ -7,11 +7,13 @@ import cupyx.scipy.sparse
 
 
 def _sparse_frobenius_norm(x):
-    if cupy.issubdtype(x.dtype, cupy.complexfloating):
-        sqnorm = abs(x).power(2).sum()
-    else:
-        sqnorm = x.power(2).sum()
-    return cupy.sqrt(sqnorm)
+    # Reduce the stored values with ``linalg.norm`` (what scipy does) rather
+    # than ``x.power(2).sum()``: ``power`` keeps an integer matrix integral,
+    # so ``int8(100) ** 2`` would wrap to 16 and the norm would come out ~25x
+    # too small.  ``linalg.norm`` upcasts integers to float64 like numpy.
+    # DIA's ``data`` holds off-matrix padding, so take the COO values there.
+    data = x.data if x.format in ('csr', 'csc', 'coo') else x.tocoo().data
+    return cupy.linalg.norm(data)
 
 
 def norm(x, ord=None, axis=None):

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -60,11 +60,20 @@ def lsqr(A, b):
     if b.ndim != 1 or len(b) != m:
         raise ValueError('b must be 1-d array whose size is same as A')
 
-    # Cast to float32 or float64
-    if A.dtype == 'f' or A.dtype == 'd':
+    # Cast to float32 or float64.  cuSOLVER reads ``A.data``/``b`` through raw
+    # pointers, so the operands must actually be converted -- picking the
+    # kernel from a promoted dtype while leaving a narrower buffer in place
+    # makes it read past the end and return garbage.
+    if A.dtype.char in 'fd':
         dtype = A.dtype
     else:
         dtype = numpy.promote_types(A.dtype, 'f')
+        if dtype.char not in 'fd':
+            # complex: ``scsrlsvqr``/``dcsrlsvqr`` are real-only (mirrors
+            # ``cupyx.cusolver.csrlsvqr``'s rejection).
+            raise TypeError('Invalid dtype (actual: {})'.format(A.dtype))
+        A = A.astype(dtype)
+    b = b.astype(dtype, copy=False)
 
     handle = device.get_cusolver_sp_handle()
     nnz = A.nnz

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_construct.py
@@ -326,9 +326,10 @@ class TestRandomInvalidArgument:
                 sp.random(3, 4, density=1.1)
 
     def test_invalid_dtype(self):
-        # Note: SciPy accepts integer (cupy does not yet).
-        with pytest.raises(NotImplementedError):
-            sparse.random(3, 4, dtype='i')
+        # Integers and the 16-bit floats are now supported; a non-numeric
+        # dtype ('U3') is not.
+        with pytest.raises(ValueError):
+            sparse.random(3, 4, dtype='U3')
 
 
 @testing.parameterize(*testing.product({

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_coo.py
@@ -455,10 +455,12 @@ class TestCooMatrixInit:
                     shape=self.shape)
 
     def test_unsupported_dtype(self):
+        # A non-numeric dtype ('U3') is unsupported; integers and the
+        # 16-bit floats (float16/bfloat16) now are.
         with pytest.raises(ValueError):
             sparse.coo_matrix(
                 (self.data(cupy), (self.row(cupy), self.col(cupy))),
-                shape=self.shape, dtype='i')
+                shape=self.shape, dtype='U3')
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_conj(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csc.py
@@ -428,10 +428,12 @@ class TestCscMatrixInit:
                     shape=self.shape)
 
     def test_unsupported_dtype(self):
+        # A non-numeric dtype ('U3') is unsupported; integers and the
+        # 16-bit floats (float16/bfloat16) now are.
         with pytest.raises(ValueError):
             sparse.csc_matrix(
                 (self.data(cupy), self.indices(cupy), self.indptr(cupy)),
-                shape=self.shape, dtype='i')
+                shape=self.shape, dtype='U3')
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_conj(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -471,10 +471,12 @@ class TestCsrMatrixInit:
                     shape=self.shape)
 
     def test_unsupported_dtype(self):
+        # A non-numeric dtype ('U3') is unsupported; integers and the
+        # 16-bit floats (float16/bfloat16) now are.
         with pytest.raises(ValueError):
             sparse.csr_matrix(
                 (self.data(cupy), self.indices(cupy), self.indptr(cupy)),
-                shape=self.shape, dtype='i')
+                shape=self.shape, dtype='U3')
 
     @testing.numpy_cupy_equal(sp_name='sp')
     def test_conj(self, xp, sp):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparray.py
@@ -392,14 +392,16 @@ class TestSparseArrayTypeIdentity:
             A.toarray(), cupy.array([[1., 2.], [3., 4.]]))
 
     @testing.with_requires('scipy')
-    @pytest.mark.parametrize('iop', [operator.imul, operator.itruediv],
-                             ids=['imul', 'itruediv'])
-    def test_inplace_bool_scalar_diverges_from_scipy(self, iop):
+    @pytest.mark.parametrize('iop,exp_dtype', [
+        (operator.imul, numpy.int64),        # bool * 2 -> int64 (numpy)
+        (operator.itruediv, numpy.float64),  # bool / 2 -> float64
+    ], ids=['imul', 'itruediv'])
+    def test_inplace_bool_scalar_diverges_from_scipy(self, iop, exp_dtype):
         # ``bool *= int`` / ``bool /= int`` violate numpy's same_kind
         # cast rule.  scipy raises ``UFuncTypeError``; CuPy intentionally
-        # diverges, promoting ``self.data`` to a cuSPARSE-supported float
-        # dtype in place while preserving ``self`` (but not ``self.data``)
-        # identity.  Assert both branches directly.
+        # diverges, promoting ``self.data`` in place (to numpy's natural
+        # result dtype -- int64 for ``*``, float64 for ``/``) while
+        # preserving ``self`` (but not ``self.data``) identity.
         data = numpy.array([[True, False], [False, True]])
 
         s = scipy.sparse.csr_array(data)
@@ -411,10 +413,10 @@ class TestSparseArrayTypeIdentity:
         iop(A, 2)
         assert A is old
         assert A.data is not old_data
-        assert A.dtype == cupy.float64
-        # Stored entries are the two ``True``s: ``True * 2 == 2.0``,
+        assert A.dtype == exp_dtype
+        # Stored entries are the two ``True``s: ``True * 2 == 2``,
         # ``True / 2 == 0.5``.
-        expected = float(iop(numpy.float64(1), 2))
+        expected = iop(numpy.float64(1), 2)
         cupy.testing.assert_array_equal(A.data, cupy.full(2, expected))
 
     # Non-in-place ``/`` follows scipy's true-division dtype rules;
@@ -1784,8 +1786,8 @@ class TestSparseArray1D:
 
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_coo_coords_as_2d_dense_array(self, xp, sp):
-        # (data, (ndim, nnz)-array) coords form must still build 2-D
-        # (regression: a dense-coords guard had rejected it).
+        # The ``(data, coords)`` form with ``coords`` a dense (ndim, nnz)
+        # array of indices (not a tuple of 1-D arrays) builds a 2-D array.
         data = xp.array([1., 2., 3.])
         coords = xp.array([[0, 1, 0], [0, 1, 2]])
         return sp.coo_array((data, coords), shape=(2, 3))
@@ -2234,7 +2236,7 @@ class TestSparseArray1D:
 
     # A 2-D operand with a *single* row is still 2-D: the result must stay
     # (1, N), decided by the operand's dimensionality, not the result shape
-    # (regression: _squeeze_to_1d wrongly collapsed a real (1, N) to 1-D).
+    # (a genuine (1, N) result must not be squeezed to 1-D).
     @testing.numpy_cupy_allclose(sp_name='sp')
     def test_1d_lt_dense_1row_stays_2d(self, xp, sp):
         return sp.csr_array(xp.array([1., 0., 2.])) < xp.array([[1., 0., 3.]])

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_int64_indices.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_int64_indices.py
@@ -189,13 +189,17 @@ class TestInt64FormatConversion:
 
 
 class TestInt64Sort:
-    """Lexsort-based fallbacks for csrsort, cscsort, sum_duplicates.
+    """Pure-CuPy sort fallbacks for csrsort, cscsort, sum_duplicates.
 
     cuSPARSE xcsrsort / xcscsort / xcoosort accept only int32 index pointers.
+    The primary path encodes ``(major, minor)`` into one int64 key and radix
+    ``argsort``s it; a two-key ``lexsort`` backs it up when that key could
+    overflow int64 (see the huge-shape fallback tests below).
     """
 
     def test_csr_sort_indices_int64(self):
-        # csrsort int64 path: expand indptr via searchsorted, then lexsort.
+        # csrsort int64 path: expand indptr via searchsorted, then sort by a
+        # composite (row, col) key.
         # Row 0 has columns [_LARGE+1, _LARGE] (deliberately unsorted).
         data = cupy.array([1.0, 2.0])
         indices = cupy.array([_LARGE + 1, _LARGE], dtype=cupy.int64)
@@ -257,6 +261,85 @@ class TestInt64Sort:
         assert m.has_sorted_indices
         testing.assert_array_equal(m.indices, cupy.array([0, 1, 2]))
         testing.assert_array_equal(m.data, cupy.array([2.0, 3.0, 1.0]))
+
+    def test_coosort_lexsort_fallback_huge_shape(self):
+        # A logical shape so large that the composite key ``row * ncol + col``
+        # would overflow int64 must fall back to a two-key lexsort.  Small
+        # major (3 rows), huge minor: 3 * ncol > 2**63 trips the guard, yet
+        # only a handful of entries are allocated (no dense-size arrays).
+        ncol = 2**62
+        assert 3 * ncol >= (1 << 63)      # guard trips -> lexsort fallback
+        row = cupy.array([2, 0, 2, 0], dtype=cupy.int64)
+        col = cupy.array([ncol - 1, ncol - 2, 5, ncol - 2], dtype=cupy.int64)
+        data = cupy.array([10.0, 20.0, 30.0, 40.0])
+        for sort_by in ('r', 'c'):
+            m = sparse.coo_matrix((data, (row, col)), shape=(3, ncol))
+            cusparse.coosort(m, sort_by)
+            r, c = cupy.asnumpy(m.row), cupy.asnumpy(m.col)
+            pairs = list(zip(r, c)) if sort_by == 'r' else list(zip(c, r))
+            assert pairs == sorted(pairs), sort_by
+            assert m.col.dtype == cupy.int64
+            assert int(c.max()) == ncol - 1   # huge col not truncated
+
+    def test_csrsort_lexsort_fallback_huge_shape(self):
+        # csrsort's within-row composite key would overflow int64 for a huge
+        # column count; the lexsort fallback keeps the sort correct.
+        ncol = 2**62
+        assert 2 * ncol >= (1 << 63)
+        # row 0: cols [ncol-1, 5] (unsorted); row 1: [ncol-2]
+        data = cupy.array([1.0, 2.0, 3.0])
+        indices = cupy.array([ncol - 1, 5, ncol - 2], dtype=cupy.int64)
+        indptr = cupy.array([0, 2, 3], dtype=cupy.int64)
+        m = sparse.csr_matrix((data, indices, indptr), shape=(2, ncol))
+        m.has_sorted_indices = False
+        m.sort_indices()
+        assert m.has_sorted_indices
+        si = cupy.asnumpy(m.indices)
+        assert list(si[:2]) == [5, ncol - 1]           # row 0 sorted
+        assert float(cupy.asnumpy(m.data)[0]) == 2.0    # data followed indices
+
+
+class TestArgsortMajorMinor:
+    """The composite sort key shared by the pure-CuPy sort fallbacks.
+
+    ``cusparse._argsort_major_minor`` encodes ``(major, minor)`` into one
+    int64 key and radix-argsorts it, falling back to a two-key ``lexsort``
+    when ``major_count * minor_range`` could overflow int64.  Both branches
+    must produce the same canonical order.
+    """
+
+    @staticmethod
+    def _sorted_pairs(major, minor, order):
+        o = cupy.asnumpy(order)
+        return list(zip(cupy.asnumpy(major)[o].tolist(),
+                        cupy.asnumpy(minor)[o].tolist()))
+
+    @pytest.mark.parametrize('dtype', [cupy.int32, cupy.int64])
+    def test_both_branches_agree(self, dtype):
+        major = cupy.array([2, 0, 1, 2, 0], dtype=dtype)
+        minor = cupy.array([4, 7, 0, 1, 3], dtype=dtype)
+        want = sorted(zip(cupy.asnumpy(major).tolist(),
+                          cupy.asnumpy(minor).tolist()))
+        order = cusparse._argsort_major_minor(major, minor, 3, 8)
+        assert self._sorted_pairs(major, minor, order) == want
+        # 2**60 * 8 == 2**63: the key would overflow, so lexsort runs instead
+        order = cusparse._argsort_major_minor(major, minor, 2**60, 8)
+        assert self._sorted_pairs(major, minor, order) == want
+
+    def test_int32_major_widened_before_multiply(self):
+        # 3000 * 10**6 exceeds int32 but not int64; without the widening cast
+        # the key would wrap negative and sort the pairs backwards.
+        major = cupy.array([3000, 1], dtype=cupy.int32)
+        minor = cupy.array([7, 5], dtype=cupy.int32)
+        order = cusparse._argsort_major_minor(major, minor, 2**31 - 1, 10**6)
+        assert self._sorted_pairs(major, minor, order) == [(1, 5), (3000, 7)]
+
+    def test_empty(self):
+        empty = cupy.empty(0, dtype=cupy.int64)
+        for major_count in (4, 2**60):    # composite-key, then lexsort
+            order = cusparse._argsort_major_minor(
+                empty, empty, major_count, 8)
+            assert order.size == 0
 
 
 class TestInt64ArithmeticFallback:
@@ -1724,6 +1807,33 @@ class TestInt64FancyMinorIndex:
         assert sub.nnz == 0
         assert sub.shape == (2, 1)
 
+    @testing.slow
+    def test_csr_fancy_col_major_axis_over_int32(self):
+        # A *major* axis past INT32_MAX must route to the sorted path too:
+        # the histogram path launches one block per row, which exceeds the
+        # CUDA gridDim.x limit (and its kernels take the row count as
+        # ``const int``, so the bound check would wrap as well).
+        # Requires ~40 GB: the (M+1)-entry int64 indptr alone is 17 GB, and
+        # the output's indptr is another.
+        mem_free = cupy.cuda.runtime.memGetInfo()[0]
+        if mem_free < 40 * (1 << 30):
+            pytest.skip('insufficient GPU memory (~40 GB needed)')
+        M, N = _LARGE + 9, 4          # M = 2**31 + 10 > INT32_MAX
+        indptr = cupy.full(M + 1, 3, dtype=cupy.int64)
+        indptr[0] = 0
+        m = sparse.csr_matrix._from_parts(
+            cupy.array([1.0, 2.0, 3.0]),
+            cupy.array([0, 1, 3], dtype=cupy.int64),
+            indptr, (M, N),
+            has_canonical_format=True, has_sorted_indices=True)
+        sub = m[:, [0, 2]]
+        assert sub.shape == (M, 2)
+        assert sub.nnz == 1
+        # Densify one row only -- the full (M, 2) dense array is 34 GB.
+        assert sub[:1].toarray().tolist() == [[1.0, 0.0]]
+        del m, sub, indptr
+        cupy.get_default_memory_pool().free_all_blocks()
+
     def test_csc_fancy_row_large_index(self):
         # CSC: minor axis is rows.  m[[_LARGE], :] triggers the same
         # _minor_index_fancy_sorted path.
@@ -2507,7 +2617,9 @@ class TestInt64SetitemInsert:
             cupy.array([_LARGE], dtype=cupy.int64),
             cupy.array([0, 1, 1], dtype=cupy.int64),
             self._shape)
-        m[1, 0] = 42.0
+        # Row 1 is empty, so this inserts a new entry.
+        with pytest.warns(sparse.SparseEfficiencyWarning):
+            m[1, 0] = 42.0
         assert m.nnz == 2
         assert float(m[1, 0]) == pytest.approx(42.0)
         assert float(m[0, _LARGE]) == pytest.approx(1.0)
@@ -2518,7 +2630,9 @@ class TestInt64SetitemInsert:
             cupy.array([_LARGE], dtype=cupy.int64),
             cupy.array([0, 1, 1], dtype=cupy.int64),
             (_LARGE + 2, 2))
-        m[0, 1] = 42.0
+        # Column 1 is empty, so this inserts a new entry.
+        with pytest.warns(sparse.SparseEfficiencyWarning):
+            m[0, 1] = 42.0
         assert m.nnz == 2
         assert m.indices.dtype == cupy.int64
         assert float(m[0, 1]) == pytest.approx(42.0)
@@ -2826,12 +2940,16 @@ class TestInt64FollowupScalarComparison:
         dense = numpy.array([[1., 0., 3.], [0., -2., 0.]])
         sp_m = scipy.sparse.csr_matrix(dense)
         cp_m = sparse.csr_matrix(cupy.array(dense))
-        for scalar in [0, 1, -1]:
-            for op in ['__eq__', '__ne__', '__gt__', '__lt__']:
-                sp_r = getattr(sp_m, op)(scalar).toarray()
-                cp_r = getattr(cp_m, op)(scalar).toarray().get()
-                assert numpy.array_equal(sp_r, cp_r), \
-                    f'{op}({scalar}) mismatch'
+        with warnings.catch_warnings():
+            # Comparisons whose result is dense are flagged as
+            # inefficient by both scipy and cupy.
+            warnings.simplefilter('ignore', sparse.SparseEfficiencyWarning)
+            for scalar in [0, 1, -1]:
+                for op in ['__eq__', '__ne__', '__gt__', '__lt__']:
+                    sp_r = getattr(sp_m, op)(scalar).toarray()
+                    cp_r = getattr(cp_m, op)(scalar).toarray().get()
+                    assert numpy.array_equal(sp_r, cp_r), \
+                        f'{op}({scalar}) mismatch'
 
     def test_large_shape_no_oom(self):
         # Without the fast path these would each allocate ~34 GB.
@@ -3242,14 +3360,19 @@ class TestInt64Operations:
 
     def test_setitem(self):
         m = _make_int64_csr(20, 20, density=0.3)
-        m[0, 0] = 99.0
+        with warnings.catch_warnings():
+            # The matrix is random, so (0, 0) may be either an update of
+            # a stored entry or an insertion.
+            warnings.simplefilter('ignore', sparse.SparseEfficiencyWarning)
+            m[0, 0] = 99.0
         assert m.indices.dtype == cupy.int64
         assert float(m[0, 0]) == 99.0
         # New entry (sparsity structure change)
         m2 = sparse.csr_matrix._from_parts(
             cupy.array([1.0]), cupy.array([0], dtype=cupy.int64),
             cupy.array([0, 1, 1, 1], dtype=cupy.int64), (3, 3))
-        m2[1, 1] = 5.0
+        with pytest.warns(sparse.SparseEfficiencyWarning):
+            m2[1, 1] = 5.0
         assert m2.indices.dtype == cupy.int64
         assert float(m2[1, 1]) == 5.0
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_value_dtypes.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_value_dtypes.py
@@ -1,0 +1,1740 @@
+"""Scipy-parity tests for the full set of supported sparse value dtypes.
+
+``cupyx.scipy.sparse`` accepts the same value dtypes as scipy: ``bool``,
+every signed/unsigned integer width, ``float32``/``float64`` and
+``complex64``/``complex128``.  cuSPARSE itself only handles float/complex, so
+bool and integer data route through pure-CuPy fallbacks; these tests pin the
+fallbacks to scipy across construction, conversion, arithmetic, matmul,
+reductions and indexing (including integer overflow, which must wrap).
+"""
+from __future__ import annotations
+
+import functools
+import operator
+
+import numpy
+import pytest
+try:
+    import scipy.sparse  # noqa: F401
+except ImportError:
+    pass
+
+import cupy
+from cupy import testing
+from cupyx import cusparse
+from cupyx.scipy import sparse
+
+# ==/<=/>= (and out-of-range </<=/!=) comparisons on a sparse matrix
+# intentionally emit SparseEfficiencyWarning; these tests check the comparison
+# RESULT, not the warning, so silence it module-wide.
+pytestmark = pytest.mark.filterwarnings(
+    'ignore::cupyx.scipy.sparse.SparseEfficiencyWarning')
+
+# These tests pin value/dtype parity, not memory layout; cupy and scipy
+# differ in the C/F contiguity of ``toarray`` for some formats (e.g. CSC),
+# which is irrelevant here, so skip the contiguity check.
+_allclose = functools.partial(
+    testing.numpy_cupy_allclose, sp_name='sp', contiguous_check=False)
+_array_equal = functools.partial(
+    testing.numpy_cupy_array_equal, sp_name='sp')
+
+
+INT_DTYPES = [
+    numpy.int8, numpy.int16, numpy.int32, numpy.int64,
+    numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64,
+]
+# Every value dtype scipy stores that the GPU can represent.
+ALL_VALUE_DTYPES = (
+    [numpy.bool_] + INT_DTYPES + [numpy.float32, numpy.float64,
+                                  numpy.complex64, numpy.complex128]
+)
+COMPRESSED_FORMATS = ('csr', 'csc', 'coo')
+
+# 16-bit floats cupy supports beyond scipy (scipy rejects both).  They have
+# no scipy oracle, so ``TestNarrowFloatVsDense`` checks them against cupy's
+# dense arrays instead.  bfloat16 needs the optional ``ml_dtypes`` package.
+NARROW_FLOAT_DTYPES = [numpy.dtype(numpy.float16)]
+try:
+    import ml_dtypes as _ml_dtypes
+    _bfloat16 = numpy.dtype(_ml_dtypes.bfloat16)
+    NARROW_FLOAT_DTYPES.append(_bfloat16)
+except ImportError:
+    _bfloat16 = None
+requires_bfloat16 = pytest.mark.skipif(
+    _bfloat16 is None, reason='ml_dtypes (bfloat16) not installed')
+
+# A representative subset of integer widths for the scipy-parity helpers.
+_scipy_dtypes = [numpy.int8, numpy.int32, numpy.int64, numpy.uint8]
+
+
+def _dense_a(xp, dtype):
+    """A fixed 4x5 array with a mix of zeros (small values, no overflow)."""
+    a = xp.array([[3, 0, 1, 0, 2],
+                  [0, 5, 0, 4, 0],
+                  [7, 0, 0, 0, 6],
+                  [0, 8, 9, 0, 0]])
+    return a.astype(dtype)
+
+
+def _dense_b(xp, dtype):
+    """A second fixed 4x5 array; sparsity distinct from ``_dense_a``."""
+    b = xp.array([[0, 2, 0, 0, 1],
+                  [4, 0, 3, 0, 0],
+                  [0, 0, 5, 6, 0],
+                  [1, 0, 0, 2, 3]])
+    return b.astype(dtype)
+
+
+def _square(xp, dtype):
+    """A fixed 4x4 array (for matmul / power)."""
+    a = xp.array([[2, 0, 1, 0],
+                  [0, 3, 0, 1],
+                  [1, 0, 2, 0],
+                  [0, 1, 0, 2]])
+    return a.astype(dtype)
+
+
+def _make(sp, xp, dense, fmt):
+    return getattr(sp, f'{fmt}_array')(dense)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestConstructionConversion:
+
+    @_allclose()
+    def test_toarray_roundtrip(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).toarray()
+
+    @_allclose()
+    def test_tocsr(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).tocsr()\
+            .toarray()
+
+    @_allclose()
+    def test_tocsc(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).tocsc()\
+            .toarray()
+
+    @_allclose()
+    def test_tocoo(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).tocoo()\
+            .toarray()
+
+    @_allclose()
+    def test_full_roundtrip(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        return a.tocsr().tocsc().tocoo().tocsr().toarray()
+
+    @_allclose()
+    def test_copy(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).copy()\
+            .toarray()
+
+    def test_dtype_preserved(self):
+        a = _make(sparse, cupy, _dense_a(cupy, self.dtype), self.fmt)
+        assert a.dtype == self.dtype
+        assert a.toarray().dtype == self.dtype
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestArithmetic:
+
+    @_allclose()
+    def test_add(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _dense_b(xp, self.dtype), self.fmt)
+        return (a + b).toarray()
+
+    @_allclose()
+    def test_multiply_elementwise(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _dense_b(xp, self.dtype), self.fmt)
+        return a.multiply(b).toarray()
+
+    @_allclose()
+    def test_multiply_dense(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        return a.multiply(_dense_b(xp, self.dtype)).toarray()
+
+    @_allclose()
+    def test_scalar_mul(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        return (a * 3).toarray()
+
+    @_allclose()
+    def test_maximum(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _dense_b(xp, self.dtype), self.fmt)
+        return a.maximum(b).toarray()
+
+    @_allclose()
+    def test_minimum(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _dense_b(xp, self.dtype), self.fmt)
+        return a.minimum(b).toarray()
+
+    @_allclose()
+    def test_matmul_sparse(self, xp, sp):
+        a = _make(sp, xp, _square(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _square(xp, self.dtype), self.fmt)
+        return (a @ b).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestSubtraction:
+
+    @_allclose()
+    def test_sub(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        b = _make(sp, xp, _dense_b(xp, self.dtype), self.fmt)
+        return (a - b).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestBoolSubtraction:
+    """``bool - bool`` matches scipy.sparse (which supports it, unlike numpy
+    dense): it is computed in int8 so a coalesced ``True - True`` cancels to
+    ``False`` rather than being OR-ed to ``True``."""
+
+    @_allclose()
+    def test_bool_sub_cancels(self, xp, sp):
+        # (0, 0) is True in both operands -> True - True -> False.
+        a = _make(sp, xp, xp.array([[True, True], [False, True]]), self.fmt)
+        b = _make(sp, xp, xp.array([[True, False], [True, True]]), self.fmt)
+        return (a - b).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+    'op': ['lt', 'le', 'gt', 'ge', 'eq', 'ne'],
+}))
+class TestComparisons:
+
+    @_allclose()
+    def test_sparse_sparse(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        b = _make(sp, xp, _dense_b(xp, self.dtype), 'csr')
+        return getattr(operator, self.op)(a, b).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': INT_DTYPES + [numpy.bool_],
+}))
+class TestMatmulDense:
+
+    @_allclose()
+    def test_sparse_at_vector(self, xp, sp):
+        a = _make(sp, xp, _square(xp, self.dtype), 'csr')
+        v = xp.arange(4).astype(self.dtype)
+        return a @ v
+
+    @_allclose()
+    def test_sparse_at_matrix(self, xp, sp):
+        a = _make(sp, xp, _square(xp, self.dtype), 'csr')
+        m = _square(xp, self.dtype).T.copy()
+        return a @ m
+
+    @_allclose()
+    def test_csc_at_matrix(self, xp, sp):
+        a = _make(sp, xp, _square(xp, self.dtype), 'csc')
+        m = _square(xp, self.dtype).T.copy()
+        return a @ m
+
+    @_allclose()
+    def test_dense_at_sparse(self, xp, sp):
+        a = _make(sp, xp, _square(xp, self.dtype), 'csr')
+        m = _square(xp, self.dtype).T.copy()
+        return m @ a
+
+
+@testing.parameterize(*testing.product({
+    'dtype': INT_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestReductionsSum:
+
+    @_allclose()
+    def test_sum_none(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).sum()
+
+    @_allclose()
+    def test_sum_axis0(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).sum(axis=0)
+
+    @_allclose()
+    def test_sum_axis1(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).sum(axis=1)
+
+    @_allclose()
+    def test_mean_axis0(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).mean(axis=0)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': INT_DTYPES,
+    # cupy exposes min/max/argmin/argmax only on the compressed formats
+    # (a pre-existing gap for COO, independent of value dtype).
+    'fmt': ('csr', 'csc'),
+}))
+class TestReductionsMinMax:
+
+    @_allclose()
+    def test_min_axis0(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        return a.min(axis=0).toarray()
+
+    @_allclose()
+    def test_max_axis1(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), self.fmt)
+        return a.max(axis=1).toarray()
+
+    @_array_equal()
+    def test_argmin_axis0(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).argmin(axis=0)
+
+    @_array_equal()
+    def test_argmax_axis1(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).argmax(axis=1)
+
+
+class TestMinMaxLargeInt64:
+    """64-bit integer magnitudes exceed float64's exact range (2**53)."""
+
+    @_allclose()
+    def test_int64_max_axis(self, xp, sp):
+        base = 2 ** 53
+        dense = xp.array([[base + 1, 0, base + 5],
+                          [0, base + 3, 0]], dtype=xp.int64)
+        return sp.csr_array(dense).max(axis=0).toarray()
+
+    @_allclose()
+    def test_uint64_max_axis(self, xp, sp):
+        base = 2 ** 63
+        dense = xp.array([[base + 1, 0, base + 5],
+                          [0, base + 3, 0]], dtype=xp.uint64)
+        return sp.csr_array(dense).max(axis=0).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+}))
+class TestIndexing:
+
+    @_allclose()
+    def test_row_slice(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), 'csr')[1:3].toarray()
+
+    @_allclose()
+    def test_row_fancy(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        return a[[0, 2, 1]].toarray()
+
+    @_allclose()
+    def test_col_fancy(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        return a[:, [4, 1, 0]].toarray()
+
+    @_allclose()
+    def test_scalar_getitem(self, xp, sp):
+        # Return the raw scalar so complex dtypes work too (``int()`` cannot
+        # cast a complex scalar); position (2, 4) holds a stored nonzero.
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        return a[2, 4]
+
+    @_allclose()
+    def test_diagonal(self, xp, sp):
+        return _make(sp, xp, _square(xp, self.dtype), 'csr').diagonal()
+
+    @_allclose()
+    def test_transpose(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), 'csr').T.toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': INT_DTYPES,
+}))
+class TestUnary:
+
+    @_allclose()
+    def test_abs(self, xp, sp):
+        return abs(_make(sp, xp, _dense_a(xp, self.dtype), 'csr')).toarray()
+
+    @_allclose()
+    def test_neg_signed(self, xp, sp):
+        if self.dtype(0).dtype.kind != 'i':
+            pytest.skip('negation only well-defined for signed integers')
+        return (-_make(sp, xp, _dense_a(xp, self.dtype), 'csr')).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.int8, numpy.int64, numpy.uint8],
+    'ddtype': [numpy.float32, numpy.float64, numpy.int64],
+}))
+class TestDivision:
+
+    @_allclose()
+    def test_div_dense(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        d = _dense_b(xp, self.ddtype) + 1  # avoid divide-by-zero
+        return (a / d).toarray()
+
+    @_allclose()
+    def test_div_scalar(self, xp, sp):
+        a = _make(sp, xp, _dense_a(xp, self.dtype), 'csr')
+        return (a / 3).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'idtype': [numpy.int8, numpy.int16, numpy.uint8],
+}))
+class TestIntegerOverflowWraps:
+    """Integer results must wrap on overflow, matching numpy/scipy."""
+
+    @_array_equal()
+    def test_add_overflow(self, xp, sp):
+        info = numpy.iinfo(self.idtype)
+        big = info.max
+        dense = xp.array([[big, 0], [0, big]]).astype(self.idtype)
+        a = sp.csr_array(dense)
+        return (a + a).toarray()
+
+    @_array_equal()
+    def test_matmul_overflow(self, xp, sp):
+        info = numpy.iinfo(self.idtype)
+        v = info.max // 2 + 1
+        dense = xp.array([[v, v], [0, v]]).astype(self.idtype)
+        a = sp.csr_array(dense)
+        return (a @ a).toarray()
+
+    @_array_equal()
+    def test_scalar_mul_overflow(self, xp, sp):
+        info = numpy.iinfo(self.idtype)
+        dense = xp.array([[info.max, 0], [0, info.max]]).astype(self.idtype)
+        return (sp.csr_array(dense) * 3).toarray()
+
+
+@testing.parameterize(*testing.product({
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestDtypeGating:
+
+    def test_longdouble_rejected(self):
+        # Extended precision cannot be stored on the GPU.
+        if numpy.dtype(numpy.longdouble).itemsize <= 8:
+            pytest.skip('longdouble aliases float64 on this platform')
+        a = getattr(sparse, f'{self.fmt}_array')(
+            cupy.eye(3, dtype=numpy.float64))
+        with pytest.raises(ValueError):
+            a.astype(numpy.longdouble)
+
+    def test_astype_to_int_ok(self):
+        a = getattr(sparse, f'{self.fmt}_array')(
+            cupy.eye(3, dtype=numpy.float64))
+        assert a.astype(numpy.int16).dtype == numpy.int16
+
+    def test_astype_to_float16_ok(self):
+        a = getattr(sparse, f'{self.fmt}_array')(
+            cupy.eye(3, dtype=numpy.float64))
+        assert a.astype(numpy.float16).dtype == numpy.float16
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+}))
+class TestRandomArray:
+
+    def test_random_dtype_and_nonzero(self):
+        r = sparse.random_array((30, 30), density=0.3, dtype=self.dtype,
+                                rng=cupy.random.RandomState(0))
+        assert r.dtype == self.dtype
+        assert r.nnz > 0
+        data = r.data.get()
+        kind = numpy.dtype(self.dtype).kind
+        if kind == 'i':
+            # Full-range sampling should produce some negative values.
+            assert (data < 0).any()
+        elif kind == 'c':
+            assert (data.imag != 0).any()
+
+
+class TestRandomDtypeGating:
+
+    def test_float16_accepted(self):
+        r = sparse.random_array((6, 6), density=0.5, dtype=numpy.float16)
+        assert r.dtype == numpy.float16
+        assert r.nnz > 0
+
+    def test_longdouble_rejected(self):
+        if numpy.dtype(numpy.longdouble).itemsize <= 8:
+            pytest.skip('longdouble aliases float64 on this platform')
+        with pytest.raises(ValueError):
+            sparse.random_array((5, 5), dtype=numpy.longdouble)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES + NARROW_FLOAT_DTYPES,
+    'fmt': ('csr', 'csc'),
+}))
+class TestEliminateZeros:
+    """``eliminate_zeros`` must work for every dtype.  One pure-CuPy
+    mask-and-rebuild path serves all dtypes: cuSPARSE's ``csr2csr_compress``
+    prunes by a signed ``value > tol`` (which drops negatives, not just
+    zeros) and is int32-only, so it is not used."""
+
+    def test_drops_stored_zero(self):
+        a = getattr(sparse, f'{self.fmt}_array')(_dense_a(cupy, self.dtype))
+        a.data[0] = 0            # force one explicitly-stored zero
+        n_before = int(a.nnz)
+        a.eliminate_zeros()
+        assert int(a.nnz) == n_before - 1
+        assert not bool((a.data == 0).any())
+
+
+def _narrow_check(sp_res, dn_res, *, dtype_match=True, rtol=4e-2):
+    """Compare a sparse result to a cupy dense oracle in float32.
+
+    The pure-CuPy fallbacks accumulate 16-bit floats in float32, so results
+    are compared after widening; a modest tolerance covers 16-bit rounding.
+    """
+    sr = sp_res.toarray() if hasattr(sp_res, 'toarray') else sp_res
+    sr = cupy.asarray(sr)
+    dn = cupy.asarray(dn_res)
+    if dtype_match:
+        assert sr.dtype == dn.dtype, f'{sr.dtype} != {dn.dtype}'
+    testing.assert_allclose(sr.astype(cupy.float32), dn.astype(cupy.float32),
+                            rtol=rtol, atol=1e-2)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': NARROW_FLOAT_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestNarrowFloatVsDense:
+    """float16/bfloat16 have no scipy equivalent, so check against cupy dense.
+
+    Covers the ops whose fallbacks route 16-bit floats through float32
+    (arithmetic, matmul, reductions); dense uses the same values.
+    """
+
+    def _pair(self):
+        da = _dense_a(cupy, self.dtype)
+        db = _dense_b(cupy, self.dtype)
+        make = getattr(sparse, f'{self.fmt}_array')
+        return make(da), make(db), da, db
+
+    def test_toarray(self):
+        A, _, da, _ = self._pair()
+        _narrow_check(A, da)
+
+    def test_add(self):
+        A, B, da, db = self._pair()
+        _narrow_check(A + B, da + db)
+
+    def test_multiply(self):
+        A, B, da, db = self._pair()
+        _narrow_check(A.multiply(B), da * db)
+
+    def test_scalar_mul(self):
+        A, _, da, _ = self._pair()
+        _narrow_check(A * 3, da * self.dtype.type(3))
+
+    def test_matmul_sparse(self):
+        d = _square(cupy, self.dtype)
+        A = getattr(sparse, f'{self.fmt}_array')(d)
+        _narrow_check(A @ A, d @ d)
+
+    def test_matmul_dense(self):
+        d = _square(cupy, self.dtype)
+        A = getattr(sparse, f'{self.fmt}_array')(d)
+        _narrow_check(A @ d, d @ d)
+
+    def test_sum_axis0(self):
+        A, _, da, _ = self._pair()
+        _narrow_check(A.sum(axis=0), da.sum(axis=0))
+
+    def test_sum_none(self):
+        A, _, da, _ = self._pair()
+        _narrow_check(A.sum(), da.sum())
+
+    def test_mean_axis0(self):
+        A, _, da, _ = self._pair()
+        _narrow_check(A.mean(axis=0), da.mean(axis=0))
+
+    def test_dtype_preserved(self):
+        A, _, _, _ = self._pair()
+        assert A.dtype == self.dtype
+        assert A.tocsc().dtype == self.dtype
+
+
+@testing.parameterize(*testing.product({
+    'dtype': NARROW_FLOAT_DTYPES,
+}))
+class TestNarrowFloatReductionsIndexing:
+    """min/max/argmin and indexing for 16-bit floats (CSR), vs cupy dense."""
+
+    def _A(self):
+        da = _dense_a(cupy, self.dtype)
+        return sparse.csr_array(da), da
+
+    def test_min_axis0(self):
+        A, da = self._A()
+        _narrow_check(A.min(axis=0), da.min(axis=0))
+
+    def test_max_axis1(self):
+        A, da = self._A()
+        _narrow_check(A.max(axis=1), da.max(axis=1))
+
+    def test_argmin_axis0(self):
+        A, da = self._A()
+        _narrow_check(A.argmin(axis=0), da.argmin(axis=0), dtype_match=False)
+
+    def test_argmax_axis1(self):
+        A, da = self._A()
+        _narrow_check(A.argmax(axis=1), da.argmax(axis=1), dtype_match=False)
+
+    def test_col_fancy(self):
+        A, da = self._A()
+        _narrow_check(A[:, [0, 2]], da[:, [0, 2]])
+
+    def test_row_fancy(self):
+        A, da = self._A()
+        _narrow_check(A[[0, 2, 1]], da[[0, 2, 1]])
+
+    def test_row_slice(self):
+        A, da = self._A()
+        _narrow_check(A[1:3], da[1:3])
+
+    def test_scalar_getitem(self):
+        A, da = self._A()
+        _narrow_check(A[2, 4], da[2, 4])
+
+    def test_transpose(self):
+        A, da = self._A()
+        _narrow_check(A.T, da.T)
+
+
+class TestValueSemanticsRegressions:
+    """Value-semantics edge cases the happy-path tests do not cover."""
+
+    @pytest.mark.parametrize('dtype', INT_DTYPES)
+    def test_matmul_dimension_mismatch_raises(self, dtype):
+        # The pure-CuPy int matmul must raise (not silently clamp the gather)
+        # on a length mismatch, like the float path and scipy.
+        a = sparse.csr_array(
+            cupy.asarray(numpy.array([[1, 0, 2, 0], [0, 3, 0, 0]], dtype)))
+        with pytest.raises(ValueError):
+            a @ cupy.arange(3).astype(dtype)          # needs length 4
+        with pytest.raises(ValueError):
+            a @ cupy.arange(3 * 2).reshape(3, 2).astype(dtype)
+
+    @pytest.mark.parametrize('op', ['argmin', 'argmax'])
+    def test_complex_argreduce_axis(self, op):
+        # Complex arg-reduction along an axis must not crash; it reduces on
+        # the real part (like complex min/max).  With distinct real parts per
+        # column that agrees with scipy's lexicographic result.
+        m = numpy.array([[1 + 2j, 0, 3], [0, 5 - 1j, 0], [4 + 0j, 0, 2 - 3j]])
+        g = getattr(sparse.csr_array(cupy.asarray(m)), op)(axis=0)
+        s = numpy.asarray(getattr(scipy.sparse.csr_array(m), op)(axis=0))
+        testing.assert_array_equal(cupy.asarray(g).ravel().get(), s.ravel())
+
+    def test_complex_argreduce_reduces_on_real_part(self):
+        # cupy compares complex by real part (consistent with min/max), which
+        # diverges from scipy's lexicographic tie-break.  Pin it so a future
+        # "parity" change is a conscious decision, not an accidental break.
+        c = cupy.array([[1 + 2j, 1 + 9j, 0]], dtype=cupy.complex64)
+        a = sparse.csr_array(c)
+        # Real parts tie at 1; the first max-real wins (not the larger imag).
+        assert int(a.argmax(axis=1).get().ravel()[0]) == 0
+        assert int(a.argmin(axis=1).get().ravel()[0]) == 2  # the implicit 0
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32, numpy.int64])
+    def test_toarray_dedups_despite_stale_flag(self, dtype):
+        # A plain scatter densify must still sum duplicates even when
+        # ``has_canonical_format`` is (wrongly) True.  Build the CSR directly
+        # (not via ``asformat``, which would coalesce first).
+        a = sparse.csr_array(
+            (cupy.array([3, 4]).astype(dtype),
+             cupy.array([0, 0], numpy.int32),
+             cupy.array([0, 2], numpy.int32)), shape=(1, 2))
+        a.has_canonical_format = True         # lie: (0, 0) is duplicated
+        testing.assert_array_equal(
+            a.toarray().get(), numpy.array([[7, 0]], dtype))
+
+    @pytest.mark.parametrize('target', [numpy.bool_, numpy.int8, numpy.int64])
+    def test_power_explicit_dtype(self, target):
+        # ``power(n, dtype=)`` must not crash on a widening target (bool**n
+        # -> int); the explicit-dtype branch is out-of-place like the default.
+        a = sparse.csr_array(
+            cupy.asarray(numpy.array([[2, 0], [0, 3]], numpy.int32)))
+        r = a.power(2, dtype=target)
+        assert r.nnz == 2
+
+    def test_uint_spgemm_negative_alpha(self):
+        # Uint operand scaling by -1 must wrap, not raise OverflowError.
+        a = sparse.csr_matrix(
+            cupy.asarray(numpy.array([[1, 0], [0, 2]], numpy.uint8)))
+        r = cusparse.spgemm(a, a, alpha=-1)
+        # (-1) * diag(1, 4) wraps in uint8: 255, 252
+        testing.assert_array_equal(
+            r.toarray().get(), numpy.array([[255, 0], [0, 252]], numpy.uint8))
+
+    @_allclose()
+    @pytest.mark.parametrize('op', ['lt', 'le', 'gt', 'ge', 'eq', 'ne'])
+    @pytest.mark.parametrize('scalar', [300, 2.5, 2, -1])
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64, numpy.uint8])
+    @pytest.mark.parametrize('fmt', COMPRESSED_FORMATS)
+    def test_int_scalar_comparison(self, xp, sp, fmt, dtype, op, scalar):
+        # Comparing an integer matrix to an out-of-range (300) or fractional
+        # (2.5) scalar must match scipy -- not overflow (casting 300 into
+        # int8) or truncate (2.5 -> 2).  The promotion is format- and
+        # width-independent, so pin it across csr/csc/coo and several ints.
+        a = _make(sp, xp, _dense_a(xp, dtype), fmt)
+        return getattr(operator, op)(a, scalar).toarray()
+
+    @pytest.mark.parametrize('dtype', INT_DTYPES)
+    def test_dia_int_sum_excludes_padding(self, dtype):
+        # DIA ``data`` holds off-matrix padding; sum(axis=None) must count
+        # only the stored values (matches scipy).
+        data = numpy.array([[1, 2, 3, 4], [5, 6, 7, 8]]).astype(dtype)
+        offsets = numpy.array([0, -1])
+        g = sparse.dia_array((cupy.asarray(data), cupy.asarray(offsets)),
+                             shape=(4, 4))
+        s = scipy.sparse.dia_array((data, offsets), shape=(4, 4))
+        assert int(g.sum()) == int(s.sum())
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64, numpy.bool_])
+    def test_spgemm_preserves_int32_indices(self, dtype):
+        # Integer/bool sparse@sparse must keep int32 indices like the float
+        # path (the pure-CuPy fallback normalises to int64 internally).
+        a = sparse.csr_array(
+            cupy.asarray(_dense_a(numpy, dtype)[:, :4]))  # 4x4, int32 indices
+        assert (a @ a.T).indices.dtype == numpy.int32
+
+    @pytest.mark.parametrize('k', [255, 256, 257, 512])
+    def test_bool_spgemm_overlap_multiple_of_256(self, k):
+        # bool sparse@sparse is a logical any-over-products: a cell is True
+        # iff the operands overlap at any position.  The pure-CuPy fallback
+        # must keep bool operands as bool -- an int8 carrier wraps 256 True
+        # products to int8(0), a spurious False whenever the shared inner
+        # dimension is a multiple of 256.
+        a = numpy.ones((1, k), dtype=bool)
+        b = numpy.ones((k, 1), dtype=bool)
+        got = (sparse.csr_array(cupy.asarray(a))
+               @ sparse.csr_array(cupy.asarray(b))).toarray()
+        exp = (scipy.sparse.csr_array(a) @ scipy.sparse.csr_array(b)).toarray()
+        assert bool(cupy.asnumpy(got)[0, 0])  # True for every k >= 1
+        testing.assert_array_equal(cupy.asnumpy(got), exp)
+
+    @pytest.mark.parametrize('dtype', NARROW_FLOAT_DTYPES)
+    def test_str_of_narrow_float(self, dtype):
+        # scipy.sparse cannot represent float16/bfloat16, so ``str`` must
+        # fall back to ``repr`` instead of raising ValueError.
+        a = sparse.csr_array(cupy.eye(3, dtype=dtype))
+        assert isinstance(str(a), str)
+        assert '{}'.format(a)
+
+    @pytest.mark.parametrize('dtype', NARROW_FLOAT_DTYPES)
+    def test_narrow_float_division_matches_dense_ufunc(self, dtype):
+        # 16-bit floats have no scipy oracle, so division dtype must match the
+        # cupy dense *ufunc* -- not numpy.result_type, which is inconsistent
+        # for bfloat16 (``result_type(bf16, 2.0)`` is float64 but the ufunc
+        # ``bf16 / 2.0`` is float32).  Scalar and dense-array divisor paths.
+        dense = _dense_a(cupy, dtype)
+        a = sparse.csr_array(dense)
+        divisors = [(2.0, 'scalar'), (cupy.full(a.shape, 2, dtype=dtype),
+                                      'dense')]
+        for divisor, label in divisors:
+            got = a / divisor
+            exp = dense / divisor
+            assert got.dtype == exp.dtype, f'{dtype}/{label}'
+            testing.assert_allclose(got.toarray().astype(cupy.float32),
+                                    exp.astype(cupy.float32), atol=1e-2)
+
+    @pytest.mark.parametrize('fmt', COMPRESSED_FORMATS)
+    def test_bool_sum_is_exact_count(self, fmt):
+        # ``bool.sum`` counts the True entries as int64 (scipy/numpy), not the
+        # any-nonzero collapse a bool-matmul would give.  bool reduces through
+        # the deduplicated float64 carrier, so pin the count and dtype on a
+        # canonical array across every axis and format.
+        dense = numpy.array([[True, True, False], [False, True, True]])
+        a = getattr(sparse, f'{fmt}_array')(cupy.asarray(dense))
+        s = getattr(scipy.sparse, f'{fmt}_array')(dense)
+        assert int(a.sum()) == int(s.sum()) == 4
+        for axis in (0, 1):
+            got, exp = a.sum(axis=axis), s.sum(axis=axis)
+            assert got.dtype == numpy.int64
+            testing.assert_array_equal(
+                cupy.asnumpy(got).ravel(), numpy.asarray(exp).ravel())
+
+    def test_bool_power_0d_cupy_exponent(self):
+        # ``power`` accepts a 0-D cupy array exponent (``isscalarlike``); the
+        # bool branch must read it to host for numpy's per-n carrier rather
+        # than compute ``numpy ** device-array`` (which raises TypeError).
+        a = sparse.csr_array(
+            cupy.asarray(numpy.array([[True, False], [True, True]])))
+        assert a.power(cupy.asarray(2)).dtype == numpy.int64
+        assert a.power(2).dtype == numpy.int8   # python int -> scipy's int8
+
+    def test_truediv_by_longdouble_scalar(self):
+        # ``matrix / longdouble(2)`` promotes to float128, which the GPU
+        # cannot store; fall back to float64 instead of crashing in
+        # ``reciprocal`` with "Wrong type (float128)".
+        dense = numpy.array([[1., 2.], [0., 4.]])
+        a = sparse.csr_array(cupy.asarray(dense))
+        r = a / numpy.longdouble(2)
+        assert r.dtype == numpy.float64
+        testing.assert_allclose(r.toarray().get(), dense / 2.0)
+
+    def test_truediv_by_clongdouble_keeps_imag(self):
+        # A clongdouble divisor promotes to complex256 (unstorable); the
+        # fallback must keep the *complex* kind (-> complex128) rather than
+        # collapse to float64 and silently drop the imaginary part.
+        dense = numpy.array([[1., 2.], [0., 4.]], numpy.complex128)
+        a = sparse.csr_array(cupy.asarray(dense))
+        r = a / numpy.clongdouble(2 + 1j)
+        assert r.dtype == numpy.complex128
+        testing.assert_allclose(
+            r.toarray().get(), dense / numpy.complex128(2 + 1j))
+
+    @pytest.mark.parametrize('op', ['min', 'max', 'argmin', 'argmax'])
+    @pytest.mark.parametrize('axis', [(0, 1), (0,), (1,)])
+    def test_tuple_axis_reduction(self, op, axis):
+        # scipy accepts a tuple ``axis`` for 2-D reductions (a length-2 tuple
+        # spanning both axes is a full reduction).  min/max/argmin/argmax
+        # collapse it the same way sum/mean do.
+        dense = _dense_a(numpy, numpy.float64)
+        g = getattr(sparse.csr_array(cupy.asarray(dense)), op)(axis=axis)
+        s = getattr(scipy.sparse.csr_array(dense), op)(axis=axis)
+        gv = g.toarray().get() if sparse.issparse(g) else cupy.asnumpy(g)
+        sv = s.toarray() if scipy.sparse.issparse(s) else numpy.asarray(s)
+        testing.assert_array_equal(
+            numpy.ravel(gv), numpy.ravel(sv))
+
+    def test_bfloat16_mixed_int_elementwise(self):
+        # bfloat16 mixed with a >= 16-bit int has no numpy promotion, but
+        # dense cupy resolves it via ufunc loops (-> float64 here); the
+        # elementwise sparse ops must match dense, while matmul rejects the
+        # mix exactly like dense.
+        ml = pytest.importorskip('ml_dtypes')
+        bf16 = ml.bfloat16
+        da = numpy.array([[1, 2], [0, 4]]).astype(bf16)
+        db = numpy.array([[1, 0], [3, 4]]).astype(numpy.int32)
+        A, B = sparse.csr_array(cupy.asarray(da)), sparse.csr_array(
+            cupy.asarray(db))
+        Ad, Bd = cupy.asarray(da), cupy.asarray(db)
+        for sfn, dfn in [(lambda: A + B, lambda: Ad + Bd),
+                         (lambda: A.multiply(B), lambda: Ad * Bd),
+                         (lambda: A.maximum(B), lambda: cupy.maximum(Ad, Bd))]:
+            s, d = sfn(), dfn()
+            assert s.dtype == d.dtype
+            testing.assert_array_equal(
+                s.toarray().get().astype(numpy.float64),
+                cupy.asnumpy(d).astype(numpy.float64))
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            A @ B
+
+    def test_bfloat16_scalar_maximum_minimum_and_imul(self):
+        # ``maximum``/``minimum`` and in-place ``*=`` with a scalar take the
+        # ``isscalarlike`` promotion branches (``_csr._maximum_minimum`` and
+        # ``_data._scalar_op_dtype``).  A bare ``numpy.result_type`` mishandles
+        # bfloat16 two ways: it RAISES for a typed numpy int (``bf16 + int16``
+        # has no abstract promotion) and OVER-PROMOTES a Python float
+        # (``result_type(bf16, 2.0)`` -> float64, where the ufunc gives
+        # float32).  Dense cupy resolves both through its ufunc loops, so the
+        # sparse ops must match dense -- neither raise nor widen;
+        # ``_sputils.promote_scalar_data_type`` probes the actual ufunc for the
+        # bfloat16 case.  Array operands and Python-int scalars dodge both
+        # quirks, so only a scalar operand exercises this.
+        ml = pytest.importorskip('ml_dtypes')
+        bf16 = ml.bfloat16
+        bf = numpy.dtype(bf16)
+        # Both failure modes of the bare promotion:
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            cupy.result_type(bf, numpy.int16(1))       # typed int -> raises
+        assert cupy.result_type(bf, 2.0) == numpy.float64  # py-float -> wider
+
+        Ad = cupy.asarray(
+            numpy.array([[3, 0, 1], [0, 5, 0], [7, 0, 6]]).astype(bf16))
+        # Both a typed numpy int and a Python float must match dense cupy in
+        # dtype and value.
+        for scalar in (numpy.int16(2), 2.0):
+            # maximum / minimum -- via ``_csr._maximum_minimum``.
+            for name, op in [('maximum', cupy.maximum),
+                             ('minimum', cupy.minimum)]:
+                got = getattr(sparse.csr_array(Ad), name)(scalar)
+                exp = op(Ad, scalar)           # float32 (dense parity)
+                assert got.dtype == exp.dtype, (name, scalar)
+                testing.assert_array_equal(
+                    got.toarray().get().astype(numpy.float64),
+                    cupy.asnumpy(exp).astype(numpy.float64))
+            # in-place ``*=`` -- via ``_data._scalar_op_dtype``.
+            A = sparse.csr_array(Ad)
+            A *= scalar
+            exp = Ad * scalar                  # float32 (dense parity)
+            assert A.dtype == exp.dtype, scalar
+            testing.assert_array_equal(
+                A.toarray().get().astype(numpy.float64),
+                cupy.asnumpy(exp).astype(numpy.float64))
+
+    def test_float16_matmul_int_dense(self):
+        # float16 sparse @ integer dense promotes to float16 (dense parity)
+        # and runs through the native cuSPARSE f16 (data) / f32 (compute)
+        # mixed path rather than upcasting the whole operand.
+        da = (numpy.arange(6).reshape(2, 3) * 0.5).astype(numpy.float16)
+        A = sparse.csr_array(cupy.asarray(da))
+        x = cupy.array([1, 2, 3], numpy.int8)
+        r = A @ x
+        ref = cupy.asarray(da) @ x
+        assert r.dtype == ref.dtype == numpy.float16
+        testing.assert_allclose(r.get(), ref.get(), atol=1e-2)
+
+
+@testing.parameterize(*testing.product({
+    # Integer ``power`` keeps its width and wraps, exactly like scipy.
+    # (Float/complex power is unchanged by this work; bool is covered below,
+    # where cupy intentionally follows its own dense-array dtype idiom.)
+    'dtype': INT_DTYPES,
+    'fmt': COMPRESSED_FORMATS,
+}))
+class TestPower:
+
+    @_array_equal()
+    def test_power_2(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).power(2)\
+            .toarray()
+
+    @_array_equal()
+    def test_power_3(self, xp, sp):
+        return _make(sp, xp, _dense_a(xp, self.dtype), self.fmt).power(3)\
+            .toarray()
+
+
+@testing.parameterize(*testing.product({
+    'fmt': COMPRESSED_FORMATS,
+    'n': [2, 3, 4],
+}))
+class TestBoolPower:
+    """Bool ``power`` matches scipy/numpy's exponent-dependent result dtype
+    (int8 at n == 2, int64 for n >= 3), not cupy dense's uniform int64 -- as a
+    scipy-compatible sparse type it follows the scipy oracle for this
+    scipy-supported dtype."""
+
+    def test_matches_scipy(self):
+        dense = _dense_a(numpy, numpy.bool_)
+        a = getattr(sparse, f'{self.fmt}_array')(cupy.asarray(dense))
+        result = a.power(self.n)
+        # numpy's own bool**n dtype is the scipy oracle (int8 @ 2, int64 @ >=3)
+        assert result.dtype == (numpy.ones(1, numpy.bool_) ** self.n).dtype
+        testing.assert_array_equal(result.toarray().get(), dense ** self.n)
+
+
+def _dia(sp, xp, dtype):
+    """A 4x4 DIA built from (data, offsets) (cupy has no dense->DIA)."""
+    data = xp.array([[1, 2, 3, 4],
+                     [5, 6, 7, 8]]).astype(dtype)
+    offsets = xp.array([0, -1])
+    return sp.dia_array((data, offsets), shape=(4, 4))
+
+
+@testing.parameterize(*testing.product({
+    'dtype': ALL_VALUE_DTYPES,
+}))
+class TestDia:
+
+    @_allclose()
+    def test_toarray(self, xp, sp):
+        return _dia(sp, xp, self.dtype).toarray()
+
+    @_allclose()
+    def test_tocsr(self, xp, sp):
+        return _dia(sp, xp, self.dtype).tocsr().toarray()
+
+    @_allclose()
+    def test_tocoo(self, xp, sp):
+        return _dia(sp, xp, self.dtype).tocoo().toarray()
+
+    def test_dtype_preserved(self):
+        assert _dia(sparse, cupy, self.dtype).dtype == self.dtype
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.bool_] + INT_DTYPES,
+    'fmt': ('csr', 'coo'),
+}))
+class TestOneDimensional:
+
+    def _vec(self, sp, xp):
+        return getattr(sp, f'{self.fmt}_array')(
+            xp.array([0, 3, 0, 5, 0, 7]).astype(self.dtype))
+
+    @_allclose()
+    def test_toarray(self, xp, sp):
+        return self._vec(sp, xp).toarray()
+
+    @_allclose()
+    def test_sum(self, xp, sp):
+        return self._vec(sp, xp).sum()
+
+    @_allclose()
+    def test_add(self, xp, sp):
+        v = self._vec(sp, xp)
+        return (v + v).toarray()
+
+    def test_ndim_and_shape(self):
+        v = self._vec(sparse, cupy)
+        assert v.ndim == 1
+        assert v.shape == (6,)
+        assert v.dtype == self.dtype
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.int64, numpy.uint64],
+}))
+class TestExactInt64PastThreshold:
+    """64-bit integer ops must stay bit-exact past 2**53 (float64's exact
+    range) -- a scatter/carrier, never a float compute type.  Pins the
+    behaviour against scipy across sum, sparse@dense, and sparse@sparse."""
+
+    def _mat(self):
+        base = 2 ** 53
+        m = numpy.array([[base + 1, 0, base + 3],
+                         [0, base + 5, 0],
+                         [base + 7, 0, base + 2]], dtype=self.dtype)
+        return m
+
+    def test_sum_none(self):
+        m = self._mat()
+        g = int(sparse.csr_array(cupy.asarray(m)).sum())
+        s = int(scipy.sparse.csr_array(m).sum())
+        assert g == s == int(m.sum(dtype=self.dtype))
+
+    def test_matmul_dense(self):
+        m = self._mat()
+        v = numpy.array([1, 1, 1], dtype=self.dtype)
+        g = (sparse.csr_array(cupy.asarray(m)) @ cupy.asarray(v)).get()
+        s = numpy.asarray(scipy.sparse.csr_array(m) @ v)
+        testing.assert_array_equal(g, s)
+        testing.assert_array_equal(g, m @ v)   # exact, not float64-rounded
+
+    def test_matmul_sparse(self):
+        # diagonal so the product entries are single (2**53+k)**2-ish terms
+        d = numpy.diag(numpy.array(
+            [2 ** 53 + 1, 2 ** 53 + 3], dtype=self.dtype))
+        g = (sparse.csr_array(cupy.asarray(d))
+             @ sparse.csr_array(cupy.asarray(d))).toarray().get()
+        s = (scipy.sparse.csr_array(d) @ scipy.sparse.csr_array(d)).toarray()
+        testing.assert_array_equal(g, s)
+
+
+@testing.with_requires('scipy')
+class TestConstructionHelpersScipyParity:
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_hstack_vstack(self, xp, sp, dtype):
+        a = sp.csr_matrix(xp.array([[1, 0], [0, 2]], dtype=dtype))
+        b = sp.csr_matrix(xp.array([[3, 0], [0, 4]], dtype=dtype))
+        h = sp.hstack([a, b])
+        v = sp.vstack([a, b])
+        return h.toarray(), v.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_kron(self, xp, sp, dtype):
+        a = sp.csr_matrix(xp.array([[1, 0], [0, 2]], dtype=dtype))
+        return sp.kron(a, a).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_eye_identity_tril(self, xp, sp, dtype):
+        e = sp.eye(3, dtype=dtype)
+        i = sp.identity(3, dtype=dtype)
+        t = sp.tril(sp.csr_matrix(
+            xp.array([[1, 2], [3, 4]], dtype=dtype)))
+        return e.toarray(), i.toarray(), t.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_block_diag(self, xp, sp, dtype):
+        a = xp.array([[1, 2], [3, 4]], dtype=dtype)
+        b = xp.array([[5]], dtype=dtype)
+        return sp.block_diag([a, b]).toarray()
+
+    @pytest.mark.parametrize('dtype',
+                             [numpy.int8, numpy.uint64, numpy.float16,
+                              numpy.bool_])
+    def test_random(self, dtype):
+        m = sparse.random(30, 40, density=0.1, dtype=dtype)
+        assert m.dtype == dtype
+        assert m.nnz == 120
+
+
+class TestValueDtypeRegressions:
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc'])
+    @pytest.mark.parametrize(
+        'dtype', [numpy.float64, numpy.float32, numpy.complex128,
+                  numpy.int32, numpy.int64])
+    def test_eliminate_zeros_keeps_negative_values(self, dtype, fmt):
+        # cuSPARSE's csr2csr_compress prunes by a signed ``value > tol``, so
+        # the old float/complex path silently dropped *negative* stored values
+        # along with the zeros.  The pure-CuPy ``data != 0`` mask is exact.
+        # Build with explicit stored zeros so the mask-and-rebuild runs, then
+        # match scipy across csr and csc (csc delegates to the csr path).
+        import scipy.sparse
+        data = numpy.array([3, -1, 0, -2, 0, 5], dtype)
+        indices = numpy.array([0, 1, 2, 0, 1, 2], numpy.int32)
+        indptr = numpy.array([0, 3, 6], numpy.int32)
+        g = getattr(sparse.csr_matrix(
+            (cupy.asarray(data), cupy.asarray(indices),
+             cupy.asarray(indptr)), shape=(2, 3)), f'to{fmt}')()
+        s = getattr(scipy.sparse.csr_matrix(
+            (data, indices, indptr), shape=(2, 3)), f'to{fmt}')()
+        g.eliminate_zeros()
+        s.eliminate_zeros()
+        testing.assert_array_equal(cupy.asnumpy(g.toarray()), s.toarray())
+        assert int(g.nnz) == int(s.nnz) == 4            # the two zeros dropped
+        assert (cupy.asnumpy(g.toarray()).real < 0).any()   # negatives survive
+
+    @requires_bfloat16
+    @pytest.mark.parametrize('container', ['csr_matrix', 'csc_matrix'])
+    @pytest.mark.parametrize('dense_dtype', [numpy.int32, numpy.int64])
+    def test_multiply_by_dense_bfloat16_int(self, container, dense_dtype):
+        # ``multiply`` of a bfloat16 matrix by an integer dense array resolves
+        # the mix through the dense CuPy ufunc (float64 here) and matches both
+        # dtype and values -- ``numpy.promote_types`` cannot resolve
+        # bfloat16 vs a >= 16-bit int.
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=_bfloat16)
+        m = getattr(sparse, container)(d)
+        dense = cupy.array([[2, 2, 2], [3, 3, 3]], dtype=dense_dtype)
+        # numpy.promote_types(bfloat16, int32/int64) raises
+        # DTypePromotionError (a TypeError subclass); dense CuPy is the oracle.
+        with pytest.raises(TypeError):
+            numpy.promote_types(_bfloat16, numpy.dtype(dense_dtype))
+        oracle = d * dense
+        r = m.multiply(dense)
+        assert numpy.dtype(r.dtype) == numpy.dtype(oracle.dtype)
+        got = r.toarray() if sparse.issparse(r) else r
+        cupy.testing.assert_array_equal(cupy.asarray(got), oracle)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_densetosparse_integer_direct(self, dtype, fmt):
+        # ``cusparse.denseToSparse`` converts a non-float dense array via a
+        # pure-CuPy fallback (cuSPARSE denseToSparse is float/complex only).
+        if not cusparse.check_availability('denseToSparse'):
+            pytest.skip('denseToSparse unavailable on this platform')
+        d = cupy.array([[1, 0, 2, 0], [0, 3, 0, 0], [4, 0, 0, 5]],
+                       dtype=dtype)
+        y = cusparse.denseToSparse(d, format=fmt)
+        assert y.format == fmt
+        assert numpy.dtype(y.dtype) == numpy.dtype(dtype)
+        cupy.testing.assert_array_equal(y.toarray(), d)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_csr_matrix_from_dense_integer_roundtrip(self, dtype):
+        # An integer dense array constructs a sparse matrix and round-trips
+        # back to the same dense array.
+        d = cupy.array([[1, 0, 2, 0], [0, 3, 0, 0], [4, 0, 0, 5]],
+                       dtype=dtype)
+        m = sparse.csr_matrix(d)
+        assert numpy.dtype(m.dtype) == numpy.dtype(dtype)
+        cupy.testing.assert_array_equal(m.toarray(), d)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('fa', ['csr_matrix', 'csc_matrix'])
+    @pytest.mark.parametrize('fb', ['csr_matrix', 'csc_matrix'])
+    def test_integer_spgemm_exact(self, dtype, fa, fb):
+        # An integer ``sparse @ sparse`` returns the exact integer product
+        # (via the pure-CuPy SpGEMM fallback, so it also works where the
+        # cuSPARSE gemm is float-only).
+        a_dense = numpy.array([[1, 0, 2], [0, 3, 0], [4, 0, 5]], dtype=dtype)
+        b_dense = numpy.array([[0, 1, 0], [2, 0, 0], [0, 0, 3]], dtype=dtype)
+        # No entry overflows the narrowest dtype here, so the numpy matmul is
+        # an exact oracle (and matches scipy's wraparound semantics).
+        oracle = (a_dense @ b_dense).astype(dtype)
+        a = getattr(sparse, fa)(cupy.asarray(a_dense))
+        b = getattr(sparse, fb)(cupy.asarray(b_dense))
+        c = a @ b
+        assert numpy.dtype(c.dtype) == numpy.dtype(dtype)
+        cupy.testing.assert_array_equal(cupy.asnumpy(c.toarray()), oracle)
+
+    @requires_bfloat16
+    def test_asfptype_preserves_bfloat16(self):
+        # asfptype() keeps a bfloat16 matrix as bfloat16 (a float), rather
+        # than upcasting to float32: bfloat16's numpy kind is 'V', so the base
+        # ``kind == 'f'`` test misses it; ``_sputils.is_float_dtype`` treats
+        # it as the float it is (matching dense CuPy, whose bf16 is a float).
+        m = sparse.csr_matrix(
+            cupy.array([[1, 0, 2], [0, 3, 0]], dtype=_bfloat16))
+        assert numpy.dtype(m.asfptype().dtype) == numpy.dtype(_bfloat16)
+        # An integer matrix still promotes to a floating dtype.
+        mi = sparse.csr_matrix(
+            cupy.array([[1, 0], [0, 2]], dtype=numpy.int32))
+        assert numpy.dtype(mi.asfptype().dtype).kind == 'f'
+
+    @pytest.mark.parametrize('op', ['maximum', 'minimum'])
+    @pytest.mark.parametrize('dtype', INT_DTYPES)
+    def test_maximum_minimum_out_of_range_scalar_raises(self, op, dtype):
+        # A Python int that does not fit the matrix dtype must raise, not
+        # wrap: value-based promotion keeps ``result_type(int8, 300)`` at
+        # int8, so a plain cast would silently turn 300 into 44.  numpy,
+        # dense CuPy and scipy all raise OverflowError here.
+        info = numpy.iinfo(dtype)
+        dense = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        m = sparse.csr_matrix(cupy.asarray(dense))
+        for scalar in (int(info.max) + 1, int(info.min) - 1):
+            with pytest.raises(OverflowError):
+                getattr(m, op)(scalar)
+
+    @pytest.mark.parametrize('other_dtype', [numpy.complex64,
+                                             numpy.complex128])
+    @pytest.mark.parametrize('dtype', [numpy.bool_, numpy.int8, numpy.int64,
+                                       numpy.complex64])
+    @pytest.mark.parametrize('dense_operand', [False, True])
+    def test_multiply_mixed_complex(self, dtype, other_dtype, dense_operand):
+        # ``multiply`` shares one promoted dtype between the sparse and the
+        # other operand: the kernel has no ``integer * thrust::complex`` (nor
+        # ``complex<float> * complex<double>``) operator, so both must be cast
+        # before launch.
+        a = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        b = numpy.array([[2, 1, 0], [0, 4, 5]], dtype=other_dtype)
+        oracle = a * b
+        m = sparse.csr_matrix(cupy.asarray(a))
+        other = cupy.asarray(b) if dense_operand else sparse.csr_matrix(
+            cupy.asarray(b))
+        r = m.multiply(other)
+        got = r.toarray() if sparse.issparse(r) else r
+        assert numpy.dtype(got.dtype) == numpy.dtype(oracle.dtype)
+        cupy.testing.assert_array_equal(cupy.asnumpy(got), oracle)
+
+    @pytest.mark.parametrize('dtype', [numpy.bool_, numpy.int8, numpy.float32])
+    @pytest.mark.parametrize('target', [numpy.bool_, numpy.int8,
+                                        numpy.float32])
+    def test_power_honours_requested_dtype(self, dtype, target):
+        # ``power(n, dtype=...)`` must return the requested dtype.  ``bool``
+        # is the one target whose ``x ** n`` promotes (numpy gives int8 at
+        # n == 2), so it needs the same carrier the ``dtype is None`` path
+        # derives.
+        dense = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        m = sparse.csr_matrix(cupy.asarray(dense))
+        expected = (dense.astype(target) ** 2).dtype
+        assert numpy.dtype(m.power(2, dtype=target).dtype) == expected
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('fmt', COMPRESSED_FORMATS)
+    def test_frobenius_norm_does_not_wrap(self, dtype, fmt):
+        # The Frobenius norm squares the stored values; squaring in the
+        # matrix's own narrow integer dtype would wrap (int8 100**2 -> 16).
+        import cupyx.scipy.sparse.linalg as cupy_spl
+        import scipy.sparse.linalg as scipy_spl
+        dense = (numpy.array([[3, 0, -4], [0, 1, 0]]) * 10).astype(dtype)
+        g = cupy_spl.norm(_make(sparse, cupy, cupy.asarray(dense), fmt))
+        s = scipy_spl.norm(_make(scipy.sparse, numpy, dense, fmt))
+        assert numpy.dtype(g.dtype) == numpy.asarray(s).dtype
+        testing.assert_allclose(cupy.asnumpy(g), numpy.asarray(s))
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_coo_scalar_getitem_keeps_dtype(self, dtype):
+        # ``coo[i, j]`` sums the stored values at the coordinate; it must
+        # accumulate in -- and return -- the matrix dtype, so duplicates wrap
+        # exactly as ``toarray()`` and the CSR path do.
+        vals = numpy.array([100, 100], dtype=dtype)
+        row = numpy.array([0, 0])
+        col = numpy.array([1, 1])
+        g = sparse.coo_array(
+            (cupy.asarray(vals), (cupy.asarray(row), cupy.asarray(col))),
+            shape=(2, 2))[0, 1]
+        # scipy's ``coo_array`` is not subscriptable (element access is a CSR
+        # operation), so take the oracle through ``tocsr`` -- it coalesces the
+        # duplicate at the storage width just like cupy's COO getitem.
+        s = numpy.asarray(scipy.sparse.coo_array(
+            (vals, (row, col)), shape=(2, 2)).tocsr()[0, 1])
+        assert numpy.dtype(g.dtype) == s.dtype
+        testing.assert_array_equal(cupy.asnumpy(g), s)
+
+
+# ---------------------------------------------------------------
+# Coverage-gap tests: mutating/utility methods, matrix_power, 64-bit
+# axis-wise exact reductions, the chunked scatter matmul, all-width
+# integer overflow, 1-D ops, mixed int+float native routing, dtype-gate
+# edges, kronsum/triu/find, unsorted-COO alignment, arg-reduce edges,
+# the complex axis min/max known bug (xfail), narrow-float float32
+# staging, and scipy interop.
+# ---------------------------------------------------------------
+
+
+def _big_int(xp, dtype):
+    """3x3 with magnitudes past float64's exact range (2**53 / 2**63)."""
+    base = 2 ** 63 if numpy.dtype(dtype).kind == 'u' else 2 ** 60
+    return xp.array([[base + 1, 0, base + 5],
+                     [0, base + 3, 0],
+                     [base + 7, 0, base + 9]], dtype=dtype)
+
+
+@testing.with_requires('scipy')
+class TestMutatingUtilityMethods:
+    """``sum_duplicates``/``sort_indices``/``setdiag``/``count_nonzero`` --
+    mutating and utility methods the happy-path suite never exercises."""
+
+    @pytest.mark.parametrize('dtype', INT_DTYPES)
+    @_array_equal()
+    def test_coo_sum_duplicates(self, xp, sp, dtype):
+        # Duplicate (0, 0) coords accumulate in the storage width: 100 + 100
+        # wraps to -56 for int8 (numpy modular overflow), matching scipy.
+        data = xp.array([100, 100, 5], dtype=dtype)
+        row = xp.array([0, 0, 1], 'i')
+        col = xp.array([0, 0, 1], 'i')
+        m = sp.coo_array((data, (row, col)), shape=(2, 2))
+        m.sum_duplicates()
+        assert m.dtype == dtype
+        return m.toarray()
+
+    def test_coo_sum_duplicates_int8_wraps_explicit(self):
+        data = cupy.array([100, 100], dtype=numpy.int8)
+        row = cupy.array([0, 0], 'i')
+        col = cupy.array([0, 0], 'i')
+        m = sparse.coo_array((data, (row, col)), shape=(1, 1))
+        m.sum_duplicates()
+        assert m.dtype == numpy.int8
+        assert int(m.toarray()[0, 0]) == -56  # 200 - 256
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_array_equal()
+    def test_sort_indices(self, xp, sp, dtype):
+        # sort_indices must gather ``data`` along with ``indices`` (not just
+        # reorder the indices), so the stored values stay put.
+        data = xp.array([2, 1], dtype=dtype)
+        indices = xp.array([2, 0], 'i')
+        indptr = xp.array([0, 2], 'i')
+        m = sp.csr_array((data, indices, indptr), shape=(1, 3))
+        m.sort_indices()
+        assert m.has_sorted_indices
+        return m.toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int16, numpy.int64, numpy.uint8])
+    @pytest.mark.parametrize('fmt', ['csr', 'csc'])
+    @_array_equal()
+    def test_setdiag_preserves_dtype_values(self, xp, sp, dtype, fmt):
+        # setdiag on a NON-bool dtype must keep the dtype and write the given
+        # diagonal values (bool CSR setdiag is a known scipy TypeError).
+        m = _make(sp, xp, _dense_a(xp, dtype), fmt)
+        m.setdiag(xp.array([11, 12, 13, 14], dtype=dtype))
+        assert m.dtype == dtype
+        return m.diagonal(), m.toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int16, numpy.int64, numpy.uint8])
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_count_nonzero_axis(self, xp, sp, dtype, axis):
+        # The counts are what matter for value-dtype support; scipy's own
+        # count array width varies by axis, so normalize to int64.
+        d = xp.array([[1, 0, 2], [0, 0, 0], [3, 0, 4]], dtype=dtype)
+        return xp.asarray(
+            sp.csr_array(d).count_nonzero(axis=axis)).astype(numpy.int64)
+
+
+@testing.with_requires('scipy')
+class TestMatrixPower:
+    """``matrix_power`` / ``A ** k`` across ints and bool, vs scipy; plus a
+    64-bit case that stays exact past 2**53."""
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64, numpy.uint8,
+                                       numpy.bool_])
+    @_array_equal()
+    def test_matrix_power(self, xp, sp, dtype):
+        from cupyx.scipy.sparse.linalg import matrix_power as cp_mp
+        if xp is numpy:
+            from scipy.sparse.linalg import matrix_power as mp
+        else:
+            mp = cp_mp
+        d = xp.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]], dtype=dtype)
+        r = mp(sp.csr_matrix(d), 3)
+        assert r.dtype == dtype
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64, numpy.uint8,
+                                       numpy.bool_])
+    @_array_equal()
+    def test_pow_operator(self, xp, sp, dtype):
+        d = xp.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]], dtype=dtype)
+        return (sp.csr_matrix(d) ** 3).toarray()
+
+    def test_matrix_power_int64_exact_past_2_53(self):
+        from cupyx.scipy.sparse.linalg import matrix_power
+        k = 4 * 10 ** 15 + 1        # 3*k = 1.2e16 + 3, odd and > 2**53
+        d = numpy.array([[1, k], [0, 1]], dtype=numpy.int64)
+        m = sparse.csr_matrix(cupy.asarray(d))
+        r = matrix_power(m, 3)      # [[1, 3k], [0, 1]]
+        assert int(r.toarray()[0, 1]) == 3 * k
+        numpy.testing.assert_array_equal(
+            r.toarray().get(), numpy.linalg.matrix_power(d, 3))
+
+
+@testing.with_requires('scipy')
+class TestExactInt64AxisReductions:
+    """64-bit axis-wise reductions must reduce in an integer accumulator, not
+    a float64 carrier, so they stay bit-exact past 2**53 / 2**63 (scipy)."""
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @pytest.mark.parametrize('fmt', COMPRESSED_FORMATS)
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_sum_axis(self, xp, sp, dtype, fmt, axis):
+        m = _make(sp, xp, _big_int(xp, dtype), fmt)
+        return xp.asarray(m.sum(axis=axis))
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @pytest.mark.parametrize('fmt', ['csr', 'csc'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_min_axis(self, xp, sp, dtype, fmt, axis):
+        m = _make(sp, xp, _big_int(xp, dtype), fmt)
+        return m.min(axis=axis).toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @pytest.mark.parametrize('op', ['argmax', 'argmin'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_arg_axis(self, xp, sp, dtype, op, axis):
+        m = _make(sp, xp, _big_int(xp, dtype), 'csr')
+        return xp.asarray(getattr(m, op)(axis=axis))
+
+
+@testing.with_requires('scipy')
+class TestChunkedScatterMatmul:
+    """The integer scatter matmul materialises an (nnz, N) product, so a wide
+    dense operand is processed in column blocks bounded by free memory.  Force
+    the chunk loop (report ~no free memory) and confirm the blocked
+    accumulation is still exact past 2**53 -- a float64 fallback would
+    round."""
+
+    def test_wide_operand_chunks_and_stays_exact(self, monkeypatch):
+        import scipy.sparse
+        d = numpy.array([[2 ** 60 + 1, 0, 3],
+                         [0, 5, 0],
+                         [7, 0, 2 ** 60]], dtype=numpy.int64)
+        x = numpy.arange(1, 13, dtype=numpy.int64).reshape(3, 4)
+        ref = numpy.asarray(scipy.sparse.csr_matrix(d) @ x)
+        ag = sparse.csr_matrix(cupy.asarray(d))
+        xg = cupy.asarray(x)
+
+        cupy.get_default_memory_pool().free_all_blocks()
+
+        class _FakePool:
+            def free_bytes(self):
+                return 0
+        # Report a tiny free amount from BOTH the driver probe and the pool's
+        # free blocks so ``block`` collapses to a single dense column.
+        monkeypatch.setattr(cupy.cuda.runtime, 'memGetInfo', lambda: (1, 1))
+        monkeypatch.setattr(cusparse._cupy, 'get_default_memory_pool',
+                            lambda: _FakePool())
+        got = cupy.asnumpy(cusparse._cupy_csr_dense_matmul(ag, xg))
+        numpy.testing.assert_array_equal(got, ref)
+        # A float64 compute would round 2**60 + 1 down to 2**60.
+        assert got[0, 0] == 2 ** 60 + 28 > 2 ** 53
+
+
+@testing.with_requires('scipy')
+class TestIntegerOverflowAllWidths:
+    """Integer results wrap modularly on overflow (numpy/scipy) at every
+    width -- not just the 8/16-bit cases the happy-path suite pins."""
+
+    @pytest.mark.parametrize('dtype', [numpy.int32, numpy.int64,
+                                       numpy.uint32, numpy.uint64])
+    @_array_equal()
+    def test_add_overflow(self, xp, sp, dtype):
+        hi = int(numpy.iinfo(dtype).max)
+        dense = xp.array([[hi, 0, hi // 2], [0, hi - 3, 0]], dtype=dtype)
+        a = _make(sp, xp, dense, 'csr')
+        return (a + a).toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int32, numpy.uint32])
+    @_array_equal()
+    def test_matmul_dense_overflow(self, xp, sp, dtype):
+        # sparse @ dense whose true product overflows must wrap, not saturate
+        # (the exact 64-bit carrier wraps on the down-cast).
+        k = 40
+        val = int(numpy.sqrt(int(numpy.iinfo(dtype).max)))  # k*val**2 >> max
+        a = sp.csr_array(xp.full((1, k), val, dtype=dtype))
+        b = xp.full((k, 1), val, dtype=dtype)
+        return a @ b
+
+
+@testing.with_requires('scipy')
+class TestOneDimensionalOps:
+    """1-D sparse arrays: reductions, indexing, and 1-D @ 2-D matmul."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize(
+        'reduction', ['sum', 'mean', 'max', 'min', 'argmax'])
+    @_allclose()
+    def test_reductions(self, xp, sp, dtype, reduction):
+        v = sp.csr_array(xp.array([100, 0, 100, 50, 0, 60], dtype=dtype))
+        return xp.asarray(getattr(v, reduction)())
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_array_equal()
+    def test_indexing(self, xp, sp, dtype):
+        v = sp.csr_array(xp.array([1, 0, 2, 3, 0, 4], dtype=dtype))
+        cols = xp.array([0, 2, 5])
+        return (xp.asarray(v[2]),
+                v[1:4].toarray(),
+                v[cols].toarray())
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_array_equal()
+    def test_matmul_2d_dense(self, xp, sp, dtype):
+        # 1-D sparse @ 2-D dense -> 1-D dense.
+        v = sp.csr_array(xp.array([1, 0, 2, 3], dtype=dtype))
+        m = xp.array([[1, 0, 2], [0, 3, 0], [4, 0, 5], [0, 0, 6]],
+                     dtype=dtype)
+        return xp.asarray(v @ m)
+
+
+@testing.with_requires('scipy')
+class TestMixedIntFloatNativePath:
+    """int + float32 promotes and routes through the native cuSPARSE path;
+    the promoted result must match scipy in dtype and value."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_allclose()
+    def test_add_int_float32_sparse(self, xp, sp, dtype):
+        a = _make(sp, xp, _dense_a(xp, dtype), 'csr')
+        b = sp.csr_array(xp.eye(4, 5, dtype=numpy.float32))
+        return (a + b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_allclose()
+    def test_spmv_int_float32_dense(self, xp, sp, dtype):
+        a = _make(sp, xp, _dense_a(xp, dtype), 'csr')
+        v = xp.arange(5, dtype=numpy.float32)
+        return a @ v
+
+
+class TestDtypeGatingEdges:
+    """The dtype gate rejects storable-looking-but-unsupported dtypes by
+    identity (not by single-char code, which aliases)."""
+
+    def test_reject_ml_dtypes_float8_int4_uint4(self):
+        # numpy.dtype(ml_dtypes.float8_e4m3b11fnuz).char == 'L' collides with
+        # uint64, so a char-only gate would wrongly accept it; identity is the
+        # correct discriminator.
+        ml_dtypes = pytest.importorskip('ml_dtypes')
+        from cupyx.scipy.sparse import _sputils
+        assert numpy.dtype(ml_dtypes.float8_e4m3b11fnuz).char == 'L'
+        names = ['float8_e4m3b11fnuz', 'float8_e5m2']
+        for extra in ('int4', 'uint4'):
+            if hasattr(ml_dtypes, extra):
+                names.append(extra)
+        for name in names:
+            dt = numpy.dtype(getattr(ml_dtypes, name))
+            assert not _sputils.is_sparse_data_dtype(dt), name
+            with pytest.raises(ValueError):
+                _sputils.check_data_dtype(dt)
+
+    def test_reject_clongdouble(self):
+        from cupyx.scipy.sparse import _sputils
+        if numpy.dtype(numpy.clongdouble).itemsize <= 16:
+            pytest.skip('clongdouble not extended on this platform')
+        assert not _sputils.is_sparse_data_dtype(numpy.clongdouble)
+        with pytest.raises(ValueError):
+            _sputils.check_data_dtype(numpy.clongdouble)
+        a = sparse.csr_array(cupy.eye(3, dtype=numpy.complex128))
+        with pytest.raises((ValueError, TypeError)):
+            a.astype(numpy.clongdouble)
+
+    def test_bool_neg_raises(self):
+        m = sparse.csr_array(
+            cupy.asarray(numpy.array([[True, False], [False, True]])))
+        with pytest.raises((NotImplementedError, TypeError)):
+            -m
+
+
+@testing.with_requires('scipy')
+class TestConstructionHelpers:
+    """``kronsum``/``triu``/``find`` preserve the value dtype (scipy)."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_array_equal()
+    def test_kronsum(self, xp, sp, dtype):
+        a = _make(sp, xp, _square(xp, dtype), 'csr')
+        r = sp.kronsum(a, a)
+        assert r.dtype == dtype
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @_array_equal()
+    def test_triu(self, xp, sp, dtype):
+        m = _make(sp, xp, _dense_a(xp, dtype), 'csr')
+        r = sp.triu(m, k=1)
+        assert r.dtype == dtype
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_find_preserves_dtype(self, dtype):
+        import scipy.sparse
+        dense = _dense_a(numpy, dtype)
+        i, j, v = sparse.find(sparse.csr_array(cupy.asarray(dense)))
+        assert v.dtype == dtype
+        # find's ordering is unspecified, so reconstruct dense (order-free).
+        got = numpy.zeros_like(dense)
+        got[cupy.asnumpy(i), cupy.asnumpy(j)] = cupy.asnumpy(v)
+        si, sj, sv = scipy.sparse.find(scipy.sparse.csr_array(dense))
+        assert sv.dtype == dtype
+        exp = numpy.zeros_like(dense)
+        exp[si, sj] = sv
+        numpy.testing.assert_array_equal(got, exp)
+
+
+@testing.with_requires('scipy')
+class TestUnsortedCooRegression:
+    """coosort must permute ``data`` along with the coordinates; an
+    explicitly stored value at a coordinate that moves during the sort must
+    stay aligned through ``tocsr``/``tocsc`` (the bool data-gather bug)."""
+
+    @pytest.mark.parametrize('to', ['tocsr', 'tocsc'])
+    @_array_equal()
+    def test_bool_explicit_false_stays_aligned(self, xp, sp, to):
+        # An explicit stored ``False`` at (0, 2) moves during the column sort;
+        # a skipped data gather would misalign it with its coordinates.
+        row = xp.array([2, 0, 1], 'i')
+        col = xp.array([0, 2, 1], 'i')
+        data = xp.array([True, False, True])
+        m = sp.coo_array((data, (row, col)), shape=(3, 3))
+        return getattr(m, to)().toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64])
+    @pytest.mark.parametrize('to', ['tocsr', 'tocsc'])
+    @_array_equal()
+    def test_int_unsorted_stays_aligned(self, xp, sp, dtype, to):
+        row = xp.array([2, 0, 1], 'i')
+        col = xp.array([0, 2, 1], 'i')
+        data = xp.array([1, 2, 3], dtype=dtype)
+        m = sp.coo_array((data, (row, col)), shape=(3, 3))
+        return getattr(m, to)().toarray()
+
+
+@testing.with_requires('scipy')
+class TestArgReduceEdges:
+    """Arg-reduction edges: bool with an all-false row/column, and complex
+    with nonzero imaginary parts (reduces on the real part, like min/max)."""
+
+    @pytest.mark.parametrize('op', ['argmax', 'argmin'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_bool_all_false_line(self, xp, sp, op, axis):
+        # Row 2 and (for axis) columns are all-False; must match scipy.
+        d = xp.array([[False, True, False],
+                      [True, False, True],
+                      [False, False, False]], dtype=xp.bool_)
+        return xp.asarray(getattr(sp.csr_array(d), op)(axis=axis))
+
+    @pytest.mark.parametrize('dtype', [numpy.complex64, numpy.complex128])
+    @pytest.mark.parametrize('op', ['argmax', 'argmin'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    @_array_equal()
+    def test_complex_nonzero_imag(self, xp, sp, dtype, op, axis):
+        d = xp.array([[1 + 9j, 0, 3 + 1j],
+                      [0, 2 + 0j, 0],
+                      [4 + 2j, 0, 5 - 7j]], dtype=dtype)
+        return xp.asarray(getattr(sp.csr_array(d), op)(axis=axis))
+
+
+@testing.with_requires('scipy')
+class TestComplexAxisMinMaxKnownBug:
+    """KNOWN BUG: complex ``max``/``min`` along an axis drops the imaginary
+    part of the winning entry (cupy returns e.g. 5+0j where scipy returns
+    5-1j).  The no-axis reduction is correct, so only the axis form is
+    xfailed."""
+
+    _M = numpy.array([[5 - 1j, -2 + 3j, 0],
+                      [0, 0, 4 + 2j],
+                      [3 + 7j, -6 - 5j, 1 - 9j]], dtype=numpy.complex128)
+
+    def _pair(self):
+        import scipy.sparse
+        return (sparse.csr_array(cupy.asarray(self._M)),
+                scipy.sparse.csr_array(self._M))
+
+    @pytest.mark.xfail(strict=True,
+                       reason='complex max(axis) drops the imaginary part')
+    def test_max_axis0_keeps_imag(self):
+        g, s = self._pair()
+        numpy.testing.assert_array_equal(
+            g.max(axis=0).toarray().ravel().get(),
+            numpy.asarray(s.max(axis=0).toarray()).ravel())
+
+    @pytest.mark.xfail(strict=True,
+                       reason='complex min(axis) drops the imaginary part')
+    def test_min_axis0_keeps_imag(self):
+        g, s = self._pair()
+        numpy.testing.assert_array_equal(
+            g.min(axis=0).toarray().ravel().get(),
+            numpy.asarray(s.min(axis=0).toarray()).ravel())
+
+    def test_noaxis_max_min_correct(self):
+        # The full (no-axis) reduction keeps the imaginary part (not xfailed).
+        g, s = self._pair()
+        assert complex(g.max()) == complex(s.max())
+        assert complex(g.min()) == complex(s.min())
+
+
+class TestNarrowFloatAccumulation:
+    """16-bit-float sparse@sparse over a few-hundred inner dimension must stay
+    near 16-bit epsilon of a float64 oracle -- proving float32 staging, not a
+    uniform 16-bit accumulation (which would compound to ~1e-2)."""
+
+    def test_float16_spgemm_stages_float32(self):
+        rng = numpy.random.default_rng(0)
+        k = 400
+        a_d = rng.random((6, k)).astype(numpy.float16)
+        b_d = rng.random((k, 6)).astype(numpy.float16)
+        a = sparse.csr_array(cupy.asarray(a_d))
+        b = sparse.csr_array(cupy.asarray(b_d))
+        got = (a @ b).toarray().get().astype(numpy.float64)
+        ref = a_d.astype(numpy.float64) @ b_d.astype(numpy.float64)
+        rel = numpy.max(numpy.abs(got - ref) / (numpy.abs(ref) + 1e-9))
+        assert rel < 5e-3, rel
+
+    @requires_bfloat16
+    def test_bfloat16_spgemm_stages_float32(self):
+        rng = numpy.random.default_rng(0)
+        k = 200
+        a_d = rng.random((6, k)).astype(numpy.float32).astype(_bfloat16)
+        b_d = rng.random((k, 6)).astype(numpy.float32).astype(_bfloat16)
+        a = sparse.csr_array(cupy.asarray(a_d))
+        b = sparse.csr_array(cupy.asarray(b_d))
+        got = (a @ b).toarray().astype(numpy.float64).get()
+        ref = a_d.astype(numpy.float64) @ b_d.astype(numpy.float64)
+        rel = numpy.max(numpy.abs(got - ref) / (numpy.abs(ref) + 1e-9))
+        assert rel < 5e-2, rel
+
+
+@testing.with_requires('scipy')
+class TestScipyInterop:
+    """Construct a cupyx matrix FROM a scipy.sparse object and ``.get()`` it
+    back; integer dtype and values must survive the round trip."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_scipy_roundtrip(self, dtype):
+        import scipy.sparse
+        d = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        s = scipy.sparse.csr_matrix(d)
+        m = sparse.csr_matrix(s)
+        assert m.dtype == dtype
+        numpy.testing.assert_array_equal(m.toarray().get(), d)
+        back = m.get()
+        assert back.dtype == dtype
+        numpy.testing.assert_array_equal(back.toarray(), d)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_value_dtypes_DELETEME.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_sparse_value_dtypes_DELETEME.py
@@ -1,0 +1,2620 @@
+"""TEMPORARY -- DELETE BEFORE MERGING.
+
+Extra sparse value-dtype tests carried over from two of the three exploratory
+branches (0a and 0b) that developed this feature in parallel; the third
+branch's tests are all already in the permanent file.  The permanent,
+de-duplicated coverage lives in ``test_sparse_value_dtypes.py``; this file
+keeps the *rest* of those branches' tests around so they run in CI and are
+available during review as a cross-check.  It is expected to be
+**removed before the pull request is merged** -- do not add new tests here and
+do not rely on it.  If a test here proves worth keeping, port it into
+``test_sparse_value_dtypes.py`` instead.
+"""
+from __future__ import annotations
+import cupyx.scipy.sparse
+from cupy import testing
+import cupy
+import pytest
+import numpy
+
+# ==/<=/>= (and out-of-range) comparisons intentionally emit
+# SparseEfficiencyWarning; these tests check the RESULT, so silence it here as
+# the permanent file does.
+pytestmark = pytest.mark.filterwarnings(
+    'ignore::cupyx.scipy.sparse.SparseEfficiencyWarning')
+
+# --- cross-branch portability shim (added for cross-pollination review) ---
+# The three dtype-support branches (0a/0b/0c) named a few private _sputils
+# helpers differently. This shim aliases the MISSING names to whatever the
+# branch under test provides, so this (foreign-branch) test file runs on any
+# of them. It only ADDS missing attributes; it never overwrites existing ones,
+# so it cannot change the branch's own behavior.
+from cupyx.scipy.sparse import _sputils as _xsp  # noqa: E402
+
+
+def _xalias(dst, *srcs):
+    if not hasattr(_xsp, dst):
+        for s in srcs:
+            if hasattr(_xsp, s):
+                setattr(_xsp, dst, getattr(_xsp, s))
+                return
+
+
+_xalias("check_data_dtype", "check_sparse_data_dtype")
+_xalias("check_sparse_data_dtype", "check_data_dtype")
+_xalias("is_bfloat16", "is_extra_float_dtype")
+_xalias("is_extra_float_dtype", "is_bfloat16")
+if not hasattr(_xsp, "bfloat16"):
+    _xbf = getattr(_xsp, "_bfloat16", None)
+    if _xbf is None:
+        _xbf = next(iter(getattr(_xsp, "_extra_float_dtypes", ()) or ()), None)
+    _xsp.bfloat16 = _xbf
+# --- end shim ---
+
+
+try:
+    import ml_dtypes
+    _bfloat16 = numpy.dtype(ml_dtypes.bfloat16)
+except ImportError:
+    _bfloat16 = None
+
+# bfloat16 is a CuPy extension available only through the optional
+# ``ml_dtypes`` package; sparse support for it is likewise optional.
+requires_bfloat16 = pytest.mark.skipif(
+    _bfloat16 is None, reason='ml_dtypes (bfloat16) not installed')
+
+
+_int_dtypes = [
+    numpy.int8, numpy.int16, numpy.int32, numpy.int64,
+    numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64,
+]
+_new_dtypes = _int_dtypes + [numpy.float16]
+# Representative subset for expensive parametrizations: one sub-32-bit
+# signed (no atomicAdd), one 32-bit, one 64-bit, one unsigned, float16.
+_key_dtypes = [numpy.int8, numpy.int32, numpy.int64,
+               numpy.uint8, numpy.float16]
+_scipy_dtypes = [numpy.int8, numpy.int32, numpy.int64, numpy.uint8]
+_containers = ['csr_matrix', 'csc_matrix', 'coo_matrix',
+               'csr_array', 'csc_array', 'coo_array']
+
+
+def _make_csr(sp, xp, dtype):
+    data = xp.array([1, 2, 3, 4, 5, 6], dtype=dtype)
+    indices = xp.array([0, 3, 1, 4, 2, 5], dtype=numpy.int32)
+    indptr = xp.array([0, 2, 2, 4, 5, 6], dtype=numpy.int32)
+    return sp.csr_matrix((data, indices, indptr), shape=(5, 6))
+
+
+def test_float16_str_and_print_do_not_crash():
+    # scipy has no float16 host kernels, so ``str(self.get())`` raises
+    # ValueError; ``__str__`` must degrade to ``repr`` rather than crash
+    # ``print()`` / ``format()`` (``repr`` already works without scipy).
+    m = cupyx.scipy.sparse.csr_matrix(
+        cupy.array([[1, 0, 2], [0, 3, 0]], dtype='float16'))
+    assert 'sparse' in str(m)
+    assert 'sparse' in '{}'.format(m)
+    assert 'sparse' in repr(m)
+
+
+class TestConstruction:
+
+    @pytest.mark.parametrize('dtype', _new_dtypes)
+    def test_from_dense_all_formats(self, dtype):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        for cls in (cupyx.scipy.sparse.csr_matrix,
+                    cupyx.scipy.sparse.csc_matrix,
+                    cupyx.scipy.sparse.coo_matrix,
+                    cupyx.scipy.sparse.csr_array,
+                    cupyx.scipy.sparse.csc_array,
+                    cupyx.scipy.sparse.coo_array):
+            m = cls(d)
+            assert m.dtype == dtype
+            cupy.testing.assert_array_equal(m.toarray(), d)
+
+    @pytest.mark.parametrize('dtype', _new_dtypes)
+    def test_empty_shape_and_copy(self, dtype):
+        m = cupyx.scipy.sparse.csr_matrix((3, 4), dtype=dtype)
+        assert m.dtype == dtype
+        assert m.nnz == 0
+        m2 = _make_csr(cupyx.scipy.sparse, cupy, dtype).copy()
+        assert m2.dtype == dtype
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_from_coo_2tuple(self, dtype):
+        data = cupy.array([2, 7], dtype=dtype)
+        row = cupy.array([0, 1], dtype=numpy.int32)
+        col = cupy.array([1, 0], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.csr_matrix((data, (row, col)), shape=(2, 2))
+        assert m.dtype == dtype
+        cupy.testing.assert_array_equal(
+            m.toarray(), cupy.array([[0, 2], [7, 0]], dtype=dtype))
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_dia_from_parts(self, dtype):
+        data = cupy.array([[1, 2, 3]], dtype=dtype)
+        offsets = cupy.array([0])
+        m = cupyx.scipy.sparse.dia_matrix((data, offsets), shape=(3, 3))
+        assert m.dtype == dtype
+        cupy.testing.assert_array_equal(
+            m.toarray(), cupy.diag(cupy.array([1, 2, 3], dtype=dtype)))
+        cupy.testing.assert_array_equal(
+            m.tocsr().toarray(), m.toarray())
+        assert m.tocsr().dtype == dtype
+
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_scipy_roundtrip(self, dtype):
+        import scipy.sparse
+        d = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        s = scipy.sparse.csr_matrix(d)
+        m = cupyx.scipy.sparse.csr_matrix(s)
+        assert m.dtype == dtype
+        numpy.testing.assert_array_equal(m.toarray().get(), d)
+        back = m.get()
+        assert back.dtype == dtype
+        numpy.testing.assert_array_equal(back.toarray(), d)
+
+
+class TestConversion:
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_format_roundtrips(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        expected = m.toarray()
+        assert expected.dtype == dtype
+        for other in (m.tocsc(), m.tocoo(), m.tocsc().tocsr(),
+                      m.tocoo().tocsc(), m.T.T):
+            assert other.dtype == dtype
+            cupy.testing.assert_array_equal(other.toarray(), expected)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    @pytest.mark.parametrize('order', ['C', 'F'])
+    def test_toarray_order(self, dtype, order):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        out = m.toarray(order=order)
+        assert out.flags['%s_CONTIGUOUS' % order]
+        cupy.testing.assert_array_equal(out, m.toarray())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_csc_toarray(self, dtype):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        m = cupyx.scipy.sparse.csc_matrix(d)
+        cupy.testing.assert_array_equal(m.toarray(), d)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_toarray_sums_duplicates(self, dtype):
+        # Non-canonical input: duplicate entries must sum on densify
+        # (the direct-write kernels for 8/16-bit ints canonicalize a
+        # copy first).
+        data = cupy.array([1, 2, 3], dtype=dtype)
+        row = cupy.array([0, 0, 1], dtype=numpy.int32)
+        col = cupy.array([1, 1, 0], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.coo_matrix(
+            (data, (row, col)), shape=(2, 2)).tocsr()
+        cupy.testing.assert_array_equal(
+            m.toarray(), cupy.array([[0, 3], [3, 0]], dtype=dtype))
+
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('to', ['tocsr', 'tocsc'])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_unsorted_bool_coo_keeps_data_aligned(self, xp, sp, to):
+        # Regression: coosort's cuSPARSE path skipped the bool data
+        # gather, so an explicitly stored ``False`` ended up misaligned
+        # from its (permuted) coordinates.  With an explicit False at
+        # (0, 2), tocsr/tocsc must still match toarray / scipy.
+        row = xp.array([2, 0, 1], 'i')
+        col = xp.array([0, 2, 1], 'i')
+        data = xp.array([True, False, True])
+        m = sp.coo_matrix((data, (row, col)), shape=(3, 3))
+        return getattr(m, to)().toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_unsorted_coo_convert_matches_toarray(self, dtype):
+        row = cupy.array([2, 0, 1], dtype=numpy.int32)
+        col = cupy.array([0, 2, 1], dtype=numpy.int32)
+        data = cupy.array([1, 2, 3], dtype=dtype)
+        m = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=(3, 3))
+        cupy.testing.assert_array_equal(m.tocsc().toarray(), m.toarray())
+        cupy.testing.assert_array_equal(m.tocsr().toarray(), m.toarray())
+
+
+class TestIndexing:
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_scalar_getitem(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        assert m[0, 0] == 1
+        assert m[0, 0].dtype == dtype
+        assert m[1, 0] == 0
+        assert m[3, 2] == 5
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_slices(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        dense = m.toarray()
+        for sub, ref in (
+                (m[0:2, :], dense[:2, :]),
+                (m[:, 1:4], dense[:, 1:4]),
+                (m[::2, :], dense[::2, :]),
+        ):
+            assert sub.dtype == dtype
+            cupy.testing.assert_array_equal(sub.toarray(), ref)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_fancy(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        dense = m.toarray()
+        rows = cupy.array([0, 2, 4])
+        cols = cupy.array([0, 3, 5])
+        sub_r = m[rows, :]
+        sub_c = m[:, cols]
+        assert sub_r.dtype == dtype
+        assert sub_c.dtype == dtype
+        cupy.testing.assert_array_equal(
+            sub_r.toarray(), dense[[0, 2, 4], :])
+        cupy.testing.assert_array_equal(
+            sub_c.toarray(), dense[:, [0, 3, 5]])
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_setitem_and_setdiag(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        ref = m.toarray()
+        with pytest.warns(cupyx.scipy.sparse.SparseEfficiencyWarning):
+            m[1, 1] = 9
+        ref[1, 1] = 9
+        cupy.testing.assert_array_equal(m.toarray(), ref)
+        m2 = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        m2.setdiag(cupy.array([7, 8], dtype=dtype))
+        ref2 = _make_csr(cupyx.scipy.sparse, cupy, dtype).toarray()
+        ref2[0, 0] = 7
+        ref2[1, 1] = 8
+        cupy.testing.assert_array_equal(m2.toarray(), ref2)
+
+
+@testing.with_requires('scipy')
+class TestArithmeticScipyParity:
+    """Value & dtype parity with scipy (dtype checked by the decorator)."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_add(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=dtype))
+        return (a + b).toarray()
+
+    @pytest.mark.parametrize('dtype',
+                             [numpy.int8, numpy.int32, numpy.int64])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sub(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=dtype))
+        return (a - b).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sub_bool(self, xp, sp):
+        # scipy computes bool subtraction in C bool arithmetic
+        # (True - True -> False, False - True -> True); numpy raises.
+        a = sp.csr_matrix(xp.array([[True, False], [False, True]]))
+        b = sp.csr_matrix(xp.array([[True, True], [False, False]]))
+        return (a - b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_scalar_multiply(self, xp, sp, dtype):
+        return (_make_csr(sp, xp, dtype) * 2).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_bool_scalar_multiply_promotes(self, xp, sp):
+        # bool * 2 -> int64 under numpy promotion (scipy does data * 2).
+        a = sp.csr_matrix(xp.array([[True, False], [False, True]]))
+        return (a * 2).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes + [numpy.uint64])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_truediv_scalar(self, xp, sp, dtype):
+        # int / scalar -> float64 for every integer width (scipy rule).
+        return (_make_csr(sp, xp, dtype) / 2).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_multiply_sparse(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=dtype) * 2)
+        return a.multiply(b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_maximum(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=dtype) * 4)
+        return a.maximum(b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_power(self, xp, sp, dtype):
+        return _make_csr(sp, xp, dtype).power(2).toarray()
+
+    @pytest.mark.parametrize('dtype',
+                             [numpy.int8, numpy.int32, numpy.int64])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_neg_abs(self, xp, sp, dtype):
+        m = _make_csr(sp, xp, dtype)
+        return abs(-m).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_comparison(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=dtype) * 3)
+        return (a != b).toarray()
+
+
+@testing.with_requires('scipy')
+class TestMatmulScipyParity:
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_spmv(self, xp, sp, dtype):
+        m = _make_csr(sp, xp, dtype)
+        v = xp.arange(6, dtype=dtype)
+        return m @ v
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_spmm(self, xp, sp, dtype):
+        # contiguous_check=False: cupy's SpMM returns F-order (as for
+        # float dtypes); scipy returns C-order.
+        m = _make_csr(sp, xp, dtype)
+        b = xp.arange(12, dtype=dtype).reshape(6, 2)
+        return m @ b
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_spgemm(self, xp, sp, dtype):
+        m = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(6, 4, dtype=dtype) * 2)
+        return (m @ b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp', contiguous_check=False)
+    def test_csc_matmul(self, xp, sp, dtype):
+        m = _make_csr(sp, xp, dtype).tocsc()
+        b = sp.csc_matrix(xp.eye(6, 4, dtype=dtype) * 2)
+        return (m @ b).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_bool_spgemm(self, xp, sp):
+        a = sp.csr_matrix(xp.array([[True, False], [True, True]]))
+        return (a @ a).toarray()
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mixed_int_float(self, xp, sp):
+        a = sp.csr_matrix(
+            xp.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.int8))
+        v = xp.array([1., 2., 3.], dtype=numpy.float32)
+        return a @ v
+
+    def test_spgemm_preserves_int32_indices(self):
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0], [0, 2]], dtype=numpy.int32))
+        c = m @ m
+        assert c.indices.dtype == numpy.int32
+        assert c.indptr.dtype == numpy.int32
+
+    def test_spgemm_int_exact(self):
+        # The pure-CuPy integer SpGEMM computes in the integer dtype:
+        # values beyond float64's 2**53 mantissa stay exact.
+        big = numpy.int64(2) ** 60 + 3
+        a = cupyx.scipy.sparse.csr_matrix(
+            (cupy.array([big, 1], dtype=numpy.int64),
+             cupy.array([0, 1], dtype=numpy.int32),
+             cupy.array([0, 1, 2], dtype=numpy.int32)),
+            shape=(2, 2))
+        eye = cupyx.scipy.sparse.csr_matrix(
+            cupy.eye(2, dtype=numpy.int64))
+        c = a @ eye
+        assert int(c[0, 0]) == int(big)
+
+
+@testing.with_requires('scipy')
+class TestReductionsScipyParity:
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_sum(self, xp, sp, dtype, axis):
+        # int8 -> int64, uint8 -> uint64 accumulators (get_sum_dtype).
+        return _make_csr(sp, xp, dtype).sum(axis=axis)
+
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_bool_sum(self, xp, sp):
+        # Regression: bool.sum() used to raise TypeError from cuSPARSE.
+        a = sp.csr_matrix(xp.array([[True, False], [True, True]]))
+        return a.sum()
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_dia_int64_sum_excludes_padding(self, xp, sp):
+        # DIA ``data`` holds unused off-matrix diagonal slots; the total
+        # sum must count only real entries (route through COO), and the
+        # axis sums must stay exact past 2**53.
+        big = 2 ** 60
+        data = xp.array([[big + 1, big + 2, big + 3],
+                         [big + 4, big + 5, big + 6]], dtype=numpy.int64)
+        offsets = xp.array([0, -1], 'i')
+        m = sp.dia_matrix((data, offsets), shape=(3, 3))
+        return (xp.asarray(m.sum()),
+                xp.asarray(m.sum(axis=0)).ravel(),
+                xp.asarray(m.sum(axis=1)).ravel())
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('array', [False, True])
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    def test_int64_sum_exact_past_2_53(self, fmt, array, axis):
+        # Summing int64 through the float64 matmul path rounds past
+        # 2**53; the segmented-cumsum path stays exact (scipy parity).
+        import scipy.sparse
+        big = 2 ** 60
+        dense = numpy.array([[big + 7, 0, big + 3],
+                             [0, big + 1, big + 5]], dtype=numpy.int64)
+        cons = getattr(cupyx.scipy.sparse,
+                       f'{fmt}_array' if array else f'{fmt}_matrix')
+        scons = getattr(scipy.sparse,
+                        f'{fmt}_array' if array else f'{fmt}_matrix')
+        m = cons(cupy.asarray(dense))
+        sm = scons(dense)
+        got = m.sum(axis=axis)
+        exp = sm.sum(axis=axis)
+        if axis is None:
+            assert int(got) == int(exp)
+        else:
+            numpy.testing.assert_array_equal(
+                cupy.asnumpy(got).ravel(), numpy.asarray(exp).ravel())
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mean(self, xp, sp, dtype, axis):
+        return _make_csr(sp, xp, dtype).mean(axis=axis)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    def test_max_min_dtype_preserved(self, dtype):
+        m = _make_csr(cupyx.scipy.sparse, cupy, dtype)
+        assert m.max().dtype == dtype
+        assert int(m.max()) == 6
+        assert m.min().dtype == dtype
+        assert int(m.min()) == 0
+        assert m.max(axis=1).dtype == dtype
+        assert m.min(axis=0).dtype == dtype
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_argmax_axis(self, xp, sp, dtype):
+        return xp.asarray(_make_csr(sp, xp, dtype).argmax(axis=1))
+
+    def test_int64_reductions_exact_past_2_53(self):
+        # int64 max/min/argmax must not round through float64.
+        big = 2 ** 60
+        vals = cupy.array([big + 7, big + 3, -(big + 5)],
+                          dtype=numpy.int64)
+        m = cupyx.scipy.sparse.csr_matrix(
+            (vals, cupy.array([0, 1, 2], dtype=numpy.int32),
+             cupy.array([0, 3], dtype=numpy.int32)), shape=(1, 3))
+        assert int(m.max()) == big + 7
+        assert int(m.min()) == -(big + 5)
+        assert int(m.max(axis=1).toarray()[0, 0]) == big + 7
+        assert int(m.argmax(axis=1)[0, 0]) == 0
+        assert int(m.argmin(axis=1)[0, 0]) == 2
+
+    def test_uint64_max_exact_past_2_53(self):
+        big = numpy.uint64(2 ** 63 + 9)
+        m = cupyx.scipy.sparse.csr_matrix(
+            (cupy.array([big, 1], dtype=numpy.uint64),
+             cupy.array([0, 1], dtype=numpy.int32),
+             cupy.array([0, 2], dtype=numpy.int32)), shape=(1, 2))
+        assert int(m.max()) == int(big)
+        assert int(m.max(axis=1).toarray()[0, 0]) == int(big)
+
+
+class TestSortEliminateDuplicates:
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_sort_indices(self, dtype):
+        data = cupy.array([2, 1], dtype=dtype)
+        indices = cupy.array([2, 0], dtype=numpy.int32)
+        indptr = cupy.array([0, 2], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.csr_matrix(
+            (data, indices, indptr), shape=(1, 3))
+        before = m.toarray().copy()
+        m.sort_indices()
+        assert m.has_sorted_indices
+        cupy.testing.assert_array_equal(m.toarray(), before)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_eliminate_zeros(self, dtype):
+        data = cupy.array([1, 0, 3], dtype=dtype)
+        indices = cupy.array([0, 1, 2], dtype=numpy.int32)
+        indptr = cupy.array([0, 3], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.csr_matrix(
+            (data, indices, indptr), shape=(1, 3))
+        m.eliminate_zeros()
+        assert m.nnz == 2
+        assert m.dtype == dtype
+
+    @pytest.mark.parametrize('dtype', _new_dtypes)
+    def test_coo_sum_duplicates(self, dtype):
+        data = cupy.array([3, 4, 5], dtype=dtype)
+        row = cupy.array([0, 0, 1], dtype=numpy.int32)
+        col = cupy.array([0, 0, 1], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.coo_matrix(
+            (data, (row, col)), shape=(2, 2))
+        m.sum_duplicates()
+        assert m.dtype == dtype
+        assert m.nnz == 2
+        assert int(m.toarray()[0, 0]) == 7
+
+    def test_coo_sum_duplicates_int8_wraparound(self):
+        # Accumulation matches numpy's modular overflow.
+        data = cupy.array([100, 100], dtype=numpy.int8)
+        row = cupy.array([0, 0], dtype=numpy.int32)
+        col = cupy.array([0, 0], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.coo_matrix(
+            (data, (row, col)), shape=(1, 1))
+        m.sum_duplicates()
+        # 100 + 100 = 200 wraps to 200 - 256 = -56 in int8.
+        assert int(m.toarray()[0, 0]) == -56
+
+
+@testing.with_requires('scipy')
+class TestConstructionHelpersScipyParity:
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_hstack_vstack(self, xp, sp, dtype):
+        a = sp.csr_matrix(xp.array([[1, 0], [0, 2]], dtype=dtype))
+        b = sp.csr_matrix(xp.array([[3, 0], [0, 4]], dtype=dtype))
+        h = sp.hstack([a, b])
+        v = sp.vstack([a, b])
+        return h.toarray(), v.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_kron(self, xp, sp, dtype):
+        a = sp.csr_matrix(xp.array([[1, 0], [0, 2]], dtype=dtype))
+        return sp.kron(a, a).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_eye_identity_tril(self, xp, sp, dtype):
+        e = sp.eye(3, dtype=dtype)
+        i = sp.identity(3, dtype=dtype)
+        t = sp.tril(sp.csr_matrix(
+            xp.array([[1, 2], [3, 4]], dtype=dtype)))
+        return e.toarray(), i.toarray(), t.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_block_diag(self, xp, sp, dtype):
+        a = xp.array([[1, 2], [3, 4]], dtype=dtype)
+        b = xp.array([[5]], dtype=dtype)
+        return sp.block_diag([a, b]).toarray()
+
+    @pytest.mark.parametrize('dtype',
+                             [numpy.int8, numpy.uint64, numpy.float16,
+                              numpy.bool_])
+    def test_random(self, dtype):
+        m = cupyx.scipy.sparse.random(30, 40, density=0.1, dtype=dtype)
+        assert m.dtype == dtype
+        assert m.nnz == 120
+
+
+class TestSparrayAnd1D:
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_csr_array_elementwise_mul(self, dtype):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        a = cupyx.scipy.sparse.csr_array(d)
+        r = a * a
+        assert r.dtype == dtype
+        cupy.testing.assert_array_equal(r.toarray(), d * d)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_coo_array_1d(self, dtype):
+        v = cupy.array([1, 0, 2, 3], dtype=dtype)
+        a = cupyx.scipy.sparse.coo_array(v)
+        assert a.dtype == dtype
+        assert a.ndim == 1
+        cupy.testing.assert_array_equal(a.toarray(), v)
+        csr = a.tocsr()
+        assert csr.dtype == dtype
+        cupy.testing.assert_array_equal(csr.toarray(), v)
+        assert int(csr.sum()) == 6
+        r = csr + csr
+        assert r.dtype == dtype
+        cupy.testing.assert_array_equal(r.toarray(), v + v)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes)
+    def test_1d_reductions(self, dtype):
+        v = cupy.array([1, 0, 2, 3], dtype=dtype)
+        a = cupyx.scipy.sparse.coo_array(v).tocsr()
+        assert int(a.max()) == 3
+        assert a.max().dtype == dtype
+        assert int(a.argmax()) == 3
+
+
+class TestFloat16:
+    """float16 is a CuPy extension (scipy rejects it); test natively."""
+
+    def test_scipy_rejects_but_cupy_accepts(self):
+        d = [[1, 0], [0, 2]]
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array(d, dtype=numpy.float16))
+        assert m.dtype == numpy.float16
+
+    def test_native_spmv(self):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        v = cupy.array([1, 2, 3], dtype=numpy.float16)
+        result = m @ v
+        assert result.dtype == numpy.float16
+        cupy.testing.assert_allclose(result, d @ v, rtol=1e-2)
+
+    def test_native_spmm(self):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.float16)
+        rhs = cupy.array([[1, 0], [0, 1], [2, 0]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        result = m @ rhs
+        assert result.dtype == numpy.float16
+        cupy.testing.assert_allclose(result, d @ rhs, rtol=5e-2)
+
+    def test_native_spgemm(self):
+        d1 = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.float16)
+        d2 = cupy.array([[1, 0], [0, 1], [2, 0]], dtype=numpy.float16)
+        a = cupyx.scipy.sparse.csr_matrix(d1)
+        b = cupyx.scipy.sparse.csr_matrix(d2)
+        c = a @ b
+        assert c.dtype == numpy.float16
+        cupy.testing.assert_allclose(c.toarray(), d1 @ d2, rtol=5e-2)
+
+    def test_spgemm_heavy_accumulation_accuracy(self):
+        # float16 SpGEMM stages through float32 (accumulates in float32,
+        # narrows once), so a long inner contraction stays near float16
+        # epsilon.  Uniform-float16 accumulation would compound to ~1e-3.
+        rng = numpy.random.default_rng(0)
+        k = 400
+        a_d = rng.random((6, k)).astype(numpy.float16)
+        b_d = rng.random((k, 6)).astype(numpy.float16)
+        a = cupyx.scipy.sparse.csr_matrix(cupy.asarray(a_d))
+        b = cupyx.scipy.sparse.csr_matrix(cupy.asarray(b_d))
+        got = (a @ b).toarray().get().astype(numpy.float64)
+        ref = a_d.astype(numpy.float64) @ b_d.astype(numpy.float64)
+        rel = numpy.max(numpy.abs(got - ref) / (numpy.abs(ref) + 1e-9))
+        assert rel < 5e-3
+
+    def test_toarray_sums_duplicates_via_atomicadd(self):
+        # float16 densify uses atomicAdd (no forced canonicalization);
+        # duplicate (row, col) entries must sum.
+        data = cupy.array([1.5, 2.5, 3.0], dtype=numpy.float16)
+        row = cupy.array([0, 0, 1], dtype=numpy.int32)
+        col = cupy.array([0, 0, 1], dtype=numpy.int32)
+        m = cupyx.scipy.sparse.coo_matrix(
+            (data, (row, col)), shape=(2, 2)).tocsr()
+        cupy.testing.assert_array_equal(
+            m.toarray(), cupy.array([[4.0, 0.0], [0.0, 3.0]],
+                                    dtype=numpy.float16))
+        cupy.testing.assert_array_equal(
+            m.toarray(order='F'), m.toarray(order='C'))
+
+    def test_mixed_f16_f32_promotes(self):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        v = cupy.array([1, 2, 3], dtype=numpy.float32)
+        result = m @ v
+        assert result.dtype == numpy.float32
+        cupy.testing.assert_allclose(result, d.astype('f') @ v, rtol=1e-6)
+
+    def test_add_and_reductions(self):
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        r = m + m
+        assert r.dtype == numpy.float16
+        cupy.testing.assert_array_equal(r.toarray(), d + d)
+        assert m.sum().dtype == numpy.float16
+        assert float(m.sum()) == 6.0
+        assert m.max().dtype == numpy.float16
+        assert float(m.max()) == 3.0
+        assert m.mean(axis=1).dtype == numpy.float16
+
+    def test_truediv_keeps_float16(self):
+        # scipy rejects float16, so dense CuPy is the oracle:
+        # ``float16 / scalar -> float16`` (not float64).
+        d = cupy.array([[4, 0], [0, 6]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        r = m / 2
+        assert r.dtype == numpy.float16
+        cupy.testing.assert_allclose(r.toarray(), d / 2)
+
+
+class TestBoolRegressions:
+
+    def test_bool_sum_dtype(self):
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[True, False], [True, True]]))
+        s = m.sum()
+        assert int(s) == 3
+        assert s.dtype == numpy.int64
+        s0 = m.sum(axis=0)
+        assert s0.dtype == numpy.int64
+
+    def test_bool_matmul_float_vector(self):
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[True, False], [False, True]]))
+        v = cupy.array([1.0, 2.0], dtype=numpy.float32)
+        cupy.testing.assert_array_equal(m @ v, cupy.array([1.0, 2.0]))
+
+    def test_bool_matmul_bool_vector(self):
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[True, False], [False, True]]))
+        v = cupy.array([True, True])
+        r = m @ v
+        assert r.dtype == numpy.bool_
+        cupy.testing.assert_array_equal(r, cupy.array([True, True]))
+
+
+@testing.with_requires('scipy')
+class TestValueSemanticsRegressions:
+    """Edge cases where a wrong dtype cast would crash or wrap silently."""
+
+    @pytest.mark.parametrize('dtype', [numpy.uint8, numpy.uint16,
+                                       numpy.uint32, numpy.uint64])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_uint_subtraction_wraps(self, xp, sp, dtype):
+        # ``uint - uint`` scales the subtrahend by -1; the coefficient
+        # must wrap modularly (``-1 -> max``) rather than raise
+        # OverflowError under NEP 50.
+        a = sp.csr_matrix(xp.array([[1, 0], [0, 5]], dtype=dtype))
+        b = sp.csr_matrix(xp.array([[3, 0], [0, 2]], dtype=dtype))
+        return (a - b).toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.uint8, numpy.int64])
+    def test_truediv_by_exotic_scalar_falls_back_to_float64(self, dtype):
+        # A scalar whose promotion is unstorable (e.g. numpy.longdouble)
+        # must fall back to float64 rather than trying to build an
+        # unstorable reciprocal dtype (which cupy.reciprocal rejects).
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[4, 0], [0, 6]], dtype=dtype))
+        r = m / numpy.longdouble(2)
+        assert r.dtype == numpy.float64
+        cupy.testing.assert_array_equal(
+            r.toarray(), cupy.array([[2.0, 0.0], [0.0, 3.0]]))
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.uint8])
+    @pytest.mark.parametrize('op', ['gt', 'lt', 'ge', 'le', 'eq', 'ne'])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_out_of_range_scalar_comparison(self, xp, sp, dtype, op):
+        # A scalar outside the matrix dtype's range must compare by
+        # magnitude, not wrap into range (int8 vs 300 -> all False for >).
+        import operator
+        m = sp.csr_matrix(xp.array([[1, 0, 100], [0, 50, 0]], dtype=dtype))
+        with numpy.errstate(over='ignore'):
+            return getattr(operator, op)(m, 300).toarray()
+
+    def test_bool_power_matches_scipy_per_n(self):
+        # numpy/scipy give ``bool ** n`` a per-exponent dtype (int8 at
+        # n==2, int64 at n>=3).  bool is a scipy-supported dtype, so scipy
+        # is the oracle -- match it exactly at every n (CuPy dense's
+        # int64-all would diverge from both scipy and numpy at n==2).
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[True, False], [True, True]]))
+        assert m.power(2).dtype == numpy.int8
+        assert m.power(3).dtype == numpy.int64
+        cupy.testing.assert_array_equal(
+            m.power(2).toarray(),
+            cupy.array([[1, 0], [1, 1]], dtype=numpy.int8))
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_int_truediv_by_dense_is_float64(self, xp, sp, dtype):
+        m = _make_csr(sp, xp, dtype)
+        div = (xp.arange(1, 31, dtype=dtype).reshape(5, 6))
+        r = m / div
+        assert r.dtype == numpy.float64
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_mixed_int_float_add(self, xp, sp, dtype):
+        # int + float32 promotes and uses the native cuSPARSE path; the
+        # decorator checks the promoted dtype matches scipy (float32 for
+        # int8/uint8, float64 for int32/int64 under numpy promotion).
+        a = _make_csr(sp, xp, dtype)
+        b = sp.csr_matrix(xp.eye(5, 6, dtype=numpy.float32))
+        return (a + b).toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mixed_int_float_spmv(self, xp, sp, dtype):
+        a = _make_csr(sp, xp, dtype)
+        v = xp.arange(6, dtype=numpy.float32)
+        return a @ v
+
+    @pytest.mark.parametrize('container',
+                             ['csr_matrix', 'csc_matrix', 'coo_matrix',
+                              'csr_array', 'csc_array', 'coo_array'])
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.uint8])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_all_containers_roundtrip(self, xp, sp, dtype, container):
+        dense = xp.array([[0, 1, 0, 2], [3, 0, 0, 0], [0, 4, 5, 0]],
+                         dtype=dtype)
+        m = getattr(sp, container)(dense)
+        assert m.dtype == dtype
+        return m.toarray()
+
+
+@testing.with_requires('scipy')
+class TestMergedApiValueDtypes:
+    """New API surface from sparray-step3 must also honor value dtypes:
+    ``matrix_power`` / ``**``, 1-D array indexing/reductions/arithmetic,
+    and ``count_nonzero(axis)``.  These build on the dtype-general matmul,
+    indexing, and reduction primitives, so they should already work --
+    these tests lock that in."""
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes + [numpy.bool_])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_matrix_power(self, xp, sp, dtype):
+        from cupyx.scipy.sparse.linalg import matrix_power as cp_mp
+        if xp is numpy:
+            from scipy.sparse.linalg import matrix_power as mp
+        else:
+            mp = cp_mp
+        d = xp.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]], dtype=dtype)
+        m = sp.csr_matrix(d)
+        r = mp(m, 3)
+        assert r.dtype == dtype
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes + [numpy.bool_])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_matrix_pow_operator(self, xp, sp, dtype):
+        d = xp.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]], dtype=dtype)
+        return (sp.csr_matrix(d) ** 3).toarray()
+
+    def test_matrix_power_float16(self):
+        from cupyx.scipy.sparse.linalg import matrix_power
+        d = cupy.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]],
+                       dtype=numpy.float16)
+        r = matrix_power(cupyx.scipy.sparse.csr_matrix(d), 3)
+        assert r.dtype == numpy.float16
+        ref = numpy.linalg.matrix_power(d.get().astype('f4'), 3)
+        cupy.testing.assert_allclose(r.toarray(), ref, rtol=1e-2)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('axis', [0, 1])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_count_nonzero_axis(self, xp, sp, dtype, axis):
+        # The counts are what matter for value-dtype support; the count
+        # array's own int width (int32/int64) is a separate, value-dtype-
+        # independent quirk (scipy even differs by axis), so normalize it.
+        d = xp.array([[1, 0, 2], [0, 0, 0], [3, 0, 4]], dtype=dtype)
+        return xp.asarray(
+            sp.csr_matrix(d).count_nonzero(axis=axis)).astype(numpy.int64)
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @pytest.mark.parametrize('reduction',
+                             ['sum', 'mean', 'max', 'min', 'argmax'])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_1d_array_reductions(self, xp, sp, dtype, reduction):
+        # 1-D array reductions must match scipy dtype+value (int8.sum ->
+        # int64, not an int8 overflow).
+        v = sp.csr_array(xp.array([100, 0, 100, 50, 0, 60], dtype=dtype))
+        return xp.asarray(getattr(v, reduction)())
+
+    def test_1d_int64_sum_exact_past_2_53(self):
+        big = 2 ** 60
+        v = cupyx.scipy.sparse.csr_array(
+            cupy.array([big + 7, 0, big + 3], dtype=numpy.int64))
+        assert int(v.sum()) == 2 * big + 10
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_1d_indexing(self, xp, sp, dtype):
+        v = sp.csr_array(xp.array([1, 0, 2, 3, 0, 4], dtype=dtype))
+        cols = xp.array([0, 2, 5])
+        return (xp.asarray(v[2]),
+                v[1:4].toarray(),
+                v[cols].toarray())
+
+    def test_1d_indexing_float16(self):
+        # scipy rejects float16, so compare against dense (CuPy extension).
+        dense = cupy.array([1, 0, 2, 3, 0, 4], dtype=numpy.float16)
+        v = cupyx.scipy.sparse.csr_array(dense)
+        assert v[2] == dense[2]
+        cupy.testing.assert_array_equal(v[1:4].toarray(), dense[1:4])
+        cols = cupy.array([0, 2, 5])
+        cupy.testing.assert_array_equal(v[cols].toarray(), dense[cols])
+
+    @pytest.mark.parametrize('dtype', _scipy_dtypes)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_1d_arithmetic(self, xp, sp, dtype):
+        a = sp.csr_array(xp.array([1, 0, 2, 3], dtype=dtype))
+        b = sp.csr_array(xp.array([0, 1, 2, 0], dtype=dtype))
+        return ((a + b).toarray(), (a * b).toarray(),
+                (a * 2).toarray(), xp.asarray(a @ b))
+
+
+@requires_bfloat16
+class TestBfloat16:
+    """bfloat16 is a CuPy extension (via ml_dtypes); scipy rejects it, so
+    these compare against dense cupy.  Its numpy ``kind`` is ``'V'`` and
+    its char ``'E'`` collides with complex-half, so sparse detects it by
+    name.  Native cuSPARSE bf16 needs sm_80+ (silently zeros on older
+    GPUs), so matmul always upcasts to float32."""
+
+    def _make(self, container='csr_matrix'):
+        dense = cupy.array([[0, 1, 0, 2], [3, 0, 0, 0], [0, 4, 5, 0]],
+                           dtype='float32').astype(_bfloat16)
+        return getattr(cupyx.scipy.sparse, container)(dense), dense
+
+    def test_gate_accepts_by_name(self):
+        m, dense = self._make()
+        assert m.dtype == _bfloat16
+        assert cupyx.scipy.sparse._sputils.is_sparse_data_dtype(_bfloat16)
+        assert _bfloat16 in cupyx.scipy.sparse._sputils.supported_dtypes
+
+    @pytest.mark.parametrize('container', _containers)
+    def test_construct_roundtrip(self, container):
+        m, dense = self._make(container)
+        assert m.dtype == _bfloat16
+        cupy.testing.assert_array_equal(m.toarray(), dense)
+        cupy.testing.assert_array_equal(
+            m.tocsc().tocoo().tocsr().toarray(), dense)
+
+    @pytest.mark.parametrize('order', ['C', 'F'])
+    def test_csc_toarray_orders(self, order):
+        m, dense = self._make('csc_matrix')
+        cupy.testing.assert_array_equal(m.toarray(order=order), dense)
+
+    def test_sum_duplicates(self):
+        # bfloat16 has kind 'V', so it must be routed to the atomicAdd
+        # accumulate path by name (else duplicates would leave zeros).
+        data = cupy.array([1.5, 2.5, 3.0], dtype='float32').astype(_bfloat16)
+        row = cupy.array([0, 0, 1], 'i')
+        col = cupy.array([0, 0, 1], 'i')
+        m = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=(2, 2))
+        m.sum_duplicates()
+        assert m.dtype == _bfloat16
+        assert float(m.toarray()[0, 0]) == 4.0
+
+    def test_arithmetic(self):
+        m, dense = self._make()
+        cupy.testing.assert_array_equal((m + m).toarray(), dense + dense)
+        cupy.testing.assert_array_equal((m * 2).toarray(),
+                                        (dense.astype('f4') * 2))
+        cupy.testing.assert_array_equal(m.multiply(m).toarray(),
+                                        (dense.astype('f4') ** 2)
+                                        * (dense.astype('f4') != 0))
+        # bf16 / int keeps bf16 (matches dense CuPy; scipy has no oracle).
+        assert (m / 2).dtype == _bfloat16
+
+    def test_matmul_upcasts_float32(self):
+        m, dense = self._make()
+        v = cupy.array([1, 2, 0, 3], dtype='float32').astype(_bfloat16)
+        r = m @ v
+        assert r.dtype == _bfloat16
+        cupy.testing.assert_allclose(
+            r.astype('f4'), dense.astype('f4') @ v.astype('f4'), rtol=1e-2)
+        p = m @ m.T
+        assert p.dtype == _bfloat16
+        cupy.testing.assert_allclose(
+            p.toarray().astype('f4'),
+            dense.astype('f4') @ dense.T.astype('f4'), rtol=1e-2)
+
+    def test_spgemm_f32_staged_accuracy(self):
+        # bfloat16 SpGEMM stages through float32 (accumulates in float32,
+        # narrows once) -- a heavy contraction stays near bf16 epsilon
+        # rather than compounding an 8-bit-mantissa accumulation.
+        rng = numpy.random.default_rng(0)
+        k = 400
+        a_d = rng.random((6, k)).astype('float32').astype(_bfloat16)
+        b_d = rng.random((k, 6)).astype('float32').astype(_bfloat16)
+        a = cupyx.scipy.sparse.csr_matrix(cupy.asarray(a_d))
+        b = cupyx.scipy.sparse.csr_matrix(cupy.asarray(b_d))
+        got = (a @ b).toarray().astype('float64').get()
+        ref = a_d.astype('float64') @ b_d.astype('float64')
+        rel = numpy.max(numpy.abs(got - ref) / (numpy.abs(ref) + 1e-9))
+        assert rel < 5e-2
+
+    def test_reductions(self):
+        m, dense = self._make()
+        assert m.sum().dtype == _bfloat16
+        assert float(m.sum()) == float(dense.astype('f4').sum())
+        assert m.max().dtype == _bfloat16
+        assert float(m.max()) == float(dense.astype('f4').max())
+        # mean keeps bfloat16, matching dense CuPy (rule 3: dense is the
+        # oracle for the scipy-rejected 16-bit floats; consistent with
+        # float16.mean -> float16), rounded to bf16's low precision.
+        assert m.mean().dtype == _bfloat16
+        cupy.testing.assert_allclose(
+            float(m.mean().astype('f4')),
+            float(dense.astype('f4').mean()), rtol=1e-1)
+        cupy.testing.assert_array_equal(
+            m.argmax(axis=1),
+            dense.astype('f4').argmax(axis=1)[:, None])
+
+    def test_fancy_indexing(self):
+        m, dense = self._make()
+        cols = cupy.array([0, 2, 3])
+        cupy.testing.assert_array_equal(m[:, cols].toarray(), dense[:, cols])
+        rows = cupy.array([0, 2])
+        cupy.testing.assert_array_equal(m[rows, :].toarray(), dense[rows, :])
+
+    def test_scalar_getitem_and_slices(self):
+        m, dense = self._make()
+        assert m[1, 0] == dense[1, 0]
+        cupy.testing.assert_array_equal(m[0:2, :].toarray(), dense[0:2, :])
+
+    def test_stack_and_eye_preserve_dtype(self):
+        m, dense = self._make()
+        assert cupyx.scipy.sparse.hstack([m, m]).dtype == _bfloat16
+        assert cupyx.scipy.sparse.vstack([m, m]).dtype == _bfloat16
+        assert cupyx.scipy.sparse.eye(
+            3, dtype=_bfloat16, format='csr').dtype == _bfloat16
+
+    def test_random(self):
+        m = cupyx.scipy.sparse.random(20, 20, density=0.3, dtype=_bfloat16)
+        assert m.dtype == _bfloat16
+        assert m.nnz == 120
+
+    def test_matrix_power(self):
+        from cupyx.scipy.sparse.linalg import matrix_power
+        d = cupy.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]],
+                       dtype='float32').astype(_bfloat16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        r = matrix_power(m, 3)
+        assert r.dtype == _bfloat16
+        cupy.testing.assert_allclose(
+            r.toarray().astype('f4'),
+            numpy.linalg.matrix_power(d.get().astype('f4'), 3), rtol=1e-2)
+        assert (m ** 3).dtype == _bfloat16
+
+    def test_1d_array(self):
+        dense = cupy.array([1, 0, 2, 3, 0, 4],
+                           dtype='float32').astype(_bfloat16)
+        v = cupyx.scipy.sparse.csr_array(dense)
+        assert v.dtype == _bfloat16
+        cupy.testing.assert_array_equal(v.toarray(), dense)
+        assert float(v.sum()) == 10.0
+        assert float(v.max()) == 4.0
+        assert float(v[2]) == 2.0
+        cupy.testing.assert_array_equal(v[1:4].toarray(), dense[1:4])
+        cupy.testing.assert_array_equal(
+            v[cupy.array([0, 2, 4])].toarray(), dense[cupy.array([0, 2, 4])])
+        cupy.testing.assert_array_equal((v + v).toarray(), dense + dense)
+        assert float(v @ v) == 30.0
+
+    def test_comparison_int_scalar(self):
+        # bfloat16's numpy kind is 'V', so _comparison must route it
+        # like a float (cast the scalar to bf16, matching dense CuPy);
+        # otherwise the scalar stays int and numpy.promote_types(
+        # bfloat16, int64) crashes binopt_csr.  s=2 exercises the fast
+        # path (op(0, 2) False, e.g. '>') and the slow O(m*n) path
+        # (op(0, 2) True, e.g. '<') across the six operators.
+        dense = cupy.array([[1, 0, 3], [0, 2, 0]],
+                           dtype='float32').astype(_bfloat16)
+        ops = [lambda a, s: a < s, lambda a, s: a > s,
+               lambda a, s: a <= s, lambda a, s: a >= s,
+               lambda a, s: a == s, lambda a, s: a != s]
+        for name in ('csr_matrix', 'csc_matrix', 'coo_matrix'):
+            m = getattr(cupyx.scipy.sparse, name)(dense)
+            for op in ops:
+                for s in (2, 0):
+                    cupy.testing.assert_array_equal(
+                        op(m, s).toarray(), op(dense, s))
+
+    def test_str_and_print_do_not_crash(self):
+        # bfloat16, like float16, has no scipy host kernels, so
+        # ``str(self.get())`` raises ValueError; ``__str__`` falls back
+        # to ``repr`` instead of crashing ``print()`` / ``format()``.
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0, 2], [0, 3, 0]],
+                       dtype='float32').astype(_bfloat16))
+        assert 'sparse' in str(m)
+        assert 'sparse' in '{}'.format(m)
+
+    @pytest.mark.parametrize('other', ['int16', 'int32', 'int64',
+                                       'uint32', 'float16'])
+    @pytest.mark.parametrize('fmt', ['csr_matrix', 'csc_matrix',
+                                     'coo_matrix'])
+    def test_mixed_dtype_elementwise_matches_dense(self, other, fmt):
+        # numpy cannot promote bfloat16 with a >=16-bit int or float16, but
+        # dense CuPy resolves it via ufunc loops (bf16+int32 -> float64);
+        # sparse +, *, comparison and maximum must match dense, not raise.
+        odt = numpy.float16 if other == 'float16' else numpy.dtype(other)
+        db = cupy.array([[1, 0, 2], [0, 3, 0]],
+                        dtype='float32').astype(_bfloat16)
+        do = cupy.array([[1, 0, 1], [0, 2, 0]], dtype='float32').astype(odt)
+        sp_cls = getattr(cupyx.scipy.sparse, fmt)
+        mb, mo = sp_cls(db), sp_cls(do)
+        assert (mb + mo).dtype == (db + do).dtype
+        cupy.testing.assert_array_equal((mb + mo).toarray(), db + do)
+        assert mb.multiply(mo).dtype == (db * do).dtype
+        cupy.testing.assert_array_equal(
+            mb.multiply(mo).toarray(), db * do)
+        assert (mb < mo).dtype == numpy.bool_
+        assert mb.maximum(mo).dtype == cupy.maximum(db, do).dtype
+
+    def test_matmul_and_concat_with_int_raise(self):
+        # dense CuPy also raises for bf16 @ int and
+        # concatenate([bf16, int]); only elementwise ops promote.
+        mb = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0, 2], [0, 3, 0]], dtype='f4').astype(_bfloat16))
+        mi = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0, 1], [0, 1, 0]], dtype='i4'))
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            mb @ cupyx.scipy.sparse.csr_matrix(
+                cupy.array([[1, 0], [0, 1], [1, 0]], dtype='i4'))
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            mb @ cupy.ones((3, 2), dtype='i4')
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            cupyx.scipy.sparse.hstack([mb, mi])
+
+
+@testing.with_requires('scipy')
+class TestExactIntegerMatmul:
+    # cuSPARSE spmv/spmm have no integer compute type; the pure-CuPy scatter
+    # must match scipy's modular integer matmul exactly -- a float64 upcast
+    # would lose precision past 2**53 and saturate (not wrap) on
+    # out-of-range integer casts.
+
+    @pytest.mark.parametrize('dtype', _int_dtypes + [numpy.bool_])
+    @pytest.mark.parametrize('fmt', ['csr_matrix', 'csc_matrix'])
+    def test_matches_scipy(self, dtype, fmt):
+        import scipy.sparse
+        rng = numpy.random.default_rng(numpy.dtype(dtype).itemsize + len(fmt))
+        d = rng.integers(0, 7, size=(4, 5)).astype(dtype)
+        d[rng.random((4, 5)) < 0.4] = 0
+        xv = rng.integers(0, 7, size=5).astype(dtype)
+        xm = rng.integers(0, 7, size=(5, 3)).astype(dtype)
+        m = getattr(cupyx.scipy.sparse, fmt)(cupy.asarray(d))
+        sm = getattr(scipy.sparse, fmt)(d)
+        numpy.testing.assert_array_equal(
+            (m @ cupy.asarray(xv)).get(), numpy.asarray(sm @ xv).ravel())
+        numpy.testing.assert_array_equal(
+            (m @ cupy.asarray(xm)).get(), numpy.asarray(sm @ xm))
+
+    def test_int64_exact_past_2_53(self):
+        import scipy.sparse
+        base = 2 ** 53
+        d = numpy.array([[base + 1, 0, base + 3],
+                         [0, base + 5, 0],
+                         [base + 7, 0, base + 2]], dtype=numpy.int64)
+        x = numpy.array([1, 1, 1], dtype=numpy.int64)
+        got = (cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+               @ cupy.asarray(x)).get()
+        numpy.testing.assert_array_equal(
+            got, numpy.asarray(scipy.sparse.csr_matrix(d) @ x).ravel())
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int32,
+                                       numpy.uint8, numpy.uint32])
+    def test_overflow_wraps_like_scipy(self, dtype):
+        import scipy.sparse
+        big = dtype(numpy.iinfo(dtype).max)
+        d = numpy.array([[big, big]], dtype=dtype)
+        x = numpy.array([2, 2], dtype=dtype)
+        got = (cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+               @ cupy.asarray(x)).get()
+        numpy.testing.assert_array_equal(
+            got, numpy.asarray(scipy.sparse.csr_matrix(d) @ x).ravel())
+
+    def test_wide_operand_chunks_and_stays_exact(self, monkeypatch):
+        # The scatter materialises an (nnz, N) product; a wide dense
+        # operand is processed in column blocks so it cannot OOM.  Force
+        # multi-chunk (block == 1) by reporting ~no free memory and confirm
+        # the chunked accumulation is still exact past 2**53 -- unlike a
+        # float64 fallback, which would round.
+        import scipy.sparse
+        cupy.get_default_memory_pool().free_all_blocks()
+        monkeypatch.setattr(cupy.cuda.runtime, 'memGetInfo', lambda: (1, 1))
+        d = numpy.array([[2**60 + 1, 0, 3], [0, 5, 0], [7, 0, 2**60]],
+                        dtype=numpy.int64)
+        x = numpy.arange(1, 13, dtype=numpy.int64).reshape(3, 4)
+        got = (cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+               @ cupy.asarray(x)).get()
+        numpy.testing.assert_array_equal(
+            got, numpy.asarray(scipy.sparse.csr_matrix(d) @ x))
+
+
+class TestUnsupportedDtypeRejected:
+
+    @pytest.mark.parametrize('name', ['float8_e4m3b11fnuz', 'float8_e5m2'])
+    def test_float8_rejected(self, name):
+        ml = pytest.importorskip('ml_dtypes')
+        from cupyx.scipy.sparse import _sputils
+        dt = numpy.dtype(getattr(ml, name))
+        # float8_e4m3b11fnuz shares dtype char 'L' with uint64, so a char
+        # test would wrongly accept it; the width-based check rejects it.
+        assert not _sputils.is_sparse_data_dtype(dt)
+        with pytest.raises(ValueError):
+            _sputils.check_data_dtype(dt)
+
+    def test_longdouble_rejected(self):
+        from cupyx.scipy.sparse import _sputils
+        assert not _sputils.is_sparse_data_dtype(numpy.longdouble)
+        with pytest.raises(ValueError):
+            _sputils.check_data_dtype(numpy.longdouble)
+
+
+@testing.with_requires('scipy')
+class TestComplexArgReduceAxis:
+    # Axis-wise argmin/argmax on a complex matrix must not crash (the
+    # arg-reduction kernel is instantiated only for real types); reduce on
+    # the real part, matching min/max.
+
+    @pytest.mark.parametrize('fmt', ['csr_matrix', 'csc_matrix'])
+    @pytest.mark.parametrize('meth', ['argmax', 'argmin'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    def test_complex_argreduce_axis(self, fmt, meth, axis):
+        import scipy.sparse
+        d = numpy.array([[0, 2 + 1j, 0, 5],
+                         [3 - 2j, 0, 0, 0],
+                         [0, 0, 7 + 9j, 1j]], dtype=numpy.complex128)
+        m = getattr(cupyx.scipy.sparse, fmt)(cupy.asarray(d))
+        sm = getattr(scipy.sparse, fmt)(d)
+        got = cupy.asnumpy(getattr(m, meth)(axis=axis)).ravel()
+        exp = numpy.asarray(getattr(sm, meth)(axis=axis)).ravel()
+        numpy.testing.assert_array_equal(got, exp)
+
+
+class TestRound2Fixes:
+    # Regressions for the round-2 correctness fixes.
+
+    def test_truediv_clongdouble_keeps_complex(self):
+        # Dividing a complex matrix by a clongdouble scalar promotes to
+        # the unstorable complex256; the fallback must stay complex128
+        # (float64 would silently drop the imaginary part).
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[2 + 0j, 0], [0, 4 + 0j]], dtype='complex128'))
+        r = m / numpy.clongdouble(2 + 1j)
+        assert r.dtype == numpy.complex128
+        cupy.testing.assert_allclose(
+            r.toarray(), cupy.asarray([[2, 0], [0, 4]], dtype='complex128')
+            / (2 + 1j))
+
+    def test_truediv_float16_stays_float16(self):
+        # scipy rejects float16, so dense CuPy is the oracle:
+        # ``float16 / 2.0 -> float16`` (not float64).
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0, 2], [0, 3, 0]], dtype='float16'))
+        assert (m / 2.0).dtype == numpy.float16
+        # float32 still promotes to float64 (scipy parity, unchanged).
+        m32 = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[1, 0, 2]], dtype='float32'))
+        assert (m32 / 2.0).dtype == numpy.float64
+
+    @pytest.mark.parametrize('n', [2, 3, 4])
+    def test_bool_power_matches_scipy_per_n(self, n):
+        # bool ** n -> numpy/scipy's per-exponent carrier (int8 @ n==2,
+        # int64 @ n>=3), derived by construction, not cupy dense's
+        # int64-all.  scipy supports bool, so scipy is the oracle.
+        m = cupyx.scipy.sparse.csr_array(
+            cupy.array([[True, False], [True, True]]))
+        r = m.power(n)
+        assert r.dtype == (numpy.ones(1, bool) ** n).dtype
+        cupy.testing.assert_array_equal(
+            r.toarray(), m.toarray().astype(numpy.int64) ** n)
+
+    @testing.with_requires('scipy')
+    @pytest.mark.parametrize('meth', ['min', 'max', 'argmin', 'argmax'])
+    @pytest.mark.parametrize('axis', [(0, 1), (1,), (0,)])
+    def test_tuple_axis_min_max(self, meth, axis):
+        import scipy.sparse
+        d = numpy.array([[0, 3, 0], [5, 0, -1], [0, 2, 0]], dtype='float64')
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        sm = scipy.sparse.csr_matrix(d)
+        got = getattr(m, meth)(axis=axis)
+        exp = getattr(sm, meth)(axis=axis)
+        got = cupy.asnumpy(got.toarray() if hasattr(got, 'toarray') else got)
+        exp = numpy.asarray(exp.toarray() if hasattr(exp, 'toarray') else exp)
+        numpy.testing.assert_array_equal(got.ravel(), exp.ravel())
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int16,
+                                       numpy.uint8, numpy.uint16])
+    def test_toarray_dedups_stale_canonical_flag(self, dtype):
+        # The 8/16-bit direct-write densify must sum duplicates even when
+        # has_canonical_format is (wrongly) True, matching scipy.
+        m = cupyx.scipy.sparse.csr_matrix(
+            (cupy.array([3, 7], dtype=dtype), cupy.array([1, 1], dtype='i4'),
+             cupy.array([0, 2], dtype='i4')), shape=(1, 3))
+        m.has_canonical_format = True  # stale: duplicates at (0, 1)
+        cupy.testing.assert_array_equal(
+            m.toarray(), cupy.array([[0, 10, 0]], dtype=dtype))
+
+
+class TestRound3Fixes:
+    # Regressions for the round-3 correctness fixes.
+
+    @pytest.mark.parametrize('exp', [2, 3])
+    def test_bool_power_accepts_0d_cupy_exponent(self, exp):
+        # ``isscalarlike`` accepts a 0-D cupy array as the exponent; the
+        # per-n carrier ``numpy.ones(1, bool) ** n`` would crash on a
+        # device array, so ``n`` is read to host first.  A 0-D array's
+        # dtype (int64) makes numpy promote to int64 -- faithful to scipy,
+        # which gives int64 for a ``np.int64`` exponent.
+        m = cupyx.scipy.sparse.csr_array(
+            cupy.array([[True, False], [True, True]]))
+        r = m.power(cupy.asarray(exp))
+        assert r.dtype == numpy.int64
+        cupy.testing.assert_array_equal(
+            r.toarray(), m.toarray().astype(numpy.int64) ** exp)
+
+    @requires_bfloat16
+    @pytest.mark.parametrize('scalar,expect', [
+        (2.0, 'float32'), (2, 'bfloat16'), (1 + 1j, 'complex64')])
+    def test_bf16_scalar_division_matches_dense_ufunc(self, scalar, expect):
+        # scipy rejects bfloat16, so the dense ufunc is the oracle -- and
+        # it differs from result_type (bf16/2.0 is float32 via the ufunc,
+        # float64 via result_type).
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype='float32').astype(
+            _bfloat16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        assert str((m / scalar).dtype) == expect
+        assert (m / scalar).dtype == (d / scalar).dtype
+
+    def test_float16_scalar_division_stays_float16(self):
+        d = cupy.array([[1, 0, 2]], dtype='float16')
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        assert (m / 2.0).dtype == numpy.float16
+        assert (m / 2.0).dtype == (d / 2.0).dtype
+
+    @requires_bfloat16
+    def test_bf16_mixed_division_promotes_not_raises(self):
+        # A bfloat16 sparse divided by a wider dense/sparse operand should
+        # promote like dense (float), not raise DTypePromotionError.
+        d = cupy.array([[1, 0, 2], [0, 3, 0]], dtype='float32').astype(
+            _bfloat16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        r = m / cupy.ones((2, 3), dtype='float16')
+        assert r.dtype == (d / cupy.ones(3, dtype='float16')).dtype  # f32
+        # wider int dense -> float64 (no raise)
+        assert (m / cupy.ones((2, 3), dtype='int32')).dtype == numpy.float64
+        # sparse divisor: no raise
+        m.__truediv__(cupyx.scipy.sparse.csr_matrix(
+            cupy.ones((2, 3), dtype='int32')))
+
+
+@testing.with_requires('scipy')
+class TestExactReductionCoverage:
+    # Coverage the round-4 comparison flagged as missing in 0a.
+
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    def test_uint64_sum_exact_past_2_53(self, fmt, axis):
+        # uint64 sums past 2**53 must stay exact (segmented cumsum), not
+        # round through the float64 matmul path.
+        import scipy.sparse
+        big = 2 ** 60
+        dense = numpy.array([[big + 7, 0, big + 3],
+                             [0, big + 1, 0]], dtype=numpy.uint64)
+        m = getattr(cupyx.scipy.sparse, f'{fmt}_matrix')(cupy.asarray(dense))
+        sm = getattr(scipy.sparse, f'{fmt}_matrix')(dense)
+        got = m.sum(axis=axis)
+        exp = sm.sum(axis=axis)
+        if axis is None:
+            assert int(got) == int(exp)
+        else:
+            numpy.testing.assert_array_equal(
+                cupy.asnumpy(got).ravel(), numpy.asarray(exp).ravel())
+
+    @pytest.mark.parametrize('meth', ['argmax', 'argmin'])
+    @pytest.mark.parametrize('axis', [0, 1])
+    def test_bool_argreduce_axis_matches_scipy(self, meth, axis):
+        # bool is a value dtype; its argmax/argmin (per axis) must match
+        # scipy, including an all-False row/column.
+        import scipy.sparse
+        d = numpy.array([[False, True, False],
+                         [True, False, True],
+                         [False, False, False]])
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        sm = scipy.sparse.csr_matrix(d)
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(getattr(m, meth)(axis=axis)).ravel(),
+            numpy.asarray(getattr(sm, meth)(axis=axis)).ravel())
+
+
+# ---- 0b session's tests below (colliding list-helpers renamed to _b) ----
+
+_int_dtypes_b = [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16,
+                 numpy.int32, numpy.uint32, numpy.int64, numpy.uint64]
+# Representative subset for expensive parametrizations: smallest signed
+# (no atomicAdd overload), smallest unsigned, and 64-bit.
+_key_dtypes_b = [numpy.int8, numpy.uint8, numpy.int64]
+
+_containers_b = ['csr_matrix', 'csc_matrix', 'coo_matrix',
+                 'csr_array', 'csc_array', 'coo_array']
+
+
+def _make(xp, sp, dtype, container='csr_matrix'):
+    dense = xp.array([[0, 1, 0, 2],
+                      [3, 0, 0, 0],
+                      [0, 4, 5, 0]], dtype=dtype)
+    return getattr(sp, container)(dense)
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeConstruction:
+
+    @pytest.mark.parametrize('container', _containers_b)
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_from_dense(self, xp, sp, dtype, container):
+        m = _make(xp, sp, dtype, container)
+        assert m.dtype == dtype
+        return m.toarray()
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_from_tuple(self, xp, sp, dtype):
+        data = xp.array([1, 2, 3], dtype=dtype)
+        indices = xp.array([0, 2, 1], 'i')
+        indptr = xp.array([0, 2, 3], 'i')
+        return sp.csr_matrix((data, indices, indptr), shape=(2, 3)).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    def test_empty_shape(self, dtype):
+        m = cupyx.scipy.sparse.csr_matrix((3, 4), dtype=dtype)
+        assert m.dtype == dtype
+        assert m.nnz == 0
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    def test_scipy_roundtrip(self, dtype):
+        scipy_sparse = pytest.importorskip('scipy.sparse')
+        d = numpy.array([[1, 0, 2], [0, 3, 0]], dtype=dtype)
+        m = cupyx.scipy.sparse.csr_matrix(scipy_sparse.csr_matrix(d))
+        assert m.dtype == dtype
+        back = m.get()
+        assert back.dtype == dtype
+        numpy.testing.assert_array_equal(back.toarray(), d)
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_dia(self, xp, sp, dtype):
+        data = xp.array([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        offsets = xp.array([0, -1], 'i')
+        m = sp.dia_matrix((data, offsets), shape=(3, 3))
+        assert m.dtype == dtype
+        return m.toarray()
+
+    def test_unsupported_dtype_message(self):
+        d = cupy.zeros((2, 2), dtype=numpy.float32)
+        with pytest.raises(ValueError, match='does not support dtype'):
+            cupyx.scipy.sparse.csr_matrix(d, dtype='U3')
+        with pytest.raises(ValueError, match='does not support dtype'):
+            cupyx.scipy.sparse.coo_matrix(d, dtype='U3')
+
+    def test_ml_dtypes_collisions_rejected(self):
+        # ml_dtypes registers custom numpy dtypes whose single-char codes
+        # collide with standard ones -- e.g.
+        # numpy.dtype(ml_dtypes.float8_e4m3b11fnuz).char == 'L', colliding
+        # with uint64.  The gate must reject the unsupported ones by dtype
+        # *identity*, not char (which would mis-accept the float8).
+        # (bfloat16 is separately supported -- see TestValueDtypeBfloat16.)
+        ml_dtypes = pytest.importorskip('ml_dtypes')
+        from cupyx.scipy.sparse import _sputils
+        for name in ('float8_e4m3b11fnuz', 'float8_e5m2',
+                     'float8_e4m3', 'int4', 'uint4'):
+            dt = numpy.dtype(getattr(ml_dtypes, name))
+            assert not _sputils.is_sparse_data_dtype(dt), name
+            with pytest.raises(ValueError, match='does not support dtype'):
+                _sputils.check_data_dtype(dt)
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeConversion:
+
+    @pytest.mark.parametrize('container', _containers_b)
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_format_roundtrips(self, xp, sp, dtype, container):
+        m = _make(xp, sp, dtype, container)
+        assert m.tocsc().dtype == dtype
+        return (m.tocsc().tocoo().tocsr().toarray(),
+                m.tocsr().toarray(),
+                m.T.toarray())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_csc_toarray_orders(self, xp, sp, dtype):
+        # csc.toarray for non-float dtypes goes through the CSR kernel.
+        m = _make(xp, sp, dtype, 'csc_matrix')
+        return m.toarray(order='C'), m.toarray(order='F')
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_unsorted_coo_tocsc(self, xp, sp, dtype):
+        # Regression: coosort must permute data along with coordinates
+        # (the bool path used to skip the data gather entirely).
+        row = xp.array([2, 0, 1], 'i')
+        col = xp.array([0, 2, 1], 'i')
+        data = xp.array([1, 2, 3], dtype=dtype)
+        m = sp.coo_matrix((data, (row, col)), shape=(3, 3))
+        return m.tocsc().toarray()
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_unsorted_bool_coo_tocsc(self, xp, sp):
+        # An explicit stored ``False`` at a coordinate that moves during
+        # the column sort: if the data gather is skipped (the old bool
+        # cuSPARSE coosort path), the False misaligns with its coords
+        # and the wrong cell reads False.
+        row = xp.array([2, 0, 1], 'i')
+        col = xp.array([0, 2, 1], 'i')
+        data = xp.array([True, False, True])
+        m = sp.coo_matrix((data, (row, col)), shape=(3, 3))
+        return m.tocsc().toarray(), m.toarray()
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sum_duplicates(self, xp, sp, dtype):
+        # 100 + 100 wraps to -56 for int8 (matching numpy overflow).
+        data = xp.array([100, 100, 5], dtype=dtype)
+        row = xp.array([0, 0, 1], 'i')
+        col = xp.array([0, 0, 1], 'i')
+        m = sp.coo_matrix((data, (row, col)), shape=(2, 2))
+        m.sum_duplicates()
+        assert m.dtype == dtype
+        return m.toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_eliminate_zeros(self, xp, sp, dtype):
+        data = xp.array([1, 0, 3], dtype=dtype)
+        indices = xp.array([0, 1, 2], 'i')
+        indptr = xp.array([0, 3], 'i')
+        m = sp.csr_matrix((data, indices, indptr), shape=(1, 3))
+        m.eliminate_zeros()
+        assert m.nnz == 2
+        return m.toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sort_indices(self, xp, sp, dtype):
+        data = xp.array([2, 1], dtype=dtype)
+        indices = xp.array([2, 0], 'i')
+        indptr = xp.array([0, 2], 'i')
+        m = sp.csr_matrix((data, indices, indptr), shape=(1, 3))
+        m.sort_indices()
+        assert m.has_sorted_indices
+        return m.toarray()
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeArithmetic:
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_add(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        r = m + m
+        assert r.dtype == dtype
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sub(self, xp, sp, dtype):
+        # uint wraps modularly; bool behaves like C bool arithmetic
+        # (a - b != 0), both matching scipy.
+        a = _make(xp, sp, dtype)
+        b = sp.csr_matrix(
+            xp.array([[1, 1, 0, 0],
+                      [0, 0, 0, 2],
+                      [0, 4, 0, 0]], dtype=dtype))
+        return (a - b).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_mixed_dtype_add(self, xp, sp, dtype):
+        # int + float32 promotes and uses the native cuSPARSE path.
+        a = _make(xp, sp, dtype)
+        b = _make(xp, sp, numpy.float32)
+        return (a + b).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_scalar_mul(self, xp, sp, dtype):
+        return (_make(xp, sp, dtype) * 2).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_truediv_scalar(self, xp, sp, dtype):
+        return (_make(xp, sp, dtype) / 2).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_truediv_dense(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        div = xp.arange(1, 13, dtype=dtype).reshape(3, 4)
+        r = m / div
+        assert r.dtype == numpy.float64
+        return r.toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_multiply(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return m.multiply(m).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_multiply_dense(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        dn = xp.arange(12, dtype=dtype).reshape(3, 4)
+        return m.multiply(dn).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_maximum_minimum(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return m.maximum(m).toarray(), m.minimum(3).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_comparison(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        # 300 is out of int8 range: must compare by value, not wrap.
+        return (m > 1).toarray(), (m != m).toarray(), (m > 300).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_power(self, xp, sp, dtype):
+        # bool ** 2 promotes to int8 (numpy rule).
+        return _make(xp, sp, dtype).power(2).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_neg_abs(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return (-m).toarray(), abs(m).toarray()
+
+    def test_bool_neg_raises(self):
+        m = _make(cupy, cupyx.scipy.sparse, bool)
+        with pytest.raises(NotImplementedError):
+            -m
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeMatmul:
+
+    @pytest.mark.parametrize('container',
+                             ['csr_matrix', 'csc_matrix', 'csr_array'])
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_spmv(self, xp, sp, dtype, container):
+        m = _make(xp, sp, dtype, container)
+        v = xp.array([1, 2, 0, 3], dtype=dtype)
+        return m @ v
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_spmm(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        b = (xp.arange(8).reshape(4, 2) % 3).astype(dtype)
+        return m @ b
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_spmv_mixed_float(self, xp, sp, dtype):
+        # int sparse @ float dense promotes and stays on cuSPARSE.
+        m = _make(xp, sp, dtype)
+        v = xp.array([1, 2, 0, 3], dtype=numpy.float32)
+        return m @ v
+
+    @pytest.mark.parametrize('other_dtype',
+                             [numpy.float16, numpy.int8, numpy.float32])
+    def test_float16_matmul_dtype_promotion(self, other_dtype):
+        # float16 matrix promotes with the dense operand:
+        #   f16 @ f16/int8 -> f16 (native mixed-precision path)
+        #   f16 @ f32      -> f32 (upcast path)
+        d = cupy.array([[1, 0, 2, 0], [0, 3, 0, 1]], dtype=numpy.float16)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        v = cupy.array([1, 2, 0, 3], dtype=other_dtype)
+        expected = numpy.promote_types(numpy.float16, other_dtype)
+        r = m @ v
+        assert r.dtype == expected
+        cupy.testing.assert_allclose(
+            r.astype(numpy.float32),
+            (d.astype(numpy.float32) @ v.astype(numpy.float32)), rtol=1e-2)
+
+    def test_int8_matmul_float16_dense(self):
+        # int8 sparse @ f16 dense -> f16 (via the exact-upcast path).
+        d = cupy.array([[1, 0, 2, 0], [0, 3, 0, 1]], dtype=numpy.int8)
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        v = cupy.array([1, 2, 0, 3], dtype=numpy.float16)
+        r = m @ v
+        assert r.dtype == numpy.float16
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_spgemm(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        r = m @ m.T
+        assert r.dtype == dtype
+        return r.toarray()
+
+    def test_spgemm_int_exact_past_2_53(self):
+        # Integer sparse @ sparse accumulates exactly (pure-CuPy),
+        # including products/sums above float64's 2**53 mantissa limit.
+        v = 1 << 30                       # v*v = 2**60 > 2**53
+        a = cupyx.scipy.sparse.csr_matrix(
+            cupy.array([[v, v], [0, v]], dtype=numpy.int64))
+        c = a @ a.T
+        ref = (numpy.array([[v, v], [0, v]], dtype=numpy.int64)
+               @ numpy.array([[v, v], [0, v]], dtype=numpy.int64).T)
+        cupy.testing.assert_array_equal(c.toarray(), cupy.asarray(ref))
+        assert int(c.toarray()[0, 0]) == 2 * v * v
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_csr_matmul_csc(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return (m @ m.T.tocsc()).toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    def test_spgemm_preserves_index_dtype(self, dtype):
+        m = _make(cupy, cupyx.scipy.sparse, dtype)
+        r = m @ m.T
+        assert r.indices.dtype == m.indices.dtype
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_matmul_1d(self, xp, sp, dtype):
+        arr = sp.csr_array(xp.array([1, 0, 2, 3], dtype=dtype))
+        m = _make(xp, sp, dtype).T  # (4, 3)
+        return arr @ m.tocsr().toarray()
+
+    @pytest.mark.parametrize('power', [0, 1, 2, 3])
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    def test_matrix_power(self, power, dtype):
+        # matrix_power builds on spgemm + eye_array, so it inherits full
+        # value-dtype support (and int exactness).
+        from cupyx.scipy.sparse.linalg import matrix_power
+        d = numpy.array([[1, 0, 1], [1, 1, 0], [0, 1, 1]], dtype=dtype)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        r = matrix_power(m, power)
+        assert r.dtype == numpy.dtype(dtype)
+        if dtype == numpy.bool_:
+            exp = numpy.linalg.matrix_power(d.astype(numpy.int64), power) != 0
+        else:
+            exp = numpy.linalg.matrix_power(d, power)  # wraps like scipy
+        cupy.testing.assert_array_equal(r.toarray(), cupy.asarray(exp))
+
+    def test_matrix_power_int64_exact(self):
+        # int64 powering stays exact past float64's 2**53: the pure-CuPy
+        # spgemm accumulates in int64, not float64.
+        from cupyx.scipy.sparse.linalg import matrix_power
+        k = 4 * 10 ** 15 + 1        # 3*k = 1.2e16 + 3, odd and > 2**53
+        d = numpy.array([[1, k], [0, 1]], dtype=numpy.int64)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        r = matrix_power(m, 3)      # [[1, 3k], [0, 1]]
+        assert int(r.toarray()[0, 1]) == 3 * k
+        cupy.testing.assert_array_equal(
+            r.toarray(), cupy.asarray(numpy.linalg.matrix_power(d, 3)))
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeReductions:
+
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sum(self, xp, sp, dtype, axis):
+        # scipy/numpy accumulate: bool/int -> int64, uint -> uint64.
+        m = _make(xp, sp, dtype)
+        return xp.asarray(m.sum(axis=axis))
+
+    @pytest.mark.parametrize('container', ['csr_matrix', 'csc_matrix',
+                                           'coo_matrix'])
+    @pytest.mark.parametrize('axis', [None, 0, 1])
+    def test_int64_sum_exact_past_2_53(self, axis, container):
+        # sum() must accumulate in int64, not float64 (the matmul path):
+        # values above 2**53 are not exactly representable in float64.
+        import scipy.sparse
+        big = 1 << 60
+        d = numpy.array([[big + 7, big + 3, 0], [big + 5, 0, big + 1]],
+                        dtype=numpy.int64)
+        m = getattr(cupyx.scipy.sparse, container)(cupy.asarray(d))
+        s = getattr(scipy.sparse, container)(d)
+        got = cupy.asnumpy(cupy.asarray(m.sum(axis=axis))).ravel()
+        ref = numpy.asarray(s.sum(axis=axis)).ravel()
+        numpy.testing.assert_array_equal(got, ref)
+
+    def test_uint64_sum_exact_past_2_53(self):
+        big = 1 << 62
+        d = numpy.array([[big + 7, big + 3, big + 5]], dtype=numpy.uint64)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        # Sum stays under 2**64 here, so it is exact (and > 2**53).
+        assert int(m.sum()) == 3 * big + 15
+
+    def test_dia_int64_sum_exact(self):
+        # DIA ``data`` holds off-matrix padding; the exact path must
+        # route through COO so padding is not counted.
+        import scipy.sparse
+        data = numpy.array([[1, 2, 3], [4, 5, 6]], dtype=numpy.int64)
+        offsets = numpy.array([0, -1])
+        m = cupyx.scipy.sparse.dia_matrix(
+            (cupy.asarray(data), cupy.asarray(offsets)), shape=(3, 3))
+        s = scipy.sparse.dia_matrix((data, offsets), shape=(3, 3))
+        assert int(m.sum()) == int(s.sum())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_allclose(sp_name='sp')
+    def test_mean(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return xp.asarray(m.mean()), xp.asarray(m.mean(axis=1))
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_min(self, xp, sp, dtype):
+        # max/min preserve the input dtype (scipy parity).
+        m = _make(xp, sp, dtype)
+        assert m.max().dtype == dtype
+        return (xp.asarray(m.max()), xp.asarray(m.min()),
+                m.max(axis=1).toarray(), m.min(axis=0).toarray())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_argmax_argmin_axis(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return (xp.asarray(m.argmax(axis=1)),
+                xp.asarray(m.argmin(axis=0)))
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    def test_tuple_axis_full_reduction(self, dtype):
+        # scipy accepts a 2-axis tuple as a full reduction; sum/mean and
+        # max/min/argmax/argmin must all collapse it, not reject it.
+        import scipy.sparse
+        d = numpy.array([[1, 0, 3], [0, 2, 0], [4, 0, 5]], dtype=dtype)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        s = scipy.sparse.csr_matrix(d)
+        assert int(m.sum(axis=(0, 1))) == int(s.sum(axis=(0, 1)))
+        assert m.max(axis=(0, 1)) == s.max(axis=(0, 1))
+        assert m.min(axis=(0, 1)) == s.min(axis=(0, 1))
+        assert int(m.argmax(axis=(0, 1))) == int(s.argmax(axis=(0, 1)))
+        assert int(m.argmin(axis=(0, 1))) == int(s.argmin(axis=(0, 1)))
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    def test_tuple_axis_length1(self, dtype):
+        # A length-1 tuple ``(i,)`` means axis ``i``.
+        import scipy.sparse
+        d = numpy.array([[1, 0, 3], [0, 2, 0], [4, 0, 5]], dtype=dtype)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        s = scipy.sparse.csr_matrix(d)
+        cupy.testing.assert_array_equal(
+            m.max(axis=(1,)).toarray().ravel(),
+            numpy.asarray(s.max(axis=(1,)).todense()).ravel())
+        cupy.testing.assert_array_equal(
+            cupy.asnumpy(m.argmin(axis=(0,))).ravel(),
+            numpy.asarray(s.argmin(axis=(0,))).ravel())
+
+    def test_int64_axis_reductions_exact_past_2_53(self):
+        # Values above 2**53 are not exactly representable in float64,
+        # so axis max/min and argmax must reduce in an int64 accumulator.
+        import scipy.sparse
+        big = (1 << 53) + 3
+        d = numpy.array([[big, 0, big + 1], [0, big + 2, 0]],
+                        dtype=numpy.int64)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        s = scipy.sparse.csr_matrix(d)
+        cupy.testing.assert_array_equal(
+            m.max(axis=1).toarray().ravel(),
+            cupy.asarray(numpy.asarray(s.max(axis=1).todense()).ravel()))
+        cupy.testing.assert_array_equal(
+            cupy.asnumpy(m.argmax(axis=1)).ravel(),
+            numpy.asarray(s.argmax(axis=1)).ravel())
+        assert int(m.max()) == big + 2
+
+    def test_uint64_axis_max_exact_past_2_53(self):
+        big = (1 << 63) + 5
+        d = numpy.array([[big, 0, big + 1], [0, big + 2, 0]],
+                        dtype=numpy.uint64)
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(d))
+        cupy.testing.assert_array_equal(
+            m.max(axis=1).toarray().ravel(),
+            cupy.asarray(d.max(axis=1)))
+        assert int(m.max()) == big + 2
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_getitem_and_slices(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return (xp.asarray(m[0, 1]),
+                m[0:2, :].toarray(),
+                m[:, 1:3].toarray())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_fancy_indexing(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        cols = xp.array([0, 2, 3])
+        rows = xp.array([0, 2])
+        return m[:, cols].toarray(), m[rows, :].toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_diagonal_setdiag(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        m.setdiag(9)
+        return m.diagonal(), m.toarray()
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeExactInt64:
+    """64-bit integer reductions must stay exact past float64's 2**53 mantissa
+    limit -- a float64 accumulator (or comparison carrier) would round.  All
+    magnitudes here exceed 2**53/2**63 yet keep sums in range, so any float64
+    rounding diverges from scipy's exact integer result.
+    """
+
+    def _big(self, xp, dtype):
+        # values > 2**53 (int64) / > 2**63 (uint64); sums stay in range
+        base = 2 ** 63 if numpy.dtype(dtype).kind == 'u' else 2 ** 53
+        return xp.array([[base + 1, 0, base + 5],
+                         [0, base + 3, 0],
+                         [base + 7, 0, base + 9]], dtype=dtype)
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sum_exact(self, xp, sp, dtype):
+        m = sp.csr_matrix(self._big(xp, dtype))
+        # axis=None returns a scalar; wrap so the comparison sees the value
+        return xp.array(m.sum()), m.sum(axis=0), m.sum(axis=1)
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @pytest.mark.parametrize('container', ['csr_matrix', 'csc_matrix'])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_max_min_axis_exact(self, xp, sp, dtype, container):
+        m = getattr(sp, container)(self._big(xp, dtype))
+        return (m.max(axis=0).toarray(), m.max(axis=1).toarray(),
+                m.min(axis=0).toarray(), m.min(axis=1).toarray())
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_argmax_axis_exact(self, xp, sp, dtype):
+        m = sp.csr_matrix(self._big(xp, dtype))
+        return m.argmax(axis=0), m.argmax(axis=1)
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeConstructFunctions:
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_stack_and_blocks(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        h = sp.hstack([m, m])
+        v = sp.vstack([m, m])
+        b = sp.block_diag([m, m])
+        assert h.dtype == v.dtype == b.dtype == dtype
+        return h.toarray(), v.toarray(), b.toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_kron(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        return (sp.kron(m, m).toarray(),
+                sp.kronsum(m[:, :3], m[:, :3]).toarray())
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_eye_identity(self, xp, sp, dtype):
+        e = sp.eye(4, dtype=dtype, format='csr')
+        assert e.dtype == dtype
+        return e.toarray(), sp.identity(3, dtype=dtype, format='coo').toarray()
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_tril_triu_find(self, xp, sp, dtype):
+        m = _make(xp, sp, dtype)
+        i, j, v = sp.find(m)
+        assert v.dtype == dtype
+        return sp.tril(m).toarray(), sp.triu(m).toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.uint64])
+    def test_random_int(self, dtype):
+        m = cupyx.scipy.sparse.random(
+            10, 10, density=0.5, dtype=dtype, random_state=7)
+        assert m.dtype == dtype
+        assert m.nnz == 50
+
+
+class TestValueDtypeFloat16:
+    """float16 is a CuPy extension: scipy.sparse rejects it, so these
+    compare against dense cupy computation instead."""
+
+    def _make(self, container='csr_matrix'):
+        dense = cupy.array([[0, 1, 0, 2],
+                            [3, 0, 0, 0],
+                            [0, 4, 5, 0]], dtype=numpy.float16)
+        return getattr(cupyx.scipy.sparse, container)(dense), dense
+
+    @pytest.mark.parametrize('container', _containers_b)
+    def test_construct_roundtrip(self, container):
+        m, dense = self._make(container)
+        assert m.dtype == numpy.float16
+        cupy.testing.assert_array_equal(m.toarray(), dense)
+        cupy.testing.assert_array_equal(m.tocsc().tocoo().tocsr().toarray(),
+                                        dense)
+
+    def test_arithmetic(self):
+        m, dense = self._make()
+        cupy.testing.assert_array_equal((m + m).toarray(), dense + dense)
+        cupy.testing.assert_array_equal((m * 2).toarray(), dense * 2)
+        cupy.testing.assert_array_equal(m.multiply(m).toarray(),
+                                        dense * dense)
+        # scipy rejects float16, so the oracle is the dense cupy ufunc:
+        # a weak scalar keeps the width (float16 / 2 -> float16), unlike
+        # scipy's "real division upcasts to float64" for float32/64.
+        q = m / 2
+        assert q.dtype == (dense / 2).dtype == numpy.float16
+        cupy.testing.assert_array_equal(q.toarray(), dense / 2)
+
+    def test_matmul(self):
+        m, dense = self._make()
+        v = cupy.array([1, 2, 0, 3], dtype=numpy.float16)
+        r = m @ v
+        assert r.dtype == numpy.float16
+        cupy.testing.assert_allclose(r, dense @ v, rtol=1e-3)
+        p = m @ m.T
+        assert p.dtype == numpy.float16
+        cupy.testing.assert_allclose(p.toarray(), dense @ dense.T, rtol=1e-3)
+
+    def test_spgemm_heavy_accumulation_accuracy(self):
+        # float16 sparse @ sparse must accumulate in float32, not
+        # float16, or heavy per-element accumulation loses ~a decimal
+        # digit.  Compare against the exact float64 reference.
+        rng = numpy.random.RandomState(0)
+        m, k, n = 40, 300, 40
+        ad = rng.rand(m, k).astype(numpy.float16)
+        bd = rng.rand(k, n).astype(numpy.float16)
+        a = cupyx.scipy.sparse.csr_matrix(cupy.asarray(ad))
+        b = cupyx.scipy.sparse.csr_matrix(cupy.asarray(bd))
+        c = cupy.asnumpy((a @ b).toarray()).astype(numpy.float64)
+        ref = ad.astype(numpy.float64) @ bd.astype(numpy.float64)
+        rel = numpy.abs(c - ref) / (numpy.abs(ref) + 1e-9)
+        # float32 accumulation keeps max rel error well under 1e-2; a
+        # float16 accumulator would be ~1e-2 here.
+        assert rel.max() < 2e-3, rel.max()
+
+    def test_reductions(self):
+        m, dense = self._make()
+        assert m.sum().dtype == numpy.float16
+        assert m.sum() == dense.sum()
+        assert m.max() == dense.max()
+        assert m.max().dtype == numpy.float16
+        cupy.testing.assert_array_equal(
+            m.argmax(axis=1), dense.argmax(axis=1)[:, None])
+
+    def test_fancy_indexing(self):
+        m, dense = self._make()
+        cols = cupy.array([0, 2, 3])
+        cupy.testing.assert_array_equal(m[:, cols].toarray(),
+                                        dense[:, cols])
+
+    def test_sum_duplicates(self):
+        data = cupy.array([1.5, 2.5], dtype=numpy.float16)
+        row = cupy.array([0, 0], 'i')
+        col = cupy.array([0, 0], 'i')
+        m = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=(1, 1))
+        m.sum_duplicates()
+        assert m.dtype == numpy.float16
+        assert m.toarray()[0, 0] == 4.0
+
+
+# bfloat16 is provided by the optional ml_dtypes package (numpy has no
+# native bfloat16); CuPy only supports it when ml_dtypes is installed AND
+# numpy >= 2.1.2.  Skip on exactly the condition the sparse gate uses
+# (``_sputils.bfloat16 is None`` captures both), while keeping the callable
+# ml_dtypes type for constructing bfloat16 scalars/arrays in the tests.
+try:
+    import ml_dtypes as _ml_dtypes
+    _bfloat16 = _ml_dtypes.bfloat16
+except ImportError:
+    _bfloat16 = None
+
+
+@pytest.mark.skipif(cupyx.scipy.sparse._sputils.bfloat16 is None,
+                    reason='requires ml_dtypes and numpy>=2.1.2')
+class TestValueDtypeBfloat16:
+    """bfloat16 is a CuPy/ml_dtypes extension (scipy.sparse rejects it, and
+    numpy has no native bfloat16), so these compare against a float32 dense
+    reference.  bfloat16 has ``kind == 'V'`` and only promotes with itself,
+    float32/64 and complex -- mixing it with ints or float16 raises
+    DTypePromotionError, exactly as dense numpy/CuPy do.
+    """
+
+    def _make(self, container='csr_matrix'):
+        # integer-valued entries are exact in bfloat16, so elementwise ops
+        # and small matmuls compare exactly against the float32 reference.
+        ref = numpy.array([[0, 1, 0, 2],
+                           [3, 0, 0, 0],
+                           [0, 4, 5, 0]], dtype=numpy.float32)
+        dense = cupy.asarray(ref.astype(_bfloat16))
+        return getattr(cupyx.scipy.sparse, container)(dense), ref
+
+    def _f32(self, x):
+        if hasattr(x, 'toarray'):
+            x = x.toarray()
+        return cupy.asnumpy(x).astype(numpy.float32)
+
+    def test_gate(self):
+        from cupyx.scipy.sparse import _sputils
+        bf = numpy.dtype(_bfloat16)
+        assert _sputils.is_sparse_data_dtype(bf)
+        assert _sputils.is_bfloat16(bf)
+        assert not _sputils.is_bfloat16(numpy.float16)
+        _sputils.check_data_dtype(bf)  # must not raise
+        # bfloat16 preserved by upcast; promotes with float32 -> float32
+        assert _sputils.upcast(bf) == bf
+        assert _sputils.upcast(bf, numpy.float32) == numpy.float32
+
+    @pytest.mark.parametrize('container', _containers_b)
+    def test_construct_roundtrip(self, container):
+        m, ref = self._make(container)
+        assert m.dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_array_equal(self._f32(m), ref)
+        numpy.testing.assert_array_equal(
+            self._f32(m.tocsc().tocoo().tocsr()), ref)
+        numpy.testing.assert_array_equal(self._f32(m.T), ref.T)
+
+    def test_arithmetic(self):
+        m, ref = self._make()
+        assert (m + m).dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_array_equal(self._f32(m + m), ref + ref)
+        numpy.testing.assert_array_equal(self._f32(m - m), ref - ref)
+        numpy.testing.assert_array_equal(self._f32(m.multiply(m)), ref * ref)
+        numpy.testing.assert_array_equal(
+            self._f32(m * _bfloat16(2.0)), ref * 2)
+        numpy.testing.assert_array_equal(self._f32(-m), -ref)
+        # scipy rejects bfloat16, so the oracle is the dense ufunc -- and it
+        # disagrees with numpy.result_type here: an integer weak scalar keeps
+        # bfloat16 (bf / 2 -> bf) while a float weak scalar promotes to
+        # float32 (bf / 2.0 -> float32), matching ``dense / scalar`` exactly.
+        dense = cupy.asarray(ref.astype(_bfloat16))
+        for scalar in (2, 2.0):
+            q = m / scalar
+            assert q.dtype == (dense / scalar).dtype, scalar
+            numpy.testing.assert_array_equal(
+                self._f32(q), self._f32(dense / scalar), err_msg=str(scalar))
+
+    def test_comparison(self):
+        # bfloat16 (kind 'V') must be treated as a float in _comparison:
+        # otherwise the scalar keeps its int dtype and ``op(bf, int)`` raises
+        # DTypePromotionError.  Every operator (esp. ==/!=/</<=) must match
+        # the dense bfloat16 result, against both int and float scalars.
+        m, ref = self._make()
+        dense = cupy.asarray(ref.astype(_bfloat16))
+        import operator
+        for op in (operator.eq, operator.ne, operator.lt, operator.le,
+                   operator.gt, operator.ge):
+            for scalar in (0, 3, 2.0):
+                numpy.testing.assert_array_equal(
+                    self._f32(op(m, scalar)).astype(bool),
+                    cupy.asnumpy(op(dense, scalar)).astype(bool),
+                    err_msg=f'{op.__name__}({scalar})')
+
+    def test_matmul(self):
+        m, ref = self._make()
+        v = cupy.asarray(numpy.array([1, 2, 0, 3],
+                                     dtype=numpy.float32).astype(_bfloat16))
+        r = m @ v
+        assert r.dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_allclose(
+            self._f32(r), ref @ numpy.array([1, 2, 0, 3], numpy.float32),
+            rtol=1e-2)
+        p = m @ m.T
+        assert p.dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_allclose(self._f32(p), ref @ ref.T, rtol=1e-2)
+
+    def test_spgemm_accuracy(self):
+        # sparse @ sparse routes through the pure-CuPy fallback (bfloat16 is
+        # not cuSPARSE-native below cc 8.0); it must widen to float32, not
+        # accumulate in bfloat16.
+        rng = numpy.random.RandomState(0)
+        ad = rng.rand(30, 200).astype(_bfloat16)
+        bd = rng.rand(200, 30).astype(_bfloat16)
+        a = cupyx.scipy.sparse.csr_matrix(cupy.asarray(ad))
+        b = cupyx.scipy.sparse.csr_matrix(cupy.asarray(bd))
+        c = self._f32(a @ b).astype(numpy.float64)
+        ref = ad.astype(numpy.float64) @ bd.astype(numpy.float64)
+        rel = numpy.abs(c - ref) / (numpy.abs(ref) + 1e-9)
+        # float32 accumulation keeps error near bfloat16's own resolution
+        # (~8-bit mantissa); a bfloat16 accumulator would be far worse.
+        assert rel.max() < 5e-2, rel.max()
+
+    def test_reductions(self):
+        m, ref = self._make()
+        assert m.sum().dtype == numpy.dtype(_bfloat16)
+        assert float(m.sum()) == ref.sum()
+        numpy.testing.assert_array_equal(self._f32(m.sum(axis=0)),
+                                         ref.sum(axis=0).reshape(1, -1))
+        numpy.testing.assert_array_equal(self._f32(m.sum(axis=1)),
+                                         ref.sum(axis=1).reshape(-1, 1))
+        assert float(m.max()) == ref.max()
+        assert m.max().dtype == numpy.dtype(_bfloat16)
+        assert float(m.min()) == ref.min()
+        # argmax/argmin stage through float32 (the bfloat16 arg kernel is
+        # not instantiated); indices must still be exact.
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(m.argmax(axis=1)),
+            ref.argmax(axis=1).reshape(-1, 1))
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(m.argmax(axis=0)),
+            ref.argmax(axis=0).reshape(1, -1))
+
+    def test_indexing(self):
+        m, ref = self._make()
+        assert float(m[1, 0]) == ref[1, 0]
+        assert float(m[0, 0]) == ref[0, 0]  # stored/implicit zero
+        cols = cupy.array([0, 2, 3])
+        numpy.testing.assert_array_equal(self._f32(m[:, cols]),
+                                         ref[:, [0, 2, 3]])
+        numpy.testing.assert_array_equal(self._f32(m[1:3]), ref[1:3])
+        numpy.testing.assert_array_equal(self._f32(m[[0, 2]]), ref[[0, 2]])
+
+    def test_sum_duplicates(self):
+        # Regression: the COO sum_duplicates scatter dispatches on
+        # ``dtype.kind``; bfloat16's kind is 'V', so before the fix it
+        # matched no branch and silently returned a zero-filled buffer.
+        data = cupy.asarray(numpy.array([1.5, 2.5],
+                                        dtype=numpy.float32).astype(_bfloat16))
+        row = cupy.array([0, 0], 'i')
+        col = cupy.array([0, 0], 'i')
+        m = cupyx.scipy.sparse.coo_matrix((data, (row, col)), shape=(1, 1))
+        m.sum_duplicates()
+        assert m.dtype == numpy.dtype(_bfloat16)
+        assert float(m.toarray()[0, 0]) == 4.0
+
+    def test_mixed_dtype_promotes_like_dense(self):
+        # bfloat16 has no scipy oracle, so ELEMENTWISE ops mixing it with an
+        # int or float16 match dense CuPy (numpy.promote_types can't resolve
+        # them, but the ufunc loops do): bf16+int32 -> float64, bf16+float16
+        # -> float32.  Matmul and concatenation still raise, exactly as dense
+        # does for ``bf16 @ int`` / ``concatenate([bf16, int])``.
+        m, ref = self._make()
+        mi = cupyx.scipy.sparse.csr_matrix(
+            cupy.asarray((ref * 2).astype(numpy.int32)))
+        r = m + mi
+        assert r.dtype == numpy.float64
+        numpy.testing.assert_allclose(self._f32(r), ref * 3, rtol=1e-2)
+        assert m.multiply(mi).dtype == numpy.float64
+        assert (m - mi).dtype == numpy.float64
+        assert m.maximum(mi).dtype == numpy.float64   # binopt path
+        assert m.minimum(mi).dtype == numpy.float64
+        assert (m == mi).dtype == numpy.bool_
+        mf16 = cupyx.scipy.sparse.csr_matrix(
+            cupy.asarray(ref.astype(numpy.float16)))
+        assert (m + mf16).dtype == numpy.float32
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            (m @ mi.T).toarray()
+        with pytest.raises(numpy.exceptions.DTypePromotionError):
+            cupyx.scipy.sparse.hstack([m, mi])
+
+    def test_random(self):
+        m = cupyx.scipy.sparse.random(
+            10, 10, density=0.5, dtype=_bfloat16, random_state=7)
+        assert m.dtype == numpy.dtype(_bfloat16)
+        assert m.nnz == 50
+
+    def test_matrix_power(self):
+        from cupyx.scipy.sparse.linalg import matrix_power
+        d = cupy.asarray((numpy.eye(4) * 2).astype(_bfloat16))
+        m = cupyx.scipy.sparse.csr_matrix(d)
+        r = matrix_power(m, 3)
+        assert r.dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_allclose(
+            self._f32(r), numpy.eye(4, dtype=numpy.float32) * 8, rtol=1e-2)
+
+    def test_stack_and_eye_preserve_dtype(self):
+        m, ref = self._make()
+        bf = numpy.dtype(_bfloat16)
+        assert cupyx.scipy.sparse.eye(3, dtype=_bfloat16).dtype == bf
+        assert cupyx.scipy.sparse.hstack([m, m]).dtype == bf
+        assert cupyx.scipy.sparse.vstack([m, m]).dtype == bf
+        numpy.testing.assert_array_equal(
+            self._f32(cupyx.scipy.sparse.hstack([m, m])),
+            numpy.hstack([ref, ref]))
+
+    def test_1d_array(self):
+        # 1-D sparse array preserves bfloat16 through construct/toarray/sum
+        ref = numpy.array([0, 1.5, 0, 2.0], dtype=numpy.float32)
+        v = cupyx.scipy.sparse.csr_array(cupy.asarray(ref.astype(_bfloat16)))
+        assert v.dtype == numpy.dtype(_bfloat16)
+        numpy.testing.assert_array_equal(self._f32(v), ref)
+        assert float(v.sum()) == ref.sum()
+
+    def test_str_does_not_crash(self):
+        # scipy rejects bfloat16, so str() must fall back to repr (not raise)
+        m, _ = self._make()
+        s = str(m)
+        assert 'bfloat16' in s and 'sparse' in s
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeStrRepr:
+    """str()/print() must never crash.  For scipy-supported dtypes ``str``
+    delegates to scipy; for CuPy-only float16 (which scipy.sparse rejects
+    with ValueError) it falls back to ``repr`` -- a regression guard, since
+    the fallback previously caught only RuntimeError/NotImplementedError.
+    """
+
+    @pytest.mark.parametrize('dtype', _key_dtypes_b + [bool, numpy.float64,
+                                                       numpy.complex128])
+    def test_str_scipy_dtypes(self, dtype):
+        m = _make(cupy, cupyx.scipy.sparse, dtype)
+        assert str(m)  # delegates to scipy, must not raise
+        assert repr(m)
+
+    def test_str_float16_falls_back_to_repr(self):
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.asarray(numpy.eye(3, dtype=numpy.float16)))
+        s = str(m)  # scipy rejects float16 -> repr fallback (no ValueError)
+        assert 'float16' in s and 'sparse' in s
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeComplexArgReduce:
+    """argmax/argmin along an axis for complex reduces on the real part
+    (matching scipy and how min/max cast complex->float64); the complex
+    arg-reduction kernel is not instantiated, so this used to crash.
+    """
+
+    @pytest.mark.parametrize('dtype', [numpy.complex64, numpy.complex128])
+    @pytest.mark.parametrize('op', ['argmax', 'argmin'])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_complex_argreduce_axis(self, xp, sp, dtype, op):
+        dense = xp.array([[1 + 9j, 0, 3 + 1j],
+                          [0, 2 + 0j, 0],
+                          [4 + 2j, 0, 5 - 7j]], dtype=dtype)
+        m = sp.csr_matrix(dense)
+        return getattr(m, op)(axis=0), getattr(m, op)(axis=1)
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeComparisonsFull:
+    """Every comparison operator, against int / out-of-range / fractional
+    scalars, across formats -- must match scipy exactly (no int-scalar
+    overflow or truncation).
+    """
+
+    @pytest.mark.parametrize('scalar', [2, 300, 2.5, -1])
+    @pytest.mark.parametrize('op', ['_eq_', '_ne_', '_lt_', '_le_',
+                                    '_gt_', '_ge_'])
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int64, numpy.uint8])
+    @pytest.mark.parametrize('container', ['csr_matrix', 'csc_matrix'])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_scalar_comparison(self, xp, sp, dtype, op, scalar, container):
+        import operator
+        m = _make(xp, sp, dtype, container)
+        pyop = getattr(operator, op.strip('_'))
+        return pyop(m, scalar).toarray()
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeRandomDtypes:
+    """random() over every storable dtype: correct dtype, exact nnz, and
+    dtype-appropriate values (ints span negatives, complex has imag).
+    """
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b + [bool, numpy.float32,
+                                                       numpy.float64,
+                                                       numpy.complex128])
+    def test_random_dtype_and_values(self, dtype):
+        m = cupyx.scipy.sparse.random(
+            12, 12, density=0.5, dtype=dtype, random_state=3)
+        assert m.dtype == numpy.dtype(dtype)
+        assert m.nnz == 72
+        data = cupy.asnumpy(m.data)
+        if numpy.dtype(dtype).kind == 'c':
+            assert numpy.any(data.imag != 0)
+        elif numpy.dtype(dtype).kind == 'i':
+            assert numpy.any(data < 0)
+
+    def test_random_float16(self):
+        m = cupyx.scipy.sparse.random(
+            10, 10, density=0.3, dtype=numpy.float16, random_state=1)
+        assert m.dtype == numpy.float16
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeGating:
+    """Extended-precision dtypes the GPU cannot store are rejected; the
+    identity/width gate must not be fooled by dtype-char aliasing.
+    """
+
+    @pytest.mark.parametrize('dtype', [numpy.longdouble, numpy.clongdouble])
+    def test_reject_extended_precision(self, dtype):
+        if numpy.dtype(dtype).itemsize <= 16 and dtype is numpy.clongdouble:
+            pytest.skip('clongdouble not extended on this platform')
+        d = cupy.zeros((2, 2), dtype=numpy.float64)
+        with pytest.raises(ValueError, match='does not support dtype'):
+            cupyx.scipy.sparse.csr_matrix(d, dtype=dtype)
+
+    def test_reject_via_astype(self):
+        m = cupyx.scipy.sparse.csr_matrix(cupy.asarray(numpy.eye(2)))
+        with pytest.raises((ValueError, TypeError)):
+            m.astype(numpy.longdouble)
+
+
+@testing.with_requires('scipy>=1.12')
+class TestValueDtypeRegressions:
+    """Regression guards for value-dtype behaviours that are easy to break:
+    exact bool/int counts, count_nonzero along an axis, explicit power dtype,
+    and float16 matrix_power.
+    """
+
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_bool_sum_is_exact_count(self, xp, sp):
+        # bool sum must widen to int64 and count exactly, NOT collapse to a
+        # bool "any-nonzero" flag.
+        dense = xp.array([[True, False, True],
+                          [True, True, False]], dtype=xp.bool_)
+        m = sp.csr_matrix(dense)
+        return xp.array(m.sum()), m.sum(axis=0), m.sum(axis=1)
+
+    @pytest.mark.parametrize('dtype', [numpy.int16, numpy.int64, bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_count_nonzero_axis(self, xp, sp, dtype):
+        # scipy's count_nonzero(axis) dtype is inconsistent (int64 for axis=0
+        # but int32 for axis=1); mine is uniformly the platform int, so
+        # compare the counts as int64.
+        m = _make(xp, sp, dtype)
+        return (m.count_nonzero(axis=0).astype(numpy.int64),
+                m.count_nonzero(axis=1).astype(numpy.int64))
+
+    @pytest.mark.parametrize('target', [numpy.int64, numpy.float64])
+    @pytest.mark.parametrize('dtype', [numpy.int8, bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_power_explicit_dtype(self, xp, sp, dtype, target):
+        m = _make(xp, sp, dtype)
+        r = m.power(2, dtype=target)
+        assert r.dtype == target
+        return r.toarray()
+
+    @pytest.mark.parametrize('n', [2, 3])
+    def test_bool_power_0d_cupy_exponent(self, n):
+        # ``isscalarlike`` accepts a 0-D cupy array, but the bool carrier is
+        # derived with numpy (``np.ones(1, bool) ** n``), which rejects a
+        # device operand -- power() must read it to host first.  A 0-D int64
+        # array exponent matches numpy's ``np.int64`` carrier (int64), not
+        # the python-int carrier (int8 at n == 2).
+        dense = numpy.array([[True, False], [False, True]])
+        m = cupyx.scipy.sparse.csr_array(cupy.asarray(dense))
+        r = m.power(cupy.asarray(n))
+        expect = (numpy.ones(1, numpy.bool_) ** numpy.int64(n)).dtype
+        assert r.dtype == expect
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(r.toarray()), (dense ** n).astype(expect))
+
+    def test_matrix_power_float16(self):
+        from cupyx.scipy.sparse.linalg import matrix_power
+        m = cupyx.scipy.sparse.csr_matrix(
+            cupy.asarray(numpy.eye(4, dtype=numpy.float16) * 2))
+        r = matrix_power(m, 3)
+        assert r.dtype == numpy.float16
+        cupy.testing.assert_allclose(
+            r.toarray(), numpy.eye(4, dtype=numpy.float32) * 8, rtol=1e-2)
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int16, numpy.int32,
+                                       numpy.int64, numpy.float16])
+    def test_toarray_dedups_despite_stale_canonical_flag(self, dtype):
+        # Duplicate coordinates must sum in toarray() even when
+        # has_canonical_format is (wrongly) True.  The 8/16-bit direct-write
+        # densify path used to trust the stale flag and skip the dedup,
+        # diverging from the atomicAdd dtypes and scipy.
+        data = cupy.asarray(numpy.array([5, 5, 3], dtype=dtype))
+        indices = cupy.asarray(numpy.array([0, 0, 1], 'i'))
+        indptr = cupy.asarray(numpy.array([0, 2, 3], 'i'))
+        m = cupyx.scipy.sparse.csr_matrix((data, indices, indptr),
+                                          shape=(2, 2))
+        m.has_canonical_format = True  # stale: (0, 0) is duplicated
+        numpy.testing.assert_array_equal(
+            cupy.asnumpy(m.toarray()),
+            numpy.array([[10, 0], [0, 3]], dtype=dtype))
+
+    @pytest.mark.parametrize('dtype', _int_dtypes_b)
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_int_add_overflow(self, xp, sp, dtype):
+        # A + B for integers must wrap modularly like numpy/scipy, on both
+        # the cuSPARSE float64-upcast fast path (<=32-bit) and the pure-CuPy
+        # fallback (64-bit).  A + A doubles every entry; near-max values
+        # overflow the dtype and must wrap, not saturate.
+        hi = int(numpy.iinfo(dtype).max)
+        dense = xp.array([[hi, 0, hi // 2], [0, hi - 3, 0]], dtype=dtype)
+        A = sp.csr_matrix(dense)
+        return (A + A).toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.int64, numpy.uint64, bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sum_duplicates_nonsquare(self, xp, sp, dtype):
+        # The composite-key ``sum_duplicates`` (row*ncols+col) must match
+        # scipy for non-square 2-D shapes, with duplicate coordinates summed.
+        row = xp.array([2, 0, 2, 0, 1], 'i')
+        col = xp.array([4, 1, 4, 1, 0], 'i')
+        data = xp.array([1, 2, 3, 4, 5], dtype=dtype)
+        m = sp.coo_matrix((data, (row, col)), shape=(3, 6))
+        m.sum_duplicates()
+        assert m.dtype == dtype
+        return m.toarray()
+
+    @pytest.mark.parametrize('dtype', [numpy.float64, numpy.int64, bool])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_sum_duplicates_1d(self, xp, sp, dtype):
+        # The composite key is 1-D-aware (via _shape_as_2d): a 1-D coo_array
+        # uses the (1, N) backing, so ``row`` is all zeros and the key is
+        # just ``col``.  Duplicate 1-D indices must coalesce like scipy.
+        coords = xp.array([3, 1, 3, 1, 4], 'i')
+        data = xp.array([1, 2, 3, 4, 5], dtype=dtype)
+        m = sp.coo_array((data, (coords,)), shape=(6,))
+        m.sum_duplicates()
+        assert m.dtype == dtype
+        return m.toarray()
+
+    @pytest.mark.parametrize('container', ['coo_array', 'csr_array'])
+    def test_1d_int64_sum_exact_past_float64(self, container):
+        # A 1-D int64 array whose total is 2**53 + 1: the float64 axis=None
+        # matmul path would round it to 2**53, but the exact-int path (sum
+        # ``data`` directly) keeps it exact -- matching scipy/numpy.
+        v = numpy.array([2 ** 53, 1], dtype=numpy.int64)
+        m = getattr(cupyx.scipy.sparse, container)(
+            (cupy.asarray(v), (cupy.asarray([0, 5]),)), shape=(6,))
+        assert int(cupy.asnumpy(m.sum())) == 2 ** 53 + 1
+
+    @pytest.mark.parametrize('dtype', [numpy.int8, numpy.int16, numpy.int32,
+                                       numpy.uint8, numpy.uint32])
+    @testing.numpy_cupy_array_equal(sp_name='sp')
+    def test_int_matmul_overflow(self, xp, sp, dtype):
+        # sparse @ dense integer matmul whose result overflows the dtype must
+        # wrap modularly like numpy, not saturate.  The exact int64-carrier
+        # scatter accumulates in a 64-bit ring and wraps on the cast back.
+        k = 40
+        val = int(numpy.sqrt(int(numpy.iinfo(dtype).max)))  # k*val**2 >> max
+        A = sp.csr_matrix(xp.full((1, k), val, dtype=dtype))
+        B = xp.full((k, 1), val, dtype=dtype)
+        return A @ B
+
+    @pytest.mark.parametrize('container', ['csr_matrix', 'csc_matrix'])
+    def test_int64_matmul_exact_past_float64(self, container):
+        # int64 @ dense whose true result is 2**53 + 1: a float64 compute
+        # rounds it to 2**53, but the exact int64-carrier scatter keeps it
+        # exact (matches scipy/numpy).
+        m = getattr(cupyx.scipy.sparse, container)(
+            cupy.asarray(numpy.array([[2 ** 53, 1]], dtype=numpy.int64)))
+        x = cupy.asarray(numpy.array([1, 1], dtype=numpy.int64))
+        assert int(cupy.asnumpy(m @ x)[0]) == 2 ** 53 + 1
+
+    def test_wide_operand_chunks_and_stays_exact(self, monkeypatch):
+        # The exact int scatter materialises an (nnz, N) product, so a wide
+        # dense operand is column-blocked to bound memory.  Force the chunk
+        # loop (tiny free memory) and assert it still matches scipy exactly,
+        # down to a 1-column block -- the blocking must not change the result.
+        import scipy.sparse
+        from cupyx import cusparse
+        rng = numpy.random.default_rng(0)
+        a = scipy.sparse.random(120, 120, density=0.1, format='csr',
+                                dtype=numpy.float64)
+        a.data = rng.integers(1, 20, a.nnz).astype(numpy.int64)
+        a = a.astype(numpy.int64)
+        x = rng.integers(1, 20, (120, 16)).astype(numpy.int64)
+        ref = a @ x
+        ag = cupyx.scipy.sparse.csr_matrix(a)
+        xg = cupy.asarray(x)
+
+        class _FakePool:
+            def free_bytes(self):
+                return 0
+        monkeypatch.setattr(cusparse._cupy, 'get_default_memory_pool',
+                            lambda: _FakePool())
+        per_col = ag.nnz * 8
+        for cols_per_block in (3, 1):  # force multi-col and 1-col blocks
+            monkeypatch.setattr(
+                cupy.cuda.runtime, 'memGetInfo',
+                lambda cpb=cols_per_block: (4 * per_col * cpb, 1 << 34))
+            got = cupy.asnumpy(cusparse._cupy_csr_dense_matmul(ag, xg))
+            numpy.testing.assert_array_equal(got, ref)


### PR DESCRIPTION
@seberg I'm guessing this PR will fall to you! This contains some follow-ups from the previous sparse PRs, and a couple fixes to boot.

Supporting bfloat16 was interesting and a bit more work than I expected. I imagine you'll want to coordinate a bit with #10002.

There were more judgements calls for these changes than the other sparse PRs, and the development of these changes was rather non-linear with multiple agent sessions, so my "apologies" for squashing this to a single commit. Philosophically, there is sometimes tension between matching scipy, cupy idioms, numpy, etc.

There's a DELETEME test file meant for review and other AI agents. Don't forget to remove it!

Here's the summary from my AI agent:

cupyx.scipy.sparse (CSR/CSC/COO/DIA) previously stored only float32/64 and complex data.  Accept every value dtype scipy stores -- bool and all signed/unsigned integer widths -- plus float16 and, when ml_dtypes is available, bfloat16, which are CuPy extensions scipy rejects.

cuSPARSE computes only float/complex, so bool and integer operations take dtype-agnostic pure-CuPy fallbacks that are exact and wrap on overflow like numpy/scipy (reusing the existing int64-index sort / transpose / SpGEMM / csrgeam paths); float16 uses native mixed-precision SpMV / SpMM / SpGEMM and bfloat16 stages through float32.  Integer and bool reductions stay bit-exact past float64's 2**53 range using 64-bit accumulators or a segmented cumsum rather than a float carrier.

Promotion follows dense CuPy where numpy has no abstract rule (bfloat16 mixed with a wider int or float16), scalar operands are built in the promoted dtype so an out-of-range value raises OverflowError like numpy, and construction rejects dtypes the GPU cannot store (extended precision, float8) by dtype char and identity.  Along the way this fixes the dtype-correctness gaps the widening exposed in reductions, matmul / multiply, the Frobenius norm, eliminate_zeros, and the cuSOLVER least-squares solvers, and routes fancy minor-axis indexing on a very large major axis to the sort-based path to stay within the CUDA grid limit.

Adds test_sparse_value_dtypes.py (scipy parity across the dtype matrix) and extends test_sparse_int64_indices.py.
test_sparse_value_dtypes_DELETEME.py is a temporary review cross-check and should be removed before merging.