### PR TITLE
Restore cupyx.scipy.linalg.kron and cupyx.scipy.special.sph_harm

### DIFF
--- a/cupyx/scipy/linalg/__init__.py
+++ b/cupyx/scipy/linalg/__init__.py
@@ -1,7 +1,7 @@
 # flake8: NOQA
 from cupyx.scipy.linalg._special_matrices import (
     toeplitz, circulant, hankel,
-    hadamard, leslie, block_diag, companion,
+    hadamard, leslie, kron, block_diag, companion,
     helmert, hilbert, dft,
     fiedler, fiedler_companion, convolution_matrix
 )

--- a/cupyx/scipy/linalg/_special_matrices.py
+++ b/cupyx/scipy/linalg/_special_matrices.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 
 import cupy
 from cupy import _core
@@ -159,6 +160,36 @@ def leslie(f, s):
     a[0] = f
     cupy.fill_diagonal(a[1:], s)
     return a
+
+
+@_uarray.implements('kron')
+def kron(a, b):
+    """Kronecker product.
+
+    The result is the block matrix::
+        a[0,0]*b    a[0,1]*b  ... a[0,-1]*b
+        a[1,0]*b    a[1,1]*b  ... a[1,-1]*b
+        ...
+        a[-1,0]*b   a[-1,1]*b ... a[-1,-1]*b
+
+    Args:
+        a (cupy.ndarray): Input array
+        b (cupy.ndarray): Input array
+
+    Returns:
+        cupy.ndarray: Kronecker product of ``a`` and ``b``.
+
+    .. seealso:: :func:`scipy.linalg.kron`
+    """
+    warnings.warn(
+        '`cupyx.scipy.linalg.kron` has been deprecated in CuPy v14 and will '
+        'be removed in the near future. Please use `cupy.kron` instead.',
+        DeprecationWarning,
+    )
+
+    o = cupy.outer(a, b)
+    o = o.reshape(a.shape + b.shape)
+    return cupy.concatenate(cupy.concatenate(o, axis=1), axis=1)
 
 
 @_uarray.implements('block_diag')

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -84,6 +84,7 @@ from cupyx.scipy.special._erf import erfcinv  # NOQA
 
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA
+from cupyx.scipy.special._sph_harm import sph_harm  # NOQA
 from cupyx.scipy.special._sph_harm import sph_harm_y  # NOQA
 
 # Other special functions

--- a/cupyx/scipy/special/_sph_harm.py
+++ b/cupyx/scipy/special/_sph_harm.py
@@ -7,6 +7,8 @@ https://github.com/scipy/scipy/blob/master/scipy/special/sph_harm.pxd
 from __future__ import annotations
 
 
+import warnings
+
 from cupy import _core
 
 from cupyx.scipy.special._poch import poch_definition
@@ -84,6 +86,20 @@ _sph_harm = _core.create_ufunc(
 
     """,
 )
+
+
+def sph_harm(m, n, theta, phi, out=None):
+    """Spherical Harmonic.
+
+    .. seealso:: :meth:`scipy.special.sph_harm`
+
+    """
+
+    warnings.warn(DeprecationWarning(
+        "`cupyx.scipy.special.sph_harm` is deprecated in CuPy v14 "
+        "and are planned to be removed in the future."))
+
+    return _sph_harm(m, n, theta, phi, out=out)
 
 
 def sph_harm_y(n, m, theta, phi, *, diff_n=0):

--- a/docs/source/reference/scipy_linalg.rst
+++ b/docs/source/reference/scipy_linalg.rst
@@ -12,6 +12,7 @@ Basics
    :toctree: generated/
 
    solve_triangular
+   kron
    khatri_rao
    bandwidth
 

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -147,7 +147,7 @@ Legendre functions
    :toctree: generated/
 
    lpmv
-   sph_harm_y
+   sph_harm
 
 
 Lambert W and related functions

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 from cupy import testing
 import cupyx.scipy.linalg  # NOQA
@@ -49,6 +50,10 @@ class TestSpecialMatricesBase(unittest.TestCase):
         'function': ['dft'],
         'args': [(4, 'sqrtn'), (5, 'n')],
     }) + testing.product({
+        # 2 arguments: both 2D arrays
+        'function': ['kron'],
+        'args': [((5, 5), (4, 5),), ((5, 4), (4, 4),), ((1, 2), (4, 5))],
+    }) + testing.product({
         # 0 or more arguments: all 1 or 2D arrays
         'function': ['block_diag'],
         'args': [(), ((5,),), ((4, 5),), ((5,), (4, 4),), ((1, 2), (4, 5)),
@@ -61,7 +66,13 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
                                  accept_error=ValueError)
     def test_special_matrix(self, xp, scp):
         function = getattr(scp.linalg, self.function)
-        return function(*[self._get_arg(xp, arg) for arg in self.args])
+
+        if self.function == "kron":
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=DeprecationWarning)
+                return function(*[self._get_arg(xp, arg) for arg in self.args])
+        else:
+            return function(*[self._get_arg(xp, arg) for arg in self.args])
 
 
 @testing.parameterize(*(

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_special_matrices.py
@@ -65,6 +65,8 @@ class TestSpecialMatrices(TestSpecialMatricesBase):
     @testing.numpy_cupy_allclose(atol=1e-5, rtol=1e-5, scipy_name='scp',
                                  accept_error=ValueError)
     def test_special_matrix(self, xp, scp):
+        if self.function == "kron" and not testing.installed("scipy<1.17"):
+            self.skipTest("scipy.linalg.kron was removed in scipy 1.17")
         function = getattr(scp.linalg, self.function)
 
         if self.function == "kron":

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
@@ -4,8 +4,12 @@ from cupy import testing
 import cupyx.scipy.linalg._uarray
 
 
-@testing.with_requires('scipy<1.17')
+@testing.with_requires('scipy')
 def test_implements_names():
     # With the newest SciPy, the decorator `@implements` must find the
     # matching scipy functions.
-    assert not cupyx.scipy.linalg._uarray._notfound
+    notfound = list(cupyx.scipy.linalg._uarray._notfound)
+    if not testing.installed('scipy<1.17'):
+        # scipy 1.17 removed scipy.linalg.kron; cupyx.scipy.linalg.kron stays.
+        notfound = [n for n in notfound if n != 'kron']
+    assert not notfound

--- a/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
+++ b/tests/cupyx_tests/scipy_tests/linalg_tests/test_uarray.py
@@ -4,7 +4,7 @@ from cupy import testing
 import cupyx.scipy.linalg._uarray
 
 
-@testing.with_requires('scipy')
+@testing.with_requires('scipy<1.17')
 def test_implements_names():
     # With the newest SciPy, the decorator `@implements` must find the
     # matching scipy functions.

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -20,6 +20,16 @@ def _get_harmonic_list(degree_max):
 @testing.with_requires("scipy")
 class TestBasic:
 
+    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+    @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
+    @testing.for_dtypes(["e", "f", "d"])
+    @numpy_cupy_allclose(scipy_name="scp", rtol=1e-7, atol=1e-10)
+    def test_sph_harm(self, xp, scp, dtype, m, n):
+        theta = xp.linspace(0, 2 * cp.pi)
+        phi = xp.linspace(0, cp.pi)
+        theta, phi = xp.meshgrid(theta, phi)
+        return scp.special.sph_harm(m, n, theta, phi)
+
     @testing.with_requires("scipy>=1.15.0")
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_sph_harm.py
@@ -20,6 +20,7 @@ def _get_harmonic_list(degree_max):
 @testing.with_requires("scipy")
 class TestBasic:
 
+    @testing.with_requires("scipy<1.17")
     @pytest.mark.filterwarnings('ignore::DeprecationWarning')
     @pytest.mark.parametrize("m, n", _get_harmonic_list(degree_max=5))
     @testing.for_dtypes(["e", "f", "d"])


### PR DESCRIPTION
Reverts #9647 and #9649; applies #10198.

Refs #10221 (we want to keep the main branch non-breaking throughout the v14.x development cycles).