### PR TITLE
Accept scipy.sparse input in `splu`/`spilu` and run `TestSplu` on CUDA 12+

### DIFF
--- a/cupyx/scipy/sparse/linalg/_solve.py
+++ b/cupyx/scipy/sparse/linalg/_solve.py
@@ -675,12 +675,26 @@ def factorized(A):
     return splu(A).solve
 
 
+def _as_host_csc(A):
+    """Return ``A`` as a ``scipy.sparse.csc_matrix`` for host factorization.
+
+    A SciPy matrix is used as is: copying it to the GPU only to copy it back
+    for SuperLU would be a pointless round trip (gh-8570).
+    """
+    if scipy.sparse.issparse(A):
+        return scipy.sparse.csc_matrix(A)
+    return A.get().tocsc()
+
+
 def splu(A, permc_spec=None, diag_pivot_thresh=None, relax=None,
          panel_size=None, options={}):
     """Computes the LU decomposition of a sparse square matrix.
 
     Args:
-        A (cupyx.scipy.sparse.spmatrix): Sparse matrix to factorize.
+        A (cupyx.scipy.sparse.spmatrix or scipy.sparse.spmatrix): Sparse
+            matrix to factorize. A SciPy matrix is factorized as is, so a
+            matrix that already lives on the host does not need to be moved
+            to the GPU first.
         permc_spec (str): (For further augments, see
             :func:`scipy.sparse.linalg.splu`)
         diag_pivot_thresh (float):
@@ -703,15 +717,16 @@ def splu(A, permc_spec=None, diag_pivot_thresh=None, relax=None,
     """
     if not scipy_available:
         raise RuntimeError('scipy is not available')
-    if not sparse.issparse(A):
-        raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
+    if not (sparse.issparse(A) or scipy.sparse.issparse(A)):
+        raise TypeError('A must be cupyx.scipy.sparse.spmatrix or '
+                        'scipy.sparse.spmatrix')
     if A.shape[0] != A.shape[1]:
         raise ValueError('A must be a square matrix (A.shape: {})'
                          .format(A.shape))
     if A.dtype.char not in 'fdFD':
         raise TypeError('Invalid dtype (actual: {})'.format(A.dtype))
 
-    a = A.get().tocsc()
+    a = _as_host_csc(A)
     a_inv = scipy.sparse.linalg.splu(
         a, permc_spec=permc_spec, diag_pivot_thresh=diag_pivot_thresh,
         relax=relax, panel_size=panel_size, options=options)
@@ -724,7 +739,10 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None,
     """Computes the incomplete LU decomposition of a sparse square matrix.
 
     Args:
-        A (cupyx.scipy.sparse.spmatrix): Sparse matrix to factorize.
+        A (cupyx.scipy.sparse.spmatrix or scipy.sparse.spmatrix): Sparse
+            matrix to factorize. A SciPy matrix is factorized as is, so a
+            matrix that already lives on the host does not need to be moved
+            to the GPU first.
         drop_tol (float): (For further augments, see
             :func:`scipy.sparse.linalg.spilu`)
         fill_factor (float):
@@ -754,8 +772,9 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None,
     """
     if not scipy_available:
         raise RuntimeError('scipy is not available')
-    if not sparse.issparse(A):
-        raise TypeError('A must be cupyx.scipy.sparse.spmatrix')
+    if not (sparse.issparse(A) or scipy.sparse.issparse(A)):
+        raise TypeError('A must be cupyx.scipy.sparse.spmatrix or '
+                        'scipy.sparse.spmatrix')
     if A.shape[0] != A.shape[1]:
         raise ValueError('A must be a square matrix (A.shape: {})'
                          .format(A.shape))
@@ -764,14 +783,16 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None,
 
     if fill_factor == 1:
         # Computes ILU(0) on the GPU using cuSparse functions
-        if not (sparse.issparse(A) and A.format == "csr"):
+        if scipy.sparse.issparse(A):
+            a = sparse.csr_matrix(scipy.sparse.csr_matrix(A))
+        elif A.format != "csr":
             a = A.tocsr()
         else:
             a = A.copy()
         cusparse.csrilu02(a)
         return CusparseLU(a)
 
-    a = A.get().tocsc()
+    a = _as_host_csc(A)
     a_inv = scipy.sparse.linalg.spilu(
         a, fill_factor=fill_factor, drop_tol=drop_tol, drop_rule=drop_rule,
         permc_spec=permc_spec, diag_pivot_thresh=diag_pivot_thresh,

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1725,7 +1725,8 @@ class TestLOBPCGForDiagInput:
     'order': ['C', 'F']
 }))
 @testing.with_requires('scipy')
-@pytest.mark.skipif(not cusparse.check_availability('csrsm2'),
+@pytest.mark.skipif(not (cusparse.check_availability('spsm')
+                         or cusparse.check_availability('csrsm2')),
                     reason='no working implementation')
 class TestSplu:
 

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -1783,6 +1783,48 @@ class TestSplu:
             ainv = sp.linalg.spilu(a)
         return ainv.solve(b)
 
+    # gh-8570: a scipy matrix is factorized on the host as is, instead of
+    # being rejected and forcing the caller through a GPU round trip. The
+    # factors must be identical to those of the cupyx matrix.
+    def _assert_same_factors(self, lu_gpu, lu_host):
+        for attr in ('perm_r', 'perm_c'):
+            cupy.testing.assert_array_equal(
+                getattr(lu_gpu, attr), getattr(lu_host, attr))
+        for attr in ('L', 'U'):
+            cupy.testing.assert_array_equal(
+                getattr(lu_gpu, attr).toarray(),
+                getattr(lu_host, attr).toarray())
+
+    @testing.for_dtypes('fdFD')
+    def test_splu_scipy_input(self, dtype):
+        a, b = self._make_matrix(dtype, cupy, sparse)
+        lu_gpu = sparse.linalg.splu(a)
+        for a_host in (a.get(), scipy.sparse.csc_array(a.get())):
+            lu_host = sparse.linalg.splu(a_host)
+            self._assert_same_factors(lu_gpu, lu_host)
+            cupy.testing.assert_allclose(
+                lu_host.solve(b), lu_gpu.solve(b), rtol=1e-5, atol=1e-5)
+
+    @testing.for_dtypes('fdFD')
+    def test_spilu_scipy_input(self, dtype):
+        a, b = self._make_matrix(dtype, cupy, sparse)
+        lu_gpu = sparse.linalg.spilu(a)
+        lu_host = sparse.linalg.spilu(a.get())
+        self._assert_same_factors(lu_gpu, lu_host)
+        cupy.testing.assert_allclose(
+            lu_host.solve(b), lu_gpu.solve(b), rtol=1e-5, atol=1e-5)
+        # fill_factor=1 runs ILU(0) on the GPU: a scipy input is moved there.
+        a, b = self._make_matrix(dtype, cupy, sparse, density=1.0)
+        x_gpu = sparse.linalg.spilu(a, fill_factor=1).solve(b)
+        x_host = sparse.linalg.spilu(a.get(), fill_factor=1).solve(b)
+        cupy.testing.assert_allclose(x_host, x_gpu, rtol=1e-5, atol=1e-5)
+
+    def test_splu_invalid_input(self):
+        with pytest.raises(TypeError):
+            sparse.linalg.splu(numpy.eye(self.n))
+        with pytest.raises(TypeError):
+            sparse.linalg.spilu(cupy.eye(self.n))
+
 
 @testing.parameterize(*testing.product({
     'damp': [0.0, 1.0, 2.0],


### PR DESCRIPTION
## Summary

`cupyx.scipy.sparse.linalg.splu` and `spilu` factorize on the host with scipy's SuperLU and only run the solve on the GPU (as their docstrings say), yet both rejected a `scipy.sparse` matrix with `TypeError`. A caller who already holds the matrix on the host had to copy it to the GPU so that `splu` could immediately call `.get()` on it (#8570).

Two commits:

1. **Accept scipy input.** Both functions now take a `scipy.sparse` matrix (or array) and factorize it as is; a cupyx matrix goes through `.get()` exactly as before. The factors are identical either way, so `SuperLU` and everything downstream are untouched. The one GPU path, `spilu(fill_factor=1)` (cuSPARSE ILU(0)), moves a scipy input to the device. The error message and the two docstrings say which types are accepted.
2. **Run `TestSplu` on supported CUDA.** The class was skipped unless the legacy `csrsm2` is available, which `cupyx.cusparse` marks as gone from CUDA 12 on, i.e. on every CUDA version this repository still supports. `SuperLU.solve` itself falls back to `cusparseSpSM` there, so the tests now gate on the same condition (`spsm or csrsm2`). Without this the new tests would inherit a skip that never lifts on the CUDA side; with it the existing 72 instances run again.

## Tests

- `test_splu_scipy_input`: for a scipy `csc_matrix` and a scipy `csc_array` input, `perm_r`, `perm_c`, `L` and `U` are equal to those of the cupyx input, and the solves agree.
- `test_spilu_scipy_input`: same for `spilu`, plus `fill_factor=1` from a scipy input matches the cupyx result.
- `test_splu_invalid_input`: dense numpy and cupy inputs still raise `TypeError`.

Verified on an H200 with the current `main` nightly (`cupy-cuda12x` 14.3.0.dev0, cuSPARSE 12.5, `csrsm2` unavailable, `spsm` available): the full `TestSplu` class passes, 126 instances with this branch, and the pre-existing 72 instances pass on unmodified `main` with only the skip relaxed, so enabling them exposes no latent failure on CUDA 12.

Fixes #8570
