### PR TITLE
CI: produce more granular test runtime data for some CI builds

### DIFF
--- a/.pfnci/linux/main-flexci.sh
+++ b/.pfnci/linux/main-flexci.sh
@@ -30,7 +30,10 @@ STAGES="cache_get build test"
 if [[ "${TARGET}" == "benchmark" ]]; then
     STAGES="cache_get build benchmark"
 fi
-BENCHMARK_DIR=/tmp/benchmark CACHE_DIR=/tmp/cupy_cache CACHE_KERNEL_TO_GCS=1 PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" "${STAGES}" 2>&1 | tee "${LOG_FILE}"
+JUNIT_DIR=/tmp/cupy_junit
+mkdir -p "${JUNIT_DIR}"
+rm -f "${JUNIT_DIR}/junit.xml"
+BENCHMARK_DIR=/tmp/benchmark CACHE_DIR=/tmp/cupy_cache JUNIT_DIR="${JUNIT_DIR}" CACHE_KERNEL_TO_GCS=1 PULL_REQUEST="${pull_req}" "$(dirname ${0})/run.sh" "${TARGET}" "${STAGES}" 2>&1 | tee "${LOG_FILE}"
 test_retval=${PIPESTATUS[0]}
 
 echo "****************************************************************************************************"
@@ -57,9 +60,20 @@ fi
 echo "Uploading the log..."
 gsutil -m -q cp "${LOG_FILE}" "gs://chainer-artifacts-pfn-public-ci/cupy-ci/${CI_JOB_ID}/"
 
+junit_url=""
+if [[ -f "${JUNIT_DIR}/junit.xml" ]]; then
+    gzip -4 -c "${JUNIT_DIR}/junit.xml" > "${JUNIT_DIR}/junit.xml.gz"
+    gsutil -m -q cp "${JUNIT_DIR}/junit.xml.gz" "gs://chainer-artifacts-pfn-public-ci/cupy-ci/${CI_JOB_ID}/"
+    junit_url="https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/${CI_JOB_ID}/junit.xml.gz"
+fi
+
 echo "****************************************************************************************************"
 echo "Full log is available at:"
 echo "https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/${CI_JOB_ID}/log.txt"
+if [[ -n "${junit_url}" ]]; then
+    echo "JUnit XML is available at:"
+    echo "${junit_url}"
+fi
 echo "****************************************************************************************************"
 
 exit ${test_retval}

--- a/.pfnci/linux/run.sh
+++ b/.pfnci/linux/run.sh
@@ -197,6 +197,12 @@ main() {
         mkdir -p ${BENCHMARK_DIR}
         docker_args+=(--volume="${BENCHMARK_DIR}:/perf-results")
       fi
+      # Host and container path must match so pytest --junit-xml (absolute)
+      # survives docker --rm. Only FlexCI sets JUNIT_DIR today.
+      if [[ "${JUNIT_DIR:-}" != "" ]]; then
+        mkdir -p "${JUNIT_DIR}"
+        docker_args+=(--volume="${JUNIT_DIR}:${JUNIT_DIR}")
+      fi
 
       if [[ ${stage} = test || ${stage} = benchmark ]]; then
         "${docker_args[@]}" --volume="${repo_root}:/src:ro" --workdir "/src" \

--- a/.pfnci/linux/tests/cuda129.sh
+++ b/.pfnci/linux/tests/cuda129.sh
@@ -13,6 +13,8 @@ export NVCC="ccache nvcc"
 
 export CUPY_ACCELERATORS="cutensor,cub"
 
+export CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"
+
 echo "================ Environment Variables ================"
 env
 echo "======================================================="

--- a/.pfnci/linux/tests/cuda12x-cuda-python.sh
+++ b/.pfnci/linux/tests/cuda12x-cuda-python.sh
@@ -15,6 +15,8 @@ export CUPY_ACCELERATORS="cutensor,cub"
 
 export CUPY_USE_CUDA_PYTHON="1"
 
+export CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"
+
 echo "================ Environment Variables ================"
 env
 echo "======================================================="

--- a/.pfnci/linux/tests/cuda133.sh
+++ b/.pfnci/linux/tests/cuda133.sh
@@ -13,6 +13,8 @@ export NVCC="ccache nvcc"
 
 export CUPY_ACCELERATORS="cutensor,cub"
 
+export CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"
+
 echo "================ Environment Variables ================"
 env
 echo "======================================================="

--- a/.pfnci/linux/tests/cuda13x-cuda-python.sh
+++ b/.pfnci/linux/tests/cuda13x-cuda-python.sh
@@ -15,6 +15,8 @@ export CUPY_ACCELERATORS="cutensor,cub"
 
 export CUPY_USE_CUDA_PYTHON="1"
 
+export CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"
+
 echo "================ Environment Variables ================"
 env
 echo "======================================================="

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -271,6 +271,7 @@
   cuda-python: null
   nvmath-python: null
   env:CUPY_ACCELERATORS: "cutensor,cub"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
   test: "unit"
 
 # CUDA 12.9 (Multi-GPU) | Linux
@@ -279,6 +280,7 @@
   tags: ["@push", "full", "mini", "multi", "linux", "cuda129"]
   target: "cuda129.multi"
   mpi4py: "4"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: null
   test: "unit-multi"
 
 # CUDA 13.0 | Linux
@@ -396,6 +398,7 @@
   cuda-python: null
   nvmath-python: null
   env:CUPY_ACCELERATORS: "cutensor,cub"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
   test: "unit"
 
 # CUDA 13.3 (Multi-GPU) | Linux
@@ -404,6 +407,7 @@
   tags: ["@push", "full", "mini", "multi", "linux", "cuda133"]
   target: "cuda133.multi"
   mpi4py: "4"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: null
   test: "unit-multi"
 
 # CUDA 13.x + Python 3.14 free-threaded | Linux
@@ -576,6 +580,7 @@
   nvmath-python: "1"
   env:CUPY_ACCELERATORS: "cutensor,cub"
   env:CUPY_USE_CUDA_PYTHON: "1"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
   test: "unit"
 
 # CUDA 13.x / CUDA Python | Linux
@@ -604,6 +609,7 @@
   nvmath-python: "1"
   env:CUPY_ACCELERATORS: "cutensor,cub"
   env:CUPY_USE_CUDA_PYTHON: "1"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
   test: "unit"
 
 ###############################################################################


### PR DESCRIPTION
## Motivation

Record per-test timing data from real FlexCI runs to enable statistical analyses of runtime differences between native vs cuda-python CuPy builds. Pytest's JUnit XML report gives full per-test timings, but FlexCI currently only uploads `log.txt`.

## What this does

Opts four targets into producing a JUnit XML report and uploads it (gzip-compressed) to the same GCS location as `log.txt`:

- `cuda129`
- `cuda133`
- `cuda12x-cuda-python`
- `cuda13x-cuda-python`

No new CI mechanism is introduced. This reuses the existing `env:CUPY_CI_PYTEST_EXTRA_OPTS` matrix axis (already used by e.g. `cuda13x-py314t`) to pass `--junit-xml=/tmp/cupy_junit/junit.xml` to pytest for these four targets in `.pfnci/matrix.yaml`.

The `cuda129.multi` / `cuda133.multi` variants inherit from `cuda129` / `cuda133` but explicitly set `env:CUPY_CI_PYTEST_EXTRA_OPTS: null` so they don't write JUnit XML.

### Plumbing

- `.pfnci/linux/run.sh`: when the caller sets `JUNIT_DIR`, bind-mount that host directory into the container at the same absolute path. This is required because the source tree is mounted read-only and the container runs with `--rm`, so pytest needs a writable, persistent path to write `junit.xml` to.
- `.pfnci/linux/main-flexci.sh`: always sets `JUNIT_DIR=/tmp/cupy_junit` before invoking `run.sh`. After the test stage, if `junit.xml` exists, it is gzip-compressed (`gzip -4`) and uploaded next to `log.txt` as `junit.xml.gz`; the URL is printed the same way the `log.txt` URL is. If the file does not exist (e.g. targets that don't opt in, or a run that times out before pytest writes it), nothing extra happens.

Artifact URL pattern:
`https://storage.googleapis.com/chainer-artifacts-pfn-public-ci/cupy-ci/junit.xml.tgz`


## Testing

`.pfnci/generate.py --dry-run` confirms the generated `linux/tests/*.sh` scripts are in sync with `matrix.yaml`. `pre-commit run -a` passes on all touched files.

Verified locally with the `cuda13x-cuda-python` Docker image: built CuPy the same way `build.sh` does, exported `CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"`, and ran `.pfnci/linux/tests/actions/unittest.sh` with `/tmp/cupy_junit` bind-mounted from the host — `junit.xml` was written correctly to the host path. The compressed JUnit XML files are about the same size as the `log.txt` files that the workflows already upload (1-2MB).

## Notes for reviewers

- No pytest/library code changes; touches only `.pfnci/matrix.yaml`, `.pfnci/linux/run.sh`, `.pfnci/linux/main-flexci.sh`, and the corresponding regenerated `.pfnci/linux/tests/*.sh` scripts for the four opted-in targets.
- `junit_logging` is left at its default (`no`) to keep the report small; this is purely a per-test timing/pass-fail artifact, not a log-capture mechanism.