### PR TITLE
Restore the pinned memory pool in TestAsarray instead of disabling it

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -150,7 +150,9 @@ class TestAsarray(unittest.TestCase):
                 cupy.cuda.set_pinned_memory_allocator(lambda _: None)
             a = cupy.asarray(a_cpu, order=cp_order)
         finally:
-            cupy.cuda.set_pinned_memory_allocator(None)
+            # None means "no pool", not "the default pool"
+            cupy.cuda.set_pinned_memory_allocator(
+                cupy.get_default_pinned_memory_pool().malloc)
         assert a.flags.c_contiguous == (cp_order == 'C')
         assert a.flags.f_contiguous == (cp_order == 'F')
         assert a.strides == strides


### PR DESCRIPTION
Fixes #10183.

`set_pinned_memory_allocator(None)` installs the raw allocator — i.e. pooling *disabled* — it does not restore the default pool that `cupy/__init__.py` sets up at import. `TestAsarray` (added in #9966) calls it in a `finally:`, so once that test runs the pinned memory pool stays off for the rest of the process.

`TestAsarray` is collected ~0.8% into the suite, so the remaining ~99% of a full CI run stages every host-to-device transfer through raw `cudaHostAlloc`/`cudaFreeHost` instead of the pool. `cudaFreeHost` synchronizes the device, so tests that upload many small arrays pay a device synchronization per transfer. Measured on `cupyx_tests/scipy_tests/signal_tests/test_signaltools.py`, the IIR/filtering classes issue ~52 pinned staging allocations per test versus ~23 for the convolution classes — which matches where the CI slowdown concentrates.

## CI time survey

Per-PR CI (`mini` subset), successful runs only. Runs are split by whether the tested commit actually contains #9966 (`git merge-base --is-ancestor dbb9605`) rather than by date, so PRs branched before #9966 but tested after are binned correctly. Medians:

| project | pre-#9966 (n=52) | +#9966 (n=7) | +#9966 +#10122 (n=4) | this PR (n=1) |
|---|---|---|---|---|
| `cupy.linux.cuda120` | 84m | 101m | 117m | **92m** |
| `cupy.linux.cuda129` | 85m | 113m | 120m | **96m** |
| `cupy.linux.cuda130` | 59m | 79m | 80m | **58m** |
| `cupy.linux.cuda132` | 59m | 82m | 80m | **58m** |

Four independent CUDA versions show the same 1.20–1.39x step at #9966, and #10122 recovered none of it. With this PR, `cuda130` and `cuda132` return to their pre-#9966 medians and `cuda120`/`cuda129` recover ~70–75% of the gap, landing near their pre-#9966 *means* (88m/91m). On all four projects this PR's run is below the minimum of every post-#9966 sample (94m/101m/76m/76m).

Merge CI on `cupy.linux.cuda128`, pytest phase only:

| commit | | pytest | passed |
|---|---|---|---|
| `0c2c511` | pre-#9966 | 6756.71s | 101494 |
| `dbb9605` | #9966 | 9984.58s | 101526 |
| `58abf05` | post-#10122 | 10276.15s | 101775 |

`dbb9605` contains only #9966. Four `v14` merge runs from the same week (which did not yet carry #9966) came in at 6281–7217s, bounding run-to-run variation well below the step.

## Notes

- This PR's run is a single sample per project; more will accumulate on merge to main and via the backport.
- The residual ~8–13% on `cuda120`/`cuda129` is not yet explained — it may be baseline spread (their pre-#9966 runs range 77–128m) or a smaller remaining effect.
- The test's intent is unchanged: it still exercises the pinned-allocation-failure path via `set_pinned_memory_allocator(lambda _: None)`; only the cleanup is corrected.