### PR TITLE
Tolerate concurrent os.replace() races in DiskKernelCacheBackend.load()

### DIFF
--- a/cupy/cuda/_compiler_cache.py
+++ b/cupy/cuda/_compiler_cache.py
@@ -160,8 +160,18 @@ class DiskKernelCacheBackend(KernelCacheBackend):
         if not os.path.exists(path):
             return None
 
-        with open(path, 'rb') as file:
-            data = file.read()
+        try:
+            with open(path, 'rb') as file:
+                data = file.read()
+        except (PermissionError, FileNotFoundError):
+            # Race with a concurrent _write_encoded() replacing the same
+            # file (mirrors the tolerance in _write_encoded() itself): on
+            # Windows, os.replace() can transiently make the destination
+            # inaccessible to a concurrent reader, raising PermissionError;
+            # the file can also disappear between the os.path.exists()
+            # check above and the open() call. Treat both as a cache miss
+            # so the caller falls back to recompiling.
+            return None
 
         return self._decode_cubin(data)
 

--- a/tests/cupy_tests/cuda_tests/test_compiler_cache.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler_cache.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import os
 import tempfile
+from unittest import mock
+
+import pytest
 
 from cupy.cuda._compiler_cache import (
     DiskKernelCacheBackend,
@@ -122,3 +125,33 @@ class TestDiskKernelCacheBackend:
             name = 'test.cubin'
             backend._write_encoded(name, backend._encode_cubin(cubin))
             assert backend.load(name) == cubin
+
+    def test_write_encoded_tolerates_concurrent_replace_permission_error(
+        self,
+    ):
+        """Test _write_encoded swallows a racing os.replace() error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backend = DiskKernelCacheBackend(cache_dir=tmpdir)
+            with mock.patch(
+                'cupy.cuda._compiler_cache.os.replace',
+                side_effect=PermissionError,
+            ):
+                # Should not raise.
+                backend._write_encoded('test.cubin', b'data')
+
+    @pytest.mark.parametrize(
+        'open_error', [PermissionError, FileNotFoundError])
+    def test_load_tolerates_concurrent_replace_errors(self, open_error):
+        """Test load treats a racing open() error as a cache miss."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backend = DiskKernelCacheBackend(cache_dir=tmpdir)
+            name = 'test.cubin'
+            backend._write_encoded(name, backend._encode_cubin(b'cubin'))
+
+            with mock.patch(
+                'cupy.cuda._compiler_cache.open',
+                side_effect=open_error,
+                create=True,
+            ):
+                result = backend.load(name)
+            assert result is None

--- a/tests/cupy_tests/cuda_tests/test_compiler_cache.py
+++ b/tests/cupy_tests/cuda_tests/test_compiler_cache.py
@@ -126,6 +126,7 @@ class TestDiskKernelCacheBackend:
             backend._write_encoded(name, backend._encode_cubin(cubin))
             assert backend.load(name) == cubin
 
+    @pytest.mark.thread_unsafe(reason="uses mock.patch")
     def test_write_encoded_tolerates_concurrent_replace_permission_error(
         self,
     ):
@@ -141,6 +142,7 @@ class TestDiskKernelCacheBackend:
 
     @pytest.mark.parametrize(
         'open_error', [PermissionError, FileNotFoundError])
+    @pytest.mark.thread_unsafe(reason="uses mock.patch")
     def test_load_tolerates_concurrent_replace_errors(self, open_error):
         """Test load treats a racing open() error as a cache miss."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes #10271