### PR TITLE
Address casting negative stride as unsigned int in dlpack

### DIFF
--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -262,6 +262,7 @@ cdef object _toDlpack(
 
     # Fill in the shape and strides information (depends on GPU vs CPU array).
     # (assumes strides are a multiple of itemsize, that should be OK for cupy.)
+    cdef itemsize = <int64_t>dtype_itemsize
     if owner is array:
         dl_tensor.data = <void *><intptr_t>(array.data.ptr)
 
@@ -269,8 +270,7 @@ cdef object _toDlpack(
             shape_strides[n] = array._shape[n]
 
         for n in range(ndim):
-            shape_strides[n + ndim] = (
-                array._strides[n] // <int64_t>dtype_itemsize)
+            shape_strides[n + ndim] = array._strides[n] // itemsize
     else:
         # Same as above, but we got a NumPy array, so go through Python
         # in the off-chance that the copy has changed the strides.
@@ -282,8 +282,7 @@ cdef object _toDlpack(
             shape_strides[n] = shape[n]
 
         for n in range(ndim):
-            shape_strides[n + ndim] = (
-                strides[n] // <int64_t>dtype_itemsize)
+            shape_strides[n + ndim] = strides[n] // itemsize
 
     return capsule
 

--- a/cupy/_core/dlpack.pyx
+++ b/cupy/_core/dlpack.pyx
@@ -269,7 +269,8 @@ cdef object _toDlpack(
             shape_strides[n] = array._shape[n]
 
         for n in range(ndim):
-            shape_strides[n + ndim] = array._strides[n] // dtype_itemsize
+            shape_strides[n + ndim] = (
+                array._strides[n] // <int64_t>dtype_itemsize)
     else:
         # Same as above, but we got a NumPy array, so go through Python
         # in the off-chance that the copy has changed the strides.
@@ -281,7 +282,8 @@ cdef object _toDlpack(
             shape_strides[n] = shape[n]
 
         for n in range(ndim):
-            shape_strides[n + ndim] = strides[n] // dtype_itemsize
+            shape_strides[n + ndim] = (
+                strides[n] // <int64_t>dtype_itemsize)
 
     return capsule
 

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -355,7 +355,8 @@ class TestDLTensorMemory:
 
 class TestDLTensorContent:
     @pytest.fixture(scope='class')
-    def configure(self):
+    @classmethod
+    def configure(cls):
         arr = _gen_array("uint32")
         arr_flip = cupy.transpose(cupy.flip(arr, axis=1), (1, 0))
         info = _inspect_dlpack(arr_flip.__dlpack__())

--- a/tests/cupy_tests/core_tests/test_dlpack.py
+++ b/tests/cupy_tests/core_tests/test_dlpack.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import ctypes
+
 import numpy
 import pytest
 
 import cupy
 from cupy import cuda
 from cupy import testing
+
+ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
+ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [
+    ctypes.py_object, ctypes.c_char_p]
 
 
 def _gen_array(dtype):
@@ -29,6 +35,33 @@ def _gen_array(dtype):
     return array
 
 
+def _inspect_dlpack(capsule):
+    ptr = ctypes.pythonapi.PyCapsule_GetPointer(capsule, b"dltensor")
+    managed = ctypes.cast(
+        ptr, ctypes.POINTER(DLManagedTensor)).contents
+    tensor = managed.dl_tensor
+
+    shape = [tensor.shape[i] for i in range(tensor.ndim)]
+    strides = None
+    if tensor.strides:
+        strides = [tensor.strides[i] for i in range(tensor.ndim)]
+
+    return {
+        "data": tensor.data,
+        "device_type": tensor.device.device_type,
+        "device_id": tensor.device.device_id,
+        "ndim": tensor.ndim,
+        "dtype": {
+            "code": tensor.dtype.code,
+            "bits": tensor.dtype.bits,
+            "lanes": tensor.dtype.lanes,
+        },
+        "shape": shape,
+        "strides": strides,
+        "byte_offset": tensor.byte_offset,
+    }
+
+
 class DLDummy:
     """Dummy object to wrap a __dlpack__ capsule, so we can use from_dlpack.
     """
@@ -42,6 +75,41 @@ class DLDummy:
 
     def __dlpack_device__(self):
         return self.device
+
+
+class DLDevice(ctypes.Structure):
+    _fields_ = [
+        ("device_type", ctypes.c_int32),
+        ("device_id", ctypes.c_int32),
+    ]
+
+
+class DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", DLDevice),
+        ("ndim", ctypes.c_int32),
+        ("dtype", DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class DLManagedTensor(ctypes.Structure):
+    _fields_ = [
+        ("dl_tensor", DLTensor),
+        ("manager_ctx", ctypes.c_void_p),
+        ("deleter", ctypes.c_void_p),
+    ]
 
 
 class TestDLPackConversion:
@@ -283,3 +351,18 @@ class TestDLTensorMemory:
         assert 'consumed multiple times' in str(e.value)
         for w in recwarn:
             assert issubclass(w.category, cupy.VisibleDeprecationWarning)
+
+
+class TestDLTensorContent:
+    @pytest.fixture(scope='class')
+    def configure(self):
+        arr = _gen_array("uint32")
+        arr_flip = cupy.transpose(cupy.flip(arr, axis=1), (1, 0))
+        info = _inspect_dlpack(arr_flip.__dlpack__())
+        yield arr_flip, info
+
+    def test_strides(self, configure):
+        arr, dlpack_interface = configure
+        array_strides = tuple(s // arr.itemsize for s in arr.strides)
+        dlpack_strides = tuple(dlpack_interface["strides"])
+        assert array_strides == dlpack_strides


### PR DESCRIPTION
Fixes #10172

Right now, `ndarray.__dlpack__` strides is incorrect because of this [line](https://github.com/cupy/cupy/blob/main/cupy/_core/dlpack.pyx#L270). The `dtype_itemsize` variable is of type `size_t`, which is unsigned. Since it's dividing a negative value with an unsigned one to calculate the stride, C/C++ arithmetic automatically treats the negative value as unsigned, resulting in this kind of arithmetic to give one the 4611686018427387903  that is currently seen: `(-4 + 2**64) // 4`.

Numpy doesn't experience this issue because their itemsize variable [here](https://github.com/numpy/numpy/blob/main/numpy/_core/src/multiarray/dlpack.c#L352) is of npy_intp type.