### PR TITLE
Add `rng=` to `eigsh`/`svds`; the default start vector is random per call

### DIFF
--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -17,19 +17,52 @@ from cupyx.scipy.sparse.linalg import _interface
 _DEFAULT_V0_SEED = 0
 
 
-def _default_v0(n, dtype, rs=None):
-    """Pseudo-random start vector of length ``n`` drawn from a fixed seed.
+_RANDOM_STATE_TYPES = (cupy.random.RandomState, cupy.random.Generator,
+                       numpy.random.RandomState, numpy.random.Generator)
 
-    A private ``RandomState`` is used so that neither ``cupy.random.seed``
-    nor any other consumer of the global generator changes the result.
+
+def _resolve_random_state(random_state):
+    """Map a ``random_state`` argument to a generator, or ``None``.
+
+    ``None`` stays ``None`` (each draw then starts from the fixed private
+    seed); an int seeds a new ``cupy.random.RandomState``; a CuPy or NumPy
+    ``RandomState``/``Generator`` is returned as is, to be advanced in place.
+    """
+    if random_state is None:
+        return None
+    if isinstance(random_state, (int, numpy.integer)):
+        return cupy.random.RandomState(int(random_state))
+    if isinstance(random_state, _RANDOM_STATE_TYPES):
+        return random_state
+    raise TypeError(
+        'random_state must be None, an int, a cupy.random.RandomState or '
+        'Generator, or a numpy.random.RandomState or Generator (actual: '
+        '{})'.format(type(random_state)))
+
+
+def _default_v0(n, dtype, rs=None):
+    """Pseudo-random start vector of length ``n``.
+
+    Drawn from ``rs`` (see :func:`_resolve_random_state`), or from a private
+    ``RandomState`` with a fixed seed when ``rs`` is ``None``, so that neither
+    ``cupy.random.seed`` nor any other consumer of the global generator
+    changes the result.
     """
     if rs is None:
         rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
-    return rs.random_sample((n,)).astype(dtype)
+    if isinstance(rs, cupy.random.RandomState):
+        u = rs.random_sample((n,))
+    elif isinstance(rs, cupy.random.Generator):
+        u = rs.random((n,))
+    elif isinstance(rs, numpy.random.RandomState):
+        u = cupy.asarray(rs.random_sample((n,)))
+    else:                                   # numpy.random.Generator
+        u = cupy.asarray(rs.random((n,)))
+    return u.astype(dtype, copy=False)
 
 
 def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
-          tol=0, return_eigenvectors=True):
+          tol=0, return_eigenvectors=True, random_state=None):
     """
     Find ``k`` eigenvalues and eigenvectors of the real symmetric square
     matrix or complex Hermitian matrix ``A``.
@@ -54,6 +87,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             repeated calls on the same input follow the same trajectory
             regardless of the global :mod:`cupy.random` state (as
             :func:`scipy.sparse.linalg.svds` does for its default start).
+            See ``random_state`` to choose that draw.
         ncv (int): The number of Lanczos vectors generated. Must be
             ``k + 1 < ncv < n``. If ``None``, default value is used.
         maxiter (int): Maximum number of Lanczos update iterations.
@@ -62,6 +96,13 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             precision is used.
         return_eigenvectors (bool): If ``True``, returns eigenvectors in
             addition to eigenvalues.
+        random_state (int, cupy.random.RandomState, cupy.random.Generator,
+            numpy.random.RandomState or numpy.random.Generator): Source of
+            the default start vector when ``v0`` is ``None``. ``None`` (the
+            default) uses a fixed private seed, so identical calls give
+            identical results; an int seeds a new generator; a generator
+            object is used and advanced in place. Ignored when ``v0`` is
+            given, as in :func:`scipy.sparse.linalg.svds`.
 
     Returns:
         tuple:
@@ -125,7 +166,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
     # Set initial vector
     if v0 is None:
-        u = _default_v0(n, a.dtype)
+        u = _default_v0(n, a.dtype, _resolve_random_state(random_state))
         V[0] = u / cublas.nrm2(u)
     else:
         u = v0.copy()          # the driver writes into u; do not mutate v0
@@ -780,7 +821,7 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
 
 
 def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
-         maxiter=None, return_singular_vectors=True):
+         maxiter=None, return_singular_vectors=True, random_state=None):
     """Finds the largest ``k`` singular values/vectors for a sparse matrix.
 
     Args:
@@ -799,11 +840,19 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
         v0 (ndarray): Starting vector for iteration, of length
             ``min(a.shape)`` as in :func:`scipy.sparse.linalg.svds`. If
             ``None``, a pseudo-random vector drawn from a fixed seed is
-            used (see :func:`eigsh`).
+            used (see :func:`eigsh` and ``random_state``).
         maxiter (int): Maximum number of Lanczos update iterations.
             If ``None``, default value is used.
         return_singular_vectors (bool): If ``True``, returns singular vectors
             in addition to singular values.
+        random_state (int, cupy.random.RandomState, cupy.random.Generator,
+            numpy.random.RandomState or numpy.random.Generator): Source of
+            the default start vector when ``v0`` is ``None``, and of the
+            orthonormal columns that complete the singular vectors of a
+            rank-deficient input. ``None`` (the default) uses a fixed
+            private seed; an int seeds a new generator; a generator object
+            is used and advanced in place. Ignored for the start vector
+            when ``v0`` is given, as in :func:`scipy.sparse.linalg.svds`.
 
     Returns:
         tuple:
@@ -836,12 +885,14 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
     else:
         aH, a = a, a.H
 
+    rs = _resolve_random_state(random_state)
     if return_singular_vectors:
         w, x = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter,
-                     tol=tol, v0=v0, return_eigenvectors=True)
+                     tol=tol, v0=v0, return_eigenvectors=True,
+                     random_state=rs)
     else:
         w = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter, tol=tol,
-                  v0=v0, return_eigenvectors=False)
+                  v0=v0, return_eigenvectors=False, random_state=rs)
 
     w = cupy.maximum(w, 0)
     t = w.dtype.char.lower()
@@ -862,22 +913,25 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
     else:
         u = x
         v = a @ u / s[:n_large]
-    u = _augmented_orthnormal_cols(u, k - n_large)
-    v = _augmented_orthnormal_cols(v, k - n_large)
+    u = _augmented_orthnormal_cols(u, k - n_large, rs)
+    v = _augmented_orthnormal_cols(v, k - n_large, rs)
 
     return u, s, v.conj().T
 
 
-def _augmented_orthnormal_cols(x, n_aug):
+def _augmented_orthnormal_cols(x, n_aug, rs=None):
     if n_aug <= 0:
         return x
     m, n = x.shape
     y = cupy.empty((m, n + n_aug), dtype=x.dtype)
     y[:, :n] = x
-    # svds calls this twice (for u and for v); each call restarts from the
-    # same seed, so for m == n the pre-projection draws coincide and only
-    # the projections onto the two different bases separate them.
-    rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
+    if rs is None:
+        # svds calls this twice (for u and for v); with no random_state each
+        # call restarts from the same seed, so for m == n the pre-projection
+        # draws coincide and only the projections onto the two different
+        # bases separate them. A caller-supplied generator is advanced
+        # across both calls instead.
+        rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
     for i in range(n, n + n_aug):
         v = _default_v0(m, x.dtype, rs)
         v -= v @ y[:, :i].conj() @ y[:, :i].T

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -96,13 +96,15 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             precision is used.
         return_eigenvectors (bool): If ``True``, returns eigenvectors in
             addition to eigenvalues.
-        random_state (int, cupy.random.RandomState, cupy.random.Generator,
-            numpy.random.RandomState or numpy.random.Generator): Source of
-            the default start vector when ``v0`` is ``None``. ``None`` (the
-            default) uses a fixed private seed, so identical calls give
-            identical results; an int seeds a new generator; a generator
-            object is used and advanced in place. Ignored when ``v0`` is
-            given, as in :func:`scipy.sparse.linalg.svds`.
+        random_state (int or generator): Source of the default start vector
+            when ``v0`` is ``None``. ``None`` (the default) uses a fixed
+            private seed, so identical calls give identical results; an int
+            seeds a new :class:`cupy.random.RandomState`; a
+            :class:`cupy.random.RandomState`, :class:`cupy.random.Generator`,
+            :class:`numpy.random.RandomState` or
+            :class:`numpy.random.Generator` is used and advanced in place.
+            Ignored when ``v0`` is given, as in
+            :func:`scipy.sparse.linalg.svds`.
 
     Returns:
         tuple:
@@ -845,14 +847,15 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
             If ``None``, default value is used.
         return_singular_vectors (bool): If ``True``, returns singular vectors
             in addition to singular values.
-        random_state (int, cupy.random.RandomState, cupy.random.Generator,
-            numpy.random.RandomState or numpy.random.Generator): Source of
-            the default start vector when ``v0`` is ``None``, and of the
-            orthonormal columns that complete the singular vectors of a
-            rank-deficient input. ``None`` (the default) uses a fixed
-            private seed; an int seeds a new generator; a generator object
-            is used and advanced in place. Ignored for the start vector
-            when ``v0`` is given, as in :func:`scipy.sparse.linalg.svds`.
+        random_state (int or generator): Source of the default start vector
+            when ``v0`` is ``None``, and of the orthonormal columns that
+            complete the singular vectors of a rank-deficient input. Accepts
+            the same values as :func:`eigsh`: ``None`` (the default) uses a
+            fixed private seed, an int seeds a new
+            :class:`cupy.random.RandomState`, and a CuPy or NumPy
+            ``RandomState`` or ``Generator`` is used and advanced in place.
+            Ignored for the start vector when ``v0`` is given, as in
+            :func:`scipy.sparse.linalg.svds`.
 
     Returns:
         tuple:

--- a/cupyx/scipy/sparse/linalg/_eigen.py
+++ b/cupyx/scipy/sparse/linalg/_eigen.py
@@ -10,46 +10,37 @@ from cupy_backends.cuda.libs import cublas as _cublas
 from cupyx.scipy.sparse import _csr
 from cupyx.scipy.sparse.linalg import _interface
 
-# Seed of the default Lanczos start vector. Drawing it from a fixed seed
-# makes eigsh and svds deterministic for a given input, as ARPACK's default
-# start is, and independent of the global cupy.random state; the trajectory
-# can still be chosen explicitly through v0.
-_DEFAULT_V0_SEED = 0
+_RNG_TYPES = (cupy.random.RandomState, cupy.random.Generator,
+              numpy.random.RandomState, numpy.random.Generator)
 
 
-_RANDOM_STATE_TYPES = (cupy.random.RandomState, cupy.random.Generator,
-                       numpy.random.RandomState, numpy.random.Generator)
+def _resolve_rng(rng):
+    """Map an ``rng`` argument to a generator object.
 
-
-def _resolve_random_state(random_state):
-    """Map a ``random_state`` argument to a generator, or ``None``.
-
-    ``None`` stays ``None`` (each draw then starts from the fixed private
-    seed); an int seeds a new ``cupy.random.RandomState``; a CuPy or NumPy
-    ``RandomState``/``Generator`` is returned as is, to be advanced in place.
+    ``None`` gives a fresh :func:`cupy.random.default_rng` (entropy from the
+    operating system, so each call starts differently, as
+    :func:`scipy.sparse.linalg.eigsh` does); the :mod:`cupy.random` module
+    itself means the global :class:`cupy.random.RandomState`, so that
+    :func:`cupy.random.seed` controls the draw; an int seeds a new
+    :func:`cupy.random.default_rng`; a CuPy or NumPy ``RandomState`` or
+    ``Generator`` is used as is and advanced in place.
     """
-    if random_state is None:
-        return None
-    if isinstance(random_state, (int, numpy.integer)):
-        return cupy.random.RandomState(int(random_state))
-    if isinstance(random_state, _RANDOM_STATE_TYPES):
-        return random_state
+    if rng is None:
+        return cupy.random.default_rng()
+    if rng is cupy.random:
+        return cupy.random.get_random_state()
+    if isinstance(rng, (int, numpy.integer)):
+        return cupy.random.default_rng(int(rng))
+    if isinstance(rng, _RNG_TYPES):
+        return rng
     raise TypeError(
-        'random_state must be None, an int, a cupy.random.RandomState or '
+        'rng must be None, an int, cupy.random, a cupy.random.RandomState or '
         'Generator, or a numpy.random.RandomState or Generator (actual: '
-        '{})'.format(type(random_state)))
+        '{})'.format(type(rng)))
 
 
-def _default_v0(n, dtype, rs=None):
-    """Pseudo-random start vector of length ``n``.
-
-    Drawn from ``rs`` (see :func:`_resolve_random_state`), or from a private
-    ``RandomState`` with a fixed seed when ``rs`` is ``None``, so that neither
-    ``cupy.random.seed`` nor any other consumer of the global generator
-    changes the result.
-    """
-    if rs is None:
-        rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
+def _default_v0(n, dtype, rs):
+    """Random start vector of length ``n`` drawn from the resolved ``rs``."""
     if isinstance(rs, cupy.random.RandomState):
         u = rs.random_sample((n,))
     elif isinstance(rs, cupy.random.Generator):
@@ -62,7 +53,7 @@ def _default_v0(n, dtype, rs=None):
 
 
 def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
-          tol=0, return_eigenvectors=True, random_state=None):
+          tol=0, return_eigenvectors=True, rng=None):
     """
     Find ``k`` eigenvalues and eigenvectors of the real symmetric square
     matrix or complex Hermitian matrix ``A``.
@@ -82,12 +73,8 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             'LA': finds ``k`` largest (algebraic) eigenvalues.
             'SA': finds ``k`` smallest (algebraic) eigenvalues.
 
-        v0 (ndarray): Starting vector for iteration. If ``None``, a
-            pseudo-random unit vector drawn from a fixed seed is used, so
-            repeated calls on the same input follow the same trajectory
-            regardless of the global :mod:`cupy.random` state (as
-            :func:`scipy.sparse.linalg.svds` does for its default start).
-            See ``random_state`` to choose that draw.
+        v0 (ndarray): Starting vector for iteration. If ``None``, a random
+            unit vector drawn from ``rng`` is used.
         ncv (int): The number of Lanczos vectors generated. Must be
             ``k + 1 < ncv < n``. If ``None``, default value is used.
         maxiter (int): Maximum number of Lanczos update iterations.
@@ -96,15 +83,16 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
             precision is used.
         return_eigenvectors (bool): If ``True``, returns eigenvectors in
             addition to eigenvalues.
-        random_state (int or generator): Source of the default start vector
-            when ``v0`` is ``None``. ``None`` (the default) uses a fixed
-            private seed, so identical calls give identical results; an int
-            seeds a new :class:`cupy.random.RandomState`; a
-            :class:`cupy.random.RandomState`, :class:`cupy.random.Generator`,
-            :class:`numpy.random.RandomState` or
-            :class:`numpy.random.Generator` is used and advanced in place.
-            Ignored when ``v0`` is given, as in
-            :func:`scipy.sparse.linalg.svds`.
+        rng (int or generator): Source of the default start vector when
+            ``v0`` is ``None``. ``None`` (the default) draws from a fresh
+            :func:`cupy.random.default_rng`, so repeated calls start
+            differently, as in :func:`scipy.sparse.linalg.eigsh`; pass an
+            int for a reproducible start, a :class:`cupy.random.Generator`,
+            :class:`cupy.random.RandomState`, :class:`numpy.random.Generator`
+            or :class:`numpy.random.RandomState` to use and advance that
+            object, or the :mod:`cupy.random` module to use the global state
+            (so that :func:`cupy.random.seed` applies). Ignored when ``v0``
+            is given.
 
     Returns:
         tuple:
@@ -168,7 +156,7 @@ def eigsh(a, k=6, *, which='LM', v0=None, ncv=None, maxiter=None,
 
     # Set initial vector
     if v0 is None:
-        u = _default_v0(n, a.dtype, _resolve_random_state(random_state))
+        u = _default_v0(n, a.dtype, _resolve_rng(rng))
         V[0] = u / cublas.nrm2(u)
     else:
         u = v0.copy()          # the driver writes into u; do not mutate v0
@@ -823,7 +811,7 @@ def _eigsh_solve_ritz(alpha, beta, beta_k, k, which):
 
 
 def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
-         maxiter=None, return_singular_vectors=True, random_state=None):
+         maxiter=None, return_singular_vectors=True, rng=None):
     """Finds the largest ``k`` singular values/vectors for a sparse matrix.
 
     Args:
@@ -841,21 +829,17 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
             values.
         v0 (ndarray): Starting vector for iteration, of length
             ``min(a.shape)`` as in :func:`scipy.sparse.linalg.svds`. If
-            ``None``, a pseudo-random vector drawn from a fixed seed is
-            used (see :func:`eigsh` and ``random_state``).
+            ``None``, a random vector drawn from ``rng`` is used.
         maxiter (int): Maximum number of Lanczos update iterations.
             If ``None``, default value is used.
         return_singular_vectors (bool): If ``True``, returns singular vectors
             in addition to singular values.
-        random_state (int or generator): Source of the default start vector
-            when ``v0`` is ``None``, and of the orthonormal columns that
-            complete the singular vectors of a rank-deficient input. Accepts
-            the same values as :func:`eigsh`: ``None`` (the default) uses a
-            fixed private seed, an int seeds a new
-            :class:`cupy.random.RandomState`, and a CuPy or NumPy
-            ``RandomState`` or ``Generator`` is used and advanced in place.
-            Ignored for the start vector when ``v0`` is given, as in
-            :func:`scipy.sparse.linalg.svds`.
+        rng (int or generator): Source of the default start vector when
+            ``v0`` is ``None``, and of the orthonormal columns that complete
+            the singular vectors of a rank-deficient input. Accepts the same
+            values as :func:`eigsh`; ``None`` (the default) draws from a
+            fresh :func:`cupy.random.default_rng`, so repeated calls start
+            differently; pass an int for a reproducible result.
 
     Returns:
         tuple:
@@ -888,14 +872,13 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
     else:
         aH, a = a, a.H
 
-    rs = _resolve_random_state(random_state)
+    rs = _resolve_rng(rng)
     if return_singular_vectors:
         w, x = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter,
-                     tol=tol, v0=v0, return_eigenvectors=True,
-                     random_state=rs)
+                     tol=tol, v0=v0, return_eigenvectors=True, rng=rs)
     else:
         w = eigsh(aH @ a, k=k, which=which, ncv=ncv, maxiter=maxiter, tol=tol,
-                  v0=v0, return_eigenvectors=False, random_state=rs)
+                  v0=v0, return_eigenvectors=False, rng=rs)
 
     w = cupy.maximum(w, 0)
     t = w.dtype.char.lower()
@@ -922,19 +905,14 @@ def svds(a, k=6, *, ncv=None, tol=0, which='LM', v0=None,
     return u, s, v.conj().T
 
 
-def _augmented_orthnormal_cols(x, n_aug, rs=None):
+def _augmented_orthnormal_cols(x, n_aug, rs):
     if n_aug <= 0:
         return x
     m, n = x.shape
     y = cupy.empty((m, n + n_aug), dtype=x.dtype)
     y[:, :n] = x
-    if rs is None:
-        # svds calls this twice (for u and for v); with no random_state each
-        # call restarts from the same seed, so for m == n the pre-projection
-        # draws coincide and only the projections onto the two different
-        # bases separate them. A caller-supplied generator is advanced
-        # across both calls instead.
-        rs = cupy.random.RandomState(_DEFAULT_V0_SEED)
+    # svds calls this twice (for u and for v) with the same generator, which
+    # is advanced across both calls.
     for i in range(n, n + n_aug):
         v = _default_v0(m, x.dtype, rs)
         v -= v @ y[:, :i].conj() @ y[:, :i].T

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -527,6 +527,84 @@ class TestSvdsV0:
         assert not bool(cupy.isnan(s).any())
 
 
+class TestRandomState:
+    # random_state= selects the source of the default start vector (and, in
+    # svds, of the columns completing the singular vectors of a
+    # rank-deficient input), with scipy's semantics: None keeps the fixed
+    # private seed, an int seeds a fresh generator, a generator object is
+    # advanced in place, and v0 takes precedence.
+
+    def test_resolve_and_draw(self):
+        from cupyx.scipy.sparse.linalg import _eigen
+        n = 50
+        u_none = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(None))
+        u_seed = _eigen._default_v0(
+            n, 'd', _eigen._resolve_random_state(_eigen._DEFAULT_V0_SEED))
+        cupy.testing.assert_array_equal(u_none, u_seed)
+        u7a = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(7))
+        u7b = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(7))
+        cupy.testing.assert_array_equal(u7a, u7b)
+        assert not bool((u7a == u_seed).all())
+        assert u7a.dtype == cupy.float64 and u7a.shape == (n,)
+        for rs in (cupy.random.RandomState(3), cupy.random.default_rng(3),
+                   numpy.random.RandomState(3), numpy.random.default_rng(3)):
+            rs = _eigen._resolve_random_state(rs)
+            first = _eigen._default_v0(n, 'f', rs)
+            second = _eigen._default_v0(n, 'f', rs)   # advanced in place
+            assert isinstance(first, cupy.ndarray)
+            assert first.dtype == cupy.float32 and first.shape == (n,)
+            assert not bool((first == second).all())
+        with pytest.raises(TypeError):
+            _eigen._resolve_random_state('seed')
+
+    @testing.for_dtypes('fdFD')
+    def test_eigsh(self, dtype):
+        b = testing.shaped_random((120, 120), cupy, dtype=dtype, seed=0)
+        a = sparse.csr_matrix(b + b.conj().T)
+        tol = 1e-5 if numpy.dtype(dtype).char in 'fF' else 1e-10
+        w1 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False,
+                                 random_state=11)
+        w2 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False,
+                                 random_state=11)
+        cupy.testing.assert_allclose(cupy.sort(w1.real), cupy.sort(w2.real),
+                                     rtol=tol, atol=0)
+        # v0 takes precedence over random_state
+        v0 = testing.shaped_random((120,), cupy, dtype=dtype, seed=1)
+        w3 = sparse.linalg.eigsh(a, k=6, v0=v0, return_eigenvectors=False)
+        w4 = sparse.linalg.eigsh(a, k=6, v0=v0, return_eigenvectors=False,
+                                 random_state=numpy.random.default_rng(2))
+        cupy.testing.assert_allclose(cupy.sort(w3.real), cupy.sort(w4.real),
+                                     rtol=tol, atol=0)
+
+    def test_svds(self):
+        a = sparse.csr_matrix(
+            testing.shaped_random((60, 45), cupy, dtype='d', seed=0))
+        s1 = sparse.linalg.svds(a, k=5, random_state=11,
+                                return_singular_vectors=False)
+        s2 = sparse.linalg.svds(a, k=5, random_state=11,
+                                return_singular_vectors=False)
+        cupy.testing.assert_allclose(cupy.sort(s1), cupy.sort(s2),
+                                     rtol=1e-9, atol=1e-9)
+        # The generator also drives the columns completing the singular
+        # vectors of a rank-deficient input: same seed, same completion;
+        # different seed, different completion.
+        m, n, rank = 40, 30, 3
+        b = (testing.shaped_random((m, rank), cupy, dtype='d', seed=0)
+             @ testing.shaped_random((rank, n), cupy, dtype='d', seed=1))
+        b = sparse.csr_matrix(b)
+        u1, _, _ = sparse.linalg.svds(b, k=6,
+                                      random_state=numpy.random.default_rng(5))
+        u2, _, _ = sparse.linalg.svds(b, k=6,
+                                      random_state=numpy.random.default_rng(5))
+        u3, _, _ = sparse.linalg.svds(b, k=6,
+                                      random_state=numpy.random.default_rng(6))
+        cupy.testing.assert_allclose(u1, u2, rtol=1e-8, atol=1e-8)
+        assert not bool(cupy.allclose(cupy.abs(u1[:, rank:]),
+                                      cupy.abs(u3[:, rank:])))
+        with pytest.raises(TypeError):
+            sparse.linalg.svds(a, k=5, random_state='seed')
+
+
 class TestDefaultStartVector:
     # The default start vector comes from a fixed seed, so a call with
     # v0=None is reproducible and the global cupy.random state cannot leak

--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -527,64 +527,67 @@ class TestSvdsV0:
         assert not bool(cupy.isnan(s).any())
 
 
-class TestRandomState:
-    # random_state= selects the source of the default start vector (and, in
-    # svds, of the columns completing the singular vectors of a
-    # rank-deficient input), with scipy's semantics: None keeps the fixed
-    # private seed, an int seeds a fresh generator, a generator object is
-    # advanced in place, and v0 takes precedence.
+class TestRng:
+    # rng= selects the source of the default start vector (and, in svds,
+    # of the columns completing the singular vectors of a rank-deficient
+    # input), with scipy's semantics: None draws from a fresh generator so
+    # calls start differently, an int is reproducible, a generator object
+    # is advanced in place, cupy.random means the global state, and v0
+    # takes precedence.
 
     def test_resolve_and_draw(self):
         from cupyx.scipy.sparse.linalg import _eigen
         n = 50
-        u_none = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(None))
-        u_seed = _eigen._default_v0(
-            n, 'd', _eigen._resolve_random_state(_eigen._DEFAULT_V0_SEED))
-        cupy.testing.assert_array_equal(u_none, u_seed)
-        u7a = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(7))
-        u7b = _eigen._default_v0(n, 'd', _eigen._resolve_random_state(7))
-        cupy.testing.assert_array_equal(u7a, u7b)
-        assert not bool((u7a == u_seed).all())
+        u1 = _eigen._default_v0(n, 'd', _eigen._resolve_rng(None))
+        u2 = _eigen._default_v0(n, 'd', _eigen._resolve_rng(None))
+        assert not bool((u1 == u2).all())                 # fresh entropy
+        u7a = _eigen._default_v0(n, 'd', _eigen._resolve_rng(7))
+        u7b = _eigen._default_v0(n, 'd', _eigen._resolve_rng(7))
+        cupy.testing.assert_array_equal(u7a, u7b)          # int reproduces
         assert u7a.dtype == cupy.float64 and u7a.shape == (n,)
+        # cupy.random means the global state: cupy.random.seed controls it
+        cupy.random.seed(5)
+        g1 = _eigen._default_v0(n, 'd', _eigen._resolve_rng(cupy.random))
+        cupy.random.seed(5)
+        g2 = _eigen._default_v0(n, 'd', _eigen._resolve_rng(cupy.random))
+        cupy.testing.assert_array_equal(g1, g2)
         for rs in (cupy.random.RandomState(3), cupy.random.default_rng(3),
                    numpy.random.RandomState(3), numpy.random.default_rng(3)):
-            rs = _eigen._resolve_random_state(rs)
+            rs = _eigen._resolve_rng(rs)
             first = _eigen._default_v0(n, 'f', rs)
             second = _eigen._default_v0(n, 'f', rs)   # advanced in place
             assert isinstance(first, cupy.ndarray)
             assert first.dtype == cupy.float32 and first.shape == (n,)
             assert not bool((first == second).all())
         with pytest.raises(TypeError):
-            _eigen._resolve_random_state('seed')
+            _eigen._resolve_rng('seed')
 
     @testing.for_dtypes('fdFD')
     def test_eigsh(self, dtype):
         b = testing.shaped_random((120, 120), cupy, dtype=dtype, seed=0)
         a = sparse.csr_matrix(b + b.conj().T)
         tol = 1e-5 if numpy.dtype(dtype).char in 'fF' else 1e-10
-        w1 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False,
-                                 random_state=11)
-        w2 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False,
-                                 random_state=11)
+        w1 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False, rng=11)
+        w2 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False, rng=11)
         cupy.testing.assert_allclose(cupy.sort(w1.real), cupy.sort(w2.real),
                                      rtol=tol, atol=0)
-        # v0 takes precedence over random_state
+        # v0 takes precedence over rng
         v0 = testing.shaped_random((120,), cupy, dtype=dtype, seed=1)
         w3 = sparse.linalg.eigsh(a, k=6, v0=v0, return_eigenvectors=False)
         w4 = sparse.linalg.eigsh(a, k=6, v0=v0, return_eigenvectors=False,
-                                 random_state=numpy.random.default_rng(2))
+                                 rng=numpy.random.default_rng(2))
         cupy.testing.assert_allclose(cupy.sort(w3.real), cupy.sort(w4.real),
                                      rtol=tol, atol=0)
 
     def test_svds(self):
         a = sparse.csr_matrix(
             testing.shaped_random((60, 45), cupy, dtype='d', seed=0))
-        s1 = sparse.linalg.svds(a, k=5, random_state=11,
-                                return_singular_vectors=False)
-        s2 = sparse.linalg.svds(a, k=5, random_state=11,
-                                return_singular_vectors=False)
+        s1 = sparse.linalg.svds(a, k=5, rng=11, return_singular_vectors=False)
+        s2 = sparse.linalg.svds(a, k=5, rng=11, return_singular_vectors=False)
         cupy.testing.assert_allclose(cupy.sort(s1), cupy.sort(s2),
                                      rtol=1e-9, atol=1e-9)
+        with pytest.raises(TypeError):
+            sparse.linalg.svds(a, k=5, rng='seed')
         # The generator also drives the columns completing the singular
         # vectors of a rank-deficient input: same seed, same completion;
         # different seed, different completion.
@@ -592,61 +595,15 @@ class TestRandomState:
         b = (testing.shaped_random((m, rank), cupy, dtype='d', seed=0)
              @ testing.shaped_random((rank, n), cupy, dtype='d', seed=1))
         b = sparse.csr_matrix(b)
-        u1, _, _ = sparse.linalg.svds(b, k=6,
-                                      random_state=numpy.random.default_rng(5))
-        u2, _, _ = sparse.linalg.svds(b, k=6,
-                                      random_state=numpy.random.default_rng(5))
-        u3, _, _ = sparse.linalg.svds(b, k=6,
-                                      random_state=numpy.random.default_rng(6))
-        cupy.testing.assert_allclose(u1, u2, rtol=1e-8, atol=1e-8)
-        assert not bool(cupy.allclose(cupy.abs(u1[:, rank:]),
-                                      cupy.abs(u3[:, rank:])))
-        with pytest.raises(TypeError):
-            sparse.linalg.svds(a, k=5, random_state='seed')
-
-
-class TestDefaultStartVector:
-    # The default start vector comes from a fixed seed, so a call with
-    # v0=None is reproducible and the global cupy.random state cannot leak
-    # into eigsh/svds results (gh-10239: the same test instance passed or
-    # failed depending on the draw).
-
-    @testing.for_dtypes('fdFD')
-    def test_default_v0_is_fixed(self, dtype):
-        from cupyx.scipy.sparse.linalg import _eigen
-        u1 = _eigen._default_v0(1000, dtype)
-        cupy.random.seed(1)
-        cupy.random.random(1000)         # advance the global generator
-        u2 = _eigen._default_v0(1000, dtype)
-        assert u1.dtype == cupy.dtype(dtype)
-        cupy.testing.assert_array_equal(u1, u2)
-        assert float(cupy.abs(u1 - u1.mean()).max()) > 0.1  # not constant
-
-    @testing.for_dtypes('fdFD')
-    def test_eigsh_repeatable(self, dtype):
-        b = testing.shaped_random((120, 120), cupy, dtype=dtype, seed=0)
-        a = sparse.csr_matrix(b + b.conj().T)
-        w1 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False)
-        cupy.random.seed(2)
-        w2 = sparse.linalg.eigsh(a, k=6, return_eigenvectors=False)
-        # Same start, same trajectory: only the parallel-reduction order in
-        # cuBLAS/cuSPARSE differs between the two runs.
-        tol = 1e-5 if numpy.dtype(dtype).char in 'fF' else 1e-10
-        cupy.testing.assert_allclose(cupy.sort(w1.real), cupy.sort(w2.real),
-                                     rtol=tol, atol=0)
-
-    def test_svds_augmented_vectors_repeatable(self):
-        # k above the rank: the missing singular vectors are completed by
-        # random orthonormal columns, which must be reproducible as well.
-        m, n, rank = 40, 30, 3
-        a = (testing.shaped_random((m, rank), cupy, dtype='d', seed=0)
-             @ testing.shaped_random((rank, n), cupy, dtype='d', seed=1))
-        u1, s1, vt1 = sparse.linalg.svds(sparse.csr_matrix(a), k=6)
-        cupy.random.seed(3)
-        u2, s2, vt2 = sparse.linalg.svds(sparse.csr_matrix(a), k=6)
-        cupy.testing.assert_allclose(s1, s2, rtol=1e-10, atol=1e-10)
-        cupy.testing.assert_allclose(u1, u2, rtol=1e-8, atol=1e-8)
-        cupy.testing.assert_allclose(vt1, vt2, rtol=1e-8, atol=1e-8)
+        u1, _, _ = sparse.linalg.svds(b, k=6, rng=numpy.random.default_rng(5))
+        u2, _, _ = sparse.linalg.svds(b, k=6, rng=numpy.random.default_rng(5))
+        u3, _, _ = sparse.linalg.svds(b, k=6, rng=numpy.random.default_rng(6))
+        # singular vectors are defined up to sign (gh-10286): compare the
+        # cross-Gram to the identity rather than the arrays
+        g = cupy.abs(u1.conj().T @ u2)
+        cupy.testing.assert_allclose(g, cupy.eye(6), rtol=1e-8, atol=1e-8)
+        g3 = cupy.abs(u1[:, rank:].conj().T @ u3[:, rank:])
+        assert not bool(cupy.allclose(g3, cupy.eye(6 - rank), atol=1e-6))
 
 
 @testing.parameterize(*testing.product({
@@ -667,8 +624,12 @@ class TestSvds:
         return a
 
     def _test_svds(self, a, xp, sp):
+        # The default start is random (gh-10239): pin CuPy's draw so the
+        # comparison against the fixed scipy reference is deterministic.
+        kwargs = {'rng': 0} if xp is cupy else {}
         ret = sp.linalg.svds(a, k=self.k,
-                             return_singular_vectors=self.return_vectors)
+                             return_singular_vectors=self.return_vectors,
+                             **kwargs)
         if self.return_vectors:
             u, s, vt = ret
             # Check the results with u @ s @ vt, as singular vectors don't


### PR DESCRIPTION
Follow-up to #10265, tracked in #10272; reworked after the discussion there.

## Summary

- `eigsh` and `svds` take `rng=`, keyword-only, with scipy 1.17's semantics: `None` (the default) draws the start vector from a fresh `cupy.random.default_rng()`, so repeated calls start differently and no library-level seed is baked in; an int gives a reproducible start via `cupy.random.default_rng(int)`; a CuPy or NumPy `Generator`/`RandomState` is used and advanced in place; the `cupy.random` module itself selects the global state, so `cupy.random.seed` applies for anyone who relied on that.
- No `random_state=` alias: scipy's `svds` has taken `rng=` since 1.15 and CuPy's baseline is 1.16.
- In `svds` the same generator also produces the orthonormal columns that complete the singular vectors of a rank-deficient input, so that path is reproducible under a seed too.
- `v0` takes precedence over `rng`, as in scipy.

## Behavior change (release note)

#10265 (unreleased, v14.3.0 milestone) had made the default start vector a fixed private seed. This reverts that decision: with `v0=None` the start is random per call again, as it was before #10265 and as it is in scipy 1.17. `cupy.random.seed` does **not** influence it by default; use `rng=<int>` for a reproducible solve, or `rng=cupy.random` to draw from the global state.

## Tests

- `TestRng`: `None` gives different draws on consecutive calls; an int reproduces; `cupy.random` follows `cupy.random.seed`; each of the four generator types is accepted, yields a device array of the requested dtype and is advanced between draws; `eigsh` reproduces under `rng=int` and `v0` wins over `rng`; `svds` reproduces under `rng=int`, rejects a string, and completes rank-deficient singular vectors reproducibly under a seed.
- `TestSvds` pins CuPy's draw in the test (`rng=0`) so the comparison against the fixed scipy reference is deterministic; this is where gh-10239 is fixed now.

Run on an H200 against the current `main` nightly with this branch's `_eigen.py`: `TestEigsh`/`TestSvds`/`TestSvdsV0`/`TestRng` 662 passed, 0 failed, repeated runs identical. Reproduced singular vectors are compared up to sign (gh-10286).

Closes #10272
