### PR TITLE
Fix data race and tap out-of-bounds read in the max_len_seq kernel

### DIFF
--- a/cupyx/scipy/signal/_max_len_seq.py
+++ b/cupyx/scipy/signal/_max_len_seq.py
@@ -31,7 +31,13 @@ extern "C" __global__ void max_len_seq(
                 next_state ^= state[tap];
             }
         }
+        // Every thread reads cells owned by other threads above and
+        // writes its own below, so the block must advance in lock-step:
+        // one barrier so all reads finish before any write, and one so
+        // all writes finish before the next iteration's reads.
+        __syncthreads();
         state[idx] = next_state;
+        __syncthreads();
     }
 }
 """
@@ -92,6 +98,10 @@ def max_len_seq(nbits, state=None, length=None, taps=None):
         if cupy.any(taps < 0) or cupy.any(taps > nbits) or taps.size < 1:
             raise ValueError('taps must be non-empty with values between '
                              'zero and nbits (inclusive)')
+        # A tap equal to nbits is accepted (matching SciPy, which wraps it
+        # to 0 in its inner loop); normalize here so the kernel never
+        # indexes past the end of the shift register.
+        taps = taps % nbits
         taps = cupy.array(taps)  # needed for Cython and Pythran
 
     n_max = (2 ** nbits) - 1

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_max_len_seq.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_max_len_seq.py
@@ -90,3 +90,21 @@ class TestMLS:
             results.append(new_m)
 
         return results
+
+    @pytest.mark.parametrize('nbits,taps', [(33, [13]), (48, [47, 21, 1]),
+                                            (64, [63, 61, 60])])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_mls_output_multi_warp(self, nbits, taps, xp, scp):
+        # A shift register wider than one warp (nbits > 32, legal with
+        # custom taps) requires the kernel's threads to be explicitly
+        # synchronized; the recurrence must still match SciPy exactly.
+        return scp.signal.max_len_seq(nbits, taps=taps, length=4096)[0]
+
+    @pytest.mark.parametrize('nbits,taps', [(3, [3, 2]), (4, [4, 1]),
+                                            (3, [3])])
+    @testing.numpy_cupy_allclose(scipy_name='scp')
+    def test_mls_tap_equal_nbits(self, nbits, taps, xp, scp):
+        # The documented tap range is [0, nbits] inclusive; a tap equal
+        # to nbits wraps (SciPy semantics) instead of reading past the
+        # end of the shift register.
+        return scp.signal.max_len_seq(nbits, taps=taps, length=12)[0]


### PR DESCRIPTION
The `max_len_seq` LFSR kernel had two independent defects:

- **Cross-thread data race** (#10162). The kernel advances the shift register with one thread per cell; every iteration each thread reads a cell owned by another thread and then writes its own, with no barrier in the loop, so correctness silently relied on lock-step execution that CUDA has not guaranteed since Volta. Within one warp current hardware still happens to execute this convergently, but `nbits > 32` (legal with custom taps) spans warps: `max_len_seq(48, taps=[47, 21, 1], length=20000)` returned ~10100 of 20000 samples different from SciPy, with the count changing between runs.
- **Out-of-bounds tap read** (#10163). The validator accepts taps up to `nbits` inclusive (SciPy's documented range), but the kernel indexes `state[tap]` on an `nbits`-element buffer, so `tap == nbits` read one byte past the register and the sequence depended on the byte after the allocation. SciPy wraps (tap `nbits` behaves as tap `0`).

Fixes #10162, fixes #10163

## Environment

- Tested at `main` (4ff0fc484) on NVIDIA L40S (sm_89); both defects also reproduced on the stock `cupy-cuda12x` 14.1.1 wheel (code identical).
- CUDA runtime 12.9 wheels, driver 12.4, NumPy 2.5.1, SciPy 1.18.0, Python 3.12.
