### PR TITLE
CI: newer merges cancel earlier in-flight push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ concurrency:
   # can't filter `labeled` by name), so any OTHER label must land in a unique,
   # throwaway group -- otherwise it would enter ci-build-<PR> and cancel the
   # in-flight vouched build before the guard no-ops it (concurrency is evaluated
-  # at queue time, ahead of the guard job). Push runs get a per-commit group
-  # (i.e. effectively none): a burst of merges must not cancel intermediate
-  # runs, each of which carries its own FlexCI dispatch.
-  group: ${{ github.event_name == 'push' && format('ci-push-{0}', github.sha) || github.event.label.name == 'ci:triggered' && format('ci-build-{0}', github.event.pull_request.number) || format('ci-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event.label.name == 'ci:triggered' }}
+  # at queue time, ahead of the guard job). Push runs share ci-push-<ref>: a
+  # burst of merges lets the newest merge supersede any earlier in-flight run
+  # on the same branch, so we don't burn build minutes on intermediate SHAs
+  # whose wheels no one will consume. ci-nightly.yml already picks the newest
+  # successful ci.yml push run, so cancelled intermediates are naturally
+  # skipped there too.
+  group: >-
+    ${{ github.event_name == 'push' && format('ci-push-{0}', github.ref)
+        || github.event.label.name == 'ci:triggered' && format('ci-build-{0}', github.event.pull_request.number)
+        || format('ci-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'push' || github.event.label.name == 'ci:triggered' }}
 
 # Least privilege: read-only by default; jobs that need more grant it
 # per-job below (only dispatch-flexci writes, via flexci_dispatcher.py).


### PR DESCRIPTION
Caught my bot made a mistake in #10193 (commit e7f9a7513). The concurrency group was mistakenly made such that in the merge CI we don't cancel prior ongoing runs. This PR fixes it.