### PR TITLE
CI: include the wheel SHA in the nightly dispatch title

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -161,7 +161,7 @@ jobs:
               after: $sha,
               head_commit: {
                 id: $sha,
-                message: "Nightly CI: @nightly matrix against most recent wheel build",
+                message: "Nightly CI: @nightly matrix against most recent wheel build (\($sha))",
                 url: $url,
                 timestamp: $ts
               },


### PR DESCRIPTION
Appends the resolved wheel commit to `ci-nightly.yml`'s synthetic push payload so the PFN CI job title reads

    Nightly CI: @nightly matrix against most recent wheel build (<SHA>)

instead of the SHA-less form it uses today. Saves a hop into the GHA run to find out which commit's wheels a nightly lane was actually testing when triaging a red lane.

The `$sha` jq arg was already bound from `${HEAD_SHA}` for other fields (`after`, `head_commit.id`); this just interpolates it into the message string with jq's `\(...)` syntax. No other behavior changes.

-- Leo's bot
