### PR TITLE
API: Add shape argument to cupy.reshape

### DIFF
--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -37,8 +37,8 @@ def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
             make the shape compatible with ``a.size``.
         newshape (int or tuple of ints):
             .. deprecated:: 14.3.0
-            Replaced by ``shape`` argument. Retained for backward
-            compatibility.
+                Replaced by ``shape`` argument. Retained for backward
+                compatibility.
         order ({'C', 'F', 'A'}):
             Read the elements of ``a`` using this index order, and place the
             elements into the reshaped array using this index order.

--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy
+import warnings
 
 import cupy
 
@@ -22,18 +23,22 @@ def shape(a):
         return numpy.shape(a)
 
 
-def reshape(a, newshape, order='C', *, copy=None):
+def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
     """Returns an array with new shape and same elements.
 
     It tries to return a view if possible, otherwise returns a copy.
 
     Args:
         a (cupy.ndarray): Array to be reshaped.
-        newshape (int or tuple of ints): The new shape of the array to return.
+        shape (int or tuple of ints): The new shape of the array to return.
             If it is an integer, then it is treated as a tuple of length one.
             It should be compatible with ``a.size``. One of the elements can be
             -1, which is automatically replaced with the appropriate value to
             make the shape compatible with ``a.size``.
+        newshape (int or tuple of ints):
+            .. deprecated:: 14.3.0
+            Replaced by ``shape`` argument. Retained for backward
+            compatibility.
         order ({'C', 'F', 'A'}):
             Read the elements of ``a`` using this index order, and place the
             elements into the reshaped array using this index order.
@@ -57,8 +62,25 @@ def reshape(a, newshape, order='C', *, copy=None):
     .. seealso:: :func:`numpy.reshape`
 
     """
+    if newshape is None and shape is None:
+        raise TypeError(
+            "reshape() missing 1 required positional argument: 'shape'")
+    if newshape is not None:
+        if shape is not None:
+            raise TypeError(
+                "You cannot specify 'newshape' and 'shape' arguments "
+                "at the same time.")
+        # Deprecated in CuPy 14.3.0, 2026-08-31
+        warnings.warn(
+            "`newshape` keyword argument is deprecated, "
+            "use `shape=...` or pass shape positionally instead. "
+            "(deprecated in CuPy 14.3.0)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        shape = newshape
     # TODO(okuta): check type
-    return a.reshape(newshape, order=order, copy=copy)
+    return a.reshape(shape, order=order, copy=copy)
 
 
 def ravel(a, order='C'):

--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -35,10 +35,6 @@ def reshape(a, /, shape=None, order='C', *, newshape=None, copy=None):
             It should be compatible with ``a.size``. One of the elements can be
             -1, which is automatically replaced with the appropriate value to
             make the shape compatible with ``a.size``.
-        newshape (int or tuple of ints):
-            .. deprecated:: 14.3.0
-                Replaced by ``shape`` argument. Retained for backward
-                compatibility.
         order ({'C', 'F', 'A'}):
             Read the elements of ``a`` using this index order, and place the
             elements into the reshaped array using this index order.
@@ -51,6 +47,10 @@ def reshape(a, /, shape=None, order='C', *, newshape=None, copy=None):
             underlying array, and only refer to the order of indexing. 'A'
             means to read / write the elements in Fortran-like index order if
             a is Fortran contiguous in memory, C-like order otherwise.
+        newshape (int or tuple of ints):
+            .. deprecated:: 14.3.0
+                Replaced by ``shape`` argument. Retained for backward
+                compatibility.
         copy (bool or optional): If ``True``, then the array data is copied. If
             ``None``, a copy will only be made if it's required by ``order``.
             For ``False`` it raises a ``ValueError`` if a copy cannot be

--- a/cupy/_manipulation/shape.py
+++ b/cupy/_manipulation/shape.py
@@ -23,7 +23,7 @@ def shape(a):
         return numpy.shape(a)
 
 
-def reshape(a, /, shape=None, *, newshape=None, order='C', copy=None):
+def reshape(a, /, shape=None, order='C', *, newshape=None, copy=None):
     """Returns an array with new shape and same elements.
 
     It tries to return a view if possible, otherwise returns a copy.

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -41,6 +41,32 @@ class TestReshape:
             return a.reshape((1, 1, 1, 4, 1, 2)).strides
         assert func(numpy) == func(cupy)
 
+    def test_reshape_shape_arg(self):
+        arr = cupy.arange(12)
+        shape = (3, 4)
+        expected = arr.reshape(shape)
+
+        with pytest.raises(
+            TypeError,
+            match="You cannot specify 'newshape' and 'shape' "
+                  "arguments at the same time."
+        ):
+            cupy.reshape(arr, shape=shape, newshape=shape)
+        with pytest.raises(
+            TypeError,
+            match=r"reshape\(\) missing 1 required positional "
+                  "argument: 'shape'"
+        ):
+            cupy.reshape(arr)
+
+        assert (cupy.reshape(arr, shape) == expected).all()
+        assert (cupy.reshape(arr, shape, order="C") == expected).all()
+        assert (cupy.reshape(arr, shape=shape) == expected).all()
+        assert (cupy.reshape(arr, shape=shape, order="C") == expected).all()
+        with pytest.warns(DeprecationWarning):
+            actual = cupy.reshape(arr, newshape=shape)
+            assert (actual == expected).all()
+
     @testing.for_orders('CFA')
     @testing.for_all_dtypes()
     @testing.numpy_cupy_array_equal()

--- a/tests/cupy_tests/manipulation_tests/test_shape.py
+++ b/tests/cupy_tests/manipulation_tests/test_shape.py
@@ -61,6 +61,7 @@ class TestReshape:
 
         assert (cupy.reshape(arr, shape) == expected).all()
         assert (cupy.reshape(arr, shape, order="C") == expected).all()
+        assert (cupy.reshape(arr, shape, "C") == expected).all()
         assert (cupy.reshape(arr, shape=shape) == expected).all()
         assert (cupy.reshape(arr, shape=shape, order="C") == expected).all()
         with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
Resolves #10149 

Remaining task to make `cupy.reshape` array API-compatible is adding the `shape` argument to `cupy.reshape`. I also used numpy's [PR](https://github.com/numpy/numpy/pull/26292) of said implementation as a guide.

Although numpy has already removed `newshape` argument in their `2.4.0` release (https://github.com/numpy/numpy/pull/30012, https://github.com/numpy/numpy/pull/29994), we will first deprecate the `newshape` argument for `14.3.0` and remove it altogether in a future release.

Because `cupy` will be a bit behind to ease our users into the new API, the tests closely resemble numpy's test implementation. I didn't take the usual approach of asserting parity behavior between numpy and cupy (e.g. asserting exceptions aren't 1-to-1 since numpy now doesn't recognize the `newshape` argument after their `2.4.0` release).

I also didn't see documentation changes with other API deprecation PRs (e.g. updating release note files), so I assume updating the docstrings is all that's needed for this PR.