### PR TITLE
Compare reproduced singular vectors up to sign in the augmented-columns test

### DIFF
--- a/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
+++ b/tests/cupyx_tests/scipy_tests/sparse_tests/test_linalg.py
@@ -567,8 +567,13 @@ class TestDefaultStartVector:
         cupy.random.seed(3)
         u2, s2, vt2 = sparse.linalg.svds(sparse.csr_matrix(a), k=6)
         cupy.testing.assert_allclose(s1, s2, rtol=1e-10, atol=1e-10)
-        cupy.testing.assert_allclose(u1, u2, rtol=1e-8, atol=1e-8)
-        cupy.testing.assert_allclose(vt1, vt2, rtol=1e-8, atol=1e-8)
+        # A singular vector is defined up to sign, and the Ritz solve does
+        # not fix it between runs (gh-10286): compare each column up to its
+        # sign, i.e. require |u1^H u2| = I and |vt1 vt2^H| = I.
+        for x, y in ((u1, u2), (vt1.T, vt2.T)):
+            g = cupy.abs(x.conj().T @ y)
+            cupy.testing.assert_allclose(g, cupy.eye(g.shape[0]),
+                                         rtol=1e-8, atol=1e-8)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
`TestDefaultStartVector.test_svds_augmented_vectors_repeatable` (added in #10265) compared two reproduced `u` / `vt` arrays directly. A singular vector is only defined up to sign, and the Ritz solve does not fix the sign between two runs, so the test could fail on a legitimate result: in the CI failure of #10286 the first *true* singular vector flipped sign while the three completing columns the test is about were identical.

Compare `|U1^H U2|` and `|V1^H V2|` to the identity instead, which checks the same-subspace, same-columns property up to sign. Verified 6/6 runs on an H200 against current `main`.

Fixes #10286
