### PR TITLE
eigsh: fail closed on a corrupt locked block; fix the sparse norm bound

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -152,14 +152,13 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
     la_shift = (which == 'LA')
 
     # Lanczos iteration
-    anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha, beta,
-                                               0, ncv, break_rtol, bias_op,
-                                               la_shift,
-                                               ortho_rtol=ortho_rtol,
-                                               norm_bound=norm_bound)
+    anorm, bias_shift, work, a_h, b_h = _lanczos_checked(
+        a, lanczos, V, u, alpha, beta, 0, ncv, break_rtol, bias_op,
+        la_shift, ortho_rtol=ortho_rtol, norm_bound=norm_bound)
 
     iter = work
-    w, s, w_host = _eigsh_solve_ritz(alpha, beta, None, k, which)
+    w, s, w_host = _eigsh_solve_ritz(alpha, beta, None, k, which,
+                                     alpha_host=a_h, beta_host=b_h)
     x = V.T @ s
 
     # Compute residual
@@ -173,8 +172,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         beta[:k] = 0
         alpha[:k] = w
         V[:k] = x.T
-        _repair_locked(a, V, alpha, k, n, ortho_rtol, bias_op,
-                       bias_shift, w_host=w_host)
+        _check_locked(V, k, ortho_rtol, w_host=w_host)
 
         # u -= u.T @ V[:k].conj().T @ V[:k]
         cublas.gemv(_cublas.CUBLAS_OP_C, 1, V[:k].T, u, 0, uu)
@@ -211,18 +209,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         V[k+1] = cupy.where(beta[k] > 0, u / beta[k], u * 0)
 
         # Lanczos iteration
-        anorm, bias_shift, work = _lanczos_checked(a, lanczos, V, u, alpha,
-                                                   beta, k + 1, ncv,
-                                                   break_rtol, bias_op,
-                                                   la_shift,
-                                                   ortho_rtol=ortho_rtol,
-                                                   norm_bound=norm_bound)
+        anorm, bias_shift, work, a_h, b_h = _lanczos_checked(
+            a, lanczos, V, u, alpha, beta, k + 1, ncv, break_rtol, bias_op,
+            la_shift, ortho_rtol=ortho_rtol, norm_bound=norm_bound)
 
         # +1 for the u = a @ V[k] above; equals the former ncv - k when no
         # repair re-sweep ran.
         iter += work + 1
-        w, s, w_host = _eigsh_solve_ritz(alpha, beta, beta_k, k,
-                                         which)
+        w, s, w_host = _eigsh_solve_ritz(alpha, beta, beta_k, k, which,
+                                         alpha_host=a_h, beta_host=b_h)
         x = V.T @ s
 
         # Compute residual
@@ -419,18 +414,20 @@ def _norm_upper_bound(a):
     LinearOperator), in which case no absolute bound can be formed and the
     caller falls back to checking only for non-finite estimates.
     """
-    try:
-        if isinstance(a, cupy.ndarray):
-            return float(cupy.abs(a).sum(axis=1).max())
-        if _csr._is_csr(a) or getattr(a, 'format', None) in (
-                'csr', 'csc', 'coo'):
-            # |A| @ 1 gives the absolute row sums; A is Hermitian here, so
-            # a CSC/COO layout yields the same bound.
-            b = a.tocsr()
-            ones = cupy.ones(b.shape[1], dtype=b.dtype)
-            return float(cupy.abs(cupy.abs(b) @ ones).max())
-    except Exception:      # pragma: no cover - bound is optional
-        return None
+    if isinstance(a, cupy.ndarray):
+        # Row-wise, without materializing |A| (an n^2 temporary).
+        return float(cupy.abs(a).sum(axis=1).max())
+    if _csr._is_csr(a) or getattr(a, 'format', None) in ('csr', 'csc', 'coo'):
+        # |A| @ 1 gives the absolute row sums; A is Hermitian here, so a
+        # CSC/COO layout yields the same bound. NOTE: the builtin abs() is
+        # required -- it dispatches to the sparse matrix's __abs__, whereas
+        # cupy.abs() is a bare ufunc that rejects sparse input. A previous
+        # revision used cupy.abs() inside a blanket except and silently
+        # returned None for EVERY sparse operator, disabling this guard on
+        # the primary input type (cupy/cupy#10257).
+        b = a.tocsr()
+        ones = cupy.ones(b.shape[1], dtype=b.dtype)
+        return float(cupy.abs(abs(b) @ ones).max())
     return None
 
 
@@ -458,7 +455,8 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
     returned rather than assumed.
 
     Returns (||A|| estimate for the driver's guard on V[k], LA reseed shift,
-    matvecs performed including re-sweeps).
+    matvecs performed including re-sweeps, host copies of alpha and beta
+    for the Ritz solve).
     """
     n = V.shape[1]
     if ortho_rtol is None:
@@ -474,8 +472,9 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
         work += i_end - start
         lanczos(a, V, u, alpha, beta, start, i_end)
         alpha_np = cupy.asnumpy(alpha)
+        beta_np = cupy.asnumpy(beta)
         alpha_h = numpy.abs(alpha_np)
-        beta_h = numpy.abs(cupy.asnumpy(beta))
+        beta_h = numpy.abs(beta_np)
         # Gershgorin-style row-sum estimate of ||T|| ~ ||A||, built by
         # walking the rows IN ORDER and stopping at the first breakdown:
         # rows past an exhausted subspace hold roundoff junk whose magnitude
@@ -494,7 +493,7 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
             anorm = float(alpha_h[0] + beta_h[0])
             shift = (anorm if (la_shift and float(alpha_np[0].real) <= 0.0)
                      else 0.0)
-            return anorm, shift, work
+            return anorm, shift, work, alpha_np, beta_np
         # float64 accumulation: alpha/beta past an exhausted subspace can be
         # huge in float32 (the junk this walk exists to exclude) and the
         # row sums would overflow to inf before we ever get to ignore them.
@@ -579,60 +578,54 @@ def _lanczos_checked(a, lanczos, V, u, alpha, beta, i_start, i_end,
                            and float(alpha_np[:end + 1].real.max()) <= 0.0)
                  else 0.0)
         if p is None:
-            return anorm, shift, work
+            # Hand back the host copies: the Ritz solve needs the same two
+            # arrays and would otherwise transfer them a second time.
+            return anorm, shift, work, alpha_np, beta_np
         beta[p] = 0
         V[p + 1] = _restart_ortho(V, p + 1, n, V.dtype, bias_op, shift)
         repaired.add(p)
         start = p + 1
 
 
-def _repair_locked(a, V, alpha, k, n, ortho_rtol, bias_op, bias_shift,
-                   w_host=None):
-    # The locked block V[:k] = (V.T @ s).T inherits orthonormality from V
-    # and from the Ritz basis s -- but only when BOTH are sound. On an
-    # eigenvalue of multiplicity > 1 the Ritz basis is degenerate by
-    # construction and several columns of s can name the same physical
-    # direction, so V[:k] can hold duplicate rows (measured: worst
-    # off-diagonal 4.0e-01 immediately after locking, where orthonormality
-    # demands ~1e-16). The sweep-boundary check cannot see this, because it
-    # only repairs positions at or after i_start - 1; a duplicate locked
-    # here would survive to poison every later reseed. So verify the block
-    # where it is created: one Gram of (k+1) x n per restart, far cheaper
-    # than the ncv x n check per sweep.
+def _check_locked(V, k, ortho_rtol, w_host=None):
+    # Consistency check on the locked block V[:k] = (V.T @ s).T, run once
+    # per restart. Because numpy.linalg.eigh returns an orthonormal s
+    # regardless of eigenvalue multiplicity, V[:k] is orthonormal exactly
+    # when V was -- so from a sound basis this check is unreachable and
+    # costs nothing beyond the gate below. It fires only when V had already
+    # lost orthogonality without the sweep-boundary check catching it.
     #
-    # A duplicated Ritz vector carries no information the block does not
-    # already have, so replacing it with a fresh orthogonal direction loses
-    # nothing. beta[:k] is zero here, i.e. T is block-decoupled, so each
-    # locked row is its own 1x1 block and alpha[j] must be updated to the
-    # new direction's Rayleigh quotient to keep T consistent.
+    # In that state no local substitution can restore T = V A V^H: a
+    # replacement row would need beta_k[j] (the arrowhead coupling to
+    # position k) and its couplings to the other locked rows recomputed,
+    # which the driver has no consistent way to do, and an arbitrary
+    # reseed with a Rayleigh-quotient alpha[j] would be carried as a
+    # converged pair with an O(1) true residual (cupy/cupy#10257). So this
+    # fails closed, like the other guards, instead of fabricating a pair.
     #
     # Gated on the Ritz values, which the driver already holds on the host:
-    # duplicate Ritz VECTORS can only arise from a degenerate Ritz basis,
-    # i.e. from (near-)repeated Ritz VALUES. That test is free -- k host
-    # floats -- whereas running the Gram unconditionally costs a device
-    # sync per restart, measured at +9-13% end to end on healthy problems.
+    # duplicate rows can only come from a degenerate Ritz basis, i.e. from
+    # (near-)repeated Ritz VALUES -- k host floats, no device sync -- so a
+    # healthy restart never pays for the Gram.
     if k < 2:
         return
     if w_host is not None:
         wr = numpy.asarray(w_host, dtype=numpy.float64).real
         scale = float(numpy.abs(wr).max()) if wr.size else 0.0
-        # Sort the SIGNED values: a +/-lambda pair is not degenerate, and
-        # sorting magnitudes would make an indefinite spectrum (common
-        # under 'LM') fire this gate for nothing.
+        # Sort the SIGNED values: a +/-lambda pair is not degenerate.
         if scale == 0.0 or not numpy.any(
                 numpy.diff(numpy.sort(wr)) <= ortho_rtol * scale):
             return
-    # Only the locked rows: the driver overwrites V[k] a few lines below,
-    # and its overlap with the locked block is |s[k, j]|, normally far
-    # above the tolerance -- including it would reseed a row that is about
-    # to be discarded, at the cost of a matvec and a sync.
     Vk = V[:k]
     gram = cupy.tril(cupy.abs(Vk @ Vk.conj().T), -1)
-    worst = cupy.asnumpy(gram.max(axis=1))
-    for j in numpy.flatnonzero(worst > ortho_rtol):
-        j = int(j)
-        V[j] = _restart_ortho(V, j, n, V.dtype, bias_op, bias_shift)
-        alpha[j] = cupy.inner(V[j].conj(), a @ V[j])
+    worst = float(cupy.asnumpy(gram.max()))
+    if worst > ortho_rtol:
+        raise RuntimeError(
+            'eigsh: locked Ritz block lost orthogonality (worst '
+            'off-diagonal {:.3e} exceeds {:.1e}); the Lanczos basis is '
+            'numerically rank-deficient and cannot be restarted safely. '
+            'Try a smaller ncv, a different v0, or float64.'.format(
+                worst, ortho_rtol))
 
 
 def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
@@ -721,12 +714,15 @@ def _restart_ortho(V, m, n, dtype, bias_op=None, bias_shift=0.0):
         'different v0.'.format(floor, 2 * len(order) + 1))
 
 
-def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
+def _eigsh_solve_ritz(alpha, beta, beta_k, k, which,
+                      alpha_host=None, beta_host=None):
     # Note: This is done on the CPU, because there is an issue in
     # cupy.linalg.eigh with CUDA 9.2, which can return NaNs. It will has little
     # impact on performance, since the matrix size processed here is not large.
-    alpha = cupy.asnumpy(alpha)
-    beta = cupy.asnumpy(beta)
+    # alpha_host/beta_host: the copies _lanczos_checked already made, so the
+    # sweep boundary costs one device->host transfer of each, not two.
+    alpha = cupy.asnumpy(alpha) if alpha_host is None else alpha_host
+    beta = cupy.asnumpy(beta) if beta_host is None else beta_host
     t = numpy.diag(alpha)
     t = t + numpy.diag(beta[:-1], k=1)
     t = t + numpy.diag(beta[:-1], k=-1)
@@ -787,6 +783,13 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
             and ``vt`` where ``u`` is left singular vectors, ``s`` is singular
             values and ``vt`` is right singular vectors. Otherwise, it returns
             only ``s``.
+
+    Raises:
+        RuntimeError: Propagated from :func:`eigsh` when the Lanczos basis
+            loses numerical orthogonality beyond repair on ``a.H @ a``;
+            see the ``Raises`` section of :func:`eigsh` for the causes and
+            remedies. Rank-deficient inputs in single precision are the
+            usual trigger.
 
     .. seealso:: :func:`scipy.sparse.linalg.svds`
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -244,13 +244,18 @@ class TestEigsh:
         a = cupy.asarray((q * evals) @ q.T).astype(dtype)
         v0 = cupy.asarray(
             numpy.random.default_rng(1).random(n)).astype(dtype)
-        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
-                                v0=v0, return_eigenvectors=False)
+        w, x = sparse.linalg.eigsh(sparse.csr_matrix(a), k=k, which='LA',
+                                   v0=v0, return_eigenvectors=True)
         assert not bool(cupy.isnan(w).any())
         assert bool((cupy.abs(w) < 1e3).all())      # no ghost / overflow
         tol = self.clustered_tol[numpy.dtype(dtype).char.lower()]
         cupy.testing.assert_allclose(
             cupy.sort(w.real), cupy.full(k, 50.0), rtol=tol, atol=tol)
+        # True residual of every returned pair, not just the eigenvalues:
+        # this is the path where a fabricated locked pair would surface.
+        r = cupy.linalg.norm(sparse.csr_matrix(a) @ x - x * w[None, :],
+                             axis=0)
+        assert bool((r <= tol * 50.0).all())
 
     @testing.for_dtypes('fdFD')
     def test_null_space_start(self, dtype):
@@ -395,10 +400,68 @@ class TestEigshLateNormDiscovery:
         v0 = numpy.random.default_rng(0).random(n)
         v0[0] = 0.0                        # exactly orthogonal to e_0
         v0 = cupy.asarray((v0 / numpy.linalg.norm(v0)).astype(dtype))
-        w = sparse.linalg.eigsh(a, k=6, which='LA', v0=v0,
-                                return_eigenvectors=False)
+        w, x = sparse.linalg.eigsh(a, k=6, which='LA', v0=v0,
+                                   return_eigenvectors=True)
         assert not bool(cupy.isnan(w).any())
         assert bool((cupy.abs(w) <= 8 * big).all())
+        # The point of the test: the dominant eigenvalue hidden from v0
+        # must actually be discovered -- six copies of 1 would otherwise
+        # satisfy the two assertions above.
+        assert abs(float(cupy.abs(w).max()) - big) <= 1e-6 * big
+        # And every returned pair must be a true eigenpair, not a value
+        # that the projected residual alone declared converged.
+        r = cupy.linalg.norm(a @ x - x * w[None, :], axis=0)
+        tol = {'f': 1e-4, 'd': 1e-9}[numpy.dtype(dtype).char.lower()]
+        assert bool((r <= tol * big).all())
+
+
+@testing.with_requires('scipy')
+class TestEigshNormBound:
+    # The divergence guard compares the Lanczos ||A|| estimate against a
+    # true upper bound computed from the operator's entries. A previous
+    # revision used cupy.abs() on a sparse matrix, which raises and was
+    # swallowed, so the bound was None -- and the guard inert -- for every
+    # sparse operator (cupy/cupy#10257). Pin the bound on all three sparse
+    # formats and confirm it is unavailable (None) for a LinearOperator.
+    @testing.for_dtypes('fdFD')
+    @pytest.mark.parametrize('fmt', ['csr', 'csc', 'coo'])
+    def test_sparse_bound_matches_dense(self, dtype, fmt):
+        from cupyx.scipy.sparse.linalg import _eigen
+        a = testing.shaped_random((40, 40), cupy, dtype=dtype, seed=0)
+        a = a + a.conj().T
+        expected = float(cupy.abs(a).sum(axis=1).max())
+        sp_a = sparse.csr_matrix(a).asformat(fmt)
+        got = _eigen._norm_upper_bound(sp_a)
+        assert got is not None
+        assert abs(got - expected) <= 1e-5 * expected
+
+    def test_linear_operator_has_no_bound(self):
+        from cupyx.scipy.sparse.linalg import _eigen
+        a = sparse.csr_matrix(cupy.eye(8))
+        lo = sparse.linalg.aslinearoperator(a)
+        assert _eigen._norm_upper_bound(lo.H @ lo) is None
+
+
+@testing.with_requires('scipy')
+class TestEigshLockedBlockFailsClosed:
+    # A duplicated row in the locked block means the basis already lost
+    # orthogonality. Substituting a fresh direction cannot restore
+    # T = V A V^H (stale arrowhead coupling), so the check must raise
+    # rather than carry a fabricated pair as converged (cupy/cupy#10257).
+    def test_duplicate_locked_row_raises(self):
+        from cupyx.scipy.sparse.linalg import _eigen
+        V = cupy.zeros((3, 3), dtype=cupy.float64)
+        V[0] = cupy.asarray([1.0, 0.0, 0.0])
+        V[1] = cupy.asarray([1.0, 0.0, 0.0])        # exact duplicate
+        tol = float(numpy.sqrt(numpy.finfo(numpy.float64).eps))
+        with pytest.raises(RuntimeError, match='locked Ritz block'):
+            _eigen._check_locked(V, 2, tol, w_host=None)
+
+    def test_orthonormal_locked_block_passes(self):
+        from cupyx.scipy.sparse.linalg import _eigen
+        V = cupy.eye(3, dtype=cupy.float64)
+        tol = float(numpy.sqrt(numpy.finfo(numpy.float64).eps))
+        _eigen._check_locked(V, 2, tol, w_host=None)   # must not raise
 
 
 @testing.with_requires('scipy')
@@ -462,11 +525,17 @@ class TestEigshDegenerateHermitian:
             expected = cupy.full((self.k,), self.shift,
                                  dtype=nonzero.dtype)
 
-        w = sparse.linalg.eigsh(sparse.csr_matrix(a), k=self.k,
-                                which=self.which,
-                                return_eigenvectors=False)
+        w, x = sparse.linalg.eigsh(sparse.csr_matrix(a), k=self.k,
+                                   which=self.which,
+                                   return_eigenvectors=True)
         assert not bool(cupy.isnan(w).any())
         assert bool(cupy.isfinite(w).all())
+        # True residual of every pair, scaled by ||A|| rather than |w|
+        # because the degenerate block sits at the shift (possibly 0).
+        r = cupy.linalg.norm(sparse.csr_matrix(a) @ x - x * w[None, :],
+                             axis=0)
+        rtol = {'f': 1e-4, 'd': 1e-9}[numpy.dtype(dtype).char.lower()]
+        assert bool((r <= rtol * float(cupy.abs(nonzero).max())).all())
         # Absolute tolerance must scale with ||A||: the degenerate block
         # sits at the roundoff floor of the largest eigenvalue, not at an
         # absolute one. Same 64*eps*||A|| scale the solver itself uses.


### PR DESCRIPTION
Addresses #10257 (follow-ups to #10098). Each item was reproduced on an A100 before being changed; per-report verdicts are in that issue.

**`_norm_upper_bound` never worked for sparse input.** `cupy.abs()` is a bare ufunc and rejects a sparse matrix; the `TypeError` was swallowed by a blanket `except`, so the function returned `None` for every sparse operator and the divergence guard only ever ran on dense arrays. Now the builtin `abs()` (dispatches to the sparse `__abs__`); the `except` is removed; the dense branch no longer materializes `|A|`.

**`_repair_locked` → `_check_locked`, fail closed.** `eigh` returns an orthonormal Ritz basis regardless of multiplicity, so the locked block is orthonormal exactly when `V` is: the branch only fired on an already-corrupted basis, and then substituted an arbitrary direction while `beta_k[j]` still described the discarded one, carrying a pair with an O(1) true residual as converged (measured 0.244 on `diag(3,2,1)`). Same free Ritz-value gate; raises like the other guards. No end-to-end wrong answer was reproducible (4 spectra × 8 seeds) — the #10098 ghost input is fixed by the sweep-boundary check.

**Also:** one device→host transfer of `alpha`/`beta` per sweep instead of two; `svds` documents the `RuntimeError` it propagates.

**Tests:** the late-norm-discovery test now asserts the hidden eigenvalue is found (it passed on six copies of 1) and, with the clustered and degenerate-Hermitian tests, checks the true residual of every returned pair; the sparse bound is pinned against the dense value for csr/csc/coo and `None` for a LinearOperator; `_check_locked` is exercised both ways.

**Validation** (A100, 14.1.1 wheel + patch): TestEigsh/TestSvds **662 passed / 0 failed**; #10098 reproducer 0/10, 0/16 across seeds; healthy-path cost −0.1…−0.9% vs `main` (4 configs).

Not in this PR, noted in #10257: a magnitude check on the Gram-derived `beta[p]` (Report 4), a product-operator bound for `svds`, and the test reparametrization cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
