### PR TITLE
CI: give ci-trigger hygiene job pull-requests:write for PR labels

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -143,8 +143,10 @@ jobs:
     if: github.repository_owner == 'cupy' && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     # Deletes the stale ci:triggered label via GITHUB_TOKEN; no checkout.
+    # Labels on a PR require pull-requests:write (issues:write only covers
+    # labels on issues), else DELETE .../issues/<pr>/labels/... returns 403.
     permissions:
-      issues: write
+      pull-requests: write
     concurrency:
       group: ci-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
The `hygiene` job in `ci-trigger.yml` clears a stale `ci:triggered` label on `pull_request_target` (synchronize/reopen) via `gh api --method DELETE .../issues/<pr>/labels/ci:triggered` using `GITHUB_TOKEN`, but the job is scoped to `issues: write`.

Modifying labels on a **pull request** requires **`pull-requests: write`** — `issues: write` only authorizes labels on issues — so the call returns `403 Resource not accessible by integration` on every PR synchronize ([failing run](https://github.com/cupy/cupy/actions/runs/31372810183/job/93405347846)).

Because `pull_request_target` runs the base branch's copy of the workflow, this only began firing once the workflow reached main (#10049); it was never exercised on the source PR.

This scopes the `hygiene` job to `pull-requests: write`. Like the other `pull_request_target` legs, it is only fully exercisable once on main.
