### PR TITLE
Allow UMP via managed memory with NumPy allocators

### DIFF
--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -128,6 +128,8 @@ cdef function.Function _get_simple_elementwise_kernel(
 cpdef inline _check_peer_access(_ndarray_base arr, int device_id):
     if arr.data.device_id == device_id:
         return
+    elif arr.data.mem.size == 0:
+        return
 
     msg = (
         f'The device where the array resides ({arr.data.device_id}) is '

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -48,6 +48,7 @@ from cupy._core cimport _routines_statistics as _statistics
 from cupy._core cimport _scalar
 from cupy._core cimport dlpack
 from cupy._core cimport internal
+from cupy._core.numpy_allocator cimport array_uses_cupy_allocator
 from cupy.cuda cimport device
 from cupy.cuda cimport function
 from cupy.cuda cimport pinned_memory
@@ -2976,10 +2977,20 @@ cdef inline _ndarray_base _try_skip_h2d_copy(
     if copy:
         return None
 
-    if not is_ump_supported(device.get_device_id()):
+    if not isinstance(obj, numpy.ndarray):
         return None
 
-    if not isinstance(obj, numpy.ndarray):
+    cdef int device_id = device.get_device_id()
+    if is_ump_supported(device_id):
+        allocator = "system"
+    elif (
+        (allocator := array_uses_cupy_allocator(<cnp.ndarray>obj)) is not None
+    ):
+        if allocator == "system" and not runtime.deviceGetAttribute(
+                runtime.cudaDevAttrPageableMemoryAccess, device_id):
+            return None  # system memory access not supported by this device
+    else:
+        # Neither UMP enabled, nor is this using the CuPy allocator for NumPy.
         return None
 
     # dtype should not change
@@ -3011,8 +3022,15 @@ cdef inline _ndarray_base _try_skip_h2d_copy(
         shape = (1,) * (ndmin - ndim) + shape
         strides = (shape[0] * strides[0],) * (ndmin - ndim) + strides
 
-    cdef memory.SystemMemory ext_mem = memory.SystemMemory.from_external(
-        ptr, nbytes, obj)
+    if allocator == "system":
+        ext_mem = memory.SystemMemory.from_external(
+            ptr, nbytes, obj)
+    elif allocator == "managed":
+        ext_mem = memory.ManagedMemory.from_external(
+            ptr, nbytes, obj)
+    else:
+        raise SystemError(f"internal error, bad allocator kind: {allocator}")
+
     cdef memory.MemoryPointer memptr = memory.MemoryPointer(ext_mem, 0)
     return ndarray(shape, obj_dtype, memptr, strides)
 

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -132,6 +132,18 @@ cdef inline bint is_ump_supported(int device_id) except*:
         return False
 
 
+cdef inline bint is_device_accessible(cnp.ndarray arr) except*:
+    """True if the GPU can access this NumPy array's data."""
+    cdef int device_id = device.get_device_id()
+    allocator = array_uses_cupy_allocator(arr)
+    if allocator == "managed":
+        return True
+    if allocator == "system":
+        return runtime.deviceGetAttribute(
+            runtime.cudaDevAttrPageableMemoryAccess, device_id) != 0
+    return is_ump_supported(device_id)
+
+
 class ndarray(_ndarray_base):
     """
     __init__(shape, dtype=float, memptr=None, strides=None, order='C')
@@ -482,7 +494,13 @@ cdef class _ndarray_base:
         cpython.Py_DECREF(self)
 
     cdef inline bint is_host_accessible(self) except*:
-        return self.data.mem.identity in ('SystemMemory', 'ManagedMemory')
+        # PooledMemory exposes `.identity`; from_external wraps are raw
+        # SystemMemory / ManagedMemory and have no such attribute.
+        mem = self.data.mem
+        if isinstance(mem, (memory.SystemMemory, memory.ManagedMemory)):
+            return True
+        identity = getattr(mem, 'identity', None)
+        return identity in ('SystemMemory', 'ManagedMemory')
 
     # The definition order of attributes and methods are borrowed from the
     # order of documentation at the following NumPy document.
@@ -502,8 +520,11 @@ cdef class _ndarray_base:
         .. seealso:: :attr:`numpy.ndarray.flags`
 
         """
-        return _flags.Flags(self._c_contiguous, self._f_contiguous,
-                            self.base is None)
+        return _flags.Flags(
+            self._c_contiguous, self._f_contiguous,
+            (self.base is None
+                # TODO(seberg): MemoryPointer should have a flag for "owning"?
+                and getattr(self.data.mem, '_owner', None) is None))
 
     property shape:
         """Lengths of axes.
@@ -2980,18 +3001,11 @@ cdef inline _ndarray_base _try_skip_h2d_copy(
     if not isinstance(obj, numpy.ndarray):
         return None
 
-    cdef int device_id = device.get_device_id()
-    if is_ump_supported(device_id):
-        allocator = "system"
-    elif (
-        (allocator := array_uses_cupy_allocator(<cnp.ndarray>obj)) is not None
-    ):
-        if allocator == "system" and not runtime.deviceGetAttribute(
-                runtime.cudaDevAttrPageableMemoryAccess, device_id):
-            return None  # system memory access not supported by this device
-    else:
-        # Neither UMP enabled, nor is this using the CuPy allocator for NumPy.
+    if not is_device_accessible(<cnp.ndarray>obj):
         return None
+    allocator = array_uses_cupy_allocator(<cnp.ndarray>obj)
+    if allocator is None:
+        allocator = "system"
 
     # dtype should not change
     obj_dtype = obj.dtype
@@ -3059,7 +3073,9 @@ cdef _ndarray_base _array_default(
     # it below. Copying (which may not be pinned) here is not useful.
     # TODO(seberg): In principle even `dtype=` is not useful here, but
     # I am hesitant to remove it for the dtype conversion/validation.
-    if isinstance(obj, numpy.ndarray) and not _is_ump_enabled:
+    # Device-accessible buffers take the wrap path, so honor `copy` there.
+    if isinstance(obj, numpy.ndarray) and not is_device_accessible(
+            <cnp.ndarray>obj):
         a_cpu = numpy.array(obj, dtype=dtype, copy=None, ndmin=ndmin)
         if order_char == b'C':
             is_correct_contiguous = a_cpu.flags.c_contiguous
@@ -3068,18 +3084,21 @@ cdef _ndarray_base _array_default(
         else:
             assert False  # assume above normalizes to C or F.
     else:
-        a_cpu = numpy.array(obj, dtype=dtype, copy=None, order=order,
-                            ndmin=ndmin)
+        a_cpu = numpy.array(
+            obj, dtype=dtype, copy=True if copy else None, order=order,
+            ndmin=ndmin)
         is_correct_contiguous = True
 
     a_cpu = a_cpu.astype(_dtype.normalize_dtype(a_cpu.dtype), copy=False)
     a_dtype = a_cpu.dtype
 
     # We already made a copy, we should be able to use it
-    if _is_ump_enabled:
+    if is_device_accessible(<cnp.ndarray>a_cpu):
         a = _try_skip_h2d_copy(a_cpu, a_dtype, False, order, ndmin)
-        assert a is not None
-        return a
+        if a is not None:
+            return a
+        # should only fail if not a supported dtype.
+        assert not _dtype.check_supported_dtype(a_dtype, error=False)
 
     cdef shape_t a_shape = a_cpu.shape
     a = ndarray(a_shape, dtype=a_dtype, order=order)

--- a/cupy/_core/numpy_allocator.pxd
+++ b/cupy/_core/numpy_allocator.pxd
@@ -1,0 +1,5 @@
+# distutils: language = c++
+
+cimport numpy as cnp
+
+cdef array_uses_cupy_allocator(cnp.ndarray arr)

--- a/cupy/_core/numpy_allocator.pyx
+++ b/cupy/_core/numpy_allocator.pyx
@@ -64,12 +64,20 @@ ELSE:
 cdef const int ALIGNMENT = 512
 
 
+cdef inline size_t _align_size(size_t size) noexcept nogil:
+    # POSIX aligned_alloc requires size to be a multiple of alignment.
+    if size == 0:
+        size = 1
+    return (size + <size_t>ALIGNMENT - 1) & ~(<size_t>ALIGNMENT - 1)
+
+
 cdef public void* _calloc(size_t nmemb, size_t size) noexcept nogil:
     errno.errno = 0
-    cdef void* buf = aligned_alloc(ALIGNMENT, nmemb * size)
+    cdef size_t nbytes = nmemb * size
+    cdef void* buf = aligned_alloc(ALIGNMENT, _align_size(nbytes))
     if buf and errno.errno == 0:
-        hint_hugepages(buf, nmemb * size)
-        buf = memset(buf, 0, nmemb * size)
+        hint_hugepages(buf, nbytes)
+        buf = memset(buf, 0, nbytes)
 
     return buf
 
@@ -78,14 +86,16 @@ cdef public void* _malloc(size_t size) noexcept nogil:
     cdef void *buf
     errno.errno = 0
     # TODO: Use madvise hugepages (for larger allocations at least)
-    buf = aligned_alloc(ALIGNMENT, size)
-    hint_hugepages(buf, size)
+    buf = aligned_alloc(ALIGNMENT, _align_size(size))
+    if buf:
+        hint_hugepages(buf, size)
     return buf
 
 
 @cython.cdivision(True)
 cdef public void* _realloc(void *ptr, size_t size) noexcept nogil:
     errno.errno = 0
+    size = _align_size(size)
     cdef void* buf = stdlib.realloc(ptr, size)
     cdef void* tmp
 
@@ -136,6 +146,10 @@ cdef void* _malloc_managed(void *ctx, size_t size) noexcept:
         mem = memory.malloc_managed(size)
     except MemoryError as e:
         # don't print out memory error, it adds nothing?
+        return NULL
+    except:  # noqa: E722
+        # noexcept would ensure this, but let's be explicit
+        cpython.PyErr_WriteUnraisable("CuPy malloc_managed")
         return NULL
 
     # TODO: Should managed memory also use hint_hugepages?
@@ -227,7 +241,7 @@ cdef array_uses_cupy_allocator(cnp.ndarray arr):
 cdef class CuPyNumPyAllocator:
     cdef object _handler
     cdef object _prev_handler
-    cdef object kind
+    cdef readonly str kind
 
     def __cinit__(self, kind=None):
         """Initialize the NumPy allcator.

--- a/cupy/_core/numpy_allocator.pyx
+++ b/cupy/_core/numpy_allocator.pyx
@@ -7,6 +7,40 @@ from libc cimport stdlib
 from libc.stdint cimport intptr_t
 from libc.string cimport memset, memcpy
 
+cimport cpython
+cimport cython
+
+cimport numpy as cnp
+
+from cupy.cuda cimport device
+from cupy.cuda cimport memory
+from cupy_backends.cuda.api cimport runtime
+
+
+cdef extern from "numpy/ndarraytypes.h" nogil:
+    cpython.PyObject* PyArray_HANDLER(cnp.ndarray arr)
+
+
+# Similar to, but simplfied from, the NumPy alloc.cpp code
+cdef extern from *:
+    r"""
+    #if defined(linux) || defined(__linux) || defined(__linux__)
+    #include <sys/mman.h>
+    #include <stdint.h>
+    #endif
+
+    static inline void hint_hugepages(void *ptr, size_t size) {
+    #ifdef MADV_HUGEPAGE
+        if (size < (1U << 22U)) {
+            return;  // do nothing for small arrays.
+        }
+        uintptr_t offset = 4096U - (uintptr_t)ptr % 4096U;
+        madvise(ptr + offset, size - offset, MADV_HUGEPAGE);
+    #endif
+    }
+    """
+    void hint_hugepages(void *ptr, size_t size) noexcept nogil
+
 
 IF UNAME_SYSNAME == "Windows":
     cdef extern from "stdlib.h" nogil:
@@ -34,14 +68,19 @@ cdef public void* _calloc(size_t nmemb, size_t size) noexcept nogil:
     errno.errno = 0
     cdef void* buf = aligned_alloc(ALIGNMENT, nmemb * size)
     if buf and errno.errno == 0:
+        hint_hugepages(buf, nmemb * size)
         buf = memset(buf, 0, nmemb * size)
 
     return buf
 
 
 cdef public void* _malloc(size_t size) noexcept nogil:
+    cdef void *buf
     errno.errno = 0
-    return aligned_alloc(ALIGNMENT, size)
+    # TODO: Use madvise hugepages (for larger allocations at least)
+    buf = aligned_alloc(ALIGNMENT, size)
+    hint_hugepages(buf, size)
+    return buf
 
 
 @cython.cdivision(True)
@@ -63,3 +102,184 @@ cdef public void* _realloc(void *ptr, size_t size) noexcept nogil:
 
 cdef public void _free(void* ptr) noexcept nogil:
     aligned_free(ptr)
+
+cdef void *_malloc_system(void *ctx, size_t size) noexcept nogil:
+    return _malloc(size)
+
+cdef void *_calloc_system(void *ctx, size_t nmemb, size_t size) noexcept nogil:
+    return _calloc(nmemb, size)
+
+cdef void *_realloc_system(void *ctx, void* ptr, size_t size) noexcept nogil:
+    return _realloc(ptr, size)
+
+cdef void _free_system(void *ctx, void* ptr, size_t size) noexcept nogil:
+    _free(ptr)
+
+# Define an allocator for aligned memory (only useful with UMP supported)
+cdef cnp.PyDataMem_Handler _aligned_handler
+# The init.pyd file uses `char *` rather than `char[127]`, making awkward:
+memcpy(_aligned_handler.name, b"cupy_aligned_handler", 21)
+_aligned_handler.version = 1
+_aligned_handler.allocator.ctx = NULL
+_aligned_handler.allocator.malloc = &_malloc_system
+_aligned_handler.allocator.calloc = &_calloc_system
+_aligned_handler.allocator.realloc = &_realloc_system
+_aligned_handler.allocator.free = &_free_system
+
+
+# Define helpers/functions for a NumPy allocator backed by managed memory.
+cdef dict _managed_blocks = {}
+
+cdef void* _malloc_managed(void *ctx, size_t size) noexcept:
+    cdef memory.MemoryPointer mem
+    try:
+        mem = memory.malloc_managed(size)
+    except MemoryError as e:
+        # don't print out memory error, it adds nothing?
+        return NULL
+
+    # TODO: Should managed memory also use hint_hugepages?
+    #       (Although if the case, that should be in memory.pyx!)
+    _managed_blocks[mem.ptr] = mem
+    return <void *>mem.ptr
+
+
+cdef void* _calloc_managed(void *ctx, size_t nmemb, size_t size) noexcept:
+    cdef memory.MemoryPointer mem
+    try:
+        mem = memory.malloc_managed(nmemb * size)
+    except MemoryError as e:
+        # don't print out memory error, it adds nothing?
+        return NULL
+    except:  # noqa: E722
+        # noexcept would ensure this, but let's be explicit
+        cpython.PyErr_WriteUnraisable("CuPy malloc_managed")
+        return NULL
+
+    memset(<void *>mem.ptr, 0, nmemb * size)
+    _managed_blocks[mem.ptr] = mem
+    return <void *>mem.ptr
+
+
+cdef void* _realloc_managed(
+    void *ctx, void* ptr, size_t size
+) noexcept with gil:
+    # Note(seberg): It appears NumPy uses realloc sometimes without the GIL
+    cdef memory.MemoryPointer old_mem = _managed_blocks[<intptr_t>ptr]
+    cdef void *new_ptr
+
+    if size <= old_mem.mem.size:
+        return ptr  # just keep using the old allocation.
+    else:
+        new_ptr = _malloc_managed(ctx, size)
+        if new_ptr == NULL:
+            return NULL
+        memcpy(new_ptr, ptr, old_mem.mem.size)
+        del _managed_blocks[old_mem.ptr]  # free old pointer
+        return new_ptr
+
+
+cdef void _free_managed(void *ctx, void* ptr, size_t size) noexcept:
+    del _managed_blocks[<intptr_t>ptr]
+
+
+# Define an allocator using managed memory
+cdef cnp.PyDataMem_Handler _managed_handler
+# The init.pyd file uses `char *` rather than `char[127]`, making awkward:
+memcpy(_managed_handler.name, b"cupy_managed_handler", 21)
+_managed_handler.version = 1
+_managed_handler.allocator.ctx = NULL
+_managed_handler.allocator.malloc = &_malloc_managed
+_managed_handler.allocator.calloc = &_calloc_managed
+_managed_handler.allocator.realloc = &_realloc_managed
+_managed_handler.allocator.free = &_free_managed
+
+
+cdef object _aligned_capsule = cpython.PyCapsule_New(
+    &_aligned_handler, b"mem_handler", NULL)
+cdef object _managed_capsule = cpython.PyCapsule_New(
+    &_managed_handler, b"mem_handler", NULL)
+
+
+cdef array_uses_cupy_allocator(cnp.ndarray arr):
+    """Check if the array uses the CuPy allocator.
+
+    Note that the alternative (and more general) approach would be to
+    check the cuda pointer attributes. If that succeeds, we know the data is
+    managed memory.
+    """
+    cdef cpython.PyObject *handler
+    cdef cpython.PyObject *base = arr.base
+    while base != NULL and isinstance(<object>base, cnp.ndarray):
+        arr = <cnp.ndarray>base
+        base = arr.base
+
+    handler = PyArray_HANDLER(arr)  # may be NULL
+    if handler == <cpython.PyObject *>_aligned_capsule:
+        return "system"
+    elif handler == <cpython.PyObject *>_managed_capsule:
+        return "managed"
+    else:
+        return None
+
+
+@cython.final
+cdef class CuPyNumPyAllocator:
+    cdef object _handler
+    cdef object _prev_handler
+    cdef object kind
+
+    def __cinit__(self, kind=None):
+        """Initialize the NumPy allcator.
+
+        The allocator object can be used as a context manager or via
+        `.use()` globally.
+        The typical use should be ``with CuPyNumPyAllocator(): ...``
+
+        Args:
+            kind (str): The kind of the allocator, maybe queried as ``.kind``
+                after initialization. Values are:
+                - "system": Use aligned system memory.
+                - "managed": Use managed allocator.
+                - None: Uses system memory if the system supports HMM direct
+                  memory access (hardware or software support).
+        """
+        if kind is None:
+            # If the system supports direct system memory access (hardware or
+            # software) we default to the system allocator.
+            if runtime.deviceGetAttribute(
+                runtime.cudaDevAttrPageableMemoryAccess,
+                device.get_device_id(),
+            ) == 1:
+                kind = "system"
+            else:
+                kind = "managed"
+
+        if kind == "system":
+            self._handler = _aligned_capsule
+        elif kind == "managed":
+            self._handler = _managed_capsule
+        else:
+            raise ValueError(f"Invalid allocator kind: {kind}")
+
+        self.kind = kind
+
+    cpdef use(self):
+        if self._prev_handler is not None:
+            raise RuntimeError("Cannot use/enter allocator twice.")
+
+        self._prev_handler = cnp.PyDataMem_SetHandler(self._handler)
+
+    cpdef restore(self):
+        if self._prev_handler is None:
+            raise RuntimeError("Allocator not in use.")
+
+        cnp.PyDataMem_SetHandler(self._prev_handler)
+        self._prev_handler = None
+
+    def __enter__(self):
+        self.use()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.restore()

--- a/cupy/cuda/memory.pxd
+++ b/cupy/cuda/memory.pxd
@@ -17,6 +17,16 @@ cdef class BaseMemory:
 
 
 @cython.no_gc
+cdef class ManagedMemory(BaseMemory):
+
+    cdef:
+        readonly object _owner
+
+    @staticmethod
+    cdef from_external(intptr_t ptr, size_t size, object owner)
+
+
+@cython.no_gc
 cdef class SystemMemory(BaseMemory):
 
     cdef:
@@ -49,7 +59,7 @@ cdef class MemoryPointer:
 
 
 cpdef MemoryPointer alloc(size)
-
+cpdef MemoryPointer malloc_managed(size_t size)
 
 cpdef set_allocator(allocator=*)
 cpdef get_allocator()

--- a/cupy/cuda/memory.pyx
+++ b/cupy/cuda/memory.pyx
@@ -240,8 +240,29 @@ cdef class ManagedMemory(BaseMemory):
         self.size = size
         self.device_id = device.get_device_id()
         self.ptr = 0
+        self._owner = None
         if size > 0:
             self.ptr = runtime.mallocManaged(size)
+
+    @staticmethod
+    cdef from_external(intptr_t ptr, size_t size, object owner):
+        cdef runtime.PointerAttributes attrs
+        cdef int device_id
+        # Note: Could also fetch this from the allocator (since it is our
+        # allocation.)
+        if size != 0:
+            attrs = runtime.pointerGetAttributes(ptr)
+            device_id = attrs.device
+        else:
+            # guess at current device:
+            device_id = device.get_device_id()
+
+        cdef ManagedMemory self = ManagedMemory.__new__(ManagedMemory)
+        self.size = size
+        self.device_id = device_id
+        self.ptr = ptr
+        self._owner = owner
+        return self
 
     def prefetch(self, stream, *, int device_id=runtime.cudaInvalidDeviceId):
         """(experimental) Prefetch memory.
@@ -266,7 +287,11 @@ cdef class ManagedMemory(BaseMemory):
 
     def __dealloc__(self):
         # Note: Cannot raise in the destructor! (cython/cython#1613)
-        if self.ptr:
+        if self._owner is not None:
+            # if we don't own the memory, we must sync before free to avoid
+            # any race condition
+            runtime.streamSynchronize(stream_module.get_current_stream_ptr())
+        elif self.ptr:
             runtime.free(self.ptr)
 
 

--- a/docs/source/user_guide/memory.rst
+++ b/docs/source/user_guide/memory.rst
@@ -226,8 +226,11 @@ To activate this capability, currently you should:
     with CuPyNumPyAllocator():
         # NumPy code creating NumPy arrays.
 
-With this setup change, all the data movement APIs such as :meth:`~cupy.ndarray.get()`, :func:`~cupy.asnumpy`  and
-:func:`~cupy.asarray` become no-op (no copy is done), and the following code is accelerated:
+NumPy stores the handler in a context variable, so :meth:`~cupy._core.numpy_allocator.CuPyNumPyAllocator.use`
+applies to the current context and is currently not inherited by worker threads (except on free-threaded Python).
+
+With this setup change, :func:`~cupy.asarray` can wrap the NumPy buffer without an H2D copy, and the following
+code is accelerated:
 
 .. code-block:: py
 
@@ -243,10 +246,10 @@ the *execution* space (whether the code should run on CPU or GPU).
 Apart from the setup configuration for NumPy/CuPy, no user code change is required.
 
 You may also set the environment variable ``CUPY_ENABLE_UMP=1`` to relax checks further.
-CuPy will accept NumPy arrays not strictly backed by it's own allocator as well as support
+CuPy will accept NumPy arrays not strictly backed by its own allocator as well as support
 system memory allocations in ``UnownedMemory``.
 
 **Managed memory:** The above is also possible on systems without HMM support. In this
-case ``CuPyNumPyAllocator()`` defaults to ``CuPyNumPyAllocator("managed")`` backing the
+case ``CuPyNumPyAllocator()`` defaults to ``CuPyNumPyAllocator("managed")``, backing the
 NumPy allocations with managed rather than system memory (otherwise the default is
-``CuPyNumPyAllocator("system")``.
+``CuPyNumPyAllocator("system")``).

--- a/docs/source/user_guide/memory.rst
+++ b/docs/source/user_guide/memory.rst
@@ -204,32 +204,27 @@ Unified memory programming (UMP) support (**experimental!**)
 ............................................................
 
 It is possible to make both NumPy and CuPy use/share system allocated memory on Heterogeneous Memory Management
-(HMM) or Address Translation Services (ATS) enabled systems, such as the NVIDIA Grace Hopper Superchip.
-To activate this capability, currently you need to:
+(HMM) or Address Translation Services (ATS) enabled systems, such as the NVIDIA Grace Hopper Superchip or via
+software support on Linux with new enough driver (535+) and kernels.
+To activate this capability, currently you should:
 
-1. Install `numpy_allocator <https://github.com/inaccel/numpy-allocator/>`_
-2. Set the environment variable ``CUPY_ENABLE_UMP=1``
-3. Make a memory pool for CuPy to draw system memory (``malloc_system``), for example:
+1. Make a memory pool for CuPy to draw system memory (``malloc_system``), for example:
 
 .. code-block:: py
 
     import cupy as cp
     cp.cuda.set_allocator(cp.cuda.MemoryPool(cp.cuda.memory.malloc_system).malloc)
 
-4. Switch to the aligned allocator for NumPy to draw system memory
+2. Set up NumPy to use the CuPy allocator to ensure aligned allocations:
 
 .. code-block:: py
-   
-    import cupy._core.numpy_allocator as ac
-    import numpy_allocator
-    import ctypes
-    lib = ctypes.CDLL(ac.__file__)
-    class my_allocator(metaclass=numpy_allocator.type):
-        _calloc_ = ctypes.addressof(lib._calloc)
-        _malloc_ = ctypes.addressof(lib._malloc)
-        _realloc_ = ctypes.addressof(lib._realloc)
-        _free_ = ctypes.addressof(lib._free)
-    my_allocator.__enter__()  # change the allocator globally
+
+    from cupy._core.numpy_allocator import CuPyNumPyAllocator
+
+    CuPyNumPyAllocator().use()
+    # or locally as a context manager:
+    with CuPyNumPyAllocator():
+        # NumPy code creating NumPy arrays.
 
 With this setup change, all the data movement APIs such as :meth:`~cupy.ndarray.get()`, :func:`~cupy.asnumpy`  and
 :func:`~cupy.asarray` become no-op (no copy is done), and the following code is accelerated:
@@ -246,3 +241,12 @@ Essentially, the distinction of CPU/GPU *memory* spaces is gone, and ``np``/``cp
 the *execution* space (whether the code should run on CPU or GPU).
 
 Apart from the setup configuration for NumPy/CuPy, no user code change is required.
+
+You may also set the environment variable ``CUPY_ENABLE_UMP=1`` to relax checks further.
+CuPy will accept NumPy arrays not strictly backed by it's own allocator as well as support
+system memory allocations in ``UnownedMemory``.
+
+**Managed memory:** The above is also possible on systems without HMM support. In this
+case ``CuPyNumPyAllocator()`` defaults to ``CuPyNumPyAllocator("managed")`` backing the
+NumPy allocations with managed rather than system memory (otherwise the default is
+``CuPyNumPyAllocator("system")``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import cupy._core.numpy_allocator as ac
+import cupy as cp
 
 import collections
 import os
@@ -146,3 +148,11 @@ if int(os.environ.get('CUPY_TEST_RANDOM_SUBSAMPLE', '0')):
                         kwargs['strict'] = False
                         node.own_markers[i] = pytest.mark.xfail(
                             *marker.args, **kwargs).mark
+
+
+# TODO(seberg): Just for testing during development, remove again!
+cp.cuda.set_allocator(cp.cuda.MemoryPool(
+    cp.cuda.memory.malloc_managed).malloc)
+
+
+ac.CuPyNumPyAllocator("managed").use()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-import cupy._core.numpy_allocator as ac
-import cupy as cp
 
 import collections
 import os
@@ -73,24 +71,17 @@ def pytest_configure(config):
                 devices = ','.join(devices)
                 os.environ['CUDA_VISIBLE_DEVICES'] = devices
 
+    if int(os.environ.get('CUPY_ENABLE_UMP', '0')) != 0:
+        # After CUDA_VISIBLE_DEVICES rotation so the CUDA context lands on
+        # this xdist worker's GPU. Match the historical UMP fixture: CuPy
+        # draws from a system-malloc pool, NumPy from the aligned system
+        # allocator (not managed).
+        import cupy as cp
+        from cupy._core.numpy_allocator import CuPyNumPyAllocator
 
-if int(os.environ.get('CUPY_ENABLE_UMP', 0)) != 0:
-    # Make sure malloc is used in a stream-ordered fashion
-    import cupy as cp
-    cp.cuda.set_allocator(cp.cuda.MemoryPool(
-        cp.cuda.memory.malloc_system).malloc)
-
-    import cupy._core.numpy_allocator as ac
-    import numpy_allocator
-    import ctypes
-    lib = ctypes.CDLL(ac.__file__)
-
-    class my_allocator(metaclass=numpy_allocator.type):
-        _calloc_ = ctypes.addressof(lib._calloc)
-        _malloc_ = ctypes.addressof(lib._malloc)
-        _realloc_ = ctypes.addressof(lib._realloc)
-        _free_ = ctypes.addressof(lib._free)
-    my_allocator.__enter__()
+        cp.cuda.set_allocator(cp.cuda.MemoryPool(
+            cp.cuda.memory.malloc_system).malloc)
+        CuPyNumPyAllocator("system").use()
 
 
 if int(os.environ.get('CUPY_CI_ENABLE_GCP_KERNEL_CACHE', 0)) != 0:
@@ -148,11 +139,3 @@ if int(os.environ.get('CUPY_TEST_RANDOM_SUBSAMPLE', '0')):
                         kwargs['strict'] = False
                         node.own_markers[i] = pytest.mark.xfail(
                             *marker.args, **kwargs).mark
-
-
-# TODO(seberg): Just for testing during development, remove again!
-cp.cuda.set_allocator(cp.cuda.MemoryPool(
-    cp.cuda.memory.malloc_managed).malloc)
-
-
-ac.CuPyNumPyAllocator("managed").use()

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -39,7 +39,7 @@ class TestArrayAdvancedIndexingGetitemPerm:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_adv_getitem(self, xp=numpy, dtype=None):
+    def test_adv_getitem(self, xp, dtype):
         a = testing.shaped_arange(self.shape, xp, dtype)
         return a[self.indexes]
 

--- a/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
+++ b/tests/cupy_tests/core_tests/test_ndarray_adv_indexing.py
@@ -39,7 +39,7 @@ class TestArrayAdvancedIndexingGetitemPerm:
 
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()
-    def test_adv_getitem(self, xp, dtype):
+    def test_adv_getitem(self, xp=numpy, dtype=None):
         a = testing.shaped_arange(self.shape, xp, dtype)
         return a[self.indexes]
 


### PR DESCRIPTION
This is towards https://github.com/cupy/cupy/issues/8711 although as discussed earlier: it is already possible to "proper" UMP on normal hardware with new linux kernels, it generally "just works".

@leofang if you have some time, this does:
* Create new custom NumPy allocators and machinery to set them, cleaning up a few things along the way as well.
* Accepting these custom NumPy allocator allocated numpy arrays for zero-copy from NumPy.
* A few fixups along the way.

Locally the test seemed passing (but not with `-n16` hinting to potential stream order issues), but since I suspect there may be a few things to figure out I'll keep this draft. For one thing, there are some issues around stream-order and others (`malloc_managed()` might not be using the pool, the `owndata` logic isn't nice, and maybe most importantly, `stream` order of a no-copy NumPy arrays deallocation is probably wrong -- we probably need to delay the full deallocate there).