### PR TITLE
Seed the default start vector of `eigsh`/`svds` and add scipy-compatible `v0=` to `svds`

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -10,6 +10,23 @@ from cupy_backends.cuda.libs import cublas as _cublas
 from cupyx.scipy.sparse import _csr
 from cupyx.scipy.sparse.linalg import _interface
 
+# Seed of the default Lanczos start vector. Drawing it from a fixed seed
+# makes eigsh and svds deterministic for a given input, as ARPACK's default
+# start is, and independent of the global cupy.random state; the trajectory
+# can still be chosen explicitly through v0.
+_DEFAULT_V0_SEED = 0
+
+
+def _default_v0(n, dtype, rs=None):
+    """Pseudo-random start vector of length ``n`` drawn from a fixed seed.
+
+    A private ``RandomState`` is used so that neither ``cupy.random.seed``
+    nor any other consumer of the global generator changes the result.
+    """
+    if rs is None:
+        rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
+    return rs.random_sample((n,)).astype(dtype)
+
 
 def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
           tol=0, return_eigenvectors=True):
@@ -32,8 +49,11 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             'LA': finds ``k`` largest (algebraic) eigenvalues.
             'SA': finds ``k`` smallest (algebraic) eigenvalues.
 
-        v0 (ndarray): Starting vector for iteration. If ``None``, a random
-            unit vector is used.
+        v0 (ndarray): Starting vector for iteration. If ``None``, a
+            pseudo-random unit vector drawn from a fixed seed is used, so
+            repeated calls on the same input follow the same trajectory
+            regardless of the global :mod:`cupy.random` state (as with the
+            default start of ARPACK in SciPy).
         ncv (int): The number of Lanczos vectors generated. Must be
             ``k + 1 < ncv < n``. If ``None``, default value is used.
         maxiter (int): Maximum number of Lanczos update iterations.
@@ -105,7 +125,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
     # Set initial vector
     if v0 is None:
-        u = cupy.random.random((n,)).astype(a.dtype)
+        u = _default_v0(n, a.dtype)
         V[0] = u / cublas.nrm2(u)
     else:
         u = v0
@@ -777,11 +797,9 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
         which (str): Only 'LM' is supported. 'LM': finds ``k`` largest singular
             values.
         v0 (ndarray): Starting vector for iteration, of length
-            ``min(a.shape)``. If ``None``, an unseeded random vector is
-            used, and repeated calls may follow different convergence
-            trajectories (matching the historical behavior). Passing a
-            fixed ``v0`` makes the solve reproducible, as in
-            :func:`scipy.sparse.linalg.svds`.
+            ``min(a.shape)`` as in :func:`scipy.sparse.linalg.svds`. If
+            ``None``, a pseudo-random vector drawn from a fixed seed is
+            used (see :func:`eigsh`).
         maxiter (int): Maximum number of Lanczos update iterations.
             If ``None``, default value is used.
         return_singular_vectors (bool): If ``True``, returns singular vectors
@@ -856,8 +874,9 @@ def _augmented_orthnormal_cols(x, n_aug):
     m, n = x.shape
     y = cupy.empty((m, n + n_aug), dtype=x.dtype)
     y[:, :n] = x
+    rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
     for i in range(n, n + n_aug):
-        v = cupy.random.random((m, )).astype(x.dtype)
+        v = _default_v0(m, x.dtype, rs)
         v -= v @ y[:, :i].conj() @ y[:, :i].T
         y[:, i] = v / cupy.linalg.norm(v)
     return y

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -759,8 +759,8 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
     return cupy.array(wk), cupy.array(sk), wk
 
 
-def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
-         return_singular_vectors=True):
+def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
+         maxiter=None, return_singular_vectors=True):
     """Finds the largest ``k`` singular values/vectors for a sparse matrix.
 
     Args:
@@ -776,6 +776,12 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
             is used.
         which (str): Only 'LM' is supported. 'LM': finds ``k`` largest singular
             values.
+        v0 (ndarray): Starting vector for iteration, of length
+            ``min(a.shape)``. If ``None``, an unseeded random vector is
+            used, and repeated calls may follow different convergence
+            trajectories (matching the historical behavior). Passing a
+            fixed ``v0`` makes the solve reproducible, as in
+            :func:`scipy.sparse.linalg.svds`.
         maxiter (int): Maximum number of Lanczos update iterations.
             If ``None``, default value is used.
         return_singular_vectors (bool): If ``True``, returns singular vectors
@@ -814,10 +820,10 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', maxiter=None,
 
     if return_singular_vectors:
         w, x = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter,
-                     tol=tol, return_eigenvectors=True)
+                     tol=tol, v0=v0, return_eigenvectors=True)
     else:
         w = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter, tol=tol,
-                  return_eigenvectors=False)
+                  v0=v0, return_eigenvectors=False)
 
     w = cupy.maximum(w, 0)
     t = w.dtype.char.lower()

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -52,8 +52,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         v0 (ndarray): Starting vector for iteration. If ``None``, a
             pseudo-random unit vector drawn from a fixed seed is used, so
             repeated calls on the same input follow the same trajectory
-            regardless of the global :mod:`cupy.random` state (as with the
-            default start of ARPACK in SciPy).
+            regardless of the global :mod:`cupy.random` state (as
+            :func:`scipy.sparse.linalg.svds` does for its default start).
         ncv (int): The number of Lanczos vectors generated. Must be
             ``k + 1 < ncv < n``. If ``None``, default value is used.
         maxiter (int): Maximum number of Lanczos update iterations.
@@ -128,8 +128,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
         u = _default_v0(n, a.dtype)
         V[0] = u / cublas.nrm2(u)
     else:
-        u = v0
-        V[0] = v0 / cublas.nrm2(v0)
+        u = v0.copy()          # the driver writes into u; do not mutate v0
+        V[0] = u / cublas.nrm2(u)
 
     # Choose Lanczos implementation, unconditionally use 'fast' for now
     upadte_impl = 'fast'
@@ -874,6 +874,9 @@ def _augmented_orthnormal_cols(x, n_aug):
     m, n = x.shape
     y = cupy.empty((m, n + n_aug), dtype=x.dtype)
     y[:, :n] = x
+    # svds calls this twice (for u and for v); each call restarts from the
+    # same seed, so for m == n the pre-projection draws coincide and only
+    # the projections onto the two different bases separate them.
     rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
     for i in range(n, n + n_aug):
         v = _default_v0(m, x.dtype, rs)

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -477,6 +477,53 @@ class TestEigshDegenerateHermitian:
             rtol=1e-4, atol=64 * eps * anorm)
 
 
+@testing.with_requires('scipy')
+class TestSvdsV0:
+    """v0= passthrough (scipy-compatible): reproducibility + parity."""
+
+    def _mat(self, xp, m=60, n=45):
+        return testing.shaped_random((m, n), xp, dtype='d', scale=1)
+
+    def test_v0_deterministic(self):
+        # v0 pins the trajectory start, which removes the run-to-run TIME
+        # variance; it is NOT bitwise: the adjoint half of the Gram apply
+        # is a transpose-mode cuSPARSE SpMV whose default algorithm uses
+        # atomics, so accumulation order (and the last bits of the
+        # result) still varies between identical calls.
+        a = sparse.csr_matrix(self._mat(cupy))
+        v0 = testing.shaped_random((45,), cupy, dtype='d', scale=1, seed=7)
+        s1 = sparse.linalg.svds(a, k=5, v0=v0.copy(),
+                                return_singular_vectors=False)
+        s2 = sparse.linalg.svds(a, k=5, v0=v0.copy(),
+                                return_singular_vectors=False)
+        cupy.testing.assert_allclose(cupy.sort(s1), cupy.sort(s2),
+                                     rtol=1e-9, atol=1e-9)
+
+    def test_v0_matches_scipy(self):
+        import numpy
+        import scipy.sparse
+        import scipy.sparse.linalg
+        a_np = testing.shaped_random((60, 45), numpy, dtype='d', scale=1)
+        v0_np = testing.shaped_random((45,), numpy, dtype='d', scale=1,
+                                      seed=7)
+        s_sp = numpy.sort(scipy.sparse.linalg.svds(
+            scipy.sparse.csr_matrix(a_np), k=5, v0=v0_np,
+            return_singular_vectors=False))
+        s_cp = cupy.sort(sparse.linalg.svds(
+            sparse.csr_matrix(cupy.asarray(a_np)), k=5,
+            v0=cupy.asarray(v0_np), return_singular_vectors=False))
+        numpy.testing.assert_allclose(cupy.asnumpy(s_cp), s_sp, rtol=1e-8,
+                                      atol=1e-8)
+
+    def test_v0_wide_matrix_length(self):
+        # v0 length is min(a.shape) regardless of orientation
+        a = sparse.csr_matrix(self._mat(cupy, m=45, n=60))
+        v0 = testing.shaped_random((45,), cupy, dtype='d', scale=1, seed=3)
+        s = sparse.linalg.svds(a, k=5, v0=v0,
+                               return_singular_vectors=False)
+        assert not bool(cupy.isnan(s).any())
+
+
 @testing.parameterize(*testing.product({
     'shape': [(30, 29), (29, 29), (29, 30)],
     'k': [3, 6, 12],

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -492,12 +492,15 @@ class TestSvdsV0:
         # result) still varies between identical calls.
         a = sparse.csr_matrix(self._mat(cupy))
         v0 = testing.shaped_random((45,), cupy, dtype='d', scale=1, seed=7)
-        s1 = sparse.linalg.svds(a, k=5, v0=v0.copy(),
+        v0_in = v0.copy()
+        s1 = sparse.linalg.svds(a, k=5, v0=v0,
                                 return_singular_vectors=False)
-        s2 = sparse.linalg.svds(a, k=5, v0=v0.copy(),
+        s2 = sparse.linalg.svds(a, k=5, v0=v0,
                                 return_singular_vectors=False)
         cupy.testing.assert_allclose(cupy.sort(s1), cupy.sort(s2),
                                      rtol=1e-9, atol=1e-9)
+        # v0 is an input, not a workspace: the caller's array is unchanged.
+        cupy.testing.assert_array_equal(v0, v0_in)
 
     def test_v0_matches_scipy(self):
         import numpy

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -524,6 +524,50 @@ class TestSvdsV0:
         assert not bool(cupy.isnan(s).any())
 
 
+class TestDefaultStartVector:
+    # The default start vector comes from a fixed seed, so a call with
+    # v0=None is reproducible and the global cupy.random state cannot leak
+    # into eigsh/svds results (gh-10239: the same test instance passed or
+    # failed depending on the draw).
+
+    @testing.for_dtypes('fdFD')
+    def test_default_v0_is_fixed(self, dtype):
+        from cupyx.scipy.sparse.linalg import _eigen
+        u1 = _eigen._default_v0(1000, dtype)
+        cupy.random.seed(1)
+        cupy.random.random(1000)         # advance the global generator
+        u2 = _eigen._default_v0(1000, dtype)
+        assert u1.dtype == cupy.dtype(dtype)
+        cupy.testing.assert_array_equal(u1, u2)
+        assert float(cupy.abs(u1 - u1.mean()).max()) > 0.1  # not constant
+
+    @testing.for_dtypes('fdFD')
+    def test_eigsh_repeatable(self, dtype):
+        b = testing.shaped_random((120, 120), cupy, dtype=dtype, seed=0)
+        a = sparse.csr_matrix(b + b.conj().T)
+        w1 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False)
+        cupy.random.seed(2)
+        w2 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False)
+        # Same start, same trajectory: only the parallel-reduction order in
+        # cuBLAS/cuSPARSE differs between the two runs.
+        tol = 1e-5 if numpy.dtype(dtype).char in 'fF' else 1e-10
+        cupy.testing.assert_allclose(cupy.sort(w1.real), cupy.sort(w2.real),
+                                     rtol=tol, atol=0)
+
+    def test_svds_augmented_vectors_repeatable(self):
+        # k above the rank: the missing singular vectors are completed by
+        # random orthonormal columns, which must be reproducible as well.
+        m, n, rank = 40, 30, 3
+        a = (testing.shaped_random((m, rank), cupy, dtype='d', seed=0)
+             @ testing.shaped_random((rank, n), cupy, dtype='d', seed=1))
+        u1, s1, vt1 = sparse.linalg.svds(sparse.csr_matrix(a), k=6)
+        cupy.random.seed(3)
+        u2, s2, vt2 = sparse.linalg.svds(sparse.csr_matrix(a), k=6)
+        cupy.testing.assert_allclose(s1, s2, rtol=1e-10, atol=1e-10)
+        cupy.testing.assert_allclose(u1, u2, rtol=1e-8, atol=1e-8)
+        cupy.testing.assert_allclose(vt1, vt2, rtol=1e-8, atol=1e-8)
+
+
 @testing.parameterize(*testing.product({
     'shape': [(30, 29), (29, 29), (29, 30)],
     'k': [3, 6, 12],

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -311,11 +311,11 @@ class TestEigsh:
             cupy.testing.assert_allclose(
                 cupy.sort(w.real), ref, atol=1e-4)
 
-    # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
-    # a run-dependent subset of these instances, so they XPASS
-    # intermittently. The blocker is not gh-5001 itself but the unseeded
-    # default v0 (see the gh-5001 analysis in #10098): non-strict until the
-    # default v0 is seeded, after which these markers can go.
+    # strict=False (pyproject sets xfail_strict): with the default v0 seeded
+    # the outcome no longer varies run to run (every instance fails on an
+    # A100), but the input B @ C is not symmetric, so what eigsh returns
+    # for it is unspecified and the comparison itself is what gh-5001 has
+    # to settle. Non-strict until the test is redefined.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,
@@ -686,11 +686,12 @@ class TestSvds:
         cupy.testing.assert_allclose(s[1:], cupy.ones(5), atol=1e-8)
         assert float(s[0]) < 1e-6
 
-    # strict=False (pyproject sets xfail_strict): the breakdown guard fixes
-    # a run-dependent subset of these instances, so they XPASS
-    # intermittently. The blocker is not gh-5001 itself but the unseeded
-    # default v0 (see the gh-5001 analysis in #10098): non-strict until the
-    # default v0 is seeded, after which these markers can go.
+    # strict=False (pyproject sets xfail_strict): with the default v0 seeded
+    # the split is deterministic -- on an A100 the 26 instances without
+    # singular vectors or with m < n pass and the 10 with vectors and
+    # m >= n fail, identically across runs -- so this is gh-5001 proper,
+    # not the start vector. Non-strict until the split is confirmed on
+    # CI hardware; the passing instances can then be asserted.
     @pytest.mark.xfail(
         reason='eigsh works wrong (#5001)',
         raises=AssertionError,


### PR DESCRIPTION
## Summary

`eigsh` started from `cupy.random.random` when `v0` was `None`, i.e. from the global generator: identical calls followed different Lanczos trajectories, and any test near its accuracy margin passed or failed depending on the draw. That is #10239 (`TestSvds[k=12, (29,29), complex128, vectors]`, 3–6 failures in 30 on stock and on #10098 alike, which just took CI down on #10156), and it is why the gh-5001 low-rank tests carry non-strict `xfail` markers.

Three commits:

1. **`svds(..., v0=)`** with scipy semantics (length `min(a.shape)`, the Gram-operator dimension on either orientation). `svds` had no way to set its start vector at all.
2. **Seed the default start.** When `v0 is None`, the start vector (and the orthonormal columns that complete the singular vectors of a rank-deficient `svds`) is drawn from a private `RandomState` with a fixed seed, as ARPACK does. Results no longer depend on `cupy.random.seed` or on other consumers of the global generator; a different trajectory is still one `v0=` away.
3. **Restate the gh-5001 markers.** In #10098 I said the non-strict `xfail` on the two `test_dense_low_rank` tests could go once the start was seeded. That was too strong: with the start seeded the instances stop flipping between XFAIL and XPASS, but 46 of 72 still fail, identically on every run. Every `TestEigsh` instance fails — its input `B @ C` is not symmetric, so what `eigsh` returns for it is unspecified and the comparison itself is what gh-5001 has to settle. `TestSvds` splits cleanly: the 26 instances without singular vectors or with m < n pass, the 10 with vectors and m ≥ n fail. The markers stay non-strict; the comments now say this instead of blaming `v0`. Once CI confirms the svds split across hardware the passing instances can be asserted.

## Behavior change

`cupy.random.seed(...)` no longer influences `eigsh`/`svds` with `v0=None` (they are now reproducible instead). Anyone who relied on varying the global seed to get different starts should pass `v0`. Documented in both docstrings.

## Measurements (A100, CuPy 14.1.1 wheel + this `_eigen.py`)

gh-10239 instance, complex128 with vectors, 30 trials on the suite's exact matrix:

| | stock | this PR |
|---|---|---|
| failures | 3/30 | 0/30 |
| max reconstruction error | 4.7e-12 | 1.3e-13 |
| min reconstruction error | 4.1e-14 | 4.2e-14 |

Sweep over dtype × `return_singular_vectors` × {csr, csc, coo, dense} on the same matrix, 10 trials each: 0 failures in all 32 configurations, worst complex128 reconstruction error 2.2e-13 against the 1e-12 bar. No tolerance change was needed. (Outputs are reproducible to that level, not bitwise: the transpose-mode cuSPARSE SpMV in the adjoint half of the Gram apply uses atomics, so csr/csc results still differ in the last bits run to run while coo and dense are bit-identical.)

gh-5001 `test_dense_low_rank` with the markers removed, 5 runs: 46 failed / 26 passed each time, the same instances every run.
Full `TestEigsh`/`TestSvds` suite with the markers kept: 661 passed, 46 xfailed, 26 xpassed, 71 skipped, 0 failed; three runs, identical outcome each. On the exact PR head: 662 passed, 46 xfailed, 26 xpassed, 0 failed.

Cost of the seeded start vs the old global draw (median of 20): 0.29 ms vs 0.03 ms at n = 10^3 and 10^5, 0.64 ms vs 0.34 ms at n = 10^7. The 0.26 ms is `RandomState` construction, paid once per call, against a 78 ms `eigsh` call at n = 1000. (A cached generator re-seeded per call measured the same 0.27 ms, so there is nothing to gain from caching; `default_rng` costs 1.1 ms; a host-side draw is 54 ms at n = 10^7.)
Healthy-path A/B vs `main` (n = 10^4 and 10^5, 11 and 51 nnz/row, k = 6 and 32): 257.4 / 1132.0 / 2547.9 / 471.2 ms vs 257.2 / 1128.2 / 2543.6 / 471.3 ms, i.e. identical within noise.

## Tests

- `TestSvdsV0` (v0 passthrough): same-`v0` repeatability, value parity with `scipy.sparse.linalg.svds` on an identical `v0`, `min(a.shape)` length on a wide matrix.
- `TestDefaultStartVector`: the default vector is bitwise fixed and independent of the global generator; `eigsh` repeatable across a `cupy.random.seed` call; augmented singular vectors of a rank-deficient `svds` repeatable.

Fixes #10239
