### PR TITLE
Fuse CSD mean averaging into spectral reduction

### DIFF
--- a/cupyx/scipy/signal/_spectral.py
+++ b/cupyx/scipy/signal/_spectral.py
@@ -31,7 +31,7 @@ import warnings
 import cupy
 from cupyx.scipy.signal.windows._windows import get_window
 from cupyx.scipy.signal._spectral_impl import (
-    _lombscargle, _spectral_helper, _median_bias, _triage_segments)
+    _lombscargle, _spectral_helper, _triage_segments)
 
 
 def lombscargle(x, y, freqs, precenter=False, normalize=False):
@@ -443,6 +443,11 @@ def csd(
     windows may require a larger overlap.
 
     """
+    if average not in ("mean", "median"):
+        raise ValueError(
+            'average must be "median" or "mean", got %s' % (average,)
+        )
+
     x = cupy.asarray(x)
     y = cupy.asarray(y)
     freqs, _, Pxy = _spectral_helper(
@@ -458,21 +463,8 @@ def csd(
         scaling,
         axis,
         mode="psd",
+        average=average,
     )
-
-    # Average over windows.
-    if len(Pxy.shape) >= 2 and Pxy.size > 0:
-        if Pxy.shape[-1] > 1:
-            if average == "median":
-                Pxy = cupy.median(Pxy, axis=-1) / _median_bias(Pxy.shape[-1])
-            elif average == "mean":
-                Pxy = Pxy.mean(axis=-1)
-            else:
-                raise ValueError(
-                    'average must be "median" or "mean", got %s' % (average,)
-                )
-        else:
-            Pxy = cupy.reshape(Pxy, Pxy.shape[:-1])
 
     return freqs, Pxy
 

--- a/cupyx/scipy/signal/_spectral_impl.py
+++ b/cupyx/scipy/signal/_spectral_impl.py
@@ -37,6 +37,17 @@ from cupyx.scipy.signal._arraytools import (
 from cupyx.scipy.signal.windows._windows import get_window
 
 
+_csd_mean_kernel = cupy.ReductionKernel(
+    'T x, T y, T scale, int64 segment_count',
+    'T z',
+    '(conj(x) * y) * scale',
+    'a + b',
+    'z = a / T(segment_count)',
+    'T(0)',
+    'cupyx_scipy_signal_csd_mean',
+)
+
+
 def _get_raw_typename(dtype):
     return cupy.dtype(dtype).name
 
@@ -224,14 +235,15 @@ def _spectral_helper(
     mode="psd",
     boundary=None,
     padded=False,
+    average=None,
 ):
     """
     Calculate various forms of windowed FFTs for PSD, CSD, etc.
 
     This is a helper function that implements the commonality between
     the stft, psd, csd, and spectrogram functions. It is not designed to
-    be called externally. The windows are not averaged over; the result
-    from each window is returned.
+    be called externally. If `average` is `None`, the windows are not averaged
+    over and the result from each window is returned.
 
     Parameters
     ---------
@@ -296,6 +308,9 @@ def _spectral_helper(
         segments, so that all of the signal is included in the output.
         Defaults to `False`. Padding occurs after boundary extension, if
         `boundary` is not `None`, and `padded` is `True`.
+    average : {None, 'mean', 'median'}, optional
+        Method used to average periodograms over segments when ``mode='psd'``.
+        Defaults to `None`, which returns every segment.
 
     Returns
     -------
@@ -316,7 +331,8 @@ def _spectral_helper(
             f"Unknown value for mode {mode}, must be one of: "
             "{'psd', 'stft'}"
         )
-
+    if average is not None and mode != "psd":
+        raise ValueError("average is only valid when mode='psd'")
     boundary_funcs = {
         "even": even_ext,
         "odd": odd_ext,
@@ -499,11 +515,24 @@ def _spectral_helper(
         # All the same operations on the y data
         result_y = _fft_helper(y, win, detrend_func,  # NOQA
                                nperseg, noverlap, nfft, sides)
-        result = cupy.conj(result) * result_y
     elif mode == "psd":
-        result = cupy.conj(result) * result
+        result_y = result
 
-    result *= scale
+    if mode == "psd" and average == "mean":
+        segment_count = result.shape[-2]
+        # Padding or detrending can give the two FFTs different precisions.
+        fft_dtype = cupy.result_type(result, result_y)
+        result = result.astype(fft_dtype, copy=False)
+        result_y = result_y.astype(fft_dtype, copy=False)
+        kernel_scale = cupy.asarray(scale, dtype=fft_dtype)
+        # Scale each periodogram before summing to avoid premature overflow.
+        result = _csd_mean_kernel(
+            result, result_y, kernel_scale, segment_count, axis=-2)
+    else:
+        if mode == "psd":
+            result = cupy.conj(result) * result_y
+        result *= scale
+
     if sides == "onesided" and mode == "psd":
         if nfft % 2:
             result[..., 1:] *= 2
@@ -519,13 +548,29 @@ def _spectral_helper(
 
     result = result.astype(outdtype)
 
+    if average is not None and average != "mean":
+        segment_count = result.shape[-2]
+        if segment_count > 1:
+            if average == "median":
+                result = (
+                    cupy.median(result, axis=-2) /
+                    _median_bias(segment_count)
+                )
+            else:
+                raise ValueError(
+                    'average must be "median" or "mean", got %s' %
+                    (average,)
+                )
+        else:
+            result = cupy.squeeze(result, axis=-2)
+
     # All imaginary parts are zero anyways
     if same_data and mode != "stft":
         result = result.real
 
-    # Output is going to have new last axis for time/window index, so a
-    # negative axis index shifts down one
-    if axis < 0:
+    # An unaveraged output has a new last axis for time/window index, so
+    # a negative axis index shifts down one.
+    if axis < 0 and average is None:
         axis -= 1
 
     # Roll frequency axis back to axis where the data came from

--- a/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
+++ b/tests/cupyx_tests/scipy_tests/signal_tests/test_spectral.py
@@ -621,6 +621,49 @@ class TestWelch:
 
 @testing.with_requires('scipy')
 class TestCSD:
+    @pytest.mark.parametrize('dtype_x,dtype_y', [
+        ('float32', 'float32'),
+        ('complex64', 'complex64'),
+        ('float32', 'float64'),
+        ('complex64', 'complex128'),
+        ('float32', 'complex64'),
+    ])
+    @pytest.mark.parametrize('lengths', [(32, 64), (64, 32)])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_padded_mean_dtype(self, dtype_x, dtype_y, lengths, xp, scp):
+        x = testing.shaped_random((lengths[0],), xp, dtype=dtype_x, seed=0)
+        y = testing.shaped_random((lengths[1],), xp, dtype=dtype_y, seed=1)
+        return scp.signal.csd(
+            x, y, nperseg=16, noverlap=8, average='mean',
+            return_onesided=False)
+
+    @pytest.mark.parametrize('same_data', [False, True])
+    @pytest.mark.parametrize('scaling', ['density', 'spectrum'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5)
+    def test_mean_large_amplitude(self, same_data, scaling, xp, scp):
+        x = xp.full(4096, 1e17, dtype=xp.float32)
+        y = x if same_data else x.copy()
+        f, p = scp.signal.csd(
+            x, y, window='boxcar', nperseg=16, noverlap=0,
+            detrend=False, scaling=scaling, average='mean')
+        assert bool(xp.isfinite(p).all())
+        return f, p
+
+    @pytest.mark.parametrize('average', [None, 'invalid'])
+    @pytest.mark.parametrize('length', [0, 16, 64])
+    def test_invalid_average(self, average, length):
+        x = cupy.ones(length)
+        with pytest.raises(ValueError, match='average must be'):
+            cupyx.scipy.signal.csd(x, x, nperseg=16, average=average)
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
+    def test_broadcasted_mean(self, dtype, xp, scp):
+        x = testing.shaped_random((2, 1, 64), xp, dtype=dtype)
+        y = testing.shaped_random((1, 3, 64), xp, dtype=dtype)
+        return scp.signal.csd(
+            x, y, nperseg=16, noverlap=8, average='mean')
+
     @testing.numpy_cupy_allclose(scipy_name='scp', rtol=1e-5, atol=1e-5)
     def test_pad_shorter_x(self, xp, scp):
         x = xp.zeros(8)


### PR DESCRIPTION
When computing CSD for all pairs of channels, the current implementation creates a large intermediate array containing the result for every segment. This uses a lot of GPU memory and limits how many channels we can process.

This PR combines the conjugate multiplication, scaling, and averaging into one reduction kernel(only when average=='mean'). This avoids storing the full intermediate array, allowing larger channel counts, and speeds up the calculation by reducing kernel launches and memory traffic.

For example, with 256 channels of 10-second data sampled at 1000 Hz (float32, all channel pairs):

- Peak memory-pool usage drops from about 9972 MiB to 168 MiB.
- Execution time drops from 66.4 ms to 6.1 ms, about 11× faster.

Below is full benchmarks:

RTX 5070 Ti; 1000 Hz, 10-second signals; nperseg=256, noverlap=128. All-pairs inputs have shapes (C, 1, 10000) and (1, C, 10000).

| Dtype | Channels | Before | After | Speedup | Peak pool memory, before → after |
|---|---:|---:|---:|---:|---:|
| float32 | 128 | 15.71 ms | 1.41 ms | 11.17× | 2502.7 → 58.0 MiB |
| float32 | 256 | 66.40 ms | 6.07 ms | 10.94× | 9971.9 → 167.9 MiB |
| float64 | 128 | 30.84 ms | 7.69 ms | 4.01× | 5005.4 → 103.4 MiB |
| float64 | 185 | 66.61 ms | 15.27 ms | 4.36× | 10430.9 → 191.0 MiB |

<details>
<summary>Benchmark code</summary>

``` python

import numpy as np
import cupy as cp
from cupyx.profiler import benchmark
from cupyx.scipy.signal import csd

pool = cp.get_default_memory_pool()
pool.set_limit(size=10600 * 1024**2)

cases = {
    "float32": [64, 96, 128, 160, 192, 224, 256, 262, 263],
    "float64": [64, 96, 128, 160, 185, 186],
}


def run_case(channels, dtype):
    rng = np.random.default_rng(20260907)
    shape = (channels, 10000)
    x = cp.asarray(rng.standard_normal(shape).astype(dtype))[:, None, :]
    y = cp.asarray(rng.standard_normal(shape).astype(dtype))[None, :, :]

    def compute():
        return csd(
            x, y, fs=1000,
            nperseg=256, noverlap=128,
            average="mean",
        )

    timing = benchmark(compute, n_repeat=40, n_warmup=3)
    median_ms = np.median(timing.gpu_times[0]) * 1000

    # Separate untimed pass: peak live pool usage, including inputs.
    peak = pool.used_bytes()

    def allocate(size):
        nonlocal peak
        pointer = pool.malloc(size)
        peak = max(peak, pool.used_bytes())
        return pointer

    with cp.cuda.using_allocator(allocate):
        output = compute()
        cp.cuda.get_current_stream().synchronize()
    del output

    print(
        f"{dtype}, C={channels}: "
        f"{median_ms:.3f} ms, peak={peak / 1024**2:.1f} MiB"
    )


for dtype, channel_counts in cases.items():
    for channels in channel_counts:
        try:
            run_case(channels, dtype)
        except cp.cuda.memory.OutOfMemoryError:
            print(f"{dtype}, C={channels}: OOM")
        finally:
            cp.fft.config.get_plan_cache().clear()
            pool.free_all_blocks()
```

</details>

BTW, currently the `_spectral_helper` function contains a lot of steps, maybe split it into small functions later?