### PR TITLE
Harden custom scan along axes against overflows.

### DIFF
--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -499,7 +499,8 @@ cdef _ndarray_base scan(
 
 @_util.memoize(for_each_device=True)
 def _inclusive_batch_scan_kernel(
-        dtype, block_size, op, src_c_cont, out_c_cont):
+        dtype, block_size, op, src_c_cont, out_c_cont,
+        use_32bit_indexing, large_batch):
     """return Prefix Sum(Scan) cuda kernel
     for a 2d array over axis 1
     used for scanning over different axes
@@ -534,89 +535,84 @@ def _inclusive_batch_scan_kernel(
 
     source = string.Template("""
     ${type_decls}
+    // blocks_per_batch: blocks spanning a single row (1 unless large_batch)
+    // remaining: valid elements in the last (padded) chunk of a row
+    // pad_batch_size: padded row length inside a block; divides block_size
+    //     and equals it when large_batch
     extern "C" __global__ void ${name}(
-        const CArray<${dtype}, 2, ${src_c_cont}> src,
-        CArray<${dtype}, 2, ${out_c_cont}> dst, int batch_size){
-        long long n = src.size();
+        const CArray<${dtype}, 2, ${src_c_cont}, ${use_32bit_indexing}> src,
+        CArray<${dtype}, 2, ${out_c_cont}, ${use_32bit_indexing}> dst,
+        unsigned int blocks_per_batch, unsigned int remaining,
+        unsigned int pad_batch_size
+    ){
+        using index_t = decltype(src)::index_t;
 
         extern __shared__ ${dtype} temp[];
 
         unsigned int thid = threadIdx.x;
-        unsigned int block = blockIdx.x * blockDim.x;
+        int n_batches_block;
+        bool must_copy;
+        index_t row, col;
 
-        unsigned int pad_batch_size = batch_size;
-        bool must_copy = true;
-
-        if (batch_size & (batch_size -1)) {
-            pad_batch_size = 1 << (32 - __clz(batch_size));
-            must_copy = (thid & (pad_batch_size-1)) < batch_size;
+        if constexpr (${large_batch}) {
+            // blockIdx.x / gridDim.x are 32-bit, so row fits. col may not:
+            // widen before multiplying by block_size.
+            unsigned int block_in_row = blockIdx.x % blocks_per_batch;
+            n_batches_block = 1;  // pad_batch_size == block_size
+            must_copy = (block_in_row + 1 != blocks_per_batch)
+                        || (thid < remaining);
+            col = static_cast<index_t>(block_in_row) * ${block_size} + thid;
+            row = blockIdx.x / blocks_per_batch;
+        } else {
+            // Multiple rows per block and `pad_batch_size` is a power of two
+            // so col is lower bits while the row is the higher.
+            unsigned int pad_batch_bits = 31U - __clz(pad_batch_size);
+            n_batches_block = ${block_size} >> pad_batch_bits;
+            col = thid & (pad_batch_size - 1);
+            row = static_cast<index_t>(blockIdx.x) * n_batches_block
+                  + (thid >> pad_batch_bits);
+            must_copy = col < remaining && row < src.shape()[0];
         }
-        if (pad_batch_size > ${block_size}) {
-            int blocks_per_batch = (batch_size - 1) / ${block_size} + 1;
-            pad_batch_size = ${block_size} * blocks_per_batch;
+        const index_t idx[] = {row, col};
 
-            // Must copy enables for all blocks but the last one in the batch
-            bool last_block = (blockIdx.x + 1) % blocks_per_batch == 0;
-            int remaining_batch = batch_size % ${block_size};
-            if (remaining_batch == 0) {
-                remaining_batch = ${block_size};
+        temp[thid] = (must_copy) ? src[idx] : (${dtype}) ${identity};
+        __syncthreads();
+        for (int j = 0; j < n_batches_block; j++) {
+            int offset = j * pad_batch_size;
+            for (int i = 1; i < pad_batch_size; i <<= 1) {
+                int index = ((threadIdx.x + 1) * 2 * i - 1);
+                int index_block = offset + index;
+                if (index < (pad_batch_size)){
+                    temp[index_block] ${op}= temp[index_block - i];
+                }
+                __syncthreads();
             }
-            must_copy = !last_block || (thid < (remaining_batch));
+            for (int i = pad_batch_size >> 1; i > 0; i >>= 1) {
+                int index = ((threadIdx.x + 1) * 2 * i - 1);
+                int index_block = offset + index;
+                if ((index + i) < (pad_batch_size)){
+                    temp[index_block + i] ${op}= temp[index_block];
+                }
+                __syncthreads();
+            }
         }
-
-        int pad_per_batch = pad_batch_size-batch_size;
-        int n_batches_block = ${block_size} / pad_batch_size;
-
-        unsigned int idx0 = thid + block;
-
-        int batch_id = idx0 / pad_batch_size;
-        idx0 = idx0 - pad_per_batch * batch_id;
-
-        int row = idx0 / batch_size;
-        int col = idx0 % batch_size;
-        const ptrdiff_t idx0_idx[] = {row, col};
-
-        if(idx0 < n){
-            temp[thid] = (must_copy) ? src[idx0_idx] : (${dtype}) ${identity};
-            __syncthreads();
-            if (!n_batches_block) {
-                n_batches_block = 1;
-                pad_batch_size = ${block_size};
-            }
-            for (int j = 0; j < n_batches_block; j++) {
-                int offset = j * pad_batch_size;
-                for (int i = 1; i <= pad_batch_size; i <<= 1) {
-                    int index = ((threadIdx.x + 1) * 2 * i - 1);
-                    int index_block = offset + index;
-                    if (index < (pad_batch_size)){
-                        temp[index_block] ${op}= temp[index_block - i];
-                    }
-                    __syncthreads();
-                }
-                for(int i = pad_batch_size >> 1; i > 0; i >>= 1){
-                    int index = ((threadIdx.x + 1) * 2 * i - 1);
-                    int index_block = offset + index;
-                    if((index + i) < (pad_batch_size)){
-                        temp[index_block + i] ${op}= temp[index_block];
-                    }
-                    __syncthreads();
-                }
-            }
-            if(must_copy){
-                dst[idx0_idx] = temp[thid];
-            }
+        if (must_copy) {
+            dst[idx] = temp[thid];
         }
     }
     """).substitute(name=name, dtype=dtype, block_size=block_size,
                     op=op_char[op], identity=identity[op],
                     src_c_cont=src_c_cont, out_c_cont=out_c_cont,
+                    use_32bit_indexing=int(use_32bit_indexing),
+                    large_batch='true' if large_batch else 'false',
                     type_decls=format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
 
 
 @_util.memoize(for_each_device=True)
-def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
+def _add_scan_batch_blocked_sum_kernel(
+        dtype, op, block_size, c_cont, use_32bit_indexing):
     name = 'cupy_add_scan_blocked_sum_kernel'
     type_decls = set()
     dtype = get_typename(dtype, type_decls)
@@ -624,32 +620,31 @@ def _add_scan_batch_blocked_sum_kernel(dtype, op, block_size, c_cont):
     ops = {scan_op.SCAN_SUM: '+', scan_op.SCAN_PROD: '*'}
     source = string.Template("""
     ${type_decls}
-    extern "C" __global__ void ${name}(CArray<${dtype}, 2, ${c_cont}> src_dst,
-        int batch_size){
-        long long n = src_dst.size();
+    extern "C" __global__ void ${name}(
+        CArray<${dtype}, 2, ${c_cont}, ${use_32bit_indexing}> src_dst,
+        unsigned int blocks_per_batch, unsigned int remaining
+    ){
+        using index_t = decltype(src_dst)::index_t;
 
         unsigned int thid = threadIdx.x;
-        unsigned int block = blockIdx.x * ${block_size};
+        unsigned int block_in_row = blockIdx.x % blocks_per_batch;
+        index_t row = blockIdx.x / blocks_per_batch;
+        index_t block_start =
+            static_cast<index_t>(block_in_row) * ${block_size};
 
-        unsigned int idx0 = thid + block;
-
-        // Respect padding
-        unsigned int row = idx0 / batch_size;
-        unsigned int col = idx0 % batch_size;
-        int my_block = ${block_size} * (col / ${block_size});
-        const ptrdiff_t dst_idx[] = {row, col};
-        const ptrdiff_t src_idx[] = {row, my_block - 1};
-
-        // Avoid for the first block of every row
-        // This can be tweaked with kernel launch settings
-        bool first = col < ${block_size};
-        bool is_block = (col % (${block_size})) == ${block_size} - 1;
-        if(idx0 < n && !first && !is_block){
+        bool in_range = (block_in_row + 1 != blocks_per_batch)
+                        || (thid < remaining);
+        // The first block of a row has nothing to add and the last thread of
+        // a block already holds the sum of its block.
+        if (in_range && block_in_row != 0 && thid != ${block_size} - 1){
+            const index_t dst_idx[] = {row, block_start + thid};
+            const index_t src_idx[] = {row, block_start - 1};
             src_dst[dst_idx] ${op}= src_dst[src_idx];
         }
     }
     """).substitute(name=name, dtype=dtype, op=ops[op], block_size=block_size,
                     c_cont=c_cont,
+                    use_32bit_indexing=int(use_32bit_indexing),
                     type_decls=format_type_decls(type_decls))
     module = compile_with_cache(source)
     return module.get_function(name)
@@ -661,32 +656,42 @@ cdef _ndarray_base _batch_scan_op(
     # TODO(ecastill) replace this with "_reduction._block_size" once it is
     # properly exposed
     block_size = 512
-    # Since we need to pad each batch we spawn more threads as some
-    # of them will be idle
-    # Calc the total number of blocks
-    padded_bs = 1 << ((batch_size - 1).bit_length())
-    if padded_bs > block_size:
+    cdef bint large_batch = batch_size > block_size
+    if large_batch:
+        # A row spans several blocks, the last one is only partially filled.
         blocks_per_batch = (batch_size - 1) // block_size + 1
-        padded_bs = block_size * blocks_per_batch
-    padded_size = a.size // batch_size * padded_bs
+        pad_batch_size = block_size
+        remaining = (batch_size - 1) % block_size + 1
+    else:
+        # Pad each row to the next power of two so several rows can share a
+        # block. pad_batch_size <= block_size.
+        blocks_per_batch = 1
+        pad_batch_size = 1 << ((batch_size - 1).bit_length())
+        remaining = batch_size
+    padded_size = a.shape[0] * blocks_per_batch * pad_batch_size
+    n_blocks = (padded_size - 1) // block_size + 1
 
     cdef int src_cont = int(a.flags.c_contiguous)
     cdef int out_cont = int(out.flags.c_contiguous)
-    kern_scan = _inclusive_batch_scan_kernel(a.dtype, block_size, op,
-                                             src_cont, out_cont)
-    kern_scan(grid=((padded_size - 1) // (block_size) + 1,),
-              block=(block_size,),
-              args=(a, out, batch_size),
+    cdef int use_32 = int(a._index_32_bits and out._index_32_bits)
+
+    # Convert to uint32 for kernel arguments (could error for huge matrices):
+    blocks_per_batch = numpy.uint32(blocks_per_batch)
+    remaining = numpy.uint32(remaining)
+    pad_batch_size = numpy.uint32(pad_batch_size)
+
+    kern_scan = _inclusive_batch_scan_kernel(
+        a.dtype, block_size, op, src_cont, out_cont, use_32, large_batch)
+    kern_scan(grid=(n_blocks,), block=(block_size,),
+              args=(a, out, blocks_per_batch, remaining, pad_batch_size),
               shared_mem=a.itemsize * block_size)
-    if batch_size > block_size:
+    if large_batch:
         blocked_sum = out[:, block_size-1::block_size]
         _batch_scan_op(blocked_sum, op, blocked_sum)
         kern_add = _add_scan_batch_blocked_sum_kernel(
-            out.dtype, op, block_size, out_cont)
-        kern_add(
-            grid=((out.size - 1) // (block_size) + 1,),
-            block=(block_size,),
-            args=(out, batch_size))
+            out.dtype, op, block_size, out_cont, use_32)
+        kern_add(grid=(n_blocks,), block=(block_size,),
+                 args=(out, blocks_per_batch, remaining))
     return out
 
 

--- a/tests/cupy_tests/math_tests/test_sumprod.py
+++ b/tests/cupy_tests/math_tests/test_sumprod.py
@@ -674,6 +674,24 @@ class TestNansumNanprodHuge:
 
 axes = [0, 1, 2]
 
+# Our scan (cumsum/cumprod) has two branches, for axes longer or shorter
+# than 512.  Vary the length around that (and its multiples) and the axis.
+_BATCH_SCAN_AXIS_CASES = [
+    ((4, 1), 1),           # 1-wide: many rows per 512-thread block
+    ((3, 7), 1),           # non-power-of-two padding
+    ((17, 256), 1),        # power-of-two, leftover rows in last block
+    ((2, 511), 1),
+    ((2, 512), 1),
+    ((7, 5), 0),           # scan axis 0 (rolled to last)
+    ((2, 8, 3), 1),        # 3d, middle axis
+    ((1, 513), 1),         # remaining = 1
+    ((3, 513), 1),
+    ((2, 1000), 1),        # remaining = 488
+    ((1, 1024), 1),        # exact two blocks
+    ((1024, 2), 0),
+    ((2, 513, 2), 1),
+]
+
 
 class TestCumsum:
 
@@ -793,6 +811,12 @@ class TestCumsum:
         with pytest.raises(TypeError):
             return cupy.cumsum(a_numpy)
 
+    @pytest.mark.parametrize('shape, axis', _BATCH_SCAN_AXIS_CASES)
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_cumsum_axis_batch_kernels(self, xp, shape, axis):
+        a = testing.shaped_arange(shape, xp, numpy.float64)
+        return self._cumsum(xp, a, axis=axis)
+
 
 class TestCumprod:
 
@@ -891,6 +915,69 @@ class TestCumprod:
         a_numpy = numpy.arange(1, 6, dtype=dtype)
         with pytest.raises(TypeError):
             return cupy.cumprod(a_numpy)
+
+    @pytest.mark.parametrize('shape, axis', _BATCH_SCAN_AXIS_CASES)
+    @testing.numpy_cupy_allclose(contiguous_check=False)
+    def test_cumprod_axis_batch_kernels(self, xp, shape, axis):
+        a = testing.shaped_arange(shape, xp, numpy.float64)
+        a *= 2 / a.size  # scale to (0, 2] to avoid overflow
+        return self._cumprod(xp, a, axis=axis)
+
+
+@testing.slow
+@pytest.mark.thread_unsafe(reason="too large allocations")
+class TestBatchScanSizeOverInt32Max:
+    # Test both branches of _batch_scan_op for very large arrays.
+    # (1, n): large-batch kernel, axis longer than INT32_MAX
+    # (n, 2): small-batch kernel, more rows than INT32_MAX (its padded size
+    #         also exceeds UINT32_MAX)
+    # (2**23 + 1, 512): small-batch kernel with a single row per padded block
+    shapes = [
+        (1, INT32_MAX + 1024),
+        (INT32_MAX + 1024, 2),
+        ((1 << 23) + 1, 512),
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _free_memory(self):
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+        yield
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+
+    def _spot_check(self, a, expected):
+        # Spot check result (to avoid the full cost).
+        n_rows, n_cols = a.shape
+        # col 512 lands in the second block, i.e. checks the add kernel
+        for row in [r for r in (0, INT32_MAX, n_rows - 1) if r < n_rows]:
+            for col in [c for c in (0, 255, 512, INT32_MAX, n_cols - 1)
+                        if c < n_cols]:
+                assert int(a[row, col]) == expected(col)
+
+    @pytest.mark.parametrize('shape', shapes)
+    def test_cumsum_axis(self, shape):
+        try:
+            a = cupy.zeros(shape, dtype=numpy.uint8)
+            a[:, 0] = 1
+            a[:, -1] = 1
+            cupy.cumsum(a, axis=1, out=a)
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+        # leading 1 plus trailing 1: 1 everywhere, last column is 2
+        n_cols = a.shape[1]
+        self._spot_check(a, lambda col: 2 if col == n_cols - 1 else 1)
+
+    @pytest.mark.parametrize('shape', shapes)
+    def test_cumprod_axis(self, shape):
+        try:
+            a = cupy.ones(shape, dtype=numpy.uint8)
+            a[:, 0] = 2
+            cupy.cumprod(a, axis=1, out=a)
+        except MemoryError:
+            pytest.skip("out of memory in test.")
+        # a leading 2 followed by ones gives 2 everywhere
+        self._spot_check(a, lambda col: 2)
 
 
 @pytest.mark.parametrize("shape", [(20,), (7, 6), (3, 4, 5)])


### PR DESCRIPTION
This also re-organizes code a bit and passes in a few more scalars to the kernel and uses a `constexpr` branch right now. (I am not sure if that may give a compiler warning but we ignore those.)

Guided the agents to do this, the tests are largely agent written, but looked pretty good to me (slow tests are not run in CI but passed locally).

The diff looks unfortunately slightly bigger because of indentation changes.

Closes gh-10268

---

It seems the small kernel cleanup changes also lead to a slight speedup:
<img width="1600" height="1280" alt="image" src="https://github.com/user-attachments/assets/9e550271-1e8a-437d-bf11-847d4e56dea5" />

(Although, wouldn't want to fully rule out it's in part random, I guess the very small axes length actually safe a bit of in-kernel computation. It does have one less thread-sync and division/modulo speedups, though.)