### PR TITLE
chore: Disable merge queue comments by Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  queue_controls_comment: false
+
 pull_request_rules:
   - name: Notify conflict
     conditions:


### PR DESCRIPTION
Suppress automatic comments by Mergify:

https://docs.mergify.com/commands/queue/#queueing-with-a-checkbox

> This is enabled by default. To turn it off, set queue_controls_comment to false in your merge_queue configuration:
> ```
> merge_queue:
>   queue_controls_comment: false
> ```