### PR TITLE
MAINT: fix `cupyx.scipy.special.lambertw` signature

### DIFF
--- a/cupyx/scipy/special/_lambertw.py
+++ b/cupyx/scipy/special/_lambertw.py
@@ -9,7 +9,7 @@ lambertw_preamble = "#include <cupy/xsf/lambertw.h>"
 
 _lambertw_scalar = _core.create_ufunc(
     "cupyx_scipy_lambertw_scalar",
-    ("Dld->D", "Fif->f"),
+    ("Dld->D", "Flf->F"),
     "out0 = xsf::lambertw(in0, in1, in2)",
     preamble=lambertw_preamble,
     doc='''Internal function. Do not use.''')

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_lambertw.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_lambertw.py
@@ -6,7 +6,7 @@ from cupy import testing
 @testing.with_requires('scipy')
 class TestLambertW:
 
-    @testing.for_dtypes('fd')
+    @testing.for_dtypes('FD')
     @testing.for_dtypes('il', name='branch_dtype')
     @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
     def test_values(self, xp, scp, dtype, branch_dtype):


### PR DESCRIPTION
While working on https://github.com/scipy/xsf/pull/267, I noticed that CuPy's lambertw declares an incorrect single-precision output type. 

The corresponding XSF overload https://github.com/scipy/xsf/blob/main/include/xsf/lambertw.h#L533 returns `std::complex<float>` so the output should be complex64 (F).