### PR TITLE
CI: pin rapidsai/sccache to v0.16.0-rapids.4

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -74,9 +74,15 @@ jobs:
         if: ${{ inputs.host-platform == 'linux-64' && endsWith(matrix.python-version, 't') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Install latest rapidsai/sccache
+      # Pinned rather than `latest`: an sccache release can change its cache-key
+      # format (v0.17.0-rapids.0 split CUDA caching into per-sub-tool
+      # ptxas/cicc/cudafe++), which invalidates the warm GHA sccache cache and
+      # forces a full recompile on every PR until the shared cache re-warms.
+      # Bump SCCACHE_VERSION deliberately.
+      - name: Install pinned rapidsai/sccache
         env:
           HOST_PLATFORM: ${{ inputs.host-platform }}
+          SCCACHE_VERSION: v0.16.0-rapids.4
         run: |
           case "${HOST_PLATFORM}" in
             linux-*)  URL_TRIPLE="$(uname -m)-unknown-linux-musl"; SCCACHE_BIN="sccache" ;;
@@ -84,7 +90,7 @@ jobs:
             *)        echo "Unsupported host-platform: ${HOST_PLATFORM}" >&2; exit 1 ;;
           esac
           mkdir -p sccache_bin
-          curl -fsSL "https://github.com/rapidsai/sccache/releases/latest/download/sccache-${URL_TRIPLE}.tar.gz" \
+          curl -fsSL "https://github.com/rapidsai/sccache/releases/download/${SCCACHE_VERSION}/sccache-${URL_TRIPLE}.tar.gz" \
             | tar -C sccache_bin -xzf - --wildcards --strip-components=1 "*/${SCCACHE_BIN}"
           SCCACHE_BIN_DIR="$(pwd)/sccache_bin"
           SCCACHE_BIN_FULL="${SCCACHE_BIN_DIR}/${SCCACHE_BIN}"


### PR DESCRIPTION
## Problem

The wheel build installs sccache from `rapidsai/sccache/releases/latest`, so a new sccache release silently changes the build toolchain mid-flight.

[`v0.17.0-rapids.0`](https://github.com/rapidsai/sccache/releases/tag/v0.17.0-rapids.0) (published 2026-08-11) reworked CUDA caching — v0.16 cached each whole `nvcc` call; v0.17 caches the sub-stages (`ptxas` / `cicc` / `cudafe++`) separately. The new keys miss the warm nvcc-level GHA cache, so the first v0.17 run is a full recompile that repopulates the cache with new-format blobs.

Same win-64 job (CUDA 12.9.2 / py3.12), identical source:

| | sccache | build | compiles | hit rate |
|---|---|---|---|---|
| [before](https://github.com/cupy/cupy/actions/runs/31514031959) | v0.16.0-rapids.4 | ~8 min | 3 | 100% |
| [after](https://github.com/cupy/cupy/actions/runs/31558138732) | v0.17.0-rapids.0 | ~42 min | 84 executed | 25.9% |

And because a PR's sccache writes don't seed other PRs' cache scope, **every** PR pays that full recompile until `main` re-warms the shared cache.

## Fix

Pin to `v0.16.0-rapids.4` — the last version the warm cache is keyed for — so builds stay fast. The version is now a single `SCCACHE_VERSION` env var, so upgrading to v0.17 later is a one-line, deliberate change (eating a single re-warm on `main`).
