### PR TITLE
Add `dawsn`, `erfi`, `voigt_profile` functions

### DIFF
--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -84,6 +84,7 @@ from cupyx.scipy.special._erf import erfinv  # NOQA
 from cupyx.scipy.special._erf import erfcinv  # NOQA
 from cupyx.scipy.special._wofz import wofz  # NOQA
 from cupyx.scipy.special._dawsn import dawsn  # NOQA
+from cupyx.scipy.special._voigt_profile import voigt_profile  # NOQA
 
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -82,6 +82,7 @@ from cupyx.scipy.special._erf import erfcx  # NOQA
 from cupyx.scipy.special._erf import erfinv  # NOQA
 from cupyx.scipy.special._erf import erfcinv  # NOQA
 from cupyx.scipy.special._wofz import wofz  # NOQA
+from cupyx.scipy.special._dawsn import dawsn  # NOQA
 
 # Legendre functions
 from cupyx.scipy.special._lpmv import lpmv  # NOQA

--- a/cupyx/scipy/special/__init__.py
+++ b/cupyx/scipy/special/__init__.py
@@ -79,6 +79,7 @@ from cupyx.scipy.special._poch import poch  # NOQA
 from cupyx.scipy.special._erf import erf  # NOQA
 from cupyx.scipy.special._erf import erfc  # NOQA
 from cupyx.scipy.special._erf import erfcx  # NOQA
+from cupyx.scipy.special._erfi import erfi  # NOQA
 from cupyx.scipy.special._erf import erfinv  # NOQA
 from cupyx.scipy.special._erf import erfcinv  # NOQA
 from cupyx.scipy.special._wofz import wofz  # NOQA

--- a/cupyx/scipy/special/_dawsn.py
+++ b/cupyx/scipy/special/_dawsn.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cupy import _core
+
+
+dawsn = _core.create_ufunc(
+    'cupyx_scipy_special_dawsn', ('f->f', 'd->d', 'F->F', 'D->D'),
+    'out0 = xsf::dawsn(in0)',
+    preamble='#include <cupy/xsf/erf.h>',
+    doc='''Dawson's integral.
+
+    .. seealso:: :func:`scipy.special.dawsn`
+
+    ''')

--- a/cupyx/scipy/special/_erfi.py
+++ b/cupyx/scipy/special/_erfi.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cupy import _core
+
+
+erfi = _core.create_ufunc(
+    'cupyx_scipy_special_erfi', ('f->f', 'd->d', 'F->F', 'D->D'),
+    'out0 = xsf::erfi(in0)',
+    preamble='#include <cupy/xsf/erf.h>',
+    doc='''Imaginary error function.
+
+    .. seealso:: :func:`scipy.special.erfi`
+
+    ''')

--- a/cupyx/scipy/special/_voigt_profile.py
+++ b/cupyx/scipy/special/_voigt_profile.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cupy import _core
+
+
+voigt_profile = _core.create_ufunc(
+    'cupyx_scipy_special_voigt_profile', ('fff->f', 'ddd->d'),
+    'out0 = xsf::voigt_profile(in0, in1, in2)',
+    preamble='#include <cupy/xsf/erf.h>',
+    doc='''Voigt profile.
+
+    .. seealso:: :func:`scipy.special.voigt_profile`
+
+    ''')

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -136,6 +136,7 @@ Error function and Fresnel integrals
    erf
    erfc
    erfcx
+   erfi
    erfinv
    erfcinv
    wofz

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -141,6 +141,7 @@ Error function and Fresnel integrals
    erfcinv
    wofz
    dawsn
+   voigt_profile
 
 
 Legendre functions

--- a/docs/source/reference/scipy_special.rst
+++ b/docs/source/reference/scipy_special.rst
@@ -139,6 +139,7 @@ Error function and Fresnel integrals
    erfinv
    erfcinv
    wofz
+   dawsn
 
 
 Legendre functions

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_dawsn.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_dawsn.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from cupy import testing
+
+
+@testing.with_requires('scipy')
+class TestDawsn:
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-6, scipy_name='scp')
+    def test_real(self, xp, scp, dtype):
+        x = xp.linspace(-100.0, 100.0, 201, dtype=dtype)
+        return scp.special.dawsn(x)
+
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-6, scipy_name='scp')
+    def test_complex(self, xp, scp, dtype):
+        x = xp.linspace(-5.0, 5.0, 21, dtype=dtype)
+        y = xp.linspace(-5.0, 5.0, 21, dtype=dtype)
+        x, y = xp.meshgrid(x, y)
+        z = (x + 1j * y).ravel()
+        return scp.special.dawsn(z)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_erfi.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_erfi.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from cupy import testing
+
+
+@testing.with_requires("scipy")
+class TestErfi:
+    @testing.for_dtypes("fd")
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-6, scipy_name="scp")
+    def test_real(self, xp, scp, dtype):
+        x = xp.linspace(-10.0, 10.0, 201, dtype=dtype)
+        return scp.special.erfi(x)
+
+    @testing.for_dtypes("fd")
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-6, scipy_name="scp")
+    def test_complex(self, xp, scp, dtype):
+        x = xp.linspace(-5.0, 5.0, 21, dtype=dtype)
+        y = xp.linspace(-5.0, 5.0, 21, dtype=dtype)
+        x, y = xp.meshgrid(x, y)
+        z = (x + 1j * y).ravel()
+        return scp.special.erfi(z)

--- a/tests/cupyx_tests/scipy_tests/special_tests/test_voigt_profile.py
+++ b/tests/cupyx_tests/scipy_tests/special_tests/test_voigt_profile.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from cupy import testing
+
+
+@testing.with_requires('scipy')
+class TestVoigtProfile:
+    @testing.for_dtypes('fd')
+    @testing.numpy_cupy_allclose(atol=1e-13, rtol=1e-6, scipy_name='scp')
+    def test_values(self, xp, scp, dtype):
+        x = xp.linspace(-100.0, 100.0, 201, dtype=dtype)[:, None, None]
+        sigma = xp.asarray([0.0, 0.1, 1.0, 10.0], dtype=dtype)[None, :, None]
+        gamma = xp.asarray([0.0, 0.1, 1.0, 10.0], dtype=dtype)[None, None, :]
+        return scp.special.voigt_profile(x, sigma, gamma)


### PR DESCRIPTION
This PR adds the special functions `dawsn`, `erfi`, `voigt_profile` following the pattern of https://github.com/cupy/cupy/pull/10276