### PR TITLE
TST: Mark test as thread-unsafe (mutates global pinned allocator)

### DIFF
--- a/tests/cupy_tests/core_tests/test_ndarray.py
+++ b/tests/cupy_tests/core_tests/test_ndarray.py
@@ -130,6 +130,7 @@ class TestNdarrayInit(unittest.TestCase):
     })
 )
 class TestAsarray(unittest.TestCase):
+    @pytest.mark.thread_unsafe(reason="mutates global pinned allocator.")
     def test_asarray(self):
         cp_order, view, strides = self.cp_setup
         shape = (2, 3, 4)


### PR DESCRIPTION
This test is thread-unsafe, it simply never triggered in a run until recently (unfortunately, that is expected that we have some flakyness).

Closes gh-10193