### PR TITLE
CI: build pyenv Python interpreters with --disable-shared

### DIFF
--- a/.pfnci/generate.py
+++ b/.pfnci/generate.py
@@ -230,7 +230,8 @@ class LinuxGenerator:
             'RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv',
             'ENV PYENV_ROOT "/opt/pyenv"',
             'ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"',
-            f'RUN pyenv install {py_spec} && \\',
+            f'RUN PYTHON_CONFIGURE_OPTS="--disable-shared"'
+            f' pyenv install {py_spec} && \\',
             f'    pyenv global {py_spec} && \\',
             '    pip install -U setuptools pip wheel && \\',
             # For GCP kernel cache backend

--- a/.pfnci/linux/tests/actions/_environment.sh
+++ b/.pfnci/linux/tests/actions/_environment.sh
@@ -31,6 +31,13 @@ fi
 # Add PATH for commands installed via `pip install --user`
 export PATH="${HOME}/.local/bin:${PATH}"
 
+# Confirm the interpreter was built with --disable-shared (static libpython),
+# as set by .pfnci/generate.py on the pyenv install line. Py_ENABLE_SHARED=0
+# and no libpython in ldd mean the flag took effect; if pyenv silently
+# dropped it, Py_ENABLE_SHARED=1 and a libpython3.x.so line will appear.
+python3 -c 'import sysconfig; print("Py_ENABLE_SHARED=" + str(sysconfig.get_config_var("Py_ENABLE_SHARED")))'
+ldd "$(readlink -f "$(command -v python3)")" | grep -i 'libpython' || echo 'no libpython in ldd (static interpreter)'
+
 # Switch to a temporary directory to run tests
 if [[ ${SHELL_MODE:-no} != yes ]]; then
     _src_dir="$(mktemp -d)"

--- a/.pfnci/linux/tests/benchmark.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/benchmark.head.Dockerfile
+++ b/.pfnci/linux/tests/benchmark.head.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda-example.Dockerfile
+++ b/.pfnci/linux/tests/cuda-example.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda-head.Dockerfile
+++ b/.pfnci/linux/tests/cuda-head.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda-slow.Dockerfile
+++ b/.pfnci/linux/tests/cuda-slow.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda120.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.10.18 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.10.18 && \
     pyenv global 3.10.18 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda120.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda120.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.10.18 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.10.18 && \
     pyenv global 3.10.18 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda121.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda121.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda121.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda122.Dockerfile
+++ b/.pfnci/linux/tests/cuda122.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda122.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda122.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda123.Dockerfile
+++ b/.pfnci/linux/tests/cuda123.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda123.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda123.multi.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda124.Dockerfile
+++ b/.pfnci/linux/tests/cuda124.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda124.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda124.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda125.Dockerfile
+++ b/.pfnci/linux/tests/cuda125.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda125.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda125.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda126.Dockerfile
+++ b/.pfnci/linux/tests/cuda126.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.13.8 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.13.8 && \
     pyenv global 3.13.8 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda126.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda126.multi.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.13.8 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.13.8 && \
     pyenv global 3.13.8 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda128.Dockerfile
+++ b/.pfnci/linux/tests/cuda128.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda128.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda128.multi.Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda129.Dockerfile
+++ b/.pfnci/linux/tests/cuda129.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/12:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda129.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda129.multi.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/12:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda12x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda12x-cuda-python.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.12.11 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.12.11 && \
     pyenv global 3.12.11 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda130.Dockerfile
+++ b/.pfnci/linux/tests/cuda130.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda130.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda130.multi.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda131.Dockerfile
+++ b/.pfnci/linux/tests/cuda131.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda131.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda131.multi.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda132.Dockerfile
+++ b/.pfnci/linux/tests/cuda132.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda132.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda132.multi.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda133.Dockerfile
+++ b/.pfnci/linux/tests/cuda133.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda133.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda133.multi.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda13x-cuda-python.Dockerfile
+++ b/.pfnci/linux/tests/cuda13x-cuda-python.Dockerfile
@@ -27,7 +27,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/13:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14.6 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pyenv global 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/cuda13x-py314t.Dockerfile
+++ b/.pfnci/linux/tests/cuda13x-py314t.Dockerfile
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.14t && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14t && \
     pyenv global 3.14t && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage

--- a/.pfnci/linux/tests/rocm-7-14.Dockerfile
+++ b/.pfnci/linux/tests/rocm-7-14.Dockerfile
@@ -33,7 +33,7 @@ ENV LDFLAGS "-L${ROCM_HOME}/lib"
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-RUN pyenv install 3.11.13 && \
+RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.11.13 && \
     pyenv global 3.11.13 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage


### PR DESCRIPTION
## Summary

CI Linux Dockerfiles are generated by `.pfnci/generate.py`. Each generated Dockerfile uses `pyenv` to build CPython from source. By default pyenv passes `--enable-shared`, producing a `libpython3.x.so` that is loaded via the dynamic
linker.

On glibc ≤ 2.38 (e.g. Ubuntu 22.04, used in current CUDA base images), any `dlopen` of a TLS-bearing shared library can push the global TLS generation counter ahead of the thread's DTV. CPython's hot thread-local `_Py_tss_tstate` lives in `libpython` and therefore uses the global-dynamic TLS model, meaning every access goes through `__tls_get_addr`. After a large batch of `dlopen`s (e.g. importing `nvmath.bindings` pulls in ~120 extra `.so`s), the DTV falls permanently behind and `__tls_get_addr` takes the slow path on every call for the life of the thread. This is [glibc BZ #19924] https://sourceware.org/bugzilla/show_bug.cgi?id=19924), fixed in glibc 2.39.

Building the interpreter with `--disable-shared` (`Py_ENABLE_SHARED=0`) embeds libpython in the executable. The linker emits **local-exec** TLS for `_Py_tss_tstate` — `__tls_get_addr` is never called and the slow path cannot be triggered. Measured on glibc 2.35: bare device-allocation ops go from ~1.5× overhead (shared) to ~1.0× (static); aggregate CI runtime on the `cuda13x-cuda-python` target is ~9–10% slower today and is expected to return to parity.

## Change

One line in the generator (`generate.py`), then regenerate:

```diff
-f'RUN pyenv install {py_spec} && \',
+f'RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install {py_spec} && \',
```