### PR TITLE
CI: add repository.ssh_url to ci-nightly synthetic payload

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -144,7 +144,12 @@ jobs:
                 url: $url,
                 timestamp: $ts
               },
-              repository: { full_name: $repo },
+              repository: {
+                full_name: $repo,
+                ssh_url: "git@github.com:\($repo).git",
+                clone_url: "https://github.com/\($repo).git",
+                html_url: "https://github.com/\($repo)"
+              },
               sender: { login: "github-actions[bot]" }
             }' > payload.json
           cat payload.json


### PR DESCRIPTION
Fix the nightly's synthetic push webhook so FlexCI can check out the repo.

Symptom: run <https://github.com/cupy/cupy/actions/runs/33508388092> dispatched 28 FlexCI jobs ([`225935`](https://ci.preferred.jp/r/job/225935)..[`225962`](https://ci.preferred.jp/r/job/225962)) at 12:34:27 UTC on 2026-09-01. All 28 CANCELED at checkout with:

```
[ABORTED] command exited with a non-zero code: 128:
  git clone --config pack.packSizeLimit=64m --recurse-submodules
  /var/tmp/imosci/default/da39a3ee5e6b4b0d3255bfef95601890afd80709
```

That path's SHA is the SHA-1 of an empty string, so FlexCI is cloning from an empty-key mirror. The FlexCI job page shows the `Repository` field is empty — sampled [`225935`](https://ci.preferred.jp/r/job/225935) (cupy.linux.cuda121), [`225936`](https://ci.preferred.jp/r/job/225936) (cupy.linux.cuda122), [`225940`](https://ci.preferred.jp/r/job/225940) (cupy.linux.cuda123), [`225945`](https://ci.preferred.jp/r/job/225945) (cupy.win.cuda122), [`225955`](https://ci.preferred.jp/r/job/225955) (cupy.win.cuda123), [`225962`](https://ci.preferred.jp/r/job/225962) (cupy.linux.cuda131.multi), all identical.

Real GitHub push webhooks put `repository.ssh_url` = `git@github.com:cupy/cupy.git` in the payload, and FlexCI reads that field for `Repository`. A successful push job for the same SHA on a mini lane ([`225925`](https://ci.preferred.jp/r/job/225925) cupy.linux.cuda120) shows the field correctly populated. Our synthetic payload only set `full_name`, so `ssh_url` came through empty and FlexCI fell back to hashing empty string → `da39a3ee...`.

This adds `ssh_url`, `clone_url`, and `html_url` (all constructible from `GITHUB_REPOSITORY`), matching the shape of a real push payload for these three fields.

After merge, trigger the nightly manually to re-run tonight's matrix against the current main tip.