### PR TITLE
CI: switch runner driver upgrade to OpenRM (nvidia-open)

### DIFF
--- a/.pfnci/linux/update-cuda-driver.sh
+++ b/.pfnci/linux/update-cuda-driver.sh
@@ -15,7 +15,11 @@ if dpkg -s "cuda-drivers-${CUDA_DRIVER_VERSION}" && ls /dev/nvidiactl ; then
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
     apt-get purge -qqy "cuda-drivers*" "*nvidia*-${CUDA_DRIVER_VERSION}"
-    apt-get install -qqy "cuda-drivers"
+    # NVIDIA r615 dropped the proprietary kernel-module packages; the CUDA
+    # repo's `cuda-drivers` meta no longer pulls in any driver. Install the
+    # open kernel modules (OpenRM) instead.
+    # https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/
+    apt-get install -qqy "nvidia-open"
 
     modprobe -r nvidia_drm nvidia_uvm nvidia_modeset nvidia
     nvidia-smi -pm 1


### PR DESCRIPTION
All Linux FlexCI mini jobs have been failing since ~2026-09-09 17:22 UTC with:

```
Preparing to unpack .../cuda-drivers_615.71.09-1ubuntu1_amd64.deb ...
Unpacking cuda-drivers:amd64 (615.71.09-1ubuntu1) ...
Setting up cuda-drivers:amd64 (615.71.09-1ubuntu1) ...
modprobe: FATAL: Module nvidia_drm not found.
command exited: code=1
```

NVIDIA's r615 CUDA apt repo dropped the proprietary kernel-module packages, and the `cuda-drivers` meta-package on the repo now unpacks with no dependencies — so the `apt-get install cuda-drivers` in `.pfnci/linux/update-cuda-driver.sh` installs zero driver bits, and the following `modprobe -r` exits with FATAL because there is no driver in the running kernel.

Switch the runner-side driver upgrade to `nvidia-open`, which is the transition path NVIDIA announced back in July 2024 (["NVIDIA Transitions Fully Towards Open-Source GPU Kernel Modules"](https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/)). `nvidia-open` is a thin meta-package (`Depends: nvidia-driver-open (>= 615.71.09)`) that correctly pulls in the full open kernel-module stack.

FlexCI's Linux runners are GCE T4 instances; T4 (Turing) is in the r615 open kernel modules' compatible-GPU list, so there is no hardware fallout.