### PR TITLE
CI: Add CUDA 13.4 support

### DIFF
--- a/.github/actions/fetch_ctk/action.yml
+++ b/.github/actions/fetch_ctk/action.yml
@@ -75,7 +75,7 @@ runs:
           function extract() {
             tar -xvf $1 -C $CACHE_TMP_DIR --strip-components=1
           }
-        elif [[ "${{ inputs.host-platform }}" == "win-64" ]]; then
+        elif [[ "${{ inputs.host-platform }}" == win-* ]]; then
           function extract() {
             _TEMP_DIR_=$(mktemp -d)
             unzip $1 -d $_TEMP_DIR_

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -112,20 +112,16 @@ jobs:
       # ptxas/cicc/cudafe++), which invalidates the warm GHA sccache cache and
       # forces a full recompile on every PR until the shared cache re-warms.
       # Bump SCCACHE_VERSION deliberately.
-      # win-arm64: rapidsai/sccache has no Windows ARM64 build, so we skip the
-      # cache and let NVCC run cold. Cheaper than cross-compiling sccache; the
-      # wheel matrix is small enough (~5 wheels per push) that it's not a
-      # bottleneck. Revisit if a native win-arm64 sccache lands upstream.
       - name: Install pinned rapidsai/sccache
-        if: ${{ inputs.host-platform != 'win-arm64' }}
         env:
           HOST_PLATFORM: ${{ inputs.host-platform }}
           SCCACHE_VERSION: v0.17.0-rapids.4
         run: |
           case "${HOST_PLATFORM}" in
-            linux-*)  URL_TRIPLE="$(uname -m)-unknown-linux-musl"; SCCACHE_BIN="sccache" ;;
-            win-*)    URL_TRIPLE="x86_64-pc-windows-msvc";         SCCACHE_BIN="sccache.exe" ;;
-            *)        echo "Unsupported host-platform: ${HOST_PLATFORM}" >&2; exit 1 ;;
+            linux-*)    URL_TRIPLE="$(uname -m)-unknown-linux-musl"; SCCACHE_BIN="sccache" ;;
+            win-64)     URL_TRIPLE="x86_64-pc-windows-msvc";         SCCACHE_BIN="sccache.exe" ;;
+            win-arm64)  URL_TRIPLE="aarch64-pc-windows-msvc";        SCCACHE_BIN="sccache.exe" ;;
+            *)          echo "Unsupported host-platform: ${HOST_PLATFORM}" >&2; exit 1 ;;
           esac
           mkdir -p sccache_bin
           curl -fsSL "https://github.com/rapidsai/sccache/releases/download/${SCCACHE_VERSION}/sccache-${URL_TRIPLE}.tar.gz" \
@@ -308,13 +304,9 @@ jobs:
           # Windows builds run natively (no container), so the ACTIONS_*
           # values would flow in from the job environment -- but set them
           # explicitly anyway so both platform blocks are self-contained.
-          # On win-arm64 sccache is not installed (no rapidsai/sccache build);
-          # NVCC runs directly and the SCCACHE_* vars are simply unused --
-          # cibuildwheel accepts unresolved env vars in this block as long as
-          # the build itself doesn't reference them.
           CIBW_ENVIRONMENT_WINDOWS: >
             CUDA_PATH="$(cygpath -w ${{ env.CUDA_PATH }})"
-            NVCC="${{ (inputs.host-platform == 'win-arm64' && 'nvcc') || 'sccache nvcc' }}"
+            NVCC="sccache nvcc"
             SCCACHE_GHA_ENABLED=true
             ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
             ACTIONS_RUNTIME_URL=${{ env.ACTIONS_RUNTIME_URL }}
@@ -365,8 +357,6 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Report sccache stats (cupy-cuda${{ env.BUILD_CUDA_MAJOR }}x)
-        # See "Install pinned rapidsai/sccache" above; no cache = no stats.
-        if: ${{ inputs.host-platform != 'win-arm64' }}
         uses: ./.github/actions/sccache-summary
         with:
           json-file: sccache_cupy.json

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       host-platform:
-        description: "linux-64, linux-aarch64, or win-64"
+        description: "linux-64, linux-aarch64, win-64, or win-arm64"
         required: true
         type: string
       cuda-version:
@@ -39,10 +39,16 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
+        exclude:
+          # CPython 3.10 has no official Windows ARM64 build (neither
+          # nuget-cpython nor actions/setup-python's manifest carries one),
+          # so it cannot be built or tested on win-arm64.
+          - python-version: ${{ (inputs.host-platform == 'win-arm64' && '3.10') || '' }}
     name: py${{ matrix.python-version }}
     runs-on: ${{ (inputs.host-platform == 'linux-64'      && 'ubuntu-22.04')     ||
                  (inputs.host-platform == 'linux-aarch64' && 'ubuntu-22.04-arm') ||
-                 (inputs.host-platform == 'win-64'        && 'windows-2022') }}
+                 (inputs.host-platform == 'win-64'        && 'windows-2022')     ||
+                 (inputs.host-platform == 'win-arm64'     && 'windows-11-arm') }}
     steps:
       - name: Verify LongPathsEnabled on Windows
         if: ${{ inputs.host-platform == 'win-64' }}
@@ -106,7 +112,12 @@ jobs:
       # ptxas/cicc/cudafe++), which invalidates the warm GHA sccache cache and
       # forces a full recompile on every PR until the shared cache re-warms.
       # Bump SCCACHE_VERSION deliberately.
+      # win-arm64: rapidsai/sccache has no Windows ARM64 build, so we skip the
+      # cache and let NVCC run cold. Cheaper than cross-compiling sccache; the
+      # wheel matrix is small enough (~5 wheels per push) that it's not a
+      # bottleneck. Revisit if a native win-arm64 sccache lands upstream.
       - name: Install pinned rapidsai/sccache
+        if: ${{ inputs.host-platform != 'win-arm64' }}
         env:
           HOST_PLATFORM: ${{ inputs.host-platform }}
           SCCACHE_VERSION: v0.17.0-rapids.4
@@ -147,10 +158,13 @@ jobs:
           # WAR: setup-python is not relocatable, and cibuildwheel hard-wires to 3.12...
           # see https://github.com/actions/setup-python/issues/871
           python-version: "3.12"
+          architecture: ${{ ((inputs.host-platform == 'linux-aarch64' || inputs.host-platform == 'win-arm64') && 'arm64') || 'x64' }}
 
       - name: Set up MSVC
         if: ${{ startsWith(inputs.host-platform, 'win') }}
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
+        with:
+          arch: ${{ (inputs.host-platform == 'win-arm64' && 'arm64') || 'x64' }}
 
       - name: Set up yq
         # GitHub made an unprofessional decision to not provide it in their Windows VMs,
@@ -158,11 +172,12 @@ jobs:
         if: ${{ startsWith(inputs.host-platform, 'win') }}
         env:
           YQ_VERSION: v4.52.5
-          YQ_SHA256: 47594981f3848a4b4447494adeca9555f908f7cf0a89c4da3fd0243a4631da1c
+          YQ_ARCH: ${{ (inputs.host-platform == 'win-arm64' && 'arm64') || 'amd64' }}
+          YQ_SHA256: ${{ (inputs.host-platform == 'win-arm64' && '236867affa7f18701d4c763cf16b6df962cf4f7e89a8570a5954cf94a38f41c7') || '47594981f3848a4b4447494adeca9555f908f7cf0a89c4da3fd0243a4631da1c' }}
           YQ_DIR: yq
         shell: pwsh -command ". '{0}'"
         run: |
-          $yqUrl = "https://github.com/mikefarah/yq/releases/download/${env:YQ_VERSION}/yq_windows_amd64.exe"
+          $yqUrl = "https://github.com/mikefarah/yq/releases/download/${env:YQ_VERSION}/yq_windows_${env:YQ_ARCH}.exe"
           mkdir -Force -ErrorAction SilentlyContinue "${env:YQ_DIR}" | Out-Null
           Invoke-WebRequest -UseBasicParsing -OutFile "${env:YQ_DIR}/yq.exe" -Uri "$yqUrl"
           $hash = (Get-FileHash -Algorithm SHA256 "${env:YQ_DIR}/yq.exe").Hash.ToLower()
@@ -206,6 +221,10 @@ jobs:
           cuda-path: ${{ runner.temp }}/cuda_toolkit
 
       - name: Install cuTENSOR preload
+        # No cuTENSOR redist for win-arm64 yet (as of CTK 13.4); skip until
+        # NVIDIA ships one. wheel_configs.PRELOAD_LIBRARIES tracks the same
+        # gap and drives the wheel metadata accordingly.
+        if: ${{ inputs.host-platform != 'win-arm64' }}
         env:
           INSTALL_LIB_ARCH: ${{ (inputs.host-platform == 'linux-aarch64' && 'aarch64') || 'x86_64' }}
         run: |
@@ -289,9 +308,13 @@ jobs:
           # Windows builds run natively (no container), so the ACTIONS_*
           # values would flow in from the job environment -- but set them
           # explicitly anyway so both platform blocks are self-contained.
+          # On win-arm64 sccache is not installed (no rapidsai/sccache build);
+          # NVCC runs directly and the SCCACHE_* vars are simply unused --
+          # cibuildwheel accepts unresolved env vars in this block as long as
+          # the build itself doesn't reference them.
           CIBW_ENVIRONMENT_WINDOWS: >
             CUDA_PATH="$(cygpath -w ${{ env.CUDA_PATH }})"
-            NVCC="sccache nvcc"
+            NVCC="${{ (inputs.host-platform == 'win-arm64' && 'nvcc') || 'sccache nvcc' }}"
             SCCACHE_GHA_ENABLED=true
             ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
             ACTIONS_RUNTIME_URL=${{ env.ACTIONS_RUNTIME_URL }}
@@ -342,6 +365,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Report sccache stats (cupy-cuda${{ env.BUILD_CUDA_MAJOR }}x)
+        # See "Install pinned rapidsai/sccache" above; no cache = no stats.
+        if: ${{ inputs.host-platform != 'win-arm64' }}
         uses: ./.github/actions/sccache-summary
         with:
           json-file: sccache_cupy.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,33 @@ jobs:
       ref: ${{ needs.guard.outputs.ref }}
       artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
 
+  # Windows-on-Arm wheels. CUDA gained WoA host support in 13.4, so this
+  # lane only runs when the build-side CTK is 13.x -- there is no CUDA 12
+  # variant to pair with, hence the single-cuda-version matrix.
+  build-win-arm64:
+    needs:
+      - guard
+      - build-sdist
+    if: |
+      needs.guard.outputs.mode == 'test' &&
+      startsWith(needs.guard.outputs.CUDA_BUILD_VER, '13.')
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        host-platform:
+          - win-arm64
+        cuda-version:
+          - ${{ needs.guard.outputs.CUDA_BUILD_VER }}
+    name: Build ${{ matrix.host-platform }}, CUDA ${{ matrix.cuda-version }}
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      host-platform: ${{ matrix.host-platform }}
+      cuda-version: ${{ matrix.cuda-version }}
+      ref: ${{ needs.guard.outputs.ref }}
+      artifact-suffix: ${{ needs.guard.outputs.artifact_suffix }}
+
   # Dispatch marker + payload for flexci.yml. Uploaded whenever this ci.yml
   # run should end in a flexci.yml dispatch call: mode=skip on PR (post
   # Skipped statuses via the dispatcher), or mode=test with all builds
@@ -232,13 +259,16 @@ jobs:
       - build-linux-64
       - build-linux-aarch64
       - build-windows
+      - build-win-arm64
     if: |
       always() && (
         (github.event_name == 'pull_request' && needs.guard.outputs.mode == 'skip') ||
         (needs.guard.outputs.mode == 'test' &&
          needs.build-linux-64.result == 'success' &&
          needs.build-linux-aarch64.result == 'success' &&
-         needs.build-windows.result == 'success')
+         needs.build-windows.result == 'success' &&
+         (needs.build-win-arm64.result == 'success' ||
+          needs.build-win-arm64.result == 'skipped'))
       )
     runs-on: ubuntu-latest
     steps:
@@ -279,6 +309,7 @@ jobs:
       - build-linux-64
       - build-linux-aarch64
       - build-windows
+      - build-win-arm64
       - build-sentinel
     steps:
       - name: Exit
@@ -299,12 +330,21 @@ jobs:
             check_result "build-linux-64"      "success" "${{ needs.build-linux-64.result }}"
             check_result "build-linux-aarch64" "success" "${{ needs.build-linux-aarch64.result }}"
             check_result "build-windows"       "success" "${{ needs.build-windows.result }}"
+            # win-arm64 only runs on CUDA 13.x build lanes; treat "skipped"
+            # as OK when CUDA_BUILD_VER is 12.x so the pre-13.4 backport
+            # branches still pass this gate.
+            if [[ "${{ needs.guard.outputs.CUDA_BUILD_VER }}" == 13.* ]]; then
+              check_result "build-win-arm64" "success" "${{ needs.build-win-arm64.result }}"
+            else
+              check_result "build-win-arm64" "skipped" "${{ needs.build-win-arm64.result }}"
+            fi
             check_result "build-sentinel"      "success" "${{ needs.build-sentinel.result }}"
             ;;
           skip)
             check_result "build-linux-64"      "skipped" "${{ needs.build-linux-64.result }}"
             check_result "build-linux-aarch64" "skipped" "${{ needs.build-linux-aarch64.result }}"
             check_result "build-windows"       "skipped" "${{ needs.build-windows.result }}"
+            check_result "build-win-arm64"     "skipped" "${{ needs.build-win-arm64.result }}"
             check_result "build-sentinel"      "success" "${{ needs.build-sentinel.result }}"
             ;;
           no-op)

--- a/.pfnci/.gitattributes
+++ b/.pfnci/.gitattributes
@@ -52,6 +52,10 @@
 /linux/tests/cuda133.sh linguist-generated
 /linux/tests/cuda133.multi.Dockerfile linguist-generated
 /linux/tests/cuda133.multi.sh linguist-generated
+/linux/tests/cuda134.Dockerfile linguist-generated
+/linux/tests/cuda134.sh linguist-generated
+/linux/tests/cuda134.multi.Dockerfile linguist-generated
+/linux/tests/cuda134.multi.sh linguist-generated
 /linux/tests/cuda13x-py314t.Dockerfile linguist-generated
 /linux/tests/cuda13x-py314t.sh linguist-generated
 /linux/tests/rocm-7-14.Dockerfile linguist-generated

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -460,6 +460,40 @@ configs {
     command: ".pfnci/linux/main-flexci.sh cuda133.multi"
   }
 }
+# CUDA 13.4 | Linux
+configs {
+  key: "cupy.linux.cuda134"
+  value {
+    requirement {
+      cpu: 8
+      memory: 60
+      disk: 30
+      gpu: 1
+    }
+    time_limit: {
+      seconds: 21600
+    }
+    environment_variables { key: "GPU" value: "1" }
+    command: ".pfnci/linux/main-flexci.sh cuda134"
+  }
+}
+# CUDA 13.4 (Multi-GPU) | Linux
+configs {
+  key: "cupy.linux.cuda134.multi"
+  value {
+    requirement {
+      cpu: 8
+      memory: 60
+      disk: 30
+      gpu: 2
+    }
+    time_limit: {
+      seconds: 21600
+    }
+    environment_variables { key: "GPU" value: "2" }
+    command: ".pfnci/linux/main-flexci.sh cuda134.multi"
+  }
+}
 # CUDA 13.x + Python 3.14 free-threaded | Linux
 configs {
   key: "cupy.linux.cuda13x-py314t"
@@ -947,5 +981,25 @@ configs {
     }
     environment_variables { key: "GPU" value: "2" }
     command: ".pfnci\\windows\\run.bat 13.3 3.14 2.4 1.16 test"
+  }
+}
+configs {
+  key: "cupy.win.cuda134"
+  value {
+    requirement {
+      cpu: 8
+      memory: 36
+      disk: 10
+      gpu: 2
+      image: "windows"
+    }
+    time_limit {
+      seconds: 72000
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    environment_variables { key: "GPU" value: "2" }
+    command: ".pfnci\\windows\\run.bat 13.4 3.14 2.4 1.16 test"
   }
 }

--- a/.pfnci/config.tags.json
+++ b/.pfnci/config.tags.json
@@ -162,19 +162,32 @@
         "cuda132"
     ],
     "cupy.linux.cuda133": [
-        "@push",
+        "@nightly",
         "full",
-        "mini",
         "linux",
         "cuda133"
     ],
     "cupy.linux.cuda133.multi": [
+        "@nightly",
+        "full",
+        "multi",
+        "linux",
+        "cuda133"
+    ],
+    "cupy.linux.cuda134": [
+        "@push",
+        "full",
+        "mini",
+        "linux",
+        "cuda134"
+    ],
+    "cupy.linux.cuda134.multi": [
         "@push",
         "full",
         "mini",
         "multi",
         "linux",
-        "cuda133"
+        "cuda134"
     ],
     "cupy.linux.cuda13x-py314t": [
         "@push",
@@ -289,11 +302,17 @@
         "cuda132"
     ],
     "cupy.win.cuda133": [
+        "@nightly",
+        "full",
+        "windows",
+        "cuda133"
+    ],
+    "cupy.win.cuda134": [
         "@push",
         "full",
         "mini",
         "windows",
-        "cuda133"
+        "cuda134"
     ],
     "cupy.linux.cuda-rapids": [
         "@nightly",

--- a/.pfnci/coverage.rst
+++ b/.pfnci/coverage.rst
@@ -45,9 +45,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - System
      - 
+     - linux
+     - linux
      - linux
      - linux
      - linux
@@ -112,16 +116,20 @@ CuPy CI Test Coverage
      - `cuda132.multi <t23_>`_ `🐳 <d23_>`_ `📜 <s23_>`_
      - `cuda133 <t24_>`_ `🐳 <d24_>`_ `📜 <s24_>`_
      - `cuda133.multi <t25_>`_ `🐳 <d25_>`_ `📜 <s25_>`_
-     - `cuda13x-py314t <t26_>`_ `🐳 <d26_>`_ `📜 <s26_>`_
-     - `rocm-7-14 <t27_>`_ `🐳 <d27_>`_ `📜 <s27_>`_
-     - `cuda-slow <t28_>`_ `🐳 <d28_>`_ `📜 <s28_>`_
-     - `cuda-example <t29_>`_ `🐳 <d29_>`_ `📜 <s29_>`_
-     - `cuda-head <t30_>`_ `🐳 <d30_>`_ `📜 <s30_>`_
-     - `cuda12x-cuda-python <t31_>`_ `🐳 <d31_>`_ `📜 <s31_>`_
-     - `cuda13x-cuda-python <t32_>`_ `🐳 <d32_>`_ `📜 <s32_>`_
-     - `benchmark.head <t33_>`_ `🐳 <d33_>`_ `📜 <s33_>`_
-     - `benchmark <t34_>`_ `🐳 <d34_>`_ `📜 <s34_>`_
+     - `cuda134 <t26_>`_ `🐳 <d26_>`_ `📜 <s26_>`_
+     - `cuda134.multi <t27_>`_ `🐳 <d27_>`_ `📜 <s27_>`_
+     - `cuda13x-py314t <t28_>`_ `🐳 <d28_>`_ `📜 <s28_>`_
+     - `rocm-7-14 <t29_>`_ `🐳 <d29_>`_ `📜 <s29_>`_
+     - `cuda-slow <t30_>`_ `🐳 <d30_>`_ `📜 <s30_>`_
+     - `cuda-example <t31_>`_ `🐳 <d31_>`_ `📜 <s31_>`_
+     - `cuda-head <t32_>`_ `🐳 <d32_>`_ `📜 <s32_>`_
+     - `cuda12x-cuda-python <t33_>`_ `🐳 <d33_>`_ `📜 <s33_>`_
+     - `cuda13x-cuda-python <t34_>`_ `🐳 <d34_>`_ `📜 <s34_>`_
+     - `benchmark.head <t35_>`_ `🐳 <d35_>`_ `📜 <s35_>`_
+     - `benchmark <t36_>`_ `🐳 <d36_>`_ `📜 <s36_>`_
    * - 
+     - 
+     - 
      - 
      - 
      - 
@@ -161,7 +169,9 @@ CuPy CI Test Coverage
      - 
    * - system
      - linux
-     - 35
+     - 37
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -235,6 +245,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - os
      - ubuntu:20.04
      - 22
@@ -266,6 +278,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - ✅
@@ -275,7 +289,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - ubuntu:22.04
-     - 13
+     - 15
      - 
      - 
      - 
@@ -294,6 +308,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -314,6 +330,8 @@ CuPy CI Test Coverage
    * - 
      - centos:7
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -387,6 +405,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - ws:2022
      - 🚨
@@ -425,9 +445,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - cuda
      - null
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -501,6 +525,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 12.1
      - 2
@@ -508,6 +534,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -577,6 +605,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 12.3
      - 2
@@ -588,6 +618,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -653,6 +685,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 12.5
      - 2
@@ -668,6 +702,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -729,6 +765,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 12.8
      - 2
@@ -748,6 +786,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -788,6 +828,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -841,6 +883,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
    * - 
@@ -868,6 +912,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -919,9 +965,53 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 13.3
+     - 2
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - ✅
+     - ✅
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 13.4
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -959,7 +1049,9 @@ CuPy CI Test Coverage
      - 
    * - rocm
      - null
-     - 34
+     - 36
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1025,6 +1117,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1036,6 +1130,8 @@ CuPy CI Test Coverage
    * - nccl
      - null
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -1109,6 +1205,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.17
      - 4
@@ -1116,6 +1214,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1185,6 +1285,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.19
      - 2
@@ -1196,6 +1298,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1261,6 +1365,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.21
      - 2
@@ -1276,6 +1382,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1337,9 +1445,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.25
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -1409,6 +1521,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1416,6 +1530,8 @@ CuPy CI Test Coverage
    * - 
      - 2.27
      - 3
+     - 
+     - 
      - 
      - 
      - 
@@ -1480,6 +1596,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1527,9 +1645,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.30
-     - 3
+     - 5
      - 
      - 
      - 
@@ -1554,6 +1674,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - 
@@ -1595,6 +1717,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1605,7 +1729,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 2.4
-     - 30
+     - 32
      - ✅
      - ✅
      - ✅
@@ -1622,6 +1746,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1660,6 +1786,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1717,9 +1845,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 0.9.1
-     - 11
+     - 13
      - 
      - 
      - 
@@ -1738,6 +1868,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1760,6 +1892,8 @@ CuPy CI Test Coverage
      - 2
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1823,6 +1957,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1852,6 +1988,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -1907,9 +2045,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 3.14
-     - 11
+     - 13
      - 
      - 
      - 
@@ -1928,6 +2068,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -1974,6 +2116,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -1986,6 +2130,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 🚨
+     - 
+     - 
      - 
      - 
      - 
@@ -2059,6 +2205,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.1
      - 4
@@ -2070,6 +2218,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2135,6 +2285,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 2.3
      - 8
@@ -2156,6 +2308,8 @@ CuPy CI Test Coverage
      - ✅
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2202,6 +2356,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2213,7 +2369,7 @@ CuPy CI Test Coverage
      - ✅
    * - 
      - 2.5
-     - 2
+     - 4
      - 
      - 
      - 
@@ -2238,6 +2394,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - 
@@ -2252,6 +2410,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -2325,6 +2485,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.14
      - 6
@@ -2342,6 +2504,8 @@ CuPy CI Test Coverage
      - 
      - ✅
      - ✅
+     - 
+     - 
      - 
      - 
      - 
@@ -2401,9 +2565,11 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 1.16
-     - 22
+     - 24
      - 
      - 
      - 
@@ -2426,6 +2592,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2477,9 +2645,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - pre
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -2553,6 +2725,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 3
      - 15
@@ -2583,6 +2757,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - ✅
@@ -2593,7 +2769,7 @@ CuPy CI Test Coverage
      - 
    * - 
      - 4
-     - 19
+     - 21
      - 
      - 
      - 
@@ -2606,6 +2782,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2632,6 +2810,8 @@ CuPy CI Test Coverage
    * - 
      - pre
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -2701,13 +2881,15 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - 
      - 
    * - 
      - 0.5
-     - 30
+     - 32
      - ✅
      - ✅
      - ✅
@@ -2718,6 +2900,8 @@ CuPy CI Test Coverage
      - ✅
      - 
      - 
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2776,6 +2960,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -2783,7 +2969,9 @@ CuPy CI Test Coverage
      - 
    * - mpi4py
      - null
-     - 22
+     - 23
+     - ✅
+     - 
      - ✅
      - 
      - ✅
@@ -2821,7 +3009,9 @@ CuPy CI Test Coverage
      - ✅
    * - 
      - 4
-     - 13
+     - 14
+     - 
+     - ✅
      - 
      - ✅
      - 
@@ -2859,7 +3049,9 @@ CuPy CI Test Coverage
      - 
    * - cython
      - 3.2
-     - 35
+     - 37
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2933,9 +3125,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - cuda-python
      - null
-     - 33
+     - 35
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -2974,6 +3170,8 @@ CuPy CI Test Coverage
    * - 
      - 12
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3047,9 +3245,53 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - 13.3
+     - 🚨
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+   * - 
+     - 13.4
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3087,7 +3329,9 @@ CuPy CI Test Coverage
      - 
    * - nvmath-python
      - null
-     - 33
+     - 35
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3157,13 +3401,17 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - 
      - 
    * - cuda-cccl
      - null
-     - 33
+     - 35
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3202,6 +3450,8 @@ CuPy CI Test Coverage
    * - 
      - cu12
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3272,12 +3522,16 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
    * - env:CUPY_ACCELERATORS
      - null
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3316,6 +3570,8 @@ CuPy CI Test Coverage
    * - 
      - 
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3389,9 +3645,13 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
    * - 
      - cub,cutensor
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3429,7 +3689,9 @@ CuPy CI Test Coverage
      - 
    * - 
      - cutensor,cub
-     - 30
+     - 32
+     - ✅
+     - ✅
      - ✅
      - ✅
      - ✅
@@ -3499,13 +3761,17 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - ✅
      - 
      - 
    * - test
      - unit
-     - 18
+     - 19
+     - ✅
+     - 
      - ✅
      - 
      - ✅
@@ -3543,7 +3809,9 @@ CuPy CI Test Coverage
      - 
    * - 
      - unit-multi
-     - 13
+     - 14
+     - 
+     - ✅
      - 
      - ✅
      - 
@@ -3582,6 +3850,8 @@ CuPy CI Test Coverage
    * - 
      - unit-slow
      - 1
+     - 
+     - 
      - 
      - 
      - 
@@ -3649,6 +3919,8 @@ CuPy CI Test Coverage
      - 
      - 
      - 
+     - 
+     - 
      - ✅
      - 
      - 
@@ -3658,6 +3930,8 @@ CuPy CI Test Coverage
    * - 
      - benchmark
      - 2
+     - 
+     - 
      - 
      - 
      - 
@@ -3772,30 +4046,36 @@ CuPy CI Test Coverage
 .. _t25: https://ci.preferred.jp/cupy.linux.cuda133.multi/
 .. _d25: linux/tests/cuda133.multi.Dockerfile
 .. _s25: linux/tests/cuda133.multi.sh
-.. _t26: https://ci.preferred.jp/cupy.linux.cuda13x-py314t/
-.. _d26: linux/tests/cuda13x-py314t.Dockerfile
-.. _s26: linux/tests/cuda13x-py314t.sh
-.. _t27: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-7-14,label=mnj-mi50/
-.. _d27: linux/tests/rocm-7-14.Dockerfile
-.. _s27: linux/tests/rocm-7-14.sh
-.. _t28: https://ci.preferred.jp/cupy.linux.cuda-slow/
-.. _d28: linux/tests/cuda-slow.Dockerfile
-.. _s28: linux/tests/cuda-slow.sh
-.. _t29: https://ci.preferred.jp/cupy.linux.cuda-example/
-.. _d29: linux/tests/cuda-example.Dockerfile
-.. _s29: linux/tests/cuda-example.sh
-.. _t30: https://ci.preferred.jp/cupy.linux.cuda-head/
-.. _d30: linux/tests/cuda-head.Dockerfile
-.. _s30: linux/tests/cuda-head.sh
-.. _t31: https://ci.preferred.jp/cupy.linux.cuda12x-cuda-python/
-.. _d31: linux/tests/cuda12x-cuda-python.Dockerfile
-.. _s31: linux/tests/cuda12x-cuda-python.sh
-.. _t32: https://ci.preferred.jp/cupy.linux.cuda13x-cuda-python/
-.. _d32: linux/tests/cuda13x-cuda-python.Dockerfile
-.. _s32: linux/tests/cuda13x-cuda-python.sh
-.. _t33: https://ci.preferred.jp/cupy.linux.benchmark.head/
-.. _d33: linux/tests/benchmark.head.Dockerfile
-.. _s33: linux/tests/benchmark.head.sh
-.. _t34: https://ci.preferred.jp/cupy.linux.benchmark.pr/
-.. _d34: linux/tests/benchmark.Dockerfile
-.. _s34: linux/tests/benchmark.sh
+.. _t26: https://ci.preferred.jp/cupy.linux.cuda134/
+.. _d26: linux/tests/cuda134.Dockerfile
+.. _s26: linux/tests/cuda134.sh
+.. _t27: https://ci.preferred.jp/cupy.linux.cuda134.multi/
+.. _d27: linux/tests/cuda134.multi.Dockerfile
+.. _s27: linux/tests/cuda134.multi.sh
+.. _t28: https://ci.preferred.jp/cupy.linux.cuda13x-py314t/
+.. _d28: linux/tests/cuda13x-py314t.Dockerfile
+.. _s28: linux/tests/cuda13x-py314t.sh
+.. _t29: https://jenkins.preferred.jp/job/chainer/job/cupy_main/TEST=rocm-7-14,label=mnj-mi50/
+.. _d29: linux/tests/rocm-7-14.Dockerfile
+.. _s29: linux/tests/rocm-7-14.sh
+.. _t30: https://ci.preferred.jp/cupy.linux.cuda-slow/
+.. _d30: linux/tests/cuda-slow.Dockerfile
+.. _s30: linux/tests/cuda-slow.sh
+.. _t31: https://ci.preferred.jp/cupy.linux.cuda-example/
+.. _d31: linux/tests/cuda-example.Dockerfile
+.. _s31: linux/tests/cuda-example.sh
+.. _t32: https://ci.preferred.jp/cupy.linux.cuda-head/
+.. _d32: linux/tests/cuda-head.Dockerfile
+.. _s32: linux/tests/cuda-head.sh
+.. _t33: https://ci.preferred.jp/cupy.linux.cuda12x-cuda-python/
+.. _d33: linux/tests/cuda12x-cuda-python.Dockerfile
+.. _s33: linux/tests/cuda12x-cuda-python.sh
+.. _t34: https://ci.preferred.jp/cupy.linux.cuda13x-cuda-python/
+.. _d34: linux/tests/cuda13x-cuda-python.Dockerfile
+.. _s34: linux/tests/cuda13x-cuda-python.sh
+.. _t35: https://ci.preferred.jp/cupy.linux.benchmark.head/
+.. _d35: linux/tests/benchmark.head.Dockerfile
+.. _s35: linux/tests/benchmark.head.sh
+.. _t36: https://ci.preferred.jp/cupy.linux.benchmark.pr/
+.. _d36: linux/tests/benchmark.Dockerfile
+.. _s36: linux/tests/benchmark.sh

--- a/.pfnci/linux/tests/cuda134.Dockerfile
+++ b/.pfnci/linux/tests/cuda134.Dockerfile
@@ -14,7 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
        && \
     apt-get -qqy install ccache git curl && \
     apt-get -qqy --allow-change-held-packages \
-            --allow-downgrades install 'libnccl2=2.30.*+cuda13.4' 'libnccl-dev=2.30.*+cuda13.4' 'libcutensor2-cuda-13=2.4.*' 'libcutensor2-dev-cuda-13=2.4.*'
+            --allow-downgrades install 'libnccl2=2.30.*+cuda13.4' 'libnccl-dev=2.30.*+cuda13.4' 'libcutensor2-cuda-13=2.4.*' 'libcutensor2-dev-cuda-13=2.4.*' 'libcusparselt0-cuda-13=0.9.1.*' 'libcusparselt0-dev-cuda-13=0.9.1.*'
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
@@ -24,6 +24,9 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 ENV CUPY_INCLUDE_PATH=/usr/include/libcutensor/13:${CUPY_INCLUDE_PATH}
 ENV CUPY_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/13:${CUPY_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/13:${LD_LIBRARY_PATH}
+ENV CUPY_INCLUDE_PATH=/usr/include/libcusparseLt/13:${CUPY_INCLUDE_PATH}
+ENV CUPY_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${CUPY_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
@@ -32,8 +35,8 @@ RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage
 
-RUN pip install -U 'numpy==2.4.*' 'scipy==1.16.*' 'optuna==4.*' 'cython==3.2.*,!=3.2.6' 'cuda-python==13.4.*' 'nvmath-python==1.*' 'cuda-cccl[minimal-sysctk13]>=1.1.1'
-RUN pip uninstall -y mpi4py ml_dtypes && \
+RUN pip install -U 'numpy==2.5.*' 'scipy==1.16.*' 'optuna==4.*' 'ml_dtypes==0.5.*' 'cython==3.2.*,!=3.2.6'
+RUN pip uninstall -y mpi4py cuda-python nvmath-python cuda-cccl && \
     pip check
 
 RUN mkdir /home/cupy-user && chmod 777 /home/cupy-user

--- a/.pfnci/linux/tests/cuda134.multi.Dockerfile
+++ b/.pfnci/linux/tests/cuda134.multi.Dockerfile
@@ -10,11 +10,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
        curl llvm libncursesw5-dev xz-utils tk-dev \
        libxml2-dev libxmlsec1-dev libffi-dev \
        liblzma-dev \
-\
+       libopenmpi-dev \
        && \
     apt-get -qqy install ccache git curl && \
     apt-get -qqy --allow-change-held-packages \
-            --allow-downgrades install 'libnccl2=2.30.*+cuda13.4' 'libnccl-dev=2.30.*+cuda13.4' 'libcutensor2-cuda-13=2.4.*' 'libcutensor2-dev-cuda-13=2.4.*'
+            --allow-downgrades install 'libnccl2=2.30.*+cuda13.4' 'libnccl-dev=2.30.*+cuda13.4' 'libcutensor2-cuda-13=2.4.*' 'libcutensor2-dev-cuda-13=2.4.*' 'libcusparselt0-cuda-13=0.9.1.*' 'libcusparselt0-dev-cuda-13=0.9.1.*'
 
 ENV PATH "/usr/lib/ccache:${PATH}"
 
@@ -24,6 +24,9 @@ RUN curl -fsSL https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_li
 ENV CUPY_INCLUDE_PATH=/usr/include/libcutensor/13:${CUPY_INCLUDE_PATH}
 ENV CUPY_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/13:${CUPY_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/13:${LD_LIBRARY_PATH}
+ENV CUPY_INCLUDE_PATH=/usr/include/libcusparseLt/13:${CUPY_INCLUDE_PATH}
+ENV CUPY_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${CUPY_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcusparseLt/13:${LD_LIBRARY_PATH}
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT "/opt/pyenv"
 ENV PATH "${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
@@ -32,8 +35,8 @@ RUN PYTHON_CONFIGURE_OPTS="--disable-shared" pyenv install 3.14.6 && \
     pip install -U setuptools pip wheel && \
     pip install -U google-cloud-storage
 
-RUN pip install -U 'numpy==2.4.*' 'scipy==1.16.*' 'optuna==4.*' 'cython==3.2.*,!=3.2.6' 'cuda-python==13.4.*' 'nvmath-python==1.*' 'cuda-cccl[minimal-sysctk13]>=1.1.1'
-RUN pip uninstall -y mpi4py ml_dtypes && \
+RUN pip install -U 'numpy==2.5.*' 'scipy==1.16.*' 'optuna==4.*' 'mpi4py==4.*' 'ml_dtypes==0.5.*' 'cython==3.2.*,!=3.2.6'
+RUN pip uninstall -y cuda-python nvmath-python cuda-cccl && \
     pip check
 
 RUN mkdir /home/cupy-user && chmod 777 /home/cupy-user

--- a/.pfnci/linux/tests/cuda134.multi.sh
+++ b/.pfnci/linux/tests/cuda134.multi.sh
@@ -20,4 +20,6 @@ echo "======================================================="
 
 trap "$ACTIONS/cleanup.sh" EXIT
 "$ACTIONS/fetch-wheel.sh"
-CUPY_CI_PYTEST_EXTRA_OPTS="${CUPY_CI_PYTEST_EXTRA_OPTS:+$CUPY_CI_PYTEST_EXTRA_OPTS }--deselect tests/install_tests/test_cupy_builder/test_features.py::test_CUDA_cuda" "$ACTIONS/unittest.sh" "not slow and not multi_gpu"
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+CUPY_CI_PYTEST_EXTRA_OPTS="${CUPY_CI_PYTEST_EXTRA_OPTS:+$CUPY_CI_PYTEST_EXTRA_OPTS }--deselect tests/install_tests/test_cupy_builder/test_features.py::test_CUDA_cuda" "$ACTIONS/unittest.sh" "not slow and multi_gpu"

--- a/.pfnci/linux/tests/cuda134.sh
+++ b/.pfnci/linux/tests/cuda134.sh
@@ -13,6 +13,8 @@ export NVCC="ccache nvcc"
 
 export CUPY_ACCELERATORS="cutensor,cub"
 
+export CUPY_CI_PYTEST_EXTRA_OPTS="--junit-xml=/tmp/cupy_junit/junit.xml"
+
 echo "================ Environment Variables ================"
 env
 echo "======================================================="

--- a/.pfnci/linux/update-cuda-driver.sh
+++ b/.pfnci/linux/update-cuda-driver.sh
@@ -15,7 +15,11 @@ if dpkg -s "cuda-drivers-${CUDA_DRIVER_VERSION}" && ls /dev/nvidiactl ; then
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
     apt-get purge -qqy "cuda-drivers*" "*nvidia*-${CUDA_DRIVER_VERSION}"
-    apt-get install -qqy "cuda-drivers"
+    # NVIDIA r615 dropped the proprietary kernel-module packages; the CUDA
+    # repo's `cuda-drivers` meta no longer pulls in any driver. Install the
+    # open kernel modules (OpenRM) instead.
+    # https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/
+    apt-get install -qqy "nvidia-open"
 
     modprobe -r nvidia_drm nvidia_uvm nvidia_modeset nvidia
     nvidia-smi -pm 1

--- a/.pfnci/matrix.yaml
+++ b/.pfnci/matrix.yaml
@@ -389,10 +389,9 @@
   test: "unit-multi"
 
 # CUDA 13.3 | Linux
-# The latest CUDA version matrix is intended to cover the highest supported combination.
 - project: "cupy.linux.cuda133"
   target: "cuda133"
-  tags: ["@push", "full", "mini", "linux", "cuda133"]
+  tags: ["@nightly", "full", "linux", "cuda133"]
   system: "linux"
   os: "ubuntu:22.04"
   cuda: "13.3"
@@ -411,14 +410,47 @@
   cuda-cccl: null
   nvmath-python: null
   env:CUPY_ACCELERATORS: "cutensor,cub"
-  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
   test: "unit"
 
 # CUDA 13.3 (Multi-GPU) | Linux
 - project: "cupy.linux.cuda133.multi"
   _inherits: "cupy.linux.cuda133"
-  tags: ["@push", "full", "mini", "multi", "linux", "cuda133"]
+  tags: ["@nightly", "full", "multi", "linux", "cuda133"]
   target: "cuda133.multi"
+  mpi4py: "4"
+  test: "unit-multi"
+
+# CUDA 13.4 | Linux
+# The latest CUDA version matrix is intended to cover the highest supported combination.
+- project: "cupy.linux.cuda134"
+  target: "cuda134"
+  tags: ["@push", "full", "mini", "linux", "cuda134"]
+  system: "linux"
+  os: "ubuntu:22.04"
+  cuda: "13.4"
+  rocm: null
+  nccl: "2.30"
+  cutensor: "2.4"
+  cusparselt: "0.9.1"
+  python: "3.14"
+  numpy: "2.5"
+  scipy: "1.16"
+  optuna: "4"
+  ml_dtypes: "0.5"
+  mpi4py: null
+  cython: "3.2"
+  cuda-python: null
+  cuda-cccl: null
+  nvmath-python: null
+  env:CUPY_ACCELERATORS: "cutensor,cub"
+  env:CUPY_CI_PYTEST_EXTRA_OPTS: "--junit-xml=/tmp/cupy_junit/junit.xml"
+  test: "unit"
+
+# CUDA 13.4 (Multi-GPU) | Linux
+- project: "cupy.linux.cuda134.multi"
+  _inherits: "cupy.linux.cuda134"
+  tags: ["@push", "full", "mini", "multi", "linux", "cuda134"]
+  target: "cuda134.multi"
   mpi4py: "4"
   env:CUPY_CI_PYTEST_EXTRA_OPTS: null
   test: "unit-multi"
@@ -611,7 +643,7 @@
   tags: ["@push", "full", "mini", "linux", "cuda-python"]
   system: "linux"
   os: "ubuntu:22.04"
-  cuda: "13.3"
+  cuda: "13.4"
   rocm: null
   nccl: "2.30"
   cutensor: "2.4"
@@ -623,7 +655,7 @@
   mpi4py: null
   ml_dtypes: null
   cython: "3.2"
-  cuda-python: "13.3"
+  cuda-python: "13.4"
   cuda-cccl: "cu13"
   nvmath-python: "1"
   env:CUPY_ACCELERATORS: "cuda_compute,cutensor,cub"
@@ -710,7 +742,13 @@
 - project: "cupy.win.cuda133"
   _extern: true
   target: "cuda133"
-  tags: ["@push", "full", "mini", "windows", "cuda133"]
+  tags: ["@nightly", "full", "windows", "cuda133"]
+  system: "windows"
+
+- project: "cupy.win.cuda134"
+  _extern: true
+  target: "cuda134"
+  tags: ["@push", "full", "mini", "windows", "cuda134"]
   system: "windows"
 
 - project: "cupy.linux.cuda-rapids"

--- a/.pfnci/schema.yaml
+++ b/.pfnci/schema.yaml
@@ -75,6 +75,9 @@ cuda:
   "13.3":
     full_version: "13.3.0"
     repository: "nvidia/cuda"
+  "13.4":
+    full_version: "13.4.0"
+    repository: "nvidia/cuda"
 rocm:
   null:
     full_version: null
@@ -178,6 +181,7 @@ nccl:
     spec: "2.30.*"
     cuda:
       "13.3":
+      "13.4":
 cutensor:
   # https://docs.nvidia.com/cuda/cutensor/
   # https://developer.nvidia.com/cutensor/downloads
@@ -199,6 +203,7 @@ cutensor:
       "13.1":
       "13.2":
       "13.3":
+      "13.4":
 cusparselt:
   # https://docs.nvidia.com/cuda/cusparselt/
   # https://developer.nvidia.com/cusparselt/downloads
@@ -215,6 +220,7 @@ cusparselt:
       "13.1":
       "13.2":
       "13.3":
+      "13.4":
 
 ###############################################################################
 # Python
@@ -393,6 +399,8 @@ cuda-python:
     spec: "==13.2.*"
   "13.3":
     spec: "==13.3.*"
+  "13.4":
+    spec: "==13.4.*"
 nvmath-python:
   null:
     spec: null

--- a/.pfnci/windows/_flexci.ps1
+++ b/.pfnci/windows/_flexci.ps1
@@ -44,8 +44,10 @@ function ActivateCUDA($version) {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V13_2
     } elseif ($version -eq "13.3") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V13_3
+    } elseif ($version -eq "13.4") {
+        $Env:CUDA_PATH = $Env:CUDA_PATH_V13_4
     } elseif ($version -eq "13.x") {
-        $Env:CUDA_PATH = $Env:CUDA_PATH_V13_3
+        $Env:CUDA_PATH = $Env:CUDA_PATH_V13_4
     } else {
         throw "Unsupported CUDA version: $version"
     }

--- a/ci/tools/env-vars
+++ b/ci/tools/env-vars
@@ -24,6 +24,8 @@ if [[ "${1}" == "build" ]]; then
     CIBW_PLATFORM_TAG="manylinux_aarch64"
   elif [[ "${HOST_PLATFORM}" == "win-64" ]]; then
     CIBW_PLATFORM_TAG="win_amd64"
+  elif [[ "${HOST_PLATFORM}" == "win-arm64" ]]; then
+    CIBW_PLATFORM_TAG="win_arm64"
   else
     echo "Error: unsupported HOST_PLATFORM=${HOST_PLATFORM}" >&2
     exit 1

--- a/ci/tools/fetch_ctk_redistrib.py
+++ b/ci/tools/fetch_ctk_redistrib.py
@@ -16,6 +16,7 @@ HOST_PLATFORM_TO_SUBDIR: dict[str, str] = {
     "linux-64": "linux-x86_64",
     "linux-aarch64": "linux-sbsa",
     "win-64": "windows-x86_64",
+    "win-arm64": "windows-arm64",
 }
 
 # CTK 13.3.0 renamed the redistrib key from cuda_cccl to cccl.

--- a/ci/tools/prepare_wheel_build.py
+++ b/ci/tools/prepare_wheel_build.py
@@ -82,6 +82,7 @@ def generate_wheel_metadata(
         "linux-64": "Linux:x86_64",
         "linux-aarch64": "Linux:aarch64",
         "win-64": "Windows:x86_64",
+        "win-arm64": "Windows:arm64",
     }[host_platform]
 
     libraries = PRELOAD_LIBRARIES[cuda_major][host_platform]
@@ -150,8 +151,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--host-platform", required=True,
-        choices=("linux-64", "linux-aarch64", "win-64"),
-        help="Build host: linux-64 = Linux x86_64, linux-aarch64 = Linux ARM64, win-64 = Windows x86_64.",
+        choices=("linux-64", "linux-aarch64", "win-64", "win-arm64"),
+        help="Build host: linux-64 = Linux x86_64, linux-aarch64 = Linux ARM64, win-64 = Windows x86_64, win-arm64 = Windows ARM64.",
     )
     parser.add_argument(
         "--source-root", type=Path, default=DEFAULT_SOURCE_ROOT,

--- a/ci/tools/wheel_configs.py
+++ b/ci/tools/wheel_configs.py
@@ -26,6 +26,9 @@ PRELOAD_LIBRARIES: dict[str, dict[str, tuple[str, ...]]] = {
         "linux-64": ("cutensor", "nccl"),
         "linux-aarch64": ("cutensor", "nccl"),
         "win-64": ("cutensor",),
+        # No cuTENSOR / NCCL redist for Windows ARM64 yet (as of CTK 13.4).
+        # Revisit once NVIDIA ships those binaries; see cupy/cupy#10294.
+        "win-arm64": (),
     },
 }
 

--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -1,5 +1,5 @@
 cuda:
   build:
-    version: "13.3.1"
+    version: "13.4.1"
   prev_build:
     version: "12.9.2"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,7 @@ Requirements
 
 * `NVIDIA CUDA GPU <https://developer.nvidia.com/cuda-gpus>`_ with the Compute Capability 3.0 or larger.
 
-* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v12.0 / v12.1 / v12.2 / v12.3 / v12.4 / v12.5 / v12.6 / v12.8 / v12.9 / v13.0 / v13.1 / v13.2 / v13.3
+* `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_: v12.0 / v12.1 / v12.2 / v12.3 / v12.4 / v12.5 / v12.6 / v12.8 / v12.9 / v13.0 / v13.1 / v13.2 / v13.3 / v13.4
 
     * If you have multiple versions of CUDA Toolkit installed, CuPy will automatically choose one of the CUDA installations.
       See :ref:`install_cuda` for details.


### PR DESCRIPTION
Part of #10219.

Adds CUDA 13.4 to the CI matrix (Linux single + multi-GPU, Windows), extends NCCL 2.31 / cuTENSOR 2.4 / cuSPARSELt 0.9.1 / cuda-python 13.4 to CUDA 13.4, and moves the "mini" per-push tag from 13.3 to 13.4 as the new highest supported combination.

The remaining checklist items in #10219 (compiler max cc, install_library, wheel duplicate detection, cupy-release-tools, website) are follow-ups.