### PR TITLE
docs: point scipy intersphinx target back at docs.scipy.org

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -367,7 +367,12 @@ autosummary_generate = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://static.scipy.org/doc/scipy/', None),
+    # static.scipy.org mirrors objects.inv but not HTML, so use it only
+    # for the inventory; links must resolve to docs.scipy.org.
+    'scipy': (
+        'https://docs.scipy.org/doc/scipy/',
+        'https://static.scipy.org/doc/scipy/objects.inv',
+    ),
     'numba': ('https://numba.readthedocs.io/en/stable', None),
     'cuquantum': ('https://docs.nvidia.com/cuda/cuquantum/latest', None),
     # blocked by data-apis/array-api#428


### PR DESCRIPTION
Follow-up to #10269. That PR pointed both the target URL and the inventory URL at `static.scipy.org`, but the R2 mirror only serves `objects.inv` + PDFs/ZIPs — it does not host the rendered HTML. As a result every scipy cross-reference in the docs generates an href like <https://static.scipy.org/doc/scipy/reference/generated/scipy.interpolate.BarycentricInterpolator.html>, which 404s.

Example on the current site: the "See also" link in <https://docs.cupy.dev/en/latest/reference/generated/cupyx.scipy.interpolate.BarycentricInterpolator.html#cupyx.scipy.interpolate.BarycentricInterpolator>.

This PR switches to the 2-tuple form of `intersphinx_mapping` so target and inventory diverge:

- Base URL for generated hrefs → `https://docs.scipy.org/doc/scipy/` (HTML is served there).
- Inventory fetched during doc builds → `https://static.scipy.org/doc/scipy/objects.inv` (fast R2 mirror; avoids the crawl-induced slowness on the origin tracked in <https://github.com/scipy/docs.scipy.org/issues/102>).

Verified `objects.inv` is currently served from the R2 mirror (HTTP 200, Sphinx v2 inventory, SciPy 1.18.0).