### PR TITLE
CI: build wheels from an in-tree sdist; enable linux-aarch64

### DIFF
--- a/.github/workflows/build-sdist.yml
+++ b/.github/workflows/build-sdist.yml
@@ -1,0 +1,77 @@
+name: Build CuPy sdist
+
+# Producer of `cupy-<version>.tar.gz`, the source distribution consumed by
+# `build-wheel.yml` (per-variant wheels build from this sdist, not from a
+# fresh checkout -- so a MANIFEST.in gap fails the CI wheel build, not a
+# downstream user). The same tarball is what publish.yml uploads to PyPI.
+#
+# Design notes:
+#   * ``submodules: recursive`` at checkout materializes third_party/
+#     submodules. setuptools resolves the vendored-header symlinks under
+#     ``cupy/_core/include/cupy/{_cccl,xsf,_jitify,_dlpack}`` and packs the
+#     real files into the tarball, so downstream wheel builds (including
+#     Windows) get portable, symlink-free source.
+#   * CUPY_INSTALL_USE_STUB=1 skips CUDA extension detection during the
+#     sdist build (see install/cupy_builder/_context.py).
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out (e.g. refs/pull/N/merge, or a merge_commit_sha)"
+        required: true
+        type: string
+      artifact-suffix:
+        description: "Suffix keying the sdist artifact name (pr<N>-<head sha> for /test builds, the push SHA post-merge)"
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -xeuo pipefail {0}
+
+permissions:
+  contents: read  # This is required for actions/checkout
+
+jobs:
+  build:
+    name: Build sdist
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout ${{ github.event.repository.name }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Python build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Prepare sdist build
+        run: python ci/tools/prepare_sdist_build.py >> "$GITHUB_ENV"
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Check sdist
+        run: twine check --strict dist/*.tar.gz
+
+      - name: List the dist contents
+        run: ls -lahR dist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cupy-sdist-${{ inputs.artifact-suffix }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          # Keep "re-run all jobs" viable: v4+ artifacts are immutable, so a
+          # second attempt's upload would otherwise collide and fail.
+          overwrite: true

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -12,11 +12,11 @@ on:
         required: true
         type: string
       ref:
-        description: "Git ref to check out (e.g. refs/pull/N/merge, or a merge_commit_sha)"
+        description: "Git ref to check out for the workflow-scoped files under .github/ + ci/ (e.g. refs/pull/N/merge, or a merge_commit_sha). The cupy source itself is unpacked from the sdist artifact -- NOT from this ref."
         required: true
         type: string
       artifact-suffix:
-        description: "Suffix keying the wheel artifact name (pr<N>-<head sha> for /test builds, the push SHA post-merge); what the test stage looks up"
+        description: "Suffix keying the wheel artifact name (pr<N>-<head sha> for /test builds, the push SHA post-merge); what the test stage looks up. The sdist artifact (cupy-sdist-<suffix>) MUST already exist under the same suffix."
         required: true
         type: string
 
@@ -40,13 +40,10 @@ jobs:
           - "3.14"
           - "3.14t"
     name: py${{ matrix.python-version }}
-    runs-on: ${{ (inputs.host-platform == 'linux-64' && 'ubuntu-22.04') ||
-                 (inputs.host-platform == 'win-64'   && 'windows-2022') }}
+    runs-on: ${{ (inputs.host-platform == 'linux-64'      && 'ubuntu-22.04')     ||
+                 (inputs.host-platform == 'linux-aarch64' && 'ubuntu-22.04-arm') ||
+                 (inputs.host-platform == 'win-64'        && 'windows-2022') }}
     steps:
-      - name: Enable symlinks on Windows (must precede checkout)
-        if: ${{ inputs.host-platform == 'win-64' }}
-        run: git config --global core.symlinks true
-
       - name: Verify LongPathsEnabled on Windows
         if: ${{ inputs.host-platform == 'win-64' }}
         shell: pwsh -command ". '{0}'"
@@ -58,12 +55,35 @@ jobs:
             exit 1
           }
 
-      - name: Checkout ${{ github.event.repository.name }}
+      # Sparse checkout of the workflow-scoped tree only: .github/actions/*
+      # (local action refs), ci/tools/*, ci/versions.yml, ci/ helper dirs.
+      # The cupy source (cupy/, cupyx/, cupy_backends/, install/,
+      # pyproject.toml, setup.py, MANIFEST.in, ...) comes from the sdist
+      # artifact, unpacked over the workspace in the next step -- guaranteeing
+      # that the wheel is built from the SAME bytes we'd publish to PyPI, so
+      # a MANIFEST.in gap fails this CI job (not a downstream user).
+      - name: Checkout workflow-scoped files
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
-          submodules: recursive
+          sparse-checkout: |
+            .github
+            ci
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5.0.0
+        with:
+          name: cupy-sdist-${{ inputs.artifact-suffix }}
+          path: ${{ runner.temp }}/sdist
+
+      # --strip-components=1 unpacks the sdist's ``cupy-<version>/`` root
+      # over the workspace, merging with the sparse checkout (which contains
+      # only .github/ + ci/ -- disjoint from sdist contents).
+      - name: Unpack sdist into workspace
+        run: |
+          tar -xf "${RUNNER_TEMP}/sdist"/cupy-*.tar.gz --strip-components=1
+          ls -lah pyproject.toml setup.py MANIFEST.in cupy cupyx cupy_backends install 2>/dev/null
 
       # Linux + free-threaded Python (e.g. 3.14t) blows the ~14 GiB default
       # runner disk during NVCC compilation -- the free-threaded ABI can't share
@@ -172,25 +192,31 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,cuda_cuxxfilt,libnvvm,cuda_nvrtc,cuda_nvtx,cuda_profiler_api,cuda_cccl,libnvjitlink,libcublas,libcufft,libcurand,libcusparse,libcusolver"
 
+      # cuTENSOR redist ships linux-x86_64, windows-x86_64 only; there is no
+      # linux-sbsa asset, so the linux-aarch64 wheel skips it and preloads
+      # NCCL only (matches cupy-release-tools' historical aarch64 config).
       - name: Install cuTENSOR preload
+        if: ${{ inputs.host-platform != 'linux-aarch64' }}
         run: |
           python cupyx/tools/install_library.py \
             --library cutensor --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
             --arch x86_64 --prefix ./preloads --action install
 
       - name: Install NCCL preload (Linux only)
-        if: ${{ inputs.host-platform == 'linux-64' }}
+        if: ${{ startsWith(inputs.host-platform, 'linux-') }}
+        env:
+          INSTALL_LIB_ARCH: ${{ (inputs.host-platform == 'linux-aarch64' && 'aarch64') || 'x86_64' }}
         run: |
           python cupyx/tools/install_library.py \
             --library nccl --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
-            --arch x86_64 --prefix ./preloads --action install
+            --arch "${INSTALL_LIB_ARCH}" --prefix ./preloads --action install
 
       - name: Prepare wheel build (Linux)
-        if: ${{ inputs.host-platform == 'linux-64' }}
+        if: ${{ startsWith(inputs.host-platform, 'linux-') }}
         run: |
           python ci/tools/prepare_wheel_build.py \
             --cuda-major ${{ env.BUILD_CUDA_MAJOR }} \
-            --host-platform linux \
+            --host-platform ${{ inputs.host-platform }} \
             --root-prefix /project >> "$GITHUB_ENV"
 
       - name: Prepare wheel build (Windows)
@@ -198,7 +224,7 @@ jobs:
         run: |
           python ci/tools/prepare_wheel_build.py \
             --cuda-major ${{ env.BUILD_CUDA_MAJOR }} \
-            --host-platform win >> "$GITHUB_ENV"
+            --host-platform win-64 >> "$GITHUB_ENV"
 
       - name: Build cupy-cuda${{ env.BUILD_CUDA_MAJOR }}x wheel
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
@@ -207,6 +233,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_ENVIRONMENT_PASS_LINUX: >
             CUPY_INSTALL_NO_RPATH
             CUPY_INSTALL_LONG_DESCRIPTION

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -192,15 +192,13 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           cuda-components: "cuda_nvcc,cuda_cudart,cuda_crt,cuda_cuxxfilt,libnvvm,cuda_nvrtc,cuda_nvtx,cuda_profiler_api,cuda_cccl,libnvjitlink,libcublas,libcufft,libcurand,libcusparse,libcusolver"
 
-      # cuTENSOR redist ships linux-x86_64, windows-x86_64 only; there is no
-      # linux-sbsa asset, so the linux-aarch64 wheel skips it and preloads
-      # NCCL only (matches cupy-release-tools' historical aarch64 config).
       - name: Install cuTENSOR preload
-        if: ${{ inputs.host-platform != 'linux-aarch64' }}
+        env:
+          INSTALL_LIB_ARCH: ${{ (inputs.host-platform == 'linux-aarch64' && 'aarch64') || 'x86_64' }}
         run: |
           python cupyx/tools/install_library.py \
             --library cutensor --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
-            --arch x86_64 --prefix ./preloads --action install
+            --arch "${INSTALL_LIB_ARCH}" --prefix ./preloads --action install
 
       - name: Install NCCL preload (Linux only)
         if: ${{ startsWith(inputs.host-platform, 'linux-') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -77,13 +77,22 @@ jobs:
           name: cupy-sdist-${{ inputs.artifact-suffix }}
           path: ${{ runner.temp }}/sdist
 
-      # --strip-components=1 unpacks the sdist's ``cupy-<version>/`` root
-      # over the workspace, merging with the sparse checkout (which contains
-      # only .github/ + ci/ -- disjoint from sdist contents).
-      - name: Unpack sdist into workspace
+      # The sdist unpacks into ./srcpkg/ (a subdirectory, NOT the workspace
+      # root). This keeps the sparse checkout's .git/ + .github/ + ci/
+      # separate from the sdist tree, so cupy_builder/_preflight.py sees a
+      # normal sdist unpack (no .git under source_root -> third_party/
+      # submodules not required). Everything the wheel build touches --
+      # source, mini-CTK, preloads, generated metadata -- lives under
+      # ./srcpkg/, so cibuildwheel's package-dir mount = /project inside
+      # the container is self-contained.
+      # --strip-components=1 drops the sdist's leading ``cupy-<version>/``.
+      # --force-local stops Git Bash's tar on Windows from parsing the
+      # runner-temp drive letter (``D:\a\_temp``) as an SSH ``host:path``.
+      - name: Unpack sdist into ./srcpkg
         run: |
-          tar -xf "${RUNNER_TEMP}/sdist"/cupy-*.tar.gz --strip-components=1
-          ls -lah pyproject.toml setup.py MANIFEST.in cupy cupyx cupy_backends install 2>/dev/null
+          mkdir -p srcpkg
+          tar --force-local -xf "${RUNNER_TEMP}/sdist"/cupy-*.tar.gz -C srcpkg --strip-components=1
+          ls -lah srcpkg/pyproject.toml srcpkg/setup.py srcpkg/MANIFEST.in srcpkg/cupy srcpkg/cupyx srcpkg/cupy_backends srcpkg/install 2>/dev/null
 
       # Linux + free-threaded Python (e.g. 3.14t) blows the ~14 GiB default
       # runner disk during NVCC compilation -- the free-threaded ABI can't share
@@ -184,6 +193,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install tomli_w pyyaml twine
 
+      # mini-CTK stays at workspace root (./cuda_toolkit) -- cibuildwheel
+      # only copies srcpkg/ into /project, so the container reaches it
+      # through the /host mount (see CUDA_PATH in CIBW_ENVIRONMENT_LINUX
+      # below), same pattern the sccache binary already uses.
       - name: Set up mini CTK
         uses: ./.github/actions/fetch_ctk
         continue-on-error: false
@@ -196,33 +209,43 @@ jobs:
         env:
           INSTALL_LIB_ARCH: ${{ (inputs.host-platform == 'linux-aarch64' && 'aarch64') || 'x86_64' }}
         run: |
-          python cupyx/tools/install_library.py \
+          python srcpkg/cupyx/tools/install_library.py \
             --library cutensor --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
-            --arch "${INSTALL_LIB_ARCH}" --prefix ./preloads --action install
+            --arch "${INSTALL_LIB_ARCH}" --prefix ./srcpkg/preloads --action install
 
       - name: Install NCCL preload (Linux only)
         if: ${{ startsWith(inputs.host-platform, 'linux-') }}
         env:
           INSTALL_LIB_ARCH: ${{ (inputs.host-platform == 'linux-aarch64' && 'aarch64') || 'x86_64' }}
         run: |
-          python cupyx/tools/install_library.py \
+          python srcpkg/cupyx/tools/install_library.py \
             --library nccl --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
-            --arch "${INSTALL_LIB_ARCH}" --prefix ./preloads --action install
+            --arch "${INSTALL_LIB_ARCH}" --prefix ./srcpkg/preloads --action install
 
-      # --root-prefix /project re-anchors the emitted CUPY_INCLUDE_PATH /
-      # CUPY_LIBRARY_PATH under cibuildwheel's manylinux container mount;
-      # Windows builds run natively (no container) so the host paths are
-      # used verbatim -- hence the linux-only flag.
+      # --source-root ./srcpkg points prepare_wheel_build.py at the
+      # unpacked sdist tree so it rewrites srcpkg/pyproject.toml (not
+      # the sparse checkout at workspace root). --root-prefix
+      # /project/srcpkg re-anchors the emitted CUPY_INCLUDE_PATH /
+      # CUPY_LIBRARY_PATH / CUPY_INSTALL_LONG_DESCRIPTION /
+      # CUPY_INSTALL_WHEEL_METADATA to the in-container location:
+      # cibuildwheel copies the ENTIRE workspace to /project, then
+      # invokes `python -m build /project/srcpkg`, so srcpkg is at
+      # /project/srcpkg inside the container. Windows builds run
+      # natively (no container) so the host paths are used verbatim --
+      # hence the linux-only flag.
       - name: Prepare wheel build
         run: |
           python ci/tools/prepare_wheel_build.py \
             --cuda-major ${{ env.BUILD_CUDA_MAJOR }} \
             --host-platform ${{ inputs.host-platform }} \
-            ${{ startsWith(inputs.host-platform, 'linux-') && '--root-prefix /project' || '' }} >> "$GITHUB_ENV"
+            --source-root ./srcpkg \
+            --preload-dir ./srcpkg/preloads \
+            ${{ startsWith(inputs.host-platform, 'linux-') && '--root-prefix /project/srcpkg' || '' }} >> "$GITHUB_ENV"
 
       - name: Build cupy-cuda${{ env.BUILD_CUDA_MAJOR }}x wheel
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         with:
+          package-dir: ./srcpkg
           output-dir: wheelhouse
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
@@ -243,11 +266,11 @@ jobs:
           # define a platform block, so keep shared variables duplicated in
           # BOTH platform blocks below.
           CIBW_ENVIRONMENT_LINUX: >
-            CUDA_PATH=/project/cuda_toolkit
-            LIBRARY_PATH=/project/cuda_toolkit/lib64/stubs
+            CUDA_PATH=/host/${{ github.workspace }}/cuda_toolkit
+            LIBRARY_PATH=/host/${{ github.workspace }}/cuda_toolkit/lib64/stubs
             CC="/host/${{ env.SCCACHE_PATH }} cc"
             CXX="/host/${{ env.SCCACHE_PATH }} c++"
-            NVCC="/host/${{ env.SCCACHE_PATH }} /project/cuda_toolkit/bin/nvcc"
+            NVCC="/host/${{ env.SCCACHE_PATH }} /host/${{ github.workspace }}/cuda_toolkit/bin/nvcc"
             SCCACHE_GHA_ENABLED=true
             ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
             ACTIONS_RUNTIME_URL=${{ env.ACTIONS_RUNTIME_URL }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -209,20 +209,16 @@ jobs:
             --library nccl --cuda ${{ env.BUILD_CUDA_MAJOR }}.x \
             --arch "${INSTALL_LIB_ARCH}" --prefix ./preloads --action install
 
-      - name: Prepare wheel build (Linux)
-        if: ${{ startsWith(inputs.host-platform, 'linux-') }}
+      # --root-prefix /project re-anchors the emitted CUPY_INCLUDE_PATH /
+      # CUPY_LIBRARY_PATH under cibuildwheel's manylinux container mount;
+      # Windows builds run natively (no container) so the host paths are
+      # used verbatim -- hence the linux-only flag.
+      - name: Prepare wheel build
         run: |
           python ci/tools/prepare_wheel_build.py \
             --cuda-major ${{ env.BUILD_CUDA_MAJOR }} \
             --host-platform ${{ inputs.host-platform }} \
-            --root-prefix /project >> "$GITHUB_ENV"
-
-      - name: Prepare wheel build (Windows)
-        if: ${{ inputs.host-platform == 'win-64' }}
-        run: |
-          python ci/tools/prepare_wheel_build.py \
-            --cuda-major ${{ env.BUILD_CUDA_MAJOR }} \
-            --host-platform win-64 >> "$GITHUB_ENV"
+            ${{ startsWith(inputs.host-platform, 'linux-') && '--root-prefix /project' || '' }} >> "$GITHUB_ENV"
 
       - name: Build cupy-cuda${{ env.BUILD_CUDA_MAJOR }}x wheel
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,23 @@ jobs:
           cuda_prev_build_ver=$(yq '.cuda.prev_build.version' ci/versions.yml)
           echo "cuda_prev_build_ver=$cuda_prev_build_ver" >> $GITHUB_OUTPUT
 
+  # Producer of cupy-<version>.tar.gz for every wheel job below. Building
+  # wheels from the sdist (instead of a fresh checkout) makes the sdist the
+  # single source of truth for what ships to PyPI -- any MANIFEST.in gap
+  # fails this CI job, not a downstream user. Also eliminates the Windows
+  # vendored-submodule symlink handling (the sdist has real files).
+  build-sdist:
+    needs:
+      - guard
+    if: needs.guard.outputs.should_run == 'true'
+    permissions:
+      contents: read
+    name: Build sdist
+    uses: ./.github/workflows/build-sdist.yml
+    with:
+      ref: ${{ needs.guard.outputs.ref }}
+      artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
+
   # NOTE: Build jobs are intentionally split by platform rather than using a
   # single matrix. This allows each test job to depend only on its
   # corresponding build, so faster platforms can proceed through build & test
@@ -119,6 +136,7 @@ jobs:
     needs:
       - guard
       - ci-vars
+      - build-sdist
     if: needs.guard.outputs.should_run == 'true'
     # Bounds the reusable build to a checkout-only token (no secrets, no writes).
     permissions:
@@ -139,34 +157,37 @@ jobs:
       ref: ${{ needs.guard.outputs.ref }}
       artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
 
-  # TODO: enable once linux-64 + win-64 are green.
-  # # See build-linux-64 for why build jobs are split by platform.
-  # build-linux-aarch64:
-  #   needs:
-  #     - guard
-  #     - ci-vars
-  #   if: needs.guard.outputs.should_run == 'true'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       host-platform:
-  #         - linux-aarch64
-  #       cuda-version:
-  #         - ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
-  #         - ${{ needs.ci-vars.outputs.CUDA_PREV_BUILD_VER }}
-  #   name: Build ${{ matrix.host-platform }}, CUDA ${{ matrix.cuda-version }}
-  #   uses: ./.github/workflows/build-wheel.yml
-  #   with:
-  #     host-platform: ${{ matrix.host-platform }}
-  #     cuda-version: ${{ matrix.cuda-version }}
-  #     ref: ${{ needs.guard.outputs.ref }}
-  #     artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
+  # See build-linux-64 for why build jobs are split by platform.
+  build-linux-aarch64:
+    needs:
+      - guard
+      - ci-vars
+      - build-sdist
+    if: needs.guard.outputs.should_run == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        host-platform:
+          - linux-aarch64
+        cuda-version:
+          - ${{ needs.ci-vars.outputs.CUDA_BUILD_VER }}
+          - ${{ needs.ci-vars.outputs.CUDA_PREV_BUILD_VER }}
+    name: Build ${{ matrix.host-platform }}, CUDA ${{ matrix.cuda-version }}
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      host-platform: ${{ matrix.host-platform }}
+      cuda-version: ${{ matrix.cuda-version }}
+      ref: ${{ needs.guard.outputs.ref }}
+      artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
 
   # See build-linux-64 for why build jobs are split by platform.
   build-windows:
     needs:
       - guard
       - ci-vars
+      - build-sdist
     if: needs.guard.outputs.should_run == 'true'
     # Bounds the reusable build to a checkout-only token (no secrets, no writes).
     permissions:
@@ -198,8 +219,9 @@ jobs:
     needs:
       - guard
       - build-linux-64
+      - build-linux-aarch64
       - build-windows
-    if: github.event_name == 'pull_request' && needs.guard.outputs.should_run == 'true' && needs.build-linux-64.result == 'success' && needs.build-windows.result == 'success'
+    if: github.event_name == 'pull_request' && needs.guard.outputs.should_run == 'true' && needs.build-linux-64.result == 'success' && needs.build-linux-aarch64.result == 'success' && needs.build-windows.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Create sentinel
@@ -224,6 +246,7 @@ jobs:
     needs:
       - guard
       - build-linux-64
+      - build-linux-aarch64
       - build-windows
     if: github.event_name == 'push' && needs.guard.outputs.should_run == 'true'
     runs-on: ubuntu-22.04
@@ -264,6 +287,7 @@ jobs:
     needs:
       - guard
       - build-linux-64
+      - build-linux-aarch64
       - build-windows
       - build-sentinel
       - dispatch-flexci
@@ -280,9 +304,10 @@ jobs:
             fi
           }
 
-          check_result "guard"          "success" "${{ needs.guard.result }}"
-          check_result "build-linux-64" "success" "${{ needs.build-linux-64.result }}"
-          check_result "build-windows"  "success" "${{ needs.build-windows.result }}"
+          check_result "guard"               "success" "${{ needs.guard.result }}"
+          check_result "build-linux-64"      "success" "${{ needs.build-linux-64.result }}"
+          check_result "build-linux-aarch64" "success" "${{ needs.build-linux-aarch64.result }}"
+          check_result "build-windows"       "success" "${{ needs.build-windows.result }}"
           case "${{ github.event_name }}" in
           pull_request)
             check_result "build-sentinel"  "success" "${{ needs.build-sentinel.result }}"

--- a/ci/tools/prepare_sdist_build.py
+++ b/ci/tools/prepare_sdist_build.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Prepare the CuPy source tree for building an sdist (``cupy-<version>.tar.gz``).
+
+Writes ``description.rst`` (becomes the sdist's ``long_description``) and
+prints env vars (one per line, ``KEY=VALUE``) to stdout for the caller to
+append to ``$GITHUB_ENV`` or eval in a shell.
+
+Local reproduction::
+
+    python ci/tools/prepare_sdist_build.py >> .env
+    set -a; . ./.env; set +a
+    CUPY_INSTALL_USE_STUB=1 python -m build --sdist
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wheel_configs import SDIST_LONG_DESCRIPTION  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    description_path = REPO_ROOT / "description.rst"
+    description_path.write_text(SDIST_LONG_DESCRIPTION, encoding="utf-8")
+    print(f"CUPY_INSTALL_LONG_DESCRIPTION={description_path.resolve()}")
+    print("CUPY_INSTALL_USE_STUB=1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools/prepare_wheel_build.py
+++ b/ci/tools/prepare_wheel_build.py
@@ -19,7 +19,7 @@ Local reproduction::
 
     python cupyx/tools/install_library.py --library cutensor --cuda 13.x --arch x86_64 --prefix ./preloads --action install
     python cupyx/tools/install_library.py --library nccl     --cuda 13.x --arch x86_64 --prefix ./preloads --action install
-    python ci/tools/prepare_wheel_build.py --cuda-major 13 --host-platform linux >> .env
+    python ci/tools/prepare_wheel_build.py --cuda-major 13 --host-platform linux-64 >> .env
     set -a; . ./.env; set +a
     pip wheel .
 """
@@ -72,8 +72,9 @@ def write_long_description(cuda_major: str) -> Path:
 
 def generate_wheel_metadata(cuda_major: str, host_platform: str) -> Path:
     target_system = {
-        "linux": "Linux:x86_64",
-        "win": "Windows:x86_64",
+        "linux-64": "Linux:x86_64",
+        "linux-aarch64": "Linux:aarch64",
+        "win-64": "Windows:x86_64",
     }[host_platform]
 
     libraries = PRELOAD_LIBRARIES[cuda_major][host_platform]
@@ -139,8 +140,9 @@ def main(argv: list[str] | None = None) -> int:
         "--cuda-major", required=True, choices=sorted(WHEEL_PACKAGE_NAMES),
     )
     parser.add_argument(
-        "--host-platform", required=True, choices=("linux", "win"),
-        help="Build host: linux = Linux x86_64, win = Windows x86_64.",
+        "--host-platform", required=True,
+        choices=("linux-64", "linux-aarch64", "win-64"),
+        help="Build host: linux-64 = Linux x86_64, linux-aarch64 = Linux ARM64, win-64 = Windows x86_64.",
     )
     parser.add_argument(
         "--preload-dir", type=Path, default=Path("./preloads"),
@@ -163,7 +165,7 @@ def main(argv: list[str] | None = None) -> int:
         args.preload_dir, args.cuda_major, args.host_platform,
     )
 
-    sep = ";" if args.host_platform == "win" else ":"
+    sep = ";" if args.host_platform == "win-64" else ":"
     env_lines = [
         "CUPY_INSTALL_NO_RPATH=1",
         f"CUPY_INSTALL_LONG_DESCRIPTION={_apply_prefix(description_path, args.root_prefix)}",

--- a/ci/tools/prepare_wheel_build.py
+++ b/ci/tools/prepare_wheel_build.py
@@ -12,6 +12,11 @@ This script:
 * Prints env vars (one per line, ``KEY=VALUE``) to stdout for the caller to
   append to ``$GITHUB_ENV`` or eval in a shell.
 
+By default the source tree is the repository root (this script's
+``parents[2]``). Pass ``--source-root`` to operate on an unpacked sdist
+sitting in a subdirectory of the repo (the CI workflow does this so the
+sdist's ``.git``-less tree is what cibuildwheel and cupy_builder see).
+
 The caller is responsible for first running
 ``cupyx/tools/install_library.py`` to populate ``--preload-dir``.
 
@@ -46,12 +51,12 @@ from wheel_configs import (  # noqa: E402
     WHEEL_PACKAGE_NAMES,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE_ROOT = Path(__file__).resolve().parents[2]
 
 
-def rename_project(cuda_major: str) -> str:
+def rename_project(source_root: Path, cuda_major: str) -> str:
     """Rewrite ``project.name`` in ``pyproject.toml`` in place."""
-    pyproject = REPO_ROOT / "pyproject.toml"
+    pyproject = source_root / "pyproject.toml"
     package_name = WHEEL_PACKAGE_NAMES[cuda_major]
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     data["project"]["name"] = package_name
@@ -60,8 +65,8 @@ def rename_project(cuda_major: str) -> str:
     return package_name
 
 
-def write_long_description(cuda_major: str) -> Path:
-    description_path = REPO_ROOT / "description.rst"
+def write_long_description(source_root: Path, cuda_major: str) -> Path:
+    description_path = source_root / "description.rst"
     description = WHEEL_LONG_DESCRIPTION_CUDA.format(
         version=f"{cuda_major}.x",
         wheel_suffix=f"{cuda_major}x",
@@ -70,7 +75,9 @@ def write_long_description(cuda_major: str) -> Path:
     return description_path
 
 
-def generate_wheel_metadata(cuda_major: str, host_platform: str) -> Path:
+def generate_wheel_metadata(
+    source_root: Path, cuda_major: str, host_platform: str
+) -> Path:
     target_system = {
         "linux-64": "Linux:x86_64",
         "linux-aarch64": "Linux:aarch64",
@@ -80,7 +87,7 @@ def generate_wheel_metadata(cuda_major: str, host_platform: str) -> Path:
     libraries = PRELOAD_LIBRARIES[cuda_major][host_platform]
     cmd = [
         sys.executable,
-        str(REPO_ROOT / "cupyx" / "tools" / "_generate_wheel_metadata.py"),
+        str(source_root / "cupyx" / "tools" / "_generate_wheel_metadata.py"),
         "--cuda", f"{cuda_major}.x",
         "--target", target_system,
     ]
@@ -89,7 +96,7 @@ def generate_wheel_metadata(cuda_major: str, host_platform: str) -> Path:
 
     output = subprocess.check_output(cmd, encoding="utf-8")
     json.loads(output)  # Sanity-check JSON; raises if invalid.
-    metadata_path = REPO_ROOT / "_wheel.json"
+    metadata_path = source_root / "_wheel.json"
     metadata_path.write_text(output, encoding="utf-8")
     return metadata_path
 
@@ -121,16 +128,18 @@ def collect_preload_paths(
     return include_dirs, library_dirs
 
 
-def _apply_prefix(path: Path, root_prefix: str | None) -> str:
+def _apply_prefix(
+    path: Path, source_root: Path, root_prefix: str | None
+) -> str:
     """Re-anchor a path under ``root_prefix`` (e.g. ``/project``).
 
     When ``root_prefix`` is ``None``, the host's absolute path is returned.
-    Otherwise the path is made relative to ``REPO_ROOT`` and joined onto
+    Otherwise the path is made relative to ``source_root`` and joined onto
     ``root_prefix`` so it works inside a cibuildwheel container.
     """
     if root_prefix is None:
         return str(path.resolve())
-    rel = path.resolve().relative_to(REPO_ROOT)
+    rel = path.resolve().relative_to(source_root.resolve())
     return os.path.join(root_prefix, str(rel))
 
 
@@ -143,6 +152,15 @@ def main(argv: list[str] | None = None) -> int:
         "--host-platform", required=True,
         choices=("linux-64", "linux-aarch64", "win-64"),
         help="Build host: linux-64 = Linux x86_64, linux-aarch64 = Linux ARM64, win-64 = Windows x86_64.",
+    )
+    parser.add_argument(
+        "--source-root", type=Path, default=DEFAULT_SOURCE_ROOT,
+        help=(
+            "Directory holding the CuPy source tree to prepare (with "
+            "pyproject.toml, cupy/, cupyx/, ...). Default: the checkout "
+            "the script lives in. Set to an unpacked-sdist path when "
+            "building wheels from an sdist."
+        ),
     )
     parser.add_argument(
         "--preload-dir", type=Path, default=Path("./preloads"),
@@ -158,9 +176,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    package_name = rename_project(args.cuda_major)
-    description_path = write_long_description(args.cuda_major)
-    metadata_path = generate_wheel_metadata(args.cuda_major, args.host_platform)
+    package_name = rename_project(args.source_root, args.cuda_major)
+    description_path = write_long_description(args.source_root, args.cuda_major)
+    metadata_path = generate_wheel_metadata(
+        args.source_root, args.cuda_major, args.host_platform,
+    )
     include_dirs, library_dirs = collect_preload_paths(
         args.preload_dir, args.cuda_major, args.host_platform,
     )
@@ -168,20 +188,22 @@ def main(argv: list[str] | None = None) -> int:
     sep = ";" if args.host_platform == "win-64" else ":"
     env_lines = [
         "CUPY_INSTALL_NO_RPATH=1",
-        f"CUPY_INSTALL_LONG_DESCRIPTION={_apply_prefix(description_path, args.root_prefix)}",
-        f"CUPY_INSTALL_WHEEL_METADATA={_apply_prefix(metadata_path, args.root_prefix)}",
+        f"CUPY_INSTALL_LONG_DESCRIPTION={_apply_prefix(description_path, args.source_root, args.root_prefix)}",
+        f"CUPY_INSTALL_WHEEL_METADATA={_apply_prefix(metadata_path, args.source_root, args.root_prefix)}",
         f"CUPY_PACKAGE_NAME={package_name}",
     ]
     if include_dirs:
         env_lines.append(
             "CUPY_INCLUDE_PATH=" + sep.join(
-                _apply_prefix(p, args.root_prefix) for p in include_dirs
+                _apply_prefix(p, args.source_root, args.root_prefix)
+                for p in include_dirs
             )
         )
     if library_dirs:
         env_lines.append(
             "CUPY_LIBRARY_PATH=" + sep.join(
-                _apply_prefix(p, args.root_prefix) for p in library_dirs
+                _apply_prefix(p, args.source_root, args.root_prefix)
+                for p in library_dirs
             )
         )
 

--- a/ci/tools/wheel_configs.py
+++ b/ci/tools/wheel_configs.py
@@ -15,18 +15,16 @@ WHEEL_PACKAGE_NAMES: dict[str, str] = {
 }
 
 # Preload libraries to bundle metadata for, by host platform per CTK major.
-# Matches what ``cupyx/tools/install_library.py`` can download. cuTENSOR's
-# NVIDIA redist has no Linux SBSA build, so linux-aarch64 gets NCCL only
-# (mirrors cupy-release-tools' historical dist_config.py aarch64 lines).
+# Matches what ``cupyx/tools/install_library.py`` can download.
 PRELOAD_LIBRARIES: dict[str, dict[str, tuple[str, ...]]] = {
     "12": {
         "linux-64": ("cutensor", "nccl"),
-        "linux-aarch64": ("nccl",),
+        "linux-aarch64": ("cutensor", "nccl"),
         "win-64": ("cutensor",),
     },
     "13": {
         "linux-64": ("cutensor", "nccl"),
-        "linux-aarch64": ("nccl",),
+        "linux-aarch64": ("cutensor", "nccl"),
         "win-64": ("cutensor",),
     },
 }

--- a/ci/tools/wheel_configs.py
+++ b/ci/tools/wheel_configs.py
@@ -15,15 +15,19 @@ WHEEL_PACKAGE_NAMES: dict[str, str] = {
 }
 
 # Preload libraries to bundle metadata for, by host platform per CTK major.
-# Matches what ``cupyx/tools/install_library.py`` can download.
+# Matches what ``cupyx/tools/install_library.py`` can download. cuTENSOR's
+# NVIDIA redist has no Linux SBSA build, so linux-aarch64 gets NCCL only
+# (mirrors cupy-release-tools' historical dist_config.py aarch64 lines).
 PRELOAD_LIBRARIES: dict[str, dict[str, tuple[str, ...]]] = {
     "12": {
-        "linux": ("cutensor", "nccl"),
-        "win": ("cutensor",),
+        "linux-64": ("cutensor", "nccl"),
+        "linux-aarch64": ("nccl",),
+        "win-64": ("cutensor",),
     },
     "13": {
-        "linux": ("cutensor", "nccl"),
-        "win": ("cutensor",),
+        "linux-64": ("cutensor", "nccl"),
+        "linux-aarch64": ("nccl",),
+        "win-64": ("cutensor",),
     },
 }
 
@@ -47,4 +51,16 @@ Alternatively, you can install this package together with all needed CUDA compon
    $ pip install cupy-cuda{wheel_suffix}[ctk]
 
 If you have another version of CUDA, or want to build from source, refer to the `Installation Guide <https://docs.cupy.dev/en/latest/install.html>`_ for instructions.
+"""
+
+SDIST_LONG_DESCRIPTION: str = _LONG_DESCRIPTION_HEADER + """\
+This package (``cupy``) is a source distribution.
+For most users, use of pre-build wheel distributions are recommended:
+
+- `cupy-cuda13x <https://pypi.org/project/cupy-cuda13x/>`_ (for NVIDIA CUDA 13.x)
+- `cupy-cuda12x <https://pypi.org/project/cupy-cuda12x/>`_ (for NVIDIA CUDA 12.x)
+
+- `cupy-rocm-7-0 <https://pypi.org/project/cupy-rocm-7-0/>`_ (for AMD ROCm 7.0)
+
+Please see `Installation Guide <https://docs.cupy.dev/en/latest/install.html>`_ for the detailed instructions.
 """

--- a/cupyx/tools/install_library.py
+++ b/cupyx/tools/install_library.py
@@ -50,30 +50,39 @@ _nccl_records = []
 library_records = {}
 
 
-def _make_cutensor_url(platform, filename):
+def _make_cutensor_url(platform_arch, filename):
     # https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.4.1.4_cuda13-archive.zip
+    # https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.4.1.4_cuda13-archive.tar.xz
     return (
         'https://developer.download.nvidia.com/compute/cutensor/' +
-        f'redist/libcutensor/{platform}-x86_64/{filename}')
+        f'redist/libcutensor/{platform_arch}/{filename}')
 
 
 def __make_cutensor_record(
         cuda_version, public_version, min_pypi_version,
-        filename_linux, filename_windows):
+        filename_linux_x86_64, filename_linux_sbsa, filename_windows):
+    linux_filenames = [
+        'libcutensor.so.{}'.format(public_version),
+        'libcutensorMg.so.{}'.format(public_version),
+    ]
     return {
         'cuda': cuda_version,
         'cutensor': public_version,
         'min_pypi_version': min_pypi_version,
         'assets': {
             'Linux:x86_64': {
-                'url': _make_cutensor_url('linux', filename_linux),
-                'filenames': [
-                    'libcutensor.so.{}'.format(public_version),
-                    'libcutensorMg.so.{}'.format(public_version),
-                ],
+                'url': _make_cutensor_url(
+                    'linux-x86_64', filename_linux_x86_64),
+                'filenames': linux_filenames,
+            },
+            'Linux:aarch64': {
+                'url': _make_cutensor_url(
+                    'linux-sbsa', filename_linux_sbsa),
+                'filenames': linux_filenames,
             },
             'Windows:x86_64': {
-                'url': _make_cutensor_url('windows', filename_windows),
+                'url': _make_cutensor_url(
+                    'windows-x86_64', filename_windows),
                 'filenames': ['cutensor.dll', 'cutensorMg.dll'],
             },
         }
@@ -89,6 +98,7 @@ def _make_cutensor_record(cuda_version):
     return __make_cutensor_record(
         cuda_version, '2.4.1', '2.3.0',
         f'libcutensor-linux-x86_64-2.4.1.4_cuda{cuda_major}-archive.tar.xz',
+        f'libcutensor-linux-sbsa-2.4.1.4_cuda{cuda_major}-archive.tar.xz',
         f'libcutensor-windows-x86_64-2.4.1.4_cuda{cuda_major}-archive.zip',
     )
 
@@ -158,11 +168,10 @@ def _unpack_archive(filename, extract_dir):
 
 
 def install_lib(cuda, prefix, library, arch):
-    if library == 'nccl' and arch in ('x86_64', 'aarch64'):
-        pass  # Supported
-    elif arch != 'x86_64':
-        raise RuntimeError('''
-Currently this tool only supports x86_64 or aarch64 architecture for NCCL.''')
+    if arch not in ('x86_64', 'aarch64'):
+        raise RuntimeError(
+            f'Unsupported architecture: {arch}. '
+            'Supported: x86_64, aarch64.')
     record = None
     lib_records = library_records
     for record in lib_records[library]:


### PR DESCRIPTION
First slice of #9974 (retire `cupy-release-tools`). Two capabilities that live only in `cupy-release-tools` today move in-tree.

## What changes

**Sdist-first wheel build.** New `.github/workflows/build-sdist.yml` produces `cupy-<version>.tar.gz` once per `/test`. Every wheel job downloads that artifact and unpacks it into `./srcpkg/` (a subdirectory of the workspace), and cibuildwheel is pointed at `package-dir: ./srcpkg` — so the `/project` mount inside the manylinux container is a self-contained sdist tree (source + preloads + generated metadata). `prepare_wheel_build.py` gets a new `--source-root` parameter so it rewrites `pyproject.toml` / writes `description.rst` / `_wheel.json` inside srcpkg, not at workspace root. Consequences:

- Any `MANIFEST.in` gap now fails this CI wheel build, not a downstream user.
- The win-64 vendored-header symlink handling (`symlink=dir` gitattributes + `core.symlinks true` git config, added in #10058 for xsf) becomes moot: setuptools resolves all vendored symlinks to real files at sdist-build time on Linux, so downstream extraction is portable across platforms with zero symlinks.
- Wheel jobs no longer need `submodules: recursive` on their checkout — the sdist already carries the resolved third_party trees.

The sdist long-description constant `SDIST_LONG_DESCRIPTION` is vendored verbatim from `cupy-release-tools/dist_config.py`.

**linux-aarch64 wheels on GH-hosted native runners.** Uncomments the `build-linux-aarch64` job, `runs-on: ubuntu-22.04-arm` (GA since 2025 on public repos). `install_library.py` gains a `Linux:aarch64` cuTENSOR asset (`libcutensor-linux-sbsa-<ver>_cuda{12,13}` — the NVIDIA redist has shipped this for a while; the tool just didn't know about it), so the aarch64 wheel preloads cuTENSOR + NCCL, matching the linux-64 preload set. `prepare_wheel_build.py`'s `--host-platform` choices are renamed to align with the workflow input names (`linux-64` / `linux-aarch64` / `win-64`), and `wheel_configs.PRELOAD_LIBRARIES` grows a per-arch axis.