### PR TITLE
Fix broken docstring formats in cuda, distributed and ndimage (#4902)

### DIFF
--- a/cupy/cuda/__init__.py
+++ b/cupy/cuda/__init__.py
@@ -167,8 +167,7 @@ from cupy.cuda.graph import Graph  # NOQA
 
 @contextlib.contextmanager
 def using_allocator(allocator=None):
-    """Sets a thread-local allocator for GPU memory inside
-       context manager
+    """Sets a thread-local allocator for GPU memory inside a context manager.
 
     Args:
         allocator (function): CuPy memory allocator. It must have the same

--- a/cupyx/distributed/_init.py
+++ b/cupyx/distributed/_init.py
@@ -71,8 +71,8 @@ def init_process_group(
             information.
             defaults to `False`.
     Returns:
-        Backend: object used to perform communications, adheres to the
-            :class:`~cupyx.distributed.Backend` specification:
+        NCCLBackend: object used to perform communications, adheres to the
+            :class:`~cupyx.distributed.NCCLBackend` interface.
     """
     if n_devices <= 0:
         raise ValueError(f'Invalid number of devices {n_devices}')

--- a/cupyx/scipy/ndimage/_interpolation.py
+++ b/cupyx/scipy/ndimage/_interpolation.py
@@ -379,10 +379,10 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None, output=None,
 
             - 2D and 3D float32 arrays as input
             - ``(ndim + 1, ndim + 1)`` homogeneous float32 transformation
-                matrix
+              matrix
             - ``mode='constant'`` and ``mode='nearest'``
             - ``order=0`` (nearest neighbor) and ``order=1`` (linear
-                interpolation)
+              interpolation)
             - NVIDIA CUDA GPUs
         float64_coords (bool): If True, force double precision computations
             internally as in scipy.ndimage.


### PR DESCRIPTION
## Summary

Three of the docstring issues listed under "Broken docstring formats" in #4902:

- `cupy.cuda.using_allocator`: the one-line summary was wrapped across two lines with the continuation under-indented, breaking the summary-line convention every other function in the file follows (e.g. `profile()`, `get_local_runtime_version()`).
- `cupyx.distributed.init_process_group`: the `Returns:` section referenced `cupyx.distributed.Backend`, which does not exist. The module only exports `init_process_group` and `NCCLBackend` (see `cupyx/distributed/__init__.py`); the base class is the private `_Backend` in `_comm.py`. `init_process_group` also only ever returns an `NCCLBackend` in practice, since `_backends = {'nccl': NCCLBackend}` is the only registered backend and any other value raises. Fixed the reference to point at the real class, and removed a dangling trailing colon that had nothing following it.
- `cupyx.scipy.ndimage.affine_transform`: the `texture_memory` parameter's bullet list had two items whose continuation line was over-indented relative to the bullet's own text column.

## Why

I verified the `affine_transform` case isn't just cosmetic: I parsed both the original and fixed docstring fragments with `docutils` and compared the resulting doctrees. The over-indentation makes RST parse "homogeneous float32 transformation" / "matrix" as a `definition_list` (term + definition) instead of one flowing bullet paragraph — a real rendering bug, not just a style nit. The fixed version produces the intended flat `paragraph` structure.

## Testing

- `python3 -c "import ast; ast.parse(open(f).read())"` on all three changed files — syntax valid.
- `docutils` doctree comparison (original vs. fixed) for the `affine_transform` bullet list, confirming the parse-structure bug and its fix, as described above.

## Note for maintainers

While investigating #4902 I checked the rest of its checklist against the current source and most items already match current behavior (e.g. `cupy.asarray`'s `order` docstring, the "Missing API Reference" entries for `cupy.max`/`min`/`ndim`/`round`/`size`, and the `cupyx.scipy.linalg`/`cupyx.scipy.special` entries). Leaving that out of this diff since there's no code change needed there, but flagging it in case the tracking issue should be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)