### PR TITLE
Add `cupy.vecdot` and `cupy.linalg.vecdot`

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -491,6 +491,7 @@ from cupy.linalg._product import matmul  # NOQA
 from cupy.linalg._product import outer  # NOQA
 from cupy.linalg._product import tensordot  # NOQA
 from cupy.linalg._product import vdot  # NOQA
+from cupy.linalg._product import vecdot  # NOQA
 
 from cupy.linalg._norms import trace  # NOQA
 

--- a/cupy/linalg/__init__.py
+++ b/cupy/linalg/__init__.py
@@ -10,7 +10,7 @@ from cupy.linalg._product import matrix_power  # NOQA
 from cupy.linalg._product import linalg_cross as cross  # NOQA
 from cupy.linalg._product import matmul     # NOQA
 from cupy.linalg._product import matrix_transpose     # NOQA
-
+from cupy.linalg._product import linalg_vecdot as vecdot     # NOQA
 
 # -----------------------------------------------------------------------------
 # Decompositions
@@ -76,4 +76,5 @@ __all__ = [
     "LinAlgError",
     "matmul",
     "matrix_transpose",
+    "vecdot",
 ]

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -82,6 +82,7 @@ _vecdot_conj_mul_sum = _core.ReductionKernel(
     'a + b', 'out = a', '0', 'cupy_vecdot_conj_mul_sum'
 )
 
+
 def _vecdot_core(a, b, out=None):
     # Deferred to avoid import cycle with cupy.cublas (which then imports
     # cupy.linalg)
@@ -113,6 +114,7 @@ def _vecdot_core(a, b, out=None):
         _core.elementwise_copy(res, out)
         return out
     return res
+
 
 vecdot = _GUFunc(
     _vecdot_core,
@@ -146,7 +148,6 @@ vecdot = _GUFunc(
     .. seealso:: :func:`numpy.vecdot`
     """
 )
-
 
 
 def dot(a, b, out=None):

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -530,3 +530,62 @@ def matrix_transpose(a):
     if ndim < 2:
         raise ValueError('Matrix dimension is less than 2')
     return a.swapaxes(ndim-1, ndim-2)
+
+
+def _vecdot_core(a, b):
+    if a.dtype.kind == 'c':
+        a = a.conj()
+    return (a * b).sum(axis=-1)
+
+
+vecdot = _GUFunc(
+    _vecdot_core,
+    '(n),(n)->()',
+    supports_batched=True,
+    name='vecdot',
+    doc="""vecdot(x1, x2, /, out=None, \\*\\*kwargs)
+
+    Vector dot product of two arrays.
+
+    Let :math:`\\mathbf{a}` be a vector in ``x1`` and :math:`\\mathbf{b}`
+    be a corresponding vector in ``x2``. The dot product is defined as:
+
+    .. math::
+       \\mathbf{a} \\cdot \\mathbf{b} = \\sum_{i=0}^{n-1} \\overline{a_i}b_i
+
+    where the sum is over the last dimension (unless ``axis`` is specified)
+    and where :math:`\\overline{a_i}` denotes the complex conjugate if
+    :math:`a_i` is complex and the identity otherwise.
+
+    Args:
+        x1 (cupy.ndarray): The first argument. It is conjugated if complex.
+        x2 (cupy.ndarray): The second argument.
+        out (cupy.ndarray, optional): Output array.
+        \\*\\*kwargs: ufunc keyword arguments.
+
+    Returns:
+        cupy.ndarray: The vector dot product of the inputs.
+
+    .. seealso:: :func:`numpy.vecdot`
+    """
+)
+
+
+def linalg_vecdot(x1, x2, /, *, axis=-1):
+    """Computes the vector dot product.
+
+    This function is restricted to arguments compatible with the Array API,
+    contrary to :func:`cupy.vecdot`.
+
+    Args:
+        x1 (cupy.ndarray): The first argument. It is conjugated if complex.
+        x2 (cupy.ndarray): The second argument.
+        axis (int): Axis over which to compute the dot product.
+            Default: ``-1``.
+
+    Returns:
+        cupy.ndarray: The vector dot product of the inputs.
+
+    .. seealso:: :func:`numpy.linalg.vecdot`
+    """
+    return vecdot(x1, x2, axis=axis)

--- a/cupy/linalg/_product.py
+++ b/cupy/linalg/_product.py
@@ -76,6 +76,78 @@ matmul = _GUFunc(
     """
 )
 
+_vecdot_conj_mul_sum = _core.ReductionKernel(
+    'S x, T y', 'U out',
+    'conj(static_cast<U>(x)) * static_cast<U>(y)',
+    'a + b', 'out = a', '0', 'cupy_vecdot_conj_mul_sum'
+)
+
+def _vecdot_core(a, b, out=None):
+    # Deferred to avoid import cycle with cupy.cublas (which then imports
+    # cupy.linalg)
+    from cupy import cublas
+
+    if a.ndim == 1 and b.ndim == 1:
+        if (a.dtype == b.dtype and a.dtype.char in 'fdFD'
+                and a.flags.c_contiguous and b.flags.c_contiguous):
+            # cuBLAS ?dot/?dotc conjugates x1 on the fly
+            return cublas.dotc(a, b, out=out)
+        # Fallback for float16, ints, bool, mixed dtypes, non-contiguous.
+        if a.dtype.kind == 'c':
+            a = a.conj()
+        return _core.tensordot_core(a, b, out, 1, 1, a.size, ())
+
+    if a.dtype.kind != 'c' and b.dtype.kind != 'c':
+        return (a * b).sum(axis=-1, out=out)
+
+    # Accumulate in the promoted (complex) dtype: the kernel's output type
+    # drives both the accumulation precision and conj(), which does not
+    # compile for real out dtypes (e.g. out= with casting='unsafe').
+    dtype = cupy.promote_types(a.dtype, b.dtype)
+    if out is None or out.dtype != dtype:
+        res = cupy.empty(cupy.broadcast_shapes(a.shape, b.shape)[:-1], dtype)
+    else:
+        res = out
+    _vecdot_conj_mul_sum(a, b, res, axis=-1)
+    if out is not None and res is not out:
+        _core.elementwise_copy(res, out)
+        return out
+    return res
+
+vecdot = _GUFunc(
+    _vecdot_core,
+    '(n),(n)->()',
+    supports_batched=True,
+    supports_out=True,
+    name='vecdot',
+    doc="""vecdot(x1, x2, /, out=None, \\*\\*kwargs)
+
+    Vector dot product of two arrays.
+
+    Let :math:`\\mathbf{a}` be a vector in ``x1`` and :math:`\\mathbf{b}`
+    be a corresponding vector in ``x2``. The dot product is defined as:
+
+    .. math::
+       \\mathbf{a} \\cdot \\mathbf{b} = \\sum_{i=0}^{n-1} \\overline{a_i}b_i
+
+    where the sum is over the last dimension (unless ``axis`` is specified)
+    and where :math:`\\overline{a_i}` denotes the complex conjugate if
+    :math:`a_i` is complex and the identity otherwise.
+
+    Args:
+        x1 (cupy.ndarray): The first argument. It is conjugated if complex.
+        x2 (cupy.ndarray): The second argument.
+        out (cupy.ndarray, optional): Output array.
+        \\*\\*kwargs: ufunc keyword arguments.
+
+    Returns:
+        cupy.ndarray: The vector dot product of the inputs.
+
+    .. seealso:: :func:`numpy.vecdot`
+    """
+)
+
+
 
 def dot(a, b, out=None):
     """Returns a dot product of two arrays.
@@ -530,45 +602,6 @@ def matrix_transpose(a):
     if ndim < 2:
         raise ValueError('Matrix dimension is less than 2')
     return a.swapaxes(ndim-1, ndim-2)
-
-
-def _vecdot_core(a, b):
-    if a.dtype.kind == 'c':
-        a = a.conj()
-    return (a * b).sum(axis=-1)
-
-
-vecdot = _GUFunc(
-    _vecdot_core,
-    '(n),(n)->()',
-    supports_batched=True,
-    name='vecdot',
-    doc="""vecdot(x1, x2, /, out=None, \\*\\*kwargs)
-
-    Vector dot product of two arrays.
-
-    Let :math:`\\mathbf{a}` be a vector in ``x1`` and :math:`\\mathbf{b}`
-    be a corresponding vector in ``x2``. The dot product is defined as:
-
-    .. math::
-       \\mathbf{a} \\cdot \\mathbf{b} = \\sum_{i=0}^{n-1} \\overline{a_i}b_i
-
-    where the sum is over the last dimension (unless ``axis`` is specified)
-    and where :math:`\\overline{a_i}` denotes the complex conjugate if
-    :math:`a_i` is complex and the identity otherwise.
-
-    Args:
-        x1 (cupy.ndarray): The first argument. It is conjugated if complex.
-        x2 (cupy.ndarray): The second argument.
-        out (cupy.ndarray, optional): Output array.
-        \\*\\*kwargs: ufunc keyword arguments.
-
-    Returns:
-        cupy.ndarray: The vector dot product of the inputs.
-
-    .. seealso:: :func:`numpy.vecdot`
-    """
-)
 
 
 def linalg_vecdot(x1, x2, /, *, axis=-1):

--- a/docs/source/reference/linalg.rst
+++ b/docs/source/reference/linalg.rst
@@ -25,8 +25,8 @@ Matrix and vector products
    dot
    # linalg.multi_dot
    vdot
-   # vecdot
-   # linalg.vecdot
+   vecdot
+   linalg.vecdot
    inner
    outer
    # linalg.outer

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -634,3 +634,82 @@ class TestLinalgMatrixTranspose:
     def test_matrix_transpose_error(self, xp, dtype):
         a = testing.shaped_arange((10,), xp, dtype)
         return xp.linalg.matrix_transpose(a)
+
+
+@pytest.mark.parametrize('shapes', [
+    ((3,), (3,)),
+    ((5, 3), (5, 3)),
+    ((2, 1, 3), (4, 3)),
+    ((0, 3), (3,)),
+    ((3, 0), (3, 0)),
+])
+class TestVecdotShapes:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot(self, xp, dtype, shapes):
+        shape_a, shape_b = shapes
+        # Distinct operands so a missing conjugation of x1 changes the
+        # complex results.
+        a = testing.shaped_random(shape_a, xp, dtype, seed=0)
+        b = testing.shaped_random(shape_b, xp, dtype, seed=1)
+        return xp.vecdot(a, b)
+
+
+class TestVecdot:
+
+    @testing.for_all_dtypes(name='dtype1')
+    @testing.for_all_dtypes(name='dtype2')
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot_dtype_combination(self, xp, dtype1, dtype2):
+        a = testing.shaped_random((4, 3), xp, dtype1, seed=0)
+        b = testing.shaped_random((4, 3), xp, dtype2, seed=1)
+        return xp.vecdot(a, b)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot_axis(self, xp, dtype):
+        a = testing.shaped_random((3, 4), xp, dtype, seed=0)
+        b = testing.shaped_random((3, 4), xp, dtype, seed=1)
+        return xp.vecdot(a, b, axis=0)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot_keepdims(self, xp, dtype):
+        a = testing.shaped_random((3, 4), xp, dtype, seed=0)
+        b = testing.shaped_random((3, 4), xp, dtype, seed=1)
+        return xp.vecdot(a, b, keepdims=True)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot_out(self, xp, dtype):
+        a = testing.shaped_random((2, 3), xp, dtype, seed=0)
+        b = testing.shaped_random((2, 3), xp, dtype, seed=1)
+        out = xp.empty((2,), dtype=dtype)
+        xp.vecdot(a, b, out=out)
+        return out
+
+    @testing.numpy_cupy_allclose(accept_error=ValueError)
+    def test_vecdot_core_dim_mismatch(self, xp):
+        return xp.vecdot(xp.ones((3,)), xp.ones((4,)))
+
+    @testing.numpy_cupy_allclose(accept_error=ValueError)
+    def test_vecdot_zero_dim(self, xp):
+        return xp.vecdot(xp.asarray(3.0), xp.ones((4,)))
+
+
+class TestLinalgVecdot:
+
+    @testing.for_all_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot(self, xp, dtype):
+        a = testing.shaped_random((5, 3), xp, dtype, seed=0)
+        b = testing.shaped_random((3,), xp, dtype, seed=1)
+        return xp.linalg.vecdot(a, b)
+
+    @testing.for_float_dtypes()
+    @testing.numpy_cupy_allclose(rtol=1e-3, atol=1e-3)
+    def test_vecdot_axis(self, xp, dtype):
+        a = testing.shaped_random((3, 4), xp, dtype, seed=0)
+        b = testing.shaped_random((3, 4), xp, dtype, seed=1)
+        return xp.linalg.vecdot(a, b, axis=0)

--- a/tests/cupy_tests/linalg_tests/test_product.py
+++ b/tests/cupy_tests/linalg_tests/test_product.py
@@ -638,6 +638,7 @@ class TestLinalgMatrixTranspose:
 
 @pytest.mark.parametrize('shapes', [
     ((3,), (3,)),
+    ((0,), (0,)),
     ((5, 3), (5, 3)),
     ((2, 1, 3), (4, 3)),
     ((0, 3), (3,)),
@@ -686,8 +687,31 @@ class TestVecdot:
         a = testing.shaped_random((2, 3), xp, dtype, seed=0)
         b = testing.shaped_random((2, 3), xp, dtype, seed=1)
         out = xp.empty((2,), dtype=dtype)
-        xp.vecdot(a, b, out=out)
+        result = xp.vecdot(a, b, out=out)
+        assert result is out
         return out
+
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_vecdot_out_complex_to_real(self, xp):
+        # Complex inputs with a real out must accumulate in complex and
+        # cast at the end (used to fail kernel compilation).
+        a = testing.shaped_random((2, 3), xp, numpy.complex128, seed=0)
+        b = testing.shaped_random((2, 3), xp, numpy.complex128, seed=1)
+        out = xp.empty((2,), dtype=numpy.float64)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', numpy.exceptions.ComplexWarning)
+            result = xp.vecdot(a, b, out=out, casting='unsafe')
+        assert result is out
+        return out
+
+    @testing.for_dtypes('dD')
+    @testing.numpy_cupy_allclose(rtol=1e-6)
+    def test_vecdot_strided(self, xp, dtype):
+        # Non-contiguous 1-D inputs must not take the cuBLAS dot(c) path,
+        # which assumes unit stride and would be silently wrong.
+        a = testing.shaped_random((8,), xp, dtype, seed=0)[::2]
+        b = testing.shaped_random((8,), xp, dtype, seed=1)[::2]
+        return xp.vecdot(a, b)
 
     @testing.numpy_cupy_allclose(accept_error=ValueError)
     def test_vecdot_core_dim_mismatch(self, xp):


### PR DESCRIPTION
Part of #6078

This adds the NumPy / Array API function `vecdot` in the following two locations:

- `cupy.vecdot`: implemented as a `_GUFunc` with signature `(n),(n)->()`, which provides broadcasting of batch dimensions and ufunc keyword handling.
- `cupy.linalg.vecdot`: the Array API version matching `numpy.linalg.vecdot`.

The implementation computes `sum(conj(x1) * x2)` over the contraction axis. Following review feedback, the core implementation now avoids materializing intermediates where possible:

- Contiguous 1-D `float32`, `float64`, `complex64`, and `complex128` inputs use cuBLAS `dotc`, which conjugates the first complex operand on the fly.
- Other 1-D inputs use `_core.tensordot_core`.
- Batched complex inputs use a fused `ReductionKernel`, avoiding separate conjugation and multiplication arrays.
- The core accepts `out` directly, avoiding an additional GUFunc output copy.
- Non-contiguous 1-D inputs avoid the unit-stride cuBLAS path.

Apart from the implementations, this PR:

- Adds the functions to the public namespaces and documentation.
- Adds tests comparing against NumPy across all dtypes, supported shape and broadcasting cases, mixed-dtype promotion, complex conjugation of the first argument, `axis`, `keepdims`, `out`, empty inputs, non-contiguous inputs, and relevant errors.

### Benchmark

I compared the optimized implementation with an exact reconstruction of the original `_GUFunc` implementation, as well as `cupy.vdot` and the underlying naive expressions. Measurements use `cupyx.profiler.benchmark` with CUDA events, 20 warmups, and repeated runs.

Results on an RTX 4090 with CUDA 13.3:

| Input | Optimized `cupy.vecdot` | Original GUFunc baseline | Speedup |
|---|---:|---:|---:|
| `float32`, 1-D, `2^24` elements | 0.159 ms | 0.278 ms | 1.75x |
| `complex128`, 1-D, `2^22` elements | 0.156 ms | 0.420 ms | 2.69x |
| `complex128`, batched `(262144, 16)` | 0.168 ms | 0.523 ms | 3.11x |
| `float32`, batched `(262144, 16)` | 0.036 ms | 0.035 ms | 0.97x |
| `complex128`, batched `(4194304, 16)` | 2.771 ms | 10.516 ms | 3.80x |
| `float32`, 1-D, 1000 elements | 0.013 ms | 0.022 ms | 1.69x |

The real batched path is effectively unchanged relative to the complete original GUFunc baseline. A raw `(a * b).sum(-1)` expression is faster for that small, L2-resident case because it does not include GUFunc dispatch and output handling.

I tested locally against NumPy 2.5.2. The targeted vecdot tests pass. I also ran the full test suite; the six unrelated failures were reproducible on `main`. The documentation builds successfully.
