### PR TITLE
Fix two defects in the sparse argmax/argmin kernel

### DIFF
--- a/cupyx/scipy/sparse/_compressed.py
+++ b/cupyx/scipy/sparse/_compressed.py
@@ -116,11 +116,12 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                 data_index = indices[x[tid]];
             } else if (block_length > 0)  {
                 // Block has at least one zero. Assign first occurrence as the
-                // starting reference
+                // starting reference. The loop is bounded by block_length so
+                // that the load stays inside the indices array even when the
+                // stored columns form a dense prefix.
                 data_value = 0;
-                for (data_index = 0; data_index < length; data_index++){
-                    if (data_index != indices[x[tid] + data_index] ||
-                        x[tid] + data_index >= y[tid]){
+                for (data_index = 0; data_index < block_length; data_index++){
+                    if (data_index != indices[x[tid] + data_index]){
                         break;
                     }
                 }
@@ -142,6 +143,22 @@ class _compressed_sparse_matrix(sparse_data._data_matrix,
                     if (data[entry] ${op} data_value){
                         data_index = indices[entry];
                         data_value = data[entry];
+                    }
+                }
+            }
+
+            // A zero can never win the strict comparison above, so when the
+            // result is a zero it is the implicit zero the accumulator was
+            // seeded with. An explicitly stored zero at a smaller column
+            // must win that tie ("first occurrence").
+            if (data_value == 0){
+                for (TI entry = x[tid]; entry < y[tid]; entry++){
+                    if (indices[entry] >= data_index){
+                        break;
+                    }
+                    if (data[entry] == 0){
+                        data_index = indices[entry];
+                        break;
                     }
                 }
             }

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_csr.py
@@ -1487,6 +1487,43 @@ class TestCsrMatrixScipyCompressedMinMax:
 
 
 @testing.parameterize(*testing.product({
+    'axis': [-2, -1, 0, 1],
+}))
+@testing.with_requires('scipy')
+class TestCsrMatrixArgMinMaxExplicitZero:
+    # An explicitly stored zero that occurs before the first implicit zero
+    # must win a tie, per the "first occurrence" contract of argmax/argmin.
+    # The dense view of the fixture is
+    #   [[0* -1  .  .]
+    #    [ 3  0*  2  .]
+    #    [ 5  .  7  .]
+    #    [ .  0*  .  .]]
+    # where . is an implicit zero and * marks explicitly stored zeros.
+    # The matrix is built directly in the compressed format the reduction
+    # runs on (CSR for axis 1, CSC for axis 0) so that both template
+    # instantiations of the kernel are exercised.
+
+    def _make(self, xp, sp):
+        if self.axis in (1, -1):
+            indptr = xp.array([0, 2, 5, 7, 8])
+            indices = xp.array([0, 1, 0, 1, 2, 0, 2, 1])
+            data = xp.array([0.0, -1.0, 3.0, 0.0, 2.0, 5.0, 7.0, 0.0])
+            return sp.csr_matrix((data, indices, indptr), shape=(4, 4))
+        indptr = xp.array([0, 3, 6, 8, 8])
+        indices = xp.array([0, 1, 2, 0, 1, 3, 1, 2])
+        data = xp.array([0.0, 3.0, 5.0, -1.0, 0.0, 0.0, 2.0, 7.0])
+        return sp.csc_matrix((data, indices, indptr), shape=(4, 4))
+
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
+    def test_argmax(self, xp, sp):
+        return xp.array(self._make(xp, sp).argmax(axis=self.axis))
+
+    @testing.numpy_cupy_array_equal(sp_name='sp', type_check=False)
+    def test_argmin(self, xp, sp):
+        return xp.array(self._make(xp, sp).argmin(axis=self.axis))
+
+
+@testing.parameterize(*testing.product({
     'dtype': [numpy.float32, numpy.float64, numpy.complex64, numpy.complex128],
 }))
 @testing.with_requires('scipy')


### PR DESCRIPTION
The arg-reduction kernel shared by CSR/CSC `argmax` and `argmin` (both template instantiations of `_argmax_argmin_code` in `cupyx/scipy/sparse/_compressed.py`) had two independent defects:

- **Stored zeros lose the tie they should win** (#10169). The accumulator is seeded with the first *implicit* zero's column and value `0`, and the scan updates only on a strict comparison, so an explicitly stored `0.0` occurring earlier can never take the index — violating the documented "index of the first occurrence" contract. `csr_matrix([[0., -1., 0.]]).argmax(axis=1)` (with the first zero stored) returned 2 instead of 0; SciPy returns 0.
- **Out-of-bounds read in the seed loop** (#10170). The loop tests `data_index != indices[x[tid] + data_index]` before its bounds check on the same `||`, so the load always happens first; a row whose stored columns form a dense prefix runs the loop to `block_length` and loads `indices[y[tid]]` — `indices[nnz]` for the last row, one element past the end. `compute-sanitizer` reports `Invalid __global__ read` on a two-nonzero matrix through the public API.

Fixes #10169, fixes #10170

## Environment

- Tested at `main` (4ff0fc484) on NVIDIA L40S (sm_89); both defects also reproduced on the stock `cupy-cuda12x` 14.1.1 wheel (kernel source identical).
- CUDA runtime 12.9 wheels, driver 12.4, NumPy 2.5.1, SciPy 1.18.0, Python 3.12.
