### PR TITLE
Fix out-of-bounds read in argrelextrema for mode='wrap' with large order

### DIFF
--- a/cupyx/scipy/signal/_peak_finding.py
+++ b/cupyx/scipy/signal/_peak_finding.py
@@ -357,7 +357,7 @@ __device__ __forceinline__ void clip_plus(
         }
     } else {
         if ( plus >= n ) {
-            plus -= n;
+            plus %= n;
         }
     }
 }
@@ -370,7 +370,7 @@ __device__ __forceinline__ void clip_minus(
         }
     } else {
         if ( minus < 0 ) {
-            minus += n;
+            minus = ( minus % n + n ) % n;
         }
     }
 }

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_peak_finding.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_peak_finding.py
@@ -440,6 +440,43 @@ class TestArgrel:
             test_data, order=order, mode='clip')[0]
         return rel_max_locs
 
+    @pytest.mark.parametrize('comparator_name,data,sentinel', [
+        ('less_equal', [1.0, 3.0, 4.0, 2.0], -1e9),
+        ('less_equal', [3.0, 4.0, 2.0, 1.0], -1e9),
+        ('greater_equal', [4.0, 1.0, 2.0, 3.0], 1e9),
+        ('greater_equal', [2.0, 3.0, 1.0, 4.0], 1e9),
+    ])
+    @pytest.mark.parametrize('order', [4, 5, 9])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_wrap_order_larger_than_axis_1d(self, comparator_name, data,
+                                            sentinel, order, xp, scp):
+        # mode='wrap' with order > len(data) must wrap indices modulo the
+        # axis length. The input is a view into a larger buffer whose
+        # out-of-view cells hold an adversarial sentinel, so an
+        # out-of-bounds read one element before/after the view changes
+        # the result deterministically.
+        buf = xp.full(6, sentinel)
+        buf[1:5] = xp.asarray(data)
+        comparator = getattr(xp, comparator_name)
+        return scp.signal.argrelextrema(
+            buf[1:5], comparator, order=order, mode='wrap')
+
+    @pytest.mark.parametrize('axis', [0, 1])
+    @pytest.mark.parametrize('order', [4, 5, 9])
+    @testing.numpy_cupy_allclose(scipy_name="scp")
+    def test_wrap_order_larger_than_axis_2d(self, axis, order, xp, scp):
+        data = xp.asarray([[1.0, 5.0, 6.0, 7.0],
+                           [3.0, 6.0, 7.0, 8.0],
+                           [4.0, 7.0, 8.0, 9.0],
+                           [2.0, 8.0, 9.0, 6.0]])
+        # Row padding keeps the view contiguous while planting sentinels
+        # in the memory right before and after it.
+        buf = xp.full((6, 4), -1e9)
+        buf[1:5, :] = data
+        return scp.signal.argrelextrema(
+            buf[1:5, :], xp.less_equal, axis=axis, order=order,
+            mode='wrap')
+
     @testing.numpy_cupy_allclose(scipy_name="scp")
     def test_2d_gaussians(self, xp, scp):
         sigmas = [1.0, 2.0, 10.0]


### PR DESCRIPTION
The wrap branch of the `ARGREL_KERNEL` helpers `clip_plus`/`clip_minus` applied a single subtraction/addition instead of a modulo. For `order <= n` (the axis length) one correction equals the modulo, but `order` is only validated as `>= 1`, and for `order > n` the index stays outside `[0, n)` and the kernel reads outside the input array. The returned mask then depends on the neighbouring allocation's contents (observable through the public API with `less_equal`/`greater_equal`/`equal` comparators), and `compute-sanitizer` reports `Invalid __global__ read` on a plain `argrelextrema(x, cupy.less_equal, order=5, mode='wrap')` call with a length-4 input. SciPy computes a true modulo for the same arguments (`numpy.take(..., mode='wrap')`).

Fixes #10165

## Environment

- Tested at `main` (4ff0fc484) on NVIDIA L40S (sm_89); bug also reproduced on the stock `cupy-cuda12x` 14.1.1 wheel (kernel source identical).
- CUDA runtime 12.9 wheels, driver 12.4, NumPy 2.5.1, SciPy 1.18.0, Python 3.12.
