### PR TITLE
Remove obsolete `_setup_win32_dll_directory`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -10,7 +10,6 @@ from cupy import _version
 
 
 _environment._detect_duplicate_installation()  # NOQA
-_environment._setup_win32_dll_directory()  # NOQA
 _environment._preload_library('cutensor')  # NOQA
 
 

--- a/cupy/_environment.py
+++ b/cupy/_environment.py
@@ -265,64 +265,6 @@ def _get_cub_path():
     return _cub_path
 
 
-def _setup_win32_dll_directory():
-    # Setup DLL directory to load CUDA Toolkit libs and shared libraries
-    # added during the build process.
-    if sys.platform.startswith('win32'):
-        # see _can_attempt_preload()
-        config = get_preload_config()
-        is_conda = (config is not None and (config['packaging'] == 'conda'))
-
-        # Path to the CUDA Toolkit binaries
-        cuda_path = get_cuda_path()
-        if cuda_path is not None:
-            if is_conda:
-                cuda_bin_path = cuda_path
-            else:
-                cuda_bin_path = os.path.join(cuda_path, 'bin')
-        else:
-            cuda_bin_path = None
-            if not is_conda:
-                warnings.warn(
-                    'CUDA path could not be detected.'
-                    ' Set CUDA_PATH environment variable if CuPy '
-                    'fails to load.')
-        _log('CUDA_PATH: {}'.format(cuda_path))
-
-        # Path to shared libraries in wheel
-        wheel_libdir = os.path.join(
-            get_cupy_install_path(), 'cupy', '.data', 'lib')
-        if os.path.isdir(wheel_libdir):
-            _log('Wheel shared libraries: {}'.format(wheel_libdir))
-        else:
-            _log('Not wheel distribution ({} not found)'.format(
-                wheel_libdir))
-            wheel_libdir = None
-
-        if (3, 8) <= sys.version_info:
-            if cuda_bin_path is not None:
-                _log('Adding DLL search path: {}'.format(cuda_bin_path))
-                os.add_dll_directory(cuda_bin_path)
-                machine = platform.machine().lower()
-                cuda_bin_arch = (
-                    'arm64' if machine in ('arm64', 'aarch64') else 'x64')
-                cuda_bin_arch_path = os.path.join(
-                    cuda_bin_path, cuda_bin_arch)
-                if os.path.exists(cuda_bin_arch_path):
-                    _log('Adding DLL search path (for CUDA 13): '
-                         f'{cuda_bin_arch_path}')
-                    os.add_dll_directory(cuda_bin_arch_path)
-            if wheel_libdir is not None:
-                _log('Adding DLL search path: {}'.format(wheel_libdir))
-                os.add_dll_directory(wheel_libdir)
-        else:
-            # Users are responsible for adding `%CUDA_PATH%/bin` to PATH.
-            if wheel_libdir is not None:
-                _log('Adding to PATH: {}'.format(wheel_libdir))
-                path = os.environ.get('PATH', '')
-                os.environ['PATH'] = wheel_libdir + os.pathsep + path
-
-
 def get_cupy_install_path():
     # Path to the directory where the package is installed.
     return os.path.abspath(

--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -68,6 +68,13 @@ def __getattr__(key):
         return cublas
     elif key == 'jitify':
         if not runtime.is_hip and driver.get_build_version() > 0:
+            from cuda import pathfinder
+            try:
+                pathfinder.load_nvidia_dynamic_lib("nvrtc")
+            except pathfinder.DynamicLibNotFoundError as e:
+                if (not (_os.environ.get('READTHEDOCS') == 'True') and
+                        not (_os.environ.get('CUPY_CI') is not None)):
+                    raise ImportError(str(e)) from e
             import cupy.cuda.jitify as jitify
         else:
             jitify = _UnavailableModule('cupy.cuda.jitify')


### PR DESCRIPTION
Windows DLL discovery is now handled by `cuda.pathfinder`, invoked before every extension module with a CUDA DLL in its import table loads:

- https://github.com/cupy/cupy/commit/9dd2cad963d9721b2413bf17fd0c94f2d34cfb99 preloads cublas / cusolver / cusparse / curand / cutensor / cusparselt / nccl via `cupy_backends/cuda/libs/__init__.py.__getattr__`, and cufft via `cupy/cuda/__init__.py.__getattr__`.
- https://github.com/cupy/cupy/commit/1f8c4cf0afcb8369e572bdfa23de07deb08870f1 defers nvrtc loading into `_cnvrtc.pxi::_get_softlink()`.
- https://github.com/cupy/cupy/commit/9bb7f1938ed5c0abf48fcd885cca58026f7769ea lets pathfinder hijack `_preload_library`.

I verified against the shipped `cupy_cuda13x==14.2.0` win_amd64 wheel that only 8 `.pyd` files carry a CUDA DLL in their import table, and 7 of them already route through a pathfinder-preloading gateway. The last one — `cupy/cuda/jitify.pyd`, which pulls `nvrtc64_130_0.dll` — was loaded before `_cnvrtc.pxi`'s deferred nvrtc preload could fire, so this PR also adds an explicit `pathfinder.load_nvidia_dynamic_lib("nvrtc")` in the `jitify` `__getattr__` branch, mirroring the existing `cufft` pattern.

Fixes #10044.