### PR TITLE
Fix disk caching of multiparameter templates

### DIFF
--- a/cupy/cuda/function.pyx
+++ b/cupy/cuda/function.pyx
@@ -144,6 +144,7 @@ cdef str demangle_cxx_name(
 # Matches CuPy's bundled Thrust internal namespace on the complex type,
 # e.g. "thrust::THRUST_300102_SM_890_NS::complex" or "thrust::complex".
 cdef object _thrust_complex_re = re.compile(r'thrust::(?:\w+::)?complex\b')
+cdef object _template_comma_re = re.compile(r'\s*,\s*')
 
 
 cdef inline str normalize_name_expr(str demangled):
@@ -161,7 +162,8 @@ cdef inline str normalize_name_expr(str demangled):
          (and any template arguments).
       3. Replace ``thrust::*::complex`` with ``complex`` (CuPy's bundled
          Thrust namespace).
-      4. Collapse whitespace before ``>`` so ``<double >`` becomes
+      4. Remove whitespace around commas between template arguments.
+      5. Collapse whitespace before ``>`` so ``<double >`` becomes
          ``<double>``.
 
     Args:
@@ -189,6 +191,7 @@ cdef inline str normalize_name_expr(str demangled):
             break
 
     s = _thrust_complex_re.sub('complex', s)
+    s = _template_comma_re.sub(',', s)
     s = s.replace(' >', '>')
 
     return s

--- a/tests/cupy_tests/core_tests/test_raw.py
+++ b/tests/cupy_tests/core_tests/test_raw.py
@@ -951,6 +951,38 @@ class TestRaw:
             # check results
             assert cupy.allclose(in_arr, out_arr)
 
+    @pytest.mark.thread_unsafe(reason="clears the global memoization cache")
+    def test_multiparameter_template_disk_cache(
+            self, backend, in_memory, clean_up, jitify):
+        if backend != 'nvrtc' or in_memory or clean_up or jitify:
+            pytest.skip('only test the NVRTC disk cache without Jitify')
+        if not compiler._is_function_enum_supported():
+            pytest.skip('requires CUDA driver 12.4 or later')
+
+        code = r'''
+        template<typename Tv, typename Tp>
+        __global__ void kernel() { return; }
+        '''
+        name_expressions = ('kernel<float,float>',)
+
+        try:
+            mod = cupy.RawModule(
+                code=code, name_expressions=name_expressions)
+            mod.compile()
+            _util.clear_memo()
+
+            compile_kernel = compiler._compile_using_nvrtc_no_warning
+            with mock.patch.object(
+                    compiler, '_compile_using_nvrtc_no_warning',
+                    wraps=compile_kernel) as compile_mock:
+                cached_mod = cupy.RawModule(
+                    code=code, name_expressions=name_expressions)
+                cached_mod.compile()
+
+            assert compile_mock.call_count == 0
+        finally:
+            _util.clear_memo()
+
     def test_template_failure(self, backend, jitify):
         name_expressions = ['my_sqrt<int>']
 


### PR DESCRIPTION
## Summary

- normalize whitespace around commas when matching demangled CUDA template names
- add a regression test proving a multiparameter `RawModule` is restored from the disk cache without invoking NVRTC again

Fixes #10173.

## Background

For `kernel<float,float>`, `libcufilt` returns the demangled spelling `kernel<float, float>`. The cache file itself is loaded successfully, but the whitespace difference prevents `_enumerate_and_build_mapping` from rebuilding the name-expression mapping. CuPy then recompiles the module and overwrites the same cache entry.

The normalization is only used for matching user-provided name expressions to demangled CUBIN symbols. Removing whitespace around template-argument commas makes the two equivalent C++ spellings compare equal without changing the cache key or the original mapping keys.

The reporter's two-expression reproducer failed on CuPy 14.1.0, 14.1.1, and current `main` before this change. After the change, the second independent process loads the same CUBIN and does not save or invoke NVRTC again; cache SHA, size, inode, and mtime remain unchanged. Reversing the expression order also hits the same cache entry and rebuilds the requested mapping order correctly.

## Testing

CUDA 13.0 / driver 580.65.06 / RTX 3090:

- regression test before the fix: `1 failed, 6 skipped`
- regression test after the fix: `1 passed, 6 skipped`
- `tests/cupy_tests/cuda_tests/test_compiler_cache.py`: `10 passed`
- targeted `RawModule` template tests: `8 passed, 4 skipped, 9 deselected`
- `test_compiler.py` and `test_function.py`: `18 passed, 4 skipped`
- pre-commit checks for both modified files: all applicable hooks passed
