### PR TITLE
chore: Update permission in auto-cc workflow

### DIFF
--- a/.github/workflows/auto-cc.yml
+++ b/.github/workflows/auto-cc.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  issues: write
+
 jobs:
   auto-notify:
     if: |


### PR DESCRIPTION
Our repository currently uses read & write permissions for GITHUB_TOKEN by default. This poses a potential security risk if a workflow or third-party action is compromised.

By explicitly declaring required permissions at the workflow level, we can change the ~repository-wide~ org-wide default token permission to read-only.