### PR TITLE
BUG: Random integer ranges should use uint internally

### DIFF
--- a/cupy/random/_generator_api.pyx
+++ b/cupy/random/_generator_api.pyx
@@ -1,4 +1,4 @@
-from libc.stdint cimport intptr_t, uint64_t, int32_t, int64_t, uint32_t
+from libc.stdint cimport intptr_t, uint64_t, uint32_t
 from libc.string cimport memcpy
 
 import numpy
@@ -31,10 +31,10 @@ cdef extern from 'cupy_distributions.cuh' nogil:
         ssize_t size, intptr_t stream)
     void interval_32(
         int generator, intptr_t state, ssize_t state_size, intptr_t out,
-        ssize_t size, intptr_t stream, int32_t mx, int32_t mask)
+        ssize_t size, intptr_t stream, uint32_t mx, uint32_t mask)
     void interval_64(
         int generator, intptr_t state, ssize_t state_size, intptr_t out,
-        ssize_t size, intptr_t stream, int64_t mx, int64_t mask)
+        ssize_t size, intptr_t stream, uint64_t mx, uint64_t mask)
     void beta(
         int generator, intptr_t state, ssize_t state_size, intptr_t out,
         ssize_t size, intptr_t stream, intptr_t a, intptr_t b)

--- a/cupy/random/cupy_distributions.cu
+++ b/cupy/random/cupy_distributions.cu
@@ -826,14 +826,14 @@ void random_uniform_float(int generator, intptr_t state, ssize_t state_size, int
 }
 
 //These functions will take the generator_id as a parameter
-void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {
-    kernel_launcher<interval_32_functor, int32_t> launcher(state_size, reinterpret_cast<cudaStream_t>(stream));
-    generator_dispatcher(generator, launcher, state, state_size, out, size, static_cast<uint32_t>(mx), static_cast<uint32_t>(mask));
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint32_t mx, uint32_t mask) {
+    kernel_launcher<interval_32_functor, uint32_t> launcher(state_size, reinterpret_cast<cudaStream_t>(stream));
+    generator_dispatcher(generator, launcher, state, state_size, out, size, mx, mask);
 }
 
-void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {
-    kernel_launcher<interval_64_functor, int64_t> launcher(state_size, reinterpret_cast<cudaStream_t>(stream));
-    generator_dispatcher(generator, launcher, state, state_size, out, size, static_cast<uint64_t>(mx), static_cast<uint64_t>(mask));
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint64_t mx, uint64_t mask) {
+    kernel_launcher<interval_64_functor, uint64_t> launcher(state_size, reinterpret_cast<cudaStream_t>(stream));
+    generator_dispatcher(generator, launcher, state, state_size, out, size, mx, mask);
 }
 
 void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {
@@ -893,8 +893,8 @@ void init_curand_generator(int generator, intptr_t state_ptr, ssize_t state_size
 void random_uniform(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void random_uniform_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void raw(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
-void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
-void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint32_t mx, uint32_t mask) {}
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint64_t mx, uint64_t mask) {}
 void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {}
 void exponential(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void geometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -63,8 +63,8 @@ void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssi
 void random_uniform(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
 void random_uniform_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
 void raw(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
-void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
-void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint32_t mx, uint32_t mask);
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint64_t mx, uint64_t mask);
 void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b);
 void exponential(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream);
 void geometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p);
@@ -85,8 +85,8 @@ void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssi
 void random_uniform(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void random_uniform_float(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void raw(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
-void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask) {}
-void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
+void interval_32(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint32_t mx, uint32_t mask) {}
+void interval_64(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, uint64_t mx, uint64_t mask) {}
 void beta(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t a, intptr_t b) {}
 void exponential(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream) {}
 void geometric(int generator, intptr_t state, ssize_t state_size, intptr_t out, ssize_t size, intptr_t stream, intptr_t p) {}

--- a/tests/cupy_tests/random_tests/test_generator_api.py
+++ b/tests/cupy_tests/random_tests/test_generator_api.py
@@ -254,6 +254,46 @@ class TestIntegers(GeneratorTestCase):
             2**40, size=2000)
 
 
+@testing.parameterize(*[
+    # Check values around, 2**31 < high <= 2**32 (used to error).
+    {'high': 2**31, 'endpoint': False},
+    {'high': 2**31 + 1, 'endpoint': False},
+    {'high': 2**32, 'endpoint': False},  # full uint32 path
+    {'high': 2**31, 'endpoint': True},
+])
+@testing.fix_random()
+class TestIntegersLargeBound(GeneratorTestCase):
+    target_method = 'integers'
+
+    def test_integers_large_bound(self):
+        out = self.generate(
+            0, self.high, size=10000, dtype=numpy.int64,
+            endpoint=self.endpoint)
+        assert out.dtype == numpy.int64
+        assert (0 <= out).all()
+        if self.endpoint:
+            assert (out <= self.high).all()
+        else:
+            assert (out < self.high).all()
+
+
+@testing.parameterize(*[
+    # The spans are 1.5x a power of two, so the mask is one bit wider than
+    # the span and the rejection loop is exercised.  The 32-bit span also
+    # exceeds 2**31, the range that used to overflow the kernel parameter.
+    {'low': -2**30, 'high': 2**31 - 1},
+    {'low': -2**61, 'high': 2**62 - 1},
+])
+@testing.with_requires('numpy>=1.17.0')
+@testing.fix_random()
+class TestIntegersLargeBoundKS(GeneratorTestCase):
+    target_method = 'integers'
+
+    @_condition.repeat_with_success_at_least(10, 3)
+    def test_integers_large_bound_ks(self):
+        self.check_ks(0.05)(self.low, self.high, size=2000)
+
+
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
 class TestRandom(InvalidOutsMixin, GeneratorTestCase):


### PR DESCRIPTION
Integer ranges are always positive and should use unsigned integers but were passed as signed integers, causing OverflowError for very large values.
(The `interval_32_functor`, etc. are already written with uint's.)

I have plotted a few histograms for confidence that uint's aren't truncated or so and the `check_ks` should also confirm things reasonably well.

Closes gh-9745

(Agent used for most changes, but tests manually iterated/changed.)