### PR TITLE
Optimize RBFInterpolator kernel evaluation

### DIFF
--- a/cupyx/scipy/interpolate/_rbfinterp.py
+++ b/cupyx/scipy/interpolate/_rbfinterp.py
@@ -9,232 +9,53 @@ import cupy as cp
 from cupyx.scipy.spatial import KDTree
 
 
-# Define the kernel functions.
-
-kernel_definitions = """
-static __device__ double linear(double r)
-{
-     return -r;
-}
-
-static __device__ float linear_f(float r)
-{
-    return -r;
-}
-
-
-static __device__ double cubic(double r)
-{
-     return r*r*r;
-}
-
-static __device__ float cubic_f(float r)
-{
-    return r*r*r;
+_KERNEL_EXPRESSIONS = {
+    "linear": "-sqrt(squared_distance)",
+    "thin_plate_spline": (
+        "squared_distance == 0 ? 0 : "
+        "0.5 * squared_distance * log(squared_distance)"
+    ),
+    "cubic": "squared_distance * sqrt(squared_distance)",
+    "quintic": (
+        "-squared_distance * squared_distance * sqrt(squared_distance)"
+    ),
+    "multiquadric": "-sqrt(squared_distance + 1)",
+    "inverse_multiquadric": "1 / sqrt(squared_distance + 1)",
+    "inverse_quadratic": "1 / (squared_distance + 1)",
+    "gaussian": "exp(-squared_distance)",
 }
 
 
-static __device__ double thin_plate_spline(double r)
-{
-    if (r == 0.0) {
-        return 0.0;
+def _make_kernel(name, expression):
+    return cp._core.ElementwiseKernel(
+        'raw T x, raw T y, int64 source_count, int32 ndim, T epsilon',
+        'T out',
+        r'''
+    const long long target = i / source_count;
+    const long long source = i - target * source_count;
+    T squared_distance = 0;
+    for (int dimension = 0; dimension < ndim; ++dimension) {
+        const T difference = epsilon * (
+            x[target * ndim + dimension]
+            - y[source * ndim + dimension]);
+        squared_distance += difference * difference;
     }
-    else {
-        return r*r*log(r);
-    }
-}
 
-static __device__ float thin_plate_spline_f(float r)
-{
-    if (r == 0.0) {
-        return 0.0;
-    }
-    else {
-        return r*r*log(r);
-    }
+    out = ''' + expression + ';',
+        f'cupyx_scipy_interpolate_{name}',
+    )
+
+
+_KERNELS = {
+    name: _make_kernel(name, expression)
+    for name, expression in _KERNEL_EXPRESSIONS.items()
 }
 
 
-static __device__ double multiquadric(double r)
-{
-    return -sqrt(r*r + 1);
-}
-
-static __device__ float multiquadric_f(float r)
-{
-    return -sqrt(r*r + 1);
-}
-
-
-static __device__ double inverse_multiquadric(double r)
-{
-    return 1.0 / sqrt(r*r + 1);
-}
-
-static __device__ float inverse_multiquadric_f(float r)
-{
-    return 1.0 / sqrt(r*r + 1);
-}
-
-
-static __device__ double inverse_quadratic(double r)
-{
-    return 1.0 / (r*r + 1);
-}
-
-static __device__ float inverse_quadrtic_f(float r)
-{
-    return 1.0 / (r*r + 1);
-}
-
-
-static __device__ double gaussian(double r)
-{
-    return exp(-r*r);
-}
-
-static __device__ float gaussian_f(float r)
-{
-    return exp(-r*r);
-}
-
-
-static __device__ double quintic(double r)
-{
-    double r2 = r*r;
-    return -r2*r2*r;
-}
-
-static __device__ float qunitic_f(float r)
-{
-    float r2 = r*r;
-    return -r2*r2*r;
-}
-
-"""
-
-linear = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_linear',
-    (('f->f', 'out0 = linear_f(in0)'),
-     'd->d'),
-    'out0 = linear(in0)',
-    preamble=kernel_definitions,
-    doc="""Linear kernel function.
-
-    ``-r``
-    """,
-)
-
-cubic = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_cubic',
-    (('f->f', 'out0 = cubic_f(in0)'),
-     'd->d'),
-    'out0 = cubic(in0)',
-    preamble=kernel_definitions,
-    doc="""Cubic kernel function.
-
-    ``r**3``
-    """,
-)
-
-thin_plate_spline = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_thin_plate_spline',
-    (('f->f', 'out0 = thin_plate_spline_f(in0)'),
-     'd->d'),
-    'out0 = thin_plate_spline(in0)',
-    preamble=kernel_definitions,
-    doc="""Thin-plate spline kernel function.
-
-    ``r**2 * log(r) if r != 0 else 0``
-    """,
-)
-
-
-multiquadric = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_multiquadric',
-    (('f->f', 'out0 = multiquadric_f(in0)'),
-     'd->d'),
-    'out0 = multiquadric(in0)',
-    preamble=kernel_definitions,
-    doc="""Multiquadric kernel function.
-
-    ``-sqrt(r**2 + 1)``
-    """,
-)
-
-
-inverse_multiquadric = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_inverse_multiquadric',
-    (('f->f', 'out0 = inverse_multiquadric_f(in0)'),
-     'd->d'),
-    'out0 = inverse_multiquadric(in0)',
-    preamble=kernel_definitions,
-    doc="""Inverse multiquadric kernel function.
-
-    ``1 / sqrt(r**2 + 1)``
-    """,
-)
-
-
-inverse_quadratic = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_inverse_quadratic',
-    (('f->f', 'out0 = inverse_quadratic_f(in0)'),
-     'd->d'),
-    'out0 = inverse_quadratic(in0)',
-    preamble=kernel_definitions,
-    doc="""Inverse quadratic kernel function.
-
-    ``1 / (r**2 + 1)``
-    """,
-)
-
-
-gaussian = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_gaussian',
-    (('f->f', 'out0 = gaussian_f(in0)'),
-     'd->d'),
-    'out0 = gaussian(in0)',
-    preamble=kernel_definitions,
-    doc="""Gaussian kernel function.
-
-    ``exp(-r**2)``
-    """,
-)
-
-
-quintic = cp._core.create_ufunc(
-    'cupyx_scipy_interpolate_quintic',
-    (('f->f', 'out0 = quintic_f(in0)'),
-     'd->d'),
-    'out0 = quintic(in0)',
-    preamble=kernel_definitions,
-    doc="""Quintic kernel function.
-
-    ``-r**5``
-    """,
-)
-
-
-NAME_TO_FUNC = {
-    "linear": linear,
-    "thin_plate_spline": thin_plate_spline,
-    "cubic": cubic,
-    "quintic": quintic,
-    "multiquadric": multiquadric,
-    "inverse_multiquadric": inverse_multiquadric,
-    "inverse_quadratic": inverse_quadratic,
-    "gaussian": gaussian
-}
-
-
-def kernel_matrix(x, kernel_func, out):
-    """Evaluate RBFs, with centers at `x`, at `x`."""
-    delta = x[None, :, :] - x[:, None, :]
-    out[...] = kernel_func(cp.linalg.norm(delta, axis=-1))
-# The above is equivalent to the original semi-scalar version:
-#        for j in range(i+1):
-#            out[i, j] = kernel_func(cp.linalg.norm(x[i] - x[j]))
-#            out[j, i] = out[i, j]
+def _kernel_matrix(x, y, kernel, epsilon, out):
+    """Evaluate RBFs, with centers at `y`, at the points `x`."""
+    _KERNELS[kernel](
+        x, y, y.shape[0], x.shape[1], epsilon, out)
 
 
 def polynomial_matrix(x, powers, out):
@@ -280,8 +101,6 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
     p = d.shape[0]
     s = d.shape[1]
     r = powers.shape[0]
-    kernel_func = NAME_TO_FUNC[kernel]
-
     # Shift and scale the polynomial domain to be between -1 and 1
     mins = cp.min(y, axis=0)
     maxs = cp.max(y, axis=0)
@@ -292,13 +111,12 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
     # zeros with ones.
     scale[scale == 0.0] = 1.0
 
-    yeps = y * epsilon
     yhat = (y - shift)/scale
 
     # Transpose to make the array fortran contiguous. This is required for
     # dgesv to not make a copy of lhs.
     lhs = cp.empty((p + r, p + r), dtype=float).T
-    kernel_matrix(yeps, kernel_func, lhs[:p, :p])
+    _kernel_matrix(y, y, kernel, epsilon, lhs[:p, :p])
     polynomial_matrix(yhat, powers, lhs[:p, p:])
     lhs[p:, :p] = lhs[:p, p:].T
     lhs[p:, p:] = 0.0
@@ -343,17 +161,12 @@ def _build_evaluation_coefficients(x, y, kernel, epsilon, powers,
     q = x.shape[0]
     p = y.shape[0]
     r = powers.shape[0]
-    kernel_func = NAME_TO_FUNC[kernel]
-
-    yeps = y*epsilon
-    xeps = x*epsilon
     xhat = (x - shift)/scale
 
     vec = cp.empty((q, p + r), dtype=float)
 
     # Evaluate RBFs, with centers at `y`, at the point `x`.
-    delta = xeps[:, None, :] - yeps[None, :, :]
-    vec[:, :p] = kernel_func(cp.linalg.norm(delta, axis=-1))
+    _kernel_matrix(x, y, kernel, epsilon, vec[:, :p])
 
     # Evaluate monomials, with exponents from `powers`, at the point `x`.
     pwr = xhat[:, None, :]**powers[None, :, :]

--- a/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
+++ b/tests/cupyx_tests/scipy_tests/interpolate_tests/test_rbfinterp.py
@@ -20,16 +20,37 @@ except ImportError:
 
 
 from cupyx.scipy.interpolate._rbfinterp import (
-    _AVAILABLE, _SCALE_INVARIANT, _NAME_TO_MIN_DEGREE, NAME_TO_FUNC,
-    _monomial_powers, polynomial_matrix, kernel_matrix)
+    _AVAILABLE, _SCALE_INVARIANT, _NAME_TO_MIN_DEGREE,
+    _build_evaluation_coefficients, _kernel_matrix as _rbf_kernel_matrix,
+    _monomial_powers, polynomial_matrix)
 
 
 def _kernel_matrix(x, kernel):
     """Return RBFs, with centers at `x`, evaluated at `x`."""
     out = cp.empty((x.shape[0], x.shape[0]), dtype=float)
-    kernel_func = NAME_TO_FUNC[kernel]
-    kernel_matrix(x, kernel_func, out)
+    _rbf_kernel_matrix(x, x, kernel, 1.0, out)
     return out
+
+
+def _kernel_values(r, kernel):
+    """Evaluate an RBF directly from distances for use as a test oracle."""
+    if kernel == 'linear':
+        return -r
+    if kernel == 'thin_plate_spline':
+        return cp.where(r == 0, 0, r**2 * cp.log(r))
+    if kernel == 'cubic':
+        return r**3
+    if kernel == 'quintic':
+        return -r**5
+    if kernel == 'multiquadric':
+        return -cp.sqrt(r**2 + 1)
+    if kernel == 'inverse_multiquadric':
+        return 1 / cp.sqrt(r**2 + 1)
+    if kernel == 'inverse_quadratic':
+        return 1 / (r**2 + 1)
+    if kernel == 'gaussian':
+        return cp.exp(-r**2)
+    raise ValueError(f'Unknown kernel: {kernel}')
 
 
 def _polynomial_matrix(x, powers):
@@ -44,6 +65,27 @@ def _vandermonde(x, degree):
     # degree evaluated at x.
     powers = _monomial_powers(x.shape[1], degree)
     return _polynomial_matrix(x, powers)
+
+
+@pytest.mark.parametrize('kernel', sorted(_AVAILABLE))
+@pytest.mark.parametrize('degree', [-1, 2])
+def test_build_evaluation_coefficients(kernel, degree):
+    rng = _np.random.RandomState(0)
+    x = cp.asarray(rng.random_sample((11, 3)))
+    y = cp.asarray(rng.random_sample((7, 3)))
+    epsilon = 1.7
+    powers = _monomial_powers(x.shape[1], degree)
+    shift = cp.asarray([0.25, 0.5, 0.75])
+    scale = cp.asarray([0.5, 0.75, 1.0])
+
+    actual = _build_evaluation_coefficients(
+        x, y, kernel, epsilon, powers, shift, scale)
+
+    delta = epsilon * (x[:, None, :] - y[None, :, :])
+    rbf = _kernel_values(cp.linalg.norm(delta, axis=-1), kernel)
+    polynomial = _polynomial_matrix((x - shift) / scale, powers)
+    expected = cp.concatenate((rbf, polynomial), axis=1)
+    testing.assert_allclose(actual, expected, rtol=1e-13, atol=1e-13)
 
 
 def _1d_test_function(x, xp):


### PR DESCRIPTION
## Summary

Fuse distance calculation and RBF evaluation into specialized `ElementwiseKernel`s.

The previous implementation materialized a `(targets, sources, dimensions)` delta tensor, reduced it to distances, and then launched another RBF kernel. The fused implementation accumulates squared distances in registers and writes only the final RBF matrix. Gaussian evaluation also avoids an unnecessary square root.

## Benchmark

Environment: RTX 5070 Ti, CUDA 13.2, float64.  
Workload: 256 source points, 100,000 target points, 3 dimensions, `epsilon=10`, `smoothing=1e-8`. The interpolator is constructed before timing.

| Kernel | Before | After | Speedup | Max abs diff |
| --- | ---: | ---: | ---: | ---: |
| linear | 64.877 ms | 2.889 ms | 22.45x | `8.53e-14` |
| thin_plate_spline | 68.898 ms | 6.299 ms | 10.94x | `2.96e-12` |
| cubic | 66.486 ms | 4.672 ms | 14.23x | `2.00e-11` |
| quintic | 70.154 ms | 8.142 ms | 8.62x | `2.45e-09` |
| multiquadric | 65.337 ms | 3.021 ms | 21.62x | `9.95e-13` |
| inverse_multiquadric | 65.935 ms | 3.265 ms | 20.19x | `1.42e-14` |
| inverse_quadratic | 65.352 ms | 2.669 ms | 24.49x | `3.22e-15` |
| gaussian | 65.893 ms | 3.330 ms | 19.78x | `5.34e-14` |

A larger Gaussian workload with 1,024 source points and 1,000,000 target points improved from 2581.7 ms to 85.6 ms (30.2x).

<details>
<summary>Benchmark code</summary>

```python
import cupy as cp
import numpy as np
from cupyx.profiler import benchmark
from cupyx.scipy.interpolate import RBFInterpolator

kernels = (
    'linear', 'thin_plate_spline', 'cubic', 'quintic',
    'multiquadric', 'inverse_multiquadric',
    'inverse_quadratic', 'gaussian',
)

rng = np.random.default_rng(0)
source = cp.asarray(rng.random((256, 3)))
values = cp.asarray(rng.random(256))
target = cp.asarray(rng.random((100_000, 3)))

for kernel in kernels:
    interpolator = RBFInterpolator(
        source,
        values,
        kernel=kernel,
        epsilon=10.0,
        smoothing=1e-8,
    )

    def evaluate():
        return interpolator(target)

    result = benchmark(evaluate, n_warmup=1, n_repeat=5)
    gpu_ms = result.gpu_times.mean() * 1e3
    print(f'{kernel}: {gpu_ms:.3f} ms')
```

Run the script against the parent revision and this PR branch.

</details>
