### PR TITLE
DOC: clean see also section of `cupyx.scipy.special.wofz`

### DIFF
--- a/cupyx/scipy/special/_wofz.py
+++ b/cupyx/scipy/special/_wofz.py
@@ -9,6 +9,6 @@ wofz = _core.create_ufunc(
     preamble='#include <cupy/xsf/erf.h>',
     doc='''Faddeeva function.
 
-    .. seealso:: :meth:`scipy.special.wofz`
+    .. seealso:: :func:`scipy.special.wofz`
 
     ''')


### PR DESCRIPTION
With https://github.com/cupy/cupy/pull/10279 in, this PR replaces `meth` with `func`.