### PR TITLE
Cache the cusparseSpSM analysis across SuperLU.solve() calls

### DIFF
--- a/cupyx/cusparse.py
+++ b/cupyx/cusparse.py
@@ -2254,6 +2254,233 @@ def sparseToDense(x, out=None):
     return out
 
 
+class SpSMDescriptor(BaseDescriptor):
+
+    @classmethod
+    def create(cls):
+        desc = _cusparse.spSM_createDescr()
+        return SpSMDescriptor(desc, None, _cusparse.spSM_destroyDescr)
+
+
+class SpSM:
+    """Sparse triangular solver with reusable analysis (cusparseSpSM).
+
+    Solves ``op(a) * x = alpha * op(b)`` for ``x``, where ``a`` is a sparse
+    triangular matrix. The cusparseSpSM analysis phase depends only on
+    ``a``, the operations, and the shape/layout of ``b`` -- not on the
+    values of ``b`` -- and typically dominates the cost of a one-shot
+    solve. This class runs the analysis at the first solve, and again only
+    when the shape/layout of ``b`` changes, so that repeated solves against
+    the same matrix pay for it once (see #8580).
+
+    Args:
+        a (cupyx.scipy.sparse.csr_matrix, cupyx.scipy.sparse.csc_matrix or
+            cupyx.scipy.sparse.coo_matrix): Sparse matrix with dimension
+            ``(M, M)``. Must not be modified (values or sparsity) while
+            this object is in use.
+        alpha (float or complex): Coefficient.
+        lower (bool):
+            True: ``a`` is lower triangle matrix.
+            False: ``a`` is upper triangle matrix.
+        unit_diag (bool):
+            True: diagonal part of ``a`` has unit elements.
+            False: diagonal part of ``a`` has non-unit elements.
+        transa (bool or str): True, False, 'N', 'T' or 'H'.
+            'N' or False: op(a) == ``a``.
+            'T' or True: op(a) == ``a.T``.
+            'H': op(a) == ``a.conj().T``.
+    """
+
+    def __init__(self, a, alpha=1.0, lower=True, unit_diag=False,
+                 transa=False):
+        if not check_availability('spsm'):
+            raise RuntimeError('spsm is not available.')
+
+        # Canonicalise transa
+        if transa is False:
+            transa = 'N'
+        elif transa is True:
+            transa = 'T'
+        elif transa not in 'NTH':
+            raise ValueError(f'Unknown transa (actual: {transa})')
+
+        # Check A's type and sparse format
+        if _is_csr_type(a):
+            pass
+        elif _is_csc_type(a):
+            if transa == 'N':
+                a = a.T
+                transa = 'T'
+            elif transa == 'T':
+                a = a.T
+                transa = 'N'
+            elif transa == 'H':
+                a = a.conj().T
+                transa = 'N'
+            lower = not lower
+        elif cupyx.scipy.sparse.issparse(a) and a.format == 'coo':
+            pass
+        else:
+            raise ValueError('a must be CSR, CSC or COO sparse matrix')
+        if not a.has_canonical_format:
+            raise ValueError('expected canonical format for a')
+        if a.shape[0] != a.shape[1]:
+            raise ValueError('mismatched shape')
+
+        # Check dtype
+        dtype = a.dtype
+        if dtype.char not in 'fdFD':
+            raise TypeError('Invalid dtype (actual: {})'.format(dtype))
+
+        # Prepare fill mode
+        if lower is True:
+            fill_mode = _cusparse.CUSPARSE_FILL_MODE_LOWER
+        elif lower is False:
+            fill_mode = _cusparse.CUSPARSE_FILL_MODE_UPPER
+        else:
+            raise ValueError('Unknown lower (actual: {})'.format(lower))
+
+        # Prepare diag type
+        if unit_diag is False:
+            diag_type = _cusparse.CUSPARSE_DIAG_TYPE_NON_UNIT
+        elif unit_diag is True:
+            diag_type = _cusparse.CUSPARSE_DIAG_TYPE_UNIT
+        else:
+            raise ValueError('Unknown unit_diag (actual: {})'.format(
+                unit_diag))
+
+        # Prepare op_a
+        if transa == 'N':
+            op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+        elif transa == 'T':
+            op_a = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
+        else:  # transa == 'H'
+            if dtype.char in 'fd':
+                op_a = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
+            else:
+                op_a = _cusparse.CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE
+
+        # Keep a reference to ``a`` (including any CSC->CSR view created
+        # above): the cuSPARSE descriptor stores raw device pointers.
+        self._a = a
+        self._dtype = dtype
+        self._alpha = _numpy.array(alpha, dtype=dtype).ctypes
+        self._op_a = op_a
+        self._mat_a = SpMatDescriptor.create(a)
+
+        # Specify Lower|Upper fill mode
+        self._mat_a.set_attribute(_cusparse.CUSPARSE_SPMAT_FILL_MODE,
+                                  fill_mode)
+
+        # Specify Unit|Non-Unit diagonal type
+        self._mat_a.set_attribute(_cusparse.CUSPARSE_SPMAT_DIAG_TYPE,
+                                  diag_type)
+
+        # Analysis state, built at the first solve and rebuilt only when
+        # the shape/layout of ``b`` changes.
+        self._key = None
+        self._spsm_descr = None
+        self._buff = None
+        self._mat_b = None
+        self._mat_c = None
+
+    def solve(self, b):
+        """Solves the system for one or several right-hand sides.
+
+        Args:
+            b (cupy.ndarray): Dense matrix with dimension ``(M)`` or
+                ``(M, K)``.
+
+        Returns:
+            cupy.ndarray: Solution ``x`` (F-contiguous for a matrix ``b``).
+        """
+        # Check B's ndim
+        if b.ndim == 1:
+            is_b_vector = True
+            b = b.reshape(-1, 1)
+        elif b.ndim == 2:
+            is_b_vector = False
+        else:
+            raise ValueError('b.ndim must be 1 or 2')
+
+        # Check shapes
+        a = self._a
+        if not (a.shape[0] == a.shape[1] == b.shape[0]):
+            raise ValueError('mismatched shape')
+
+        # Check dtypes
+        if self._dtype != b.dtype:
+            raise TypeError('dtype mismatch')
+
+        # Prepare op_b
+        if b._f_contiguous:
+            op_b = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+        elif b._c_contiguous:
+            b = b.T
+            op_b = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
+        else:
+            raise ValueError('b must be F-contiguous or C-contiguous.')
+
+        # Allocate space for matrix C. Note that it is known cusparseSpSM
+        # requires the output matrix zero initialized.
+        m, _ = a.shape
+        if op_b == _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE:
+            _, n = b.shape
+        else:
+            n, _ = b.shape
+        c_shape = m, n
+        c = _cupy.zeros(c_shape, dtype=self._dtype, order='f')
+
+        handle = _device.get_cusparse_handle()
+        cuda_dtype = _dtype.to_cuda_dtype(self._dtype)
+        algo = _cusparse.CUSPARSE_SPSM_ALG_DEFAULT
+
+        key = (n, op_b)
+        if key != self._key:
+            # (Re)run the analysis for this right-hand-side shape/layout.
+            self._key = None
+            self._spsm_descr = None
+            mat_b = DnMatDescriptor.create(b)
+            mat_c = DnMatDescriptor.create(c)
+            spsm_descr = SpSMDescriptor.create()
+
+            # Allocate the workspace needed by the succeeding phases
+            buff_size = _cusparse.spSM_bufferSize(
+                handle, self._op_a, op_b, self._alpha.data, self._mat_a.desc,
+                mat_b.desc, mat_c.desc, cuda_dtype, algo, spsm_descr.desc)
+            buff = _cupy.empty(buff_size, dtype=_cupy.int8)
+
+            # Perform the analysis phase
+            _cusparse.spSM_analysis(
+                handle, self._op_a, op_b, self._alpha.data, self._mat_a.desc,
+                mat_b.desc, mat_c.desc, cuda_dtype, algo, spsm_descr.desc,
+                buff.data.ptr)
+
+            self._mat_b = mat_b
+            self._mat_c = mat_c
+            self._spsm_descr = spsm_descr
+            self._buff = buff
+            self._key = key
+        else:
+            # Same shape/layout as the analysed system: only the values of
+            # B and C change. cusparseDnMatSetValues is the documented way
+            # to rebind them without re-running the analysis.
+            _cusparse.dnMatSetValues(self._mat_b.desc, b.data.ptr)
+            _cusparse.dnMatSetValues(self._mat_c.desc, c.data.ptr)
+
+        # Executes the solve phase
+        _cusparse.spSM_solve(
+            handle, self._op_a, op_b, self._alpha.data, self._mat_a.desc,
+            self._mat_b.desc, self._mat_c.desc, cuda_dtype, algo,
+            self._spsm_descr.desc, self._buff.data.ptr)
+
+        # Reshape back if B was a vector
+        if is_b_vector:
+            c = c.reshape(-1)
+
+        return c
+
+
 def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
     """Solves a sparse triangular linear system op(a) * x = alpha * op(b).
 
@@ -2272,147 +2499,12 @@ def spsm(a, b, alpha=1.0, lower=True, unit_diag=False, transa=False):
             'N' or False: op(a) == ``a``.
             'T' or True: op(a) == ``a.T``.
             'H': op(a) == ``a.conj().T``.
+
+    .. seealso:: :class:`cupyx.cusparse.SpSM` for reusing the analysis
+        across repeated solves against the same matrix.
     """
-    if not check_availability('spsm'):
-        raise RuntimeError('spsm is not available.')
-
-    # Canonicalise transa
-    if transa is False:
-        transa = 'N'
-    elif transa is True:
-        transa = 'T'
-    elif transa not in 'NTH':
-        raise ValueError(f'Unknown transa (actual: {transa})')
-
-    # Check A's type and sparse format
-    if _is_csr_type(a):
-        pass
-    elif _is_csc_type(a):
-        if transa == 'N':
-            a = a.T
-            transa = 'T'
-        elif transa == 'T':
-            a = a.T
-            transa = 'N'
-        elif transa == 'H':
-            a = a.conj().T
-            transa = 'N'
-        lower = not lower
-    elif cupyx.scipy.sparse.issparse(a) and a.format == 'coo':
-        pass
-    else:
-        raise ValueError('a must be CSR, CSC or COO sparse matrix')
-    if not a.has_canonical_format:
-        raise ValueError('expected canonical format for a')
-
-    # Check B's ndim
-    if b.ndim == 1:
-        is_b_vector = True
-        b = b.reshape(-1, 1)
-    elif b.ndim == 2:
-        is_b_vector = False
-    else:
-        raise ValueError('b.ndim must be 1 or 2')
-
-    # Check shapes
-    if not (a.shape[0] == a.shape[1] == b.shape[0]):
-        raise ValueError('mismatched shape')
-
-    # Check dtypes
-    dtype = a.dtype
-    if dtype.char not in 'fdFD':
-        raise TypeError('Invalid dtype (actual: {})'.format(dtype))
-    if dtype != b.dtype:
-        raise TypeError('dtype mismatch')
-
-    # Prepare fill mode
-    if lower is True:
-        fill_mode = _cusparse.CUSPARSE_FILL_MODE_LOWER
-    elif lower is False:
-        fill_mode = _cusparse.CUSPARSE_FILL_MODE_UPPER
-    else:
-        raise ValueError('Unknown lower (actual: {})'.format(lower))
-
-    # Prepare diag type
-    if unit_diag is False:
-        diag_type = _cusparse.CUSPARSE_DIAG_TYPE_NON_UNIT
-    elif unit_diag is True:
-        diag_type = _cusparse.CUSPARSE_DIAG_TYPE_UNIT
-    else:
-        raise ValueError('Unknown unit_diag (actual: {})'.format(unit_diag))
-
-    # Prepare op_a
-    if transa == 'N':
-        op_a = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
-    elif transa == 'T':
-        op_a = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
-    else:  # transa == 'H'
-        if dtype.char in 'fd':
-            op_a = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
-        else:
-            op_a = _cusparse.CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE
-
-    # Prepare op_b
-    if b._f_contiguous:
-        op_b = _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
-    elif b._c_contiguous:
-        b = b.T
-        op_b = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
-    else:
-        raise ValueError('b must be F-contiguous or C-contiguous.')
-
-    # Allocate space for matrix C. Note that it is known cusparseSpSM requires
-    # the output matrix zero initialized.
-    m, _ = a.shape
-    if op_b == _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE:
-        _, n = b.shape
-    else:
-        n, _ = b.shape
-    c_shape = m, n
-    c = _cupy.zeros(c_shape, dtype=a.dtype, order='f')
-
-    # Prepare descriptors and other parameters
-    handle = _device.get_cusparse_handle()
-    mat_a = SpMatDescriptor.create(a)
-    mat_b = DnMatDescriptor.create(b)
-    mat_c = DnMatDescriptor.create(c)
-    spsm_descr = _cusparse.spSM_createDescr()
-    alpha = _numpy.array(alpha, dtype=c.dtype).ctypes
-    cuda_dtype = _dtype.to_cuda_dtype(c.dtype)
-    algo = _cusparse.CUSPARSE_SPSM_ALG_DEFAULT
-
-    try:
-        # Specify Lower|Upper fill mode
-        mat_a.set_attribute(_cusparse.CUSPARSE_SPMAT_FILL_MODE, fill_mode)
-
-        # Specify Unit|Non-Unit diagonal type
-        mat_a.set_attribute(_cusparse.CUSPARSE_SPMAT_DIAG_TYPE, diag_type)
-
-        # Allocate the workspace needed by the succeeding phases
-        buff_size = _cusparse.spSM_bufferSize(
-            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc,
-            mat_c.desc, cuda_dtype, algo, spsm_descr)
-        buff = _cupy.empty(buff_size, dtype=_cupy.int8)
-
-        # Perform the analysis phase
-        _cusparse.spSM_analysis(
-            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc,
-            mat_c.desc, cuda_dtype, algo, spsm_descr, buff.data.ptr)
-
-        # Executes the solve phase
-        _cusparse.spSM_solve(
-            handle, op_a, op_b, alpha.data, mat_a.desc, mat_b.desc,
-            mat_c.desc, cuda_dtype, algo, spsm_descr, buff.data.ptr)
-
-        # Reshape back if B was a vector
-        if is_b_vector:
-            c = c.reshape(-1)
-
-        return c
-
-    finally:
-        # Destroy matrix/vector descriptors
-        _cusparse.spSM_destroyDescr(spsm_descr)
+    return SpSM(a, alpha=alpha, lower=lower, unit_diag=unit_diag,
+                transa=transa).solve(b)
 
 
 def _cupy_spgemm_int64(a, b, alpha):

--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -587,8 +587,21 @@ class SuperLU:
             raise ValueError('trans must be \'N\', \'T\', or \'H\'')
 
         if cusparse.check_availability('spsm') and _should_use_spsm():
+            # Reuse the cusparseSpSM analysis across solve() calls: it
+            # depends only on the factor and the rhs shape/layout, and it
+            # dominates the cost of a one-shot solve (see #8580). Fetched
+            # lazily because subclasses do not call SuperLU.__init__.
+            cache = getattr(self, '_spsm_cache', None)
+            if cache is None:
+                cache = self._spsm_cache = {}
+
             def spsm(A, B, lower, transa):
-                return cusparse.spsm(A, B, lower=lower, transa=transa)
+                key = (lower, transa)
+                solver = cache.get(key)
+                if solver is None:
+                    solver = cache[key] = cusparse.SpSM(
+                        A, lower=lower, transa=transa)
+                return solver.solve(B)
             sm = spsm
         elif cusparse.check_availability('csrsm2'):
             def csrsm2(A, B, lower, transa):

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1454,6 +1454,44 @@ class TestSplu:
 
     @testing.for_dtypes('fdFD')
     @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_splu_solve_repeated(self, dtype, xp, sp):
+        # Subsequent solves reuse the cached cusparseSpSM analysis (#8580)
+        # and must agree with scipy just like the first one.
+        a, b = self._make_matrix(dtype, xp, sp)
+        lu = sp.linalg.splu(a)
+        x0 = lu.solve(b)
+        x1 = lu.solve(2 * b)
+        x2 = lu.solve(b - x1)
+        return x0, x1, x2
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_splu_solve_trans_interleaved(self, dtype, xp, sp):
+        # Each (factor, trans) pair keeps its own cached analysis; make
+        # sure interleaving them returns correct results throughout.
+        a, b = self._make_matrix(dtype, xp, sp)
+        lu = sp.linalg.splu(a)
+        results = []
+        for trans in ('N', 'T', 'H', 'N', 'T', 'H'):
+            results.append(lu.solve(b + len(results), trans=trans))
+        return results
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
+    def test_splu_solve_rhs_shape_change(self, dtype, xp, sp):
+        # Changing the rhs shape or layout between calls must re-run the
+        # cusparseSpSM analysis, then hit the cache again on the way back.
+        a, b = self._make_matrix(dtype, xp, sp)
+        b1 = b if b.ndim == 2 else b.reshape(-1, 1)
+        b2 = xp.concatenate([b1, 2 * b1], axis=1)
+        lu = sp.linalg.splu(a)
+        x0 = lu.solve(b)
+        x1 = lu.solve(b2)
+        x2 = lu.solve(b)
+        return x0, x1, x2
+
+    @testing.for_dtypes('fdFD')
+    @testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-5, sp_name='sp')
     def test_spilu(self, dtype, xp, sp):
         a, b = self._make_matrix(dtype, xp, sp)
         return sp.linalg.spilu(a).solve(b)

--- a/tests/cupyx_tests/test_cusparse.py
+++ b/tests/cupyx_tests/test_cusparse.py
@@ -1096,6 +1096,40 @@ class TestSpsm:
             tol = 1e-12
         testing.assert_allclose(lhs, rhs, rtol=tol, atol=tol)
 
+    def test_spsm_reuse(self, lower, unit_diag, transa, b_order, dtype,
+                        format):
+        # Solves after the first reuse the cached analysis (#8580); each
+        # must see the values of its own right-hand side.
+        if not cusparse.check_availability('spsm'):
+            pytest.skip('spsm is not available')
+        if runtime.is_hip:
+            if format == 'coo' or b_order == 'c':
+                pytest.skip('may be buggy or not supported')
+        a = self.sparse_matrix(self.a)
+        solver = cusparse.SpSM(
+            a, alpha=self.alpha, lower=lower, unit_diag=unit_diag,
+            transa=transa)
+
+        if transa == 'N':
+            op_a = self.op_a
+        elif transa == 'T':
+            op_a = self.op_a.T
+        else:
+            op_a = self.op_a.conj().T
+
+        if dtype in (cupy.float32, cupy.complex64):
+            tol = 1e-5
+        else:
+            tol = 1e-12
+
+        for k in range(3):
+            op_b = (k + 1) * self.op_b
+            b = cupy.array(op_b, order=b_order)
+            c = solver.solve(b)
+            lhs = op_a.dot(c.get())
+            testing.assert_allclose(
+                lhs, self.alpha * op_b, rtol=tol, atol=tol)
+
 
 class TestCheckAvailabilityVersionSkew:
     # Regression for the wheel-based CI: a wheel built against a newer


### PR DESCRIPTION
Fixes #8580.

## Problem

`cupyx.scipy.sparse.linalg.splu(...).solve(rhs)` is dramatically slower than SciPy's on repeated calls — the whole point of keeping a factorization — as reported in #8580 (~120x on the reporter's matrix).

The cause is visible in `cupyx.cusparse.spsm`: every call runs the full five-phase cuSPARSE sequence

```
spSM_createDescr -> spSM_bufferSize -> spSM_analysis -> spSM_solve -> spSM_destroyDescr
```

and `SuperLU.solve()` calls it twice (L then U). The `spSM_analysis` phase — the level scheduling of the triangular dependency DAG — depends only on the sparse factor, the operations, and the shape/layout of the right-hand side, *not on its values*, and it dominates the cost of a one-shot solve. NVIDIA's documented usage pattern is analyze once, solve many; CuPy paid the analysis on every solve and destroyed the result.

Credit where due: @pentschev's nsys trace located the time, @aloumakos identified the analysis phase as the dominant cost, and @kburns pointed at the documented analysis-reuse pattern. This PR implements that.

## Change

- New stateful `cupyx.cusparse.SpSM` class: runs `bufferSize` + `analysis` at the first `solve()`, and again only when the rhs shape/layout changes; subsequent solves rebind the B/C values with `cusparseDnMatSetValues` (the documented reuse mechanism) and go straight to `spSM_solve`.
- `cupyx.cusparse.spsm()` becomes a thin one-shot wrapper over the class, so its behavior is unchanged and the existing `TestSpsm` matrix (format x transa x layout x dtype) exercises the new code path as-is.
- `SuperLU.solve()` keeps one `SpSM` per (factor, trans) pair in a lazy per-object cache (lazy because `CusparseLU` does not call `SuperLU.__init__`). `factorized()` and `spilu()` inherit the fix.
- The `csrsm2` (HIP) path is untouched.

Memory note: the cache holds the cuSPARSE workspace per (factor, trans, rhs-shape) for the lifetime of the `SuperLU` object — the same lifetime users already accept for the factors themselves.

## Results (A100, H200, L40S; float64, steady-state per-solve)

Measured with this change overlaid on the v14.1.1 pip wheel (CUDA 12). Two regimes, deliberately:

- `poisson2d` (n=90k five-point Laplacian): genuinely sparse factors — the regime of the follow-up report in #8580 (repeated solves of a very sparse factorization spending their time in the analysis).
- `random-d05` (n=3000, density 0.5): the original report's setup — near-dense factors, analysis catastrophically slow. Included for fidelity to the report; such matrices should really use a dense solver.

K = number of right-hand sides per solve.

| case | K | A100 stock→patched | H200 stock→patched | L40S stock→patched |
|---|---|---|---|---|
| poisson2d | 1 | 373→23.1 ms (**16.2x**) | 350→23.4 ms (**15.0x**) | 203→19.4 ms (**10.5x**) |
| poisson2d | 8 | 355→38.0 ms (**9.3x**) | 362→35.2 ms (**10.3x**) | 211→31.2 ms (**6.8x**) |
| random-d05 | 1 | 863→48.3 ms (**17.9x**) | 815→47.4 ms (**17.2x**) | 500→39.0 ms (**12.8x**) |
| random-d05 | 8 | 900→85.3 ms (**10.6x**) | 836→79.0 ms (**10.6x**) | 527→65.7 ms (**8.0x**) |

Every timed solve was verified against SciPy's solution on all three GPUs. The first solve still pays the analysis, by design (unchanged, ~0.3–0.9 s depending on GPU/case); the win is every solve after it.

Two honest observations:

- The patched steady-state K=1 time is nearly architecture-independent (~19–23 ms poisson2d, ~39–48 ms random-d05 across all three GPUs): the remaining cost is the level-scheduled triangular solve and its launch chain, not memory bandwidth. Consequently the GPU-vs-CPU verdict at K=1 depends mostly on the host CPU — parity with `scipy` on two of the three hosts here, while the newest host CPU still wins single-rhs solves. The GPU pulls ahead with block right-hand sides.
- On the near-dense case the GPU remains behind the CPU even patched — that residual is the SpSM solve phase itself on ~48%-dense factors, which a dense-`trsm` fallback (measured much faster in the #8580 thread) would address; proposed as a possible follow-up, out of scope here.

## Tests

- `TestSpsm::test_spsm_reuse`: low-level — three solves through one `SpSM`, each right-hand side's values verified independently, across the full existing parameter matrix.
- `TestSplu::test_splu_solve_repeated`: repeated `solve()` vs scipy.
- `TestSplu::test_splu_solve_trans_interleaved`: interleaved 'N'/'T'/'H' — each (factor, trans) pair holds its own cached analysis.
- `TestSplu::test_splu_solve_rhs_shape_change`: 1-D -> wider 2-D -> 1-D forces re-analysis and then a cache hit again.

## Notes for review

- The one risk class here is descriptor/workspace lifetime: the `SpSM` object owns the descriptors, the workspace, and a reference to the matrix (the cuSPARSE descriptor stores raw device pointers), so nothing the analysis depends on can be freed or pool-recycled under it. The matrix must not be modified in place while the object is alive; for `SuperLU` the factors are private and never mutated.
- `cusparseSpSM_updateMatrix` (CUDA >= 12.1) could additionally support in-place value updates of the factor without re-analysis; not needed for `SuperLU` (factors are immutable), left out to keep the surface minimal.

