### PR TITLE
Add wofz function

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -81,6 +81,7 @@ from cupyx.scipy.special._erf import erfc  # NOQA
 from cupyx.scipy.special._erf import erfcx  # NOQA
 from cupyx.scipy.special._erf import erfinv  # NOQA
 from cupyx.scipy.special._erf import erfcinv  # NOQA
+from cupyx.scipy.special._wofz import wofz  # NOQA
 
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA

--- a/cupyx/scipy/special/_wofz.py
+++ b/cupyx/scipy/special/_wofz.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cupy import _core
+
+
+wofz = _core.create_ufunc(
+    'cupyx_scipy_special_wofz', ('F->F', 'D->D'),
+    'out0 = xsf::wofz(in0)',
+    preamble='#include <cupy/xsf/erf.h>',
+    doc='''Faddeeva function.
+
+    .. seealso:: :meth:`scipy.special.wofz`
+
+    ''')

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -138,6 +138,7 @@ Error function and Fresnel integrals
    erfcx
    erfinv
    erfcinv
+   wofz
 
 
 Legendre functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_wofz.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_wofz.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from cupy import testing
+
+
+@testing.with_requires('scipy')
+class TestWofz:
+
+    @testing.for_dtypes('FD')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
+    def test_complex(self, xp, scp, dtype):
+        x = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
+        y = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
+        x, y = xp.meshgrid(x, y)
+        z = (x + 1j * y).ravel()
+        return scp.special.wofz(z)
+
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
+    def test_real(self, xp, scp, dtype):
+        x = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
+        return scp.special.wofz(x)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_wofz.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_wofz.py
@@ -3,20 +3,13 @@ from __future__ import annotations
 from cupy import testing
 
 
-@testing.with_requires('scipy')
+@testing.with_requires("scipy")
 class TestWofz:
-
-    @testing.for_dtypes('FD')
-    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
+    @testing.for_dtypes("fd")
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name="scp")
     def test_complex(self, xp, scp, dtype):
         x = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
         y = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
         x, y = xp.meshgrid(x, y)
         z = (x + 1j * y).ravel()
         return scp.special.wofz(z)
-
-    @testing.for_dtypes('fd')
-    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-10, scipy_name='scp')
-    def test_real(self, xp, scp, dtype):
-        x = xp.linspace(-100.0, 100.0, 21, dtype=dtype)
-        return scp.special.wofz(x)


### PR DESCRIPTION
Reference: https://github.com/cupy/cupy/issues/9907

This PR adds the `wofz` function (Faddeeva function) to CuPy. This is the first time I am adding a CuPy function using XSF so I am not 100% sure this is the correct approach. I've tried to follow the pattern of https://github.com/cupy/cupy/pull/8140.