### PR TITLE
docs: use static.scipy.org mirror for scipy intersphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,7 +367,7 @@ autosummary_generate = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'scipy': ('https://static.scipy.org/doc/scipy/', None),
     'numba': ('https://numba.readthedocs.io/en/stable', None),
     'cuquantum': ('https://docs.nvidia.com/cuda/cuquantum/latest', None),
     # blocked by data-apis/array-api#428


### PR DESCRIPTION
`docs.scipy.org` has been intermittently unreachable from CI in the last few days due to an ongoing distributed crawl against the SciPy stable-docs host, causing recent Sphinx intersphinx inventory fetches to time out. Example from a recent doc-build run:

```
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectTimeout'>: HTTPSConnectionPool(host='docs.scipy.org', port=443): Max retries exceeded with url: /doc/scipy/objects.inv (Caused by ConnectTimeoutError(...))
```

Switch to the R2-backed `static.scipy.org` mirror, as recommended by the SciPy admins in https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5535454644. The inventory file at https://static.scipy.org/doc/scipy/objects.inv is auto-mirrored hourly from `docs.scipy.org` and served from more reliable infrastructure.

The equivalent swap for downstreams using `intersphinx_registry` is proposed in https://github.com/Quansight-Labs/intersphinx_registry/pull/123.